### PR TITLE
Added extra constraints to disallow out of bounds memory reads/writes.

### DIFF
--- a/risc0/r0vm/circuit/compute_cycle.cpp
+++ b/risc0/r0vm/circuit/compute_cycle.cpp
@@ -121,6 +121,7 @@ void ComputeCycle::set(StepState& state, int highID) {
       Value cycle = state.code.cycle.get();                                                        \
       if (doLoad) {                                                                                \
         state.data.memIO.doRead(cycle, x1.getPart(2, kMemBits));                                   \
+        equate(x1.getPart(2 + kMemBits, 32 - kMemBits - 2), 0);                                    \
       } else {                                                                                     \
         state.data.memIO.doRead(cycle, 0);                                                         \
       }                                                                                            \

--- a/risc0/r0vm/circuit/final_cycle.cpp
+++ b/risc0/r0vm/circuit/final_cycle.cpp
@@ -28,6 +28,7 @@ void FinalCycle::set(StepState& state) {
   BYZ_IF(resultInfo.doStore.get()) {
     Value isWOM = compute.x1.get(kMemBits + 1);
     Value memAddr = compute.x1.getPart(2, kMemBits);
+    equate(compute.x1.getPart(2 + kMemBits, 32 - kMemBits - 2), 0);
     state.data.memIO.doWrite(cycle, memAddr, result, isWOM);
   }
   BYZ_IF(1 - resultInfo.doStore.get()) { state.data.memIO.doRead(cycle); }


### PR DESCRIPTION
This is based on the one useful change I made trying to debug the game engine stuff.  Previously upper bits were ignored on memory I/O, so reads/writes to huge memory addresses just wrapped around, leading to later very strange behavior.  This tightens the requirements of the code to not allow such accesses.