### PR TITLE
Clean up compiler warnings on gcc and clang

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,9 +10,6 @@ build --incompatible_enable_cc_toolchain_resolution
 #build --toolchain_resolution_debug
 build --flag_alias=accel=//risc0/zkp/accel:flag
 build --//bazel/rules/clang_format:config=//:.clang-format
-build --copt=-Werror
-# TODO(nils): Clean up the violations of strict aliasing.
-build --copt=-Wno-error=strict-aliasing
 
 build:cpu --accel=cpu
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,9 @@ build --incompatible_enable_cc_toolchain_resolution
 #build --toolchain_resolution_debug
 build --flag_alias=accel=//risc0/zkp/accel:flag
 build --//bazel/rules/clang_format:config=//:.clang-format
+build --copt=-Werror
+# TODO(nils): Clean up the violations of strict aliasing.
+build --copt=-Wno-error=strict-aliasing
 
 build:cpu --accel=cpu
 

--- a/bazel/rules/cc/defs.bzl
+++ b/bazel/rules/cc/defs.bzl
@@ -9,10 +9,7 @@ def _copts(std):
         "//conditions:default": [
             "-std=" + std,
             "-Werror",
-            # TODO(nils): Clean up type punning violations;
-            # this is easy to do once we get to c++20 because then we
-            # can use std::bit_cast
-            "-Wno-strict-aliasing",
+            "-fno-strict-aliasing",
         ],
     })
 

--- a/bazel/rules/cc/defs.bzl
+++ b/bazel/rules/cc/defs.bzl
@@ -9,7 +9,6 @@ def _copts(std):
         "//conditions:default": [
             "-std=" + std,
             "-Werror",
-            "-fno-strict-aliasing",
         ],
     })
 

--- a/bazel/rules/cc/defs.bzl
+++ b/bazel/rules/cc/defs.bzl
@@ -6,7 +6,14 @@ def _copts(std):
             "/std:" + std,
             "/Zc:preprocessor",
         ],
-        "//conditions:default": ["-std=" + std],
+        "//conditions:default": [
+            "-std=" + std,
+            "-Werror",
+            # TODO(nils): Clean up type punning violations;
+            # this is easy to do once we get to c++20 because then we
+            # can use std::bit_cast
+            "-Wno-strict-aliasing",
+        ],
     })
 
 def cc_binary(name, std = DEFAULT_CXX_STD, copts = [], **kwargs):

--- a/examples/cpp/battleship/battleship.h
+++ b/examples/cpp/battleship/battleship.h
@@ -58,7 +58,7 @@ struct Ship {
 
   template <typename Archive> void transfer(Archive& ar) {
     ar.transfer(pos);
-    ar.transfer(reinterpret_cast<uint16_t&>(dir));
+    ar.transfer(dir);
     ar.transfer(hit_mask);
   }
 
@@ -111,7 +111,7 @@ struct RoundResult {
 
   template <typename Archive> void transfer(Archive& ar) {
     ar.transfer(state);
-    ar.transfer(reinterpret_cast<uint32_t&>(hit));
+    ar.transfer(hit);
   }
 
   bool operator==(const RoundResult& rhs) const;

--- a/examples/cpp/battleship/core.cpp
+++ b/examples/cpp/battleship/core.cpp
@@ -147,7 +147,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 
 std::ostream& operator<<(std::ostream& os, const GameState& state) {
   os << "GameState{";
-  for (unsigned i = 0; i < NUM_SHIPS; i++) {
+  for (uint32_t i = 0; i < NUM_SHIPS; i++) {
     const Ship& ship = state.ships[i];
     if (i > 0) {
       os << ", ";

--- a/examples/cpp/battleship/core.cpp
+++ b/examples/cpp/battleship/core.cpp
@@ -147,13 +147,13 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 
 std::ostream& operator<<(std::ostream& os, const GameState& state) {
   os << "GameState{";
-  for (int i = 0; i < NUM_SHIPS; i++) {
+  for (unsigned i = 0; i < NUM_SHIPS; i++) {
     const Ship& ship = state.ships[i];
     if (i > 0) {
       os << ", ";
     }
     os << "{" << ship.pos << ", " << ship.dir << ", ";
-    for (int j = 0; j < SHIP_SPANS[i]; j++) {
+    for (unsigned j = 0; j < SHIP_SPANS[i]; j++) {
       if (ship.hit_mask & (1 << j)) {
         os << 'X';
       } else {

--- a/examples/cpp/battleship/protocol.h
+++ b/examples/cpp/battleship/protocol.h
@@ -50,7 +50,7 @@ struct RoundMessage {
       ar.transfer(old_state);
       ar.transfer(new_state);
       ar.transfer(shot);
-      ar.transfer(reinterpret_cast<uint32_t&>(hit));
+      ar.transfer(hit);
     }
   };
 

--- a/risc0/core/log.cpp
+++ b/risc0/core/log.cpp
@@ -20,13 +20,13 @@
 
 namespace risc0 {
 
-int gLogLevel = 0;
+unsigned gLogLevel = 0;
 
-void setLogLevel(int level) {
+void setLogLevel(unsigned level) {
   gLogLevel = level;
 }
 
-int getLogLevel() {
+unsigned getLogLevel() {
   return gLogLevel;
 }
 

--- a/risc0/core/log.h
+++ b/risc0/core/log.h
@@ -32,11 +32,11 @@
 namespace risc0 {
 
 /// Set the logging level so that logs of level <= \p level are printed
-void setLogLevel(int level);
+void setLogLevel(unsigned level);
 
 /// Get the currently log level.
 /// Usually used to optionally do extra computation required only for logging.
-int getLogLevel();
+unsigned getLogLevel();
 
 /// Logs a timestamp to cerr (the first part of a log message)
 void logTimestamp();

--- a/risc0/zkp/accel/backend/cpu/impl.cpp
+++ b/risc0/zkp/accel/backend/cpu/impl.cpp
@@ -130,7 +130,7 @@ void batchEvaluateAny(AccelConstSlice<Fp> coeffs,
     size_t id = reinterpret_cast<const uint32_t*>(which.buf()->buf)[i];
     Fp4 x = reinterpret_cast<const Fp4*>(xs.buf()->buf)[i];
     const Fp* coeffLocal = coeffsPtr + (1 << po2) * id;
-    for (size_t i = 0; i < (1 << po2); i++) {
+    for (size_t i = 0; i < (1U << po2); i++) {
       tot += cur * coeffLocal[i];
       cur *= x;
     }

--- a/risc0/zkp/accel/backend/cpu/impl.cpp
+++ b/risc0/zkp/accel/backend/cpu/impl.cpp
@@ -130,7 +130,7 @@ void batchEvaluateAny(AccelConstSlice<Fp> coeffs,
     size_t id = reinterpret_cast<const uint32_t*>(which.buf()->buf)[i];
     Fp4 x = reinterpret_cast<const Fp4*>(xs.buf()->buf)[i];
     const Fp* coeffLocal = coeffsPtr + (1 << po2) * id;
-    for (size_t i = 0; i < ((size_t)1 << po2); i++) {
+    for (size_t i = 0; i < (static_cast<size_t>(1) << po2); i++) {
       tot += cur * coeffLocal[i];
       cur *= x;
     }

--- a/risc0/zkp/accel/backend/cpu/impl.cpp
+++ b/risc0/zkp/accel/backend/cpu/impl.cpp
@@ -130,7 +130,7 @@ void batchEvaluateAny(AccelConstSlice<Fp> coeffs,
     size_t id = reinterpret_cast<const uint32_t*>(which.buf()->buf)[i];
     Fp4 x = reinterpret_cast<const Fp4*>(xs.buf()->buf)[i];
     const Fp* coeffLocal = coeffsPtr + (1 << po2) * id;
-    for (size_t i = 0; i < (1U << po2); i++) {
+    for (size_t i = 0; i < ((size_t)1 << po2); i++) {
       tot += cur * coeffLocal[i];
       cur *= x;
     }

--- a/risc0/zkp/verify/merkle.cpp
+++ b/risc0/zkp/verify/merkle.cpp
@@ -18,10 +18,10 @@ namespace risc0 {
 
 MerkeTreeParams::MerkeTreeParams(size_t rowSize, size_t colSize, size_t queries)
     : rowSize(rowSize), colSize(colSize), queries(queries), layers(log2Ceil(rowSize)) {
-  REQUIRE(1 << layers == rowSize);
+  REQUIRE(1U << layers == rowSize);
   topLayer = 0;
   for (size_t i = 1; i < layers; i++) {
-    if ((1 << i) > queries) {
+    if ((1U << i) > queries) {
       break;
     }
     topLayer = i;

--- a/risc0/zkvm/circuit/poly_context.cpp
+++ b/risc0/zkvm/circuit/poly_context.cpp
@@ -439,7 +439,7 @@ std::string PolyContext::done() {
     impl->tapToID[tap] = nextID++;
   }
   std::string finalName = impl->eval(result);
-  if (result->degree() > kMaxDegree) {
+  if ((unsigned)result->degree() > kMaxDegree) {
     result->findCriticalPath(*impl);
     throw std::runtime_error("Degree too large!");
   }

--- a/risc0/zkvm/prove/exec.cpp
+++ b/risc0/zkvm/prove/exec.cpp
@@ -151,7 +151,7 @@ void ExecState::expand() {
     std::vector<Fp> newData(data.size() * 2);
 #endif
     setupCode(newCode.data(), context.numSteps * 2, startAddr, image);
-    for (int j = 0; j < kDataSize; j++) {
+    for (unsigned j = 0; j < kDataSize; j++) {
       std::copy(data.begin() + j * context.numSteps,
                 data.begin() + j * context.numSteps + context.curStep,
                 newData.begin() + j * context.numSteps * 2);

--- a/risc0/zkvm/prove/step.cpp
+++ b/risc0/zkvm/prove/step.cpp
@@ -35,7 +35,7 @@ namespace risc0 {
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 #if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #endif
 
 #define STEP_INC

--- a/risc0/zkvm/prove/step.cpp
+++ b/risc0/zkvm/prove/step.cpp
@@ -28,6 +28,10 @@
 
 namespace risc0 {
 
+// Ignore values in generated code that are computed unnecessarily;
+// the optimizer should remove these.
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+
 #define STEP_INC
 #include "risc0/zkvm/circuit/step.cpp.inc"
 

--- a/risc0/zkvm/prove/step.cpp
+++ b/risc0/zkvm/prove/step.cpp
@@ -30,12 +30,10 @@ namespace risc0 {
 
 // Ignore values in generated code that are computed unnecessarily;
 // the optimizer should remove these.
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wunused-variable"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 #define STEP_INC

--- a/risc0/zkvm/prove/step.cpp
+++ b/risc0/zkvm/prove/step.cpp
@@ -32,10 +32,10 @@ namespace risc0 {
 // the optimizer should remove these.
 
 #if defined(__GNUC__)
-# pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 #if defined(__clang__)
-# pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 #define STEP_INC

--- a/risc0/zkvm/prove/step.cpp
+++ b/risc0/zkvm/prove/step.cpp
@@ -30,7 +30,13 @@ namespace risc0 {
 
 // Ignore values in generated code that are computed unnecessarily;
 // the optimizer should remove these.
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+#if defined(__clang__)
+# pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#endif
 
 #define STEP_INC
 #include "risc0/zkvm/circuit/step.cpp.inc"

--- a/risc0/zkvm/prove/step_context.cpp
+++ b/risc0/zkvm/prove/step_context.cpp
@@ -148,7 +148,7 @@ void StepContext::requireDigits(Fp* buf, size_t bits, size_t offset, size_t size
       set(buf, offset + i, Fp(0));
     }
 #endif
-    if (get(buf, offset + i, 0).asUInt32() >= (1 << bits)) {
+    if (get(buf, offset + i, 0).asUInt32() >= (1U << bits)) {
       throw std::runtime_error("Invalid requireDigits\n");
     }
   }


### PR DESCRIPTION
This adds -Werror to gcc and clang compilations, and fixes warnings (mostly signed vs unsigned comparisons).
