### PR TITLE
Step-by-step VM guest debugging and GDB Server

### DIFF
--- a/risc0/r0vm/prove/BUILD.bazel
+++ b/risc0/r0vm/prove/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
         "step.cpp",
         "step_context.cpp",
         ":step_inc_gen",
+        "debug.cpp",
     ],
     hdrs = [
         "c_api.h",
@@ -28,6 +29,7 @@ cc_library(
         "proof.h",
         "riscv.h",
         "step.h",
+        "debug.h",
     ],
     linkstatic = True,
     deps = [

--- a/risc0/r0vm/prove/debug.cpp
+++ b/risc0/r0vm/prove/debug.cpp
@@ -12,28 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
-#include "risc0/r0vm/prove/step.h"
-
-#include <string>
-#include <vector>
+#include "risc0/r0vm/prove/debug.h"
 
 namespace risc0 {
 
-class ExecState {
-public:
-  ExecState(const std::string& elfFile);
-  void run(const size_t maxSteps, MemoryHandler& io);
+void DebugState::start(const size_t maxSteps, MemoryHandler& io) {
+  init(maxSteps, io);
+}
 
-  uint32_t startAddr;
-  std::map<uint32_t, uint32_t> image;
-  StepContext context;
-  std::vector<Fp> code;
-  std::vector<Fp> data;
-
-protected:
-  void init(const size_t maxSteps, MemoryHandler& io);
-};
+void DebugState::step() {
+  // TODO define step interface and event loop
+}
 
 } // namespace risc0

--- a/risc0/r0vm/prove/debug.h
+++ b/risc0/r0vm/prove/debug.h
@@ -14,26 +14,13 @@
 
 #pragma once
 
-#include "risc0/r0vm/prove/step.h"
-
-#include <string>
-#include <vector>
+#include "risc0/r0vm/prove/exec.h"
 
 namespace risc0 {
 
-class ExecState {
+class DebugState : public ExecState {
 public:
-  ExecState(const std::string& elfFile);
-  void run(const size_t maxSteps, MemoryHandler& io);
-
-  uint32_t startAddr;
-  std::map<uint32_t, uint32_t> image;
-  StepContext context;
-  std::vector<Fp> code;
-  std::vector<Fp> data;
-
-protected:
-  void init(const size_t maxSteps, MemoryHandler& io);
+  void start(const size_t maxSteps, MemoryHandler& io);
+  void step();
 };
-
 } // namespace risc0


### PR DESCRIPTION
Currently a WIP for first refactoring the VM runtime to support step-by-step debgging, to be followed by implementing the hooks to drive incremental state transition updates and reporting to consumers, followed by implementation of a GDB server for debugging VM guest code as a GDB target.

Creating this draft pull request so that progress can be tracked on the shape of the refactoring changes and API to ensure we are in agreement.