### PR TITLE
Fix Windows Build (include stdexcept where it is required)

### DIFF
--- a/risc0/zkp/verify/taps.h
+++ b/risc0/zkp/verify/taps.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <stdexcept>
 
 namespace risc0 {
 


### PR DESCRIPTION
This is required for Windows to build in the x86_x64 Cross Tools dev environment for VS2019 Build Tools 
Notes: 
   This is on a fresh install of the all components, including windows itself
   If you have run bazelisk previously, be sure to run "bazelisk clean --expunge" after updating your build tool chain to remove crufty commands