### PR TITLE
Clean up and comment "Buffer" type and stream buffers

### DIFF
--- a/risc0/core/archive.h
+++ b/risc0/core/archive.h
@@ -234,7 +234,7 @@ static_assert(is_stream_reader<BufferStreamReader>(),
               "BufferStreamReader must conform to the stream reader model");
 
 // VectorStreamWriter is a stream writer which accumulates written data into a
-// std::fector<uint32_t>.
+// std::vector<uint32_t>.
 struct VectorStreamWriter {
   void write_word(uint32_t word) { vec.push_back(word); }
 

--- a/risc0/core/test/archive.cpp
+++ b/risc0/core/test/archive.cpp
@@ -63,7 +63,7 @@ struct StringPair {
   }
 };
 
-struct Buffer {
+struct ArchiveTestBuffer {
   std::unique_ptr<uint32_t[]> buf;
   size_t size;
 };
@@ -77,11 +77,11 @@ public:
   size_t size = 0;
 };
 
-template <typename T> Buffer serialize(T& obj) {
+template <typename T> ArchiveTestBuffer serialize(T& obj) {
   WordCounter wc;
   ArchiveWriter writer1(wc);
   writer1.transfer(obj);
-  Buffer buf{std::unique_ptr<uint32_t[]>(new uint32_t[wc.size]), wc.size};
+  ArchiveTestBuffer buf{std::unique_ptr<uint32_t[]>(new uint32_t[wc.size]), wc.size};
   BufferStreamWriter stream(buf.buf.get());
   ArchiveWriter writer2(stream);
   writer2.transfer(obj);
@@ -97,7 +97,7 @@ template <typename T> T deserialize(void* ptr) {
 }
 
 template <typename T> T roundtrip(T pre) {
-  Buffer buf = serialize(pre);
+  ArchiveTestBuffer buf = serialize(pre);
   LOG(0, "buf: ");
   for (size_t i = 0; i < buf.size; i++) {
     LOG(0, "  [" << hex(i, 2) << "]: " << hex(buf.buf[i]));

--- a/risc0/zkvm/circuit/accum_regs.cpp
+++ b/risc0/zkvm/circuit/accum_regs.cpp
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 void AccumRegs::set(StepState& state) {
   // Only verify when code is active
@@ -96,5 +95,4 @@ void AccumRegs::set(StepState& state) {
   } // End if (isAcive)
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/accum_regs.cpp
+++ b/risc0/zkvm/circuit/accum_regs.cpp
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 void AccumRegs::set(StepState& state) {
   // Only verify when code is active
@@ -95,4 +96,5 @@ void AccumRegs::set(StepState& state) {
   } // End if (isAcive)
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/accum_regs.h
+++ b/risc0/zkvm/circuit/accum_regs.h
@@ -17,8 +17,7 @@
 #include "risc0/zkvm/circuit/constants.h"
 #include "risc0/zkvm/circuit/types.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct AccumRegs {
   Buffer prod1;
@@ -37,5 +36,4 @@ struct AccumRegs {
   void set(StepState& state);
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/accum_regs.h
+++ b/risc0/zkvm/circuit/accum_regs.h
@@ -18,6 +18,7 @@
 #include "risc0/zkvm/circuit/types.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct AccumRegs {
   Buffer prod1;
@@ -36,4 +37,5 @@ struct AccumRegs {
   void set(StepState& state);
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/code_regs.h
+++ b/risc0/zkvm/circuit/code_regs.h
@@ -18,6 +18,7 @@
 #include "risc0/zkvm/circuit/types.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct CodeRegs {
   Reg cycle;
@@ -38,4 +39,5 @@ struct CodeRegs {
       , data2(alloc) {}
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/code_regs.h
+++ b/risc0/zkvm/circuit/code_regs.h
@@ -17,8 +17,7 @@
 #include "risc0/zkvm/circuit/constants.h"
 #include "risc0/zkvm/circuit/types.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct CodeRegs {
   Reg cycle;
@@ -39,5 +38,4 @@ struct CodeRegs {
       , data2(alloc) {}
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/compute_cycle.cpp
+++ b/risc0/zkvm/circuit/compute_cycle.cpp
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 // Do the compute cycle.  Turn off max function size since macro inclusion make it too big.
 // NOLINTNEXTLINE(readability-function-size)
@@ -169,4 +170,5 @@ void ComputeCycle::set(StepState& state, int highID) {
   setStatusFlags();
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/compute_cycle.cpp
+++ b/risc0/zkvm/circuit/compute_cycle.cpp
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 // Do the compute cycle.  Turn off max function size since macro inclusion make it too big.
 // NOLINTNEXTLINE(readability-function-size)
@@ -170,5 +169,4 @@ void ComputeCycle::set(StepState& state, int highID) {
   setStatusFlags();
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/compute_cycle.h
+++ b/risc0/zkvm/circuit/compute_cycle.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/cycle.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct ComputeCycle {
   ComputeCycle(BufAlloc& alloc)
@@ -55,4 +56,5 @@ struct ComputeCycle {
   MakeBoolRegs nzHigh;
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/compute_cycle.h
+++ b/risc0/zkvm/circuit/compute_cycle.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/cycle.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct ComputeCycle {
   ComputeCycle(BufAlloc& alloc)
@@ -56,5 +55,4 @@ struct ComputeCycle {
   MakeBoolRegs nzHigh;
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/context.cpp
+++ b/risc0/zkvm/circuit/context.cpp
@@ -15,6 +15,7 @@
 #include "risc0/zkvm/circuit/context.h"
 
 namespace risc0 {
+namespace circuit {
 
 namespace {
 Context* gContext;
@@ -28,4 +29,5 @@ Context* getGlobalContext() {
   return gContext;
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/context.cpp
+++ b/risc0/zkvm/circuit/context.cpp
@@ -14,8 +14,7 @@
 
 #include "risc0/zkvm/circuit/context.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 namespace {
 Context* gContext;
@@ -29,5 +28,4 @@ Context* getGlobalContext() {
   return gContext;
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/context.h
+++ b/risc0/zkvm/circuit/context.h
@@ -21,8 +21,7 @@
 #include <memory>
 #include <vector>
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct ValueImplBase {
   virtual ~ValueImplBase() {}
@@ -87,5 +86,4 @@ public:
 void setGlobalContext(Context* context);
 Context* getGlobalContext();
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/context.h
+++ b/risc0/zkvm/circuit/context.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 namespace risc0 {
+namespace circuit {
 
 struct ValueImplBase {
   virtual ~ValueImplBase() {}
@@ -86,4 +87,5 @@ public:
 void setGlobalContext(Context* context);
 Context* getGlobalContext();
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/cycle.h
+++ b/risc0/zkvm/circuit/cycle.h
@@ -17,8 +17,7 @@
 #include "risc0/zkvm/circuit/code_regs.h"
 #include "risc0/zkvm/circuit/types.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct ResultInfoRegs {
   RegU32 result;
@@ -29,5 +28,4 @@ struct ResultInfoRegs {
   ResultInfoRegs(BufAlloc& alloc) : result(alloc), setReg(alloc), doStore(alloc), pcRaw(alloc) {}
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/cycle.h
+++ b/risc0/zkvm/circuit/cycle.h
@@ -18,6 +18,7 @@
 #include "risc0/zkvm/circuit/types.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct ResultInfoRegs {
   RegU32 result;
@@ -28,4 +29,5 @@ struct ResultInfoRegs {
   ResultInfoRegs(BufAlloc& alloc) : result(alloc), setReg(alloc), doStore(alloc), pcRaw(alloc) {}
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/data_regs.cpp
+++ b/risc0/zkvm/circuit/data_regs.cpp
@@ -18,6 +18,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 void DataRegs::setExec(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -194,4 +195,5 @@ void DataRegs::setMemCheck(StepState& state) { // NOLINT
   }
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/data_regs.cpp
+++ b/risc0/zkvm/circuit/data_regs.cpp
@@ -17,8 +17,7 @@
 #include "risc0/zkvm/circuit/mem_check.h"
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 void DataRegs::setExec(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -195,5 +194,4 @@ void DataRegs::setMemCheck(StepState& state) { // NOLINT
   }
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/data_regs.h
+++ b/risc0/zkvm/circuit/data_regs.h
@@ -24,6 +24,7 @@
 #include "risc0/zkvm/circuit/sha_cycle.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct DataRegs {
   static constexpr size_t kMemCheckSize = 16;
@@ -86,4 +87,5 @@ struct DataRegs {
   }
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/data_regs.h
+++ b/risc0/zkvm/circuit/data_regs.h
@@ -23,8 +23,7 @@
 #include "risc0/zkvm/circuit/multiply_cycle.h"
 #include "risc0/zkvm/circuit/sha_cycle.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct DataRegs {
   static constexpr size_t kMemCheckSize = 16;
@@ -87,5 +86,4 @@ struct DataRegs {
   }
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/decode_cycle.cpp
+++ b/risc0/zkvm/circuit/decode_cycle.cpp
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 // Helper for matching in nondet sections
 static Value match(int pat, Value x) {
@@ -163,4 +164,5 @@ void DecodeCycle::set(StepState& state) {
 #undef OPD
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/decode_cycle.cpp
+++ b/risc0/zkvm/circuit/decode_cycle.cpp
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 // Helper for matching in nondet sections
 static Value match(int pat, Value x) {
@@ -164,5 +163,4 @@ void DecodeCycle::set(StepState& state) {
 #undef OPD
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/decode_cycle.h
+++ b/risc0/zkvm/circuit/decode_cycle.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/cycle.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct DecodeCycle {
   DecodeCycle(BufAlloc& alloc)
@@ -63,5 +62,4 @@ struct DecodeCycle {
   Reg nextCycleType;
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/decode_cycle.h
+++ b/risc0/zkvm/circuit/decode_cycle.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/cycle.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct DecodeCycle {
   DecodeCycle(BufAlloc& alloc)
@@ -62,4 +63,5 @@ struct DecodeCycle {
   Reg nextCycleType;
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/divide_cycle.cpp
+++ b/risc0/zkvm/circuit/divide_cycle.cpp
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 void DivideCycle::set(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -155,5 +154,4 @@ void DivideCycle::set(StepState& state) {
   resultInfo.pcRaw.set(final.pc + 4);
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/divide_cycle.cpp
+++ b/risc0/zkvm/circuit/divide_cycle.cpp
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 void DivideCycle::set(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -154,4 +155,5 @@ void DivideCycle::set(StepState& state) {
   resultInfo.pcRaw.set(final.pc + 4);
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/divide_cycle.h
+++ b/risc0/zkvm/circuit/divide_cycle.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/cycle.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct DivideCycle {
   DivideCycle(BufAlloc& alloc)
@@ -63,4 +64,5 @@ struct DivideCycle {
   RegU32 numer32;
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/divide_cycle.h
+++ b/risc0/zkvm/circuit/divide_cycle.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/cycle.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct DivideCycle {
   DivideCycle(BufAlloc& alloc)
@@ -64,5 +63,4 @@ struct DivideCycle {
   RegU32 numer32;
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/edsl.h
+++ b/risc0/zkvm/circuit/edsl.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/context.h"
 
 namespace risc0 {
+namespace circuit {
 
 class Value {
 public:
@@ -225,4 +226,5 @@ public:
 #define BYZ_GROUP if (auto groupGuard = GroupGuard())
 #define BYZ_IF(cond) if (auto ifGuard = IfGuard(cond))
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/edsl.h
+++ b/risc0/zkvm/circuit/edsl.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/context.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 class Value {
 public:
@@ -226,5 +225,4 @@ public:
 #define BYZ_GROUP if (auto groupGuard = GroupGuard())
 #define BYZ_IF(cond) if (auto ifGuard = IfGuard(cond))
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/final_cycle.cpp
+++ b/risc0/zkvm/circuit/final_cycle.cpp
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 void FinalCycle::set(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -51,4 +52,5 @@ void FinalCycle::set(StepState& state) {
             pc.getPart(2, kMemBits) * 4});
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/final_cycle.cpp
+++ b/risc0/zkvm/circuit/final_cycle.cpp
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 void FinalCycle::set(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -52,5 +51,4 @@ void FinalCycle::set(StepState& state) {
             pc.getPart(2, kMemBits) * 4});
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/final_cycle.h
+++ b/risc0/zkvm/circuit/final_cycle.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/cycle.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct FinalCycle {
   static std::vector<RegU32> allocVec(BufAlloc& alloc) {
@@ -46,5 +45,4 @@ struct FinalCycle {
   std::vector<RegU32> regs;
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/final_cycle.h
+++ b/risc0/zkvm/circuit/final_cycle.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/cycle.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct FinalCycle {
   static std::vector<RegU32> allocVec(BufAlloc& alloc) {
@@ -45,4 +46,5 @@ struct FinalCycle {
   std::vector<RegU32> regs;
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/gen_context.cpp
+++ b/risc0/zkvm/circuit/gen_context.cpp
@@ -14,8 +14,7 @@
 
 #include "risc0/zkvm/circuit/gen_context.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 namespace {
 
@@ -314,5 +313,4 @@ Context::ValPtr GenContext::newDef() {
   return ret;
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/gen_context.cpp
+++ b/risc0/zkvm/circuit/gen_context.cpp
@@ -15,6 +15,7 @@
 #include "risc0/zkvm/circuit/gen_context.h"
 
 namespace risc0 {
+namespace circuit {
 
 namespace {
 
@@ -313,4 +314,5 @@ Context::ValPtr GenContext::newDef() {
   return ret;
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/gen_context.h
+++ b/risc0/zkvm/circuit/gen_context.h
@@ -19,6 +19,7 @@
 #include "risc0/zkvm/circuit/context.h"
 
 namespace risc0 {
+namespace circuit {
 
 class GenContext : public Context {
 public:
@@ -81,4 +82,5 @@ private:
   ValPtr newDef();
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/gen_context.h
+++ b/risc0/zkvm/circuit/gen_context.h
@@ -18,8 +18,7 @@
 
 #include "risc0/zkvm/circuit/context.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 class GenContext : public Context {
 public:
@@ -82,5 +81,4 @@ private:
   ValPtr newDef();
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/make-circuit/make-circuit.cpp
+++ b/risc0/zkvm/circuit/make-circuit/make-circuit.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 
 using namespace risc0;
+using namespace risc0::circuit;
 
 int main(int argc, char* argv[]) {
   setLogLevel(1);

--- a/risc0/zkvm/circuit/mem_check.cpp
+++ b/risc0/zkvm/circuit/mem_check.cpp
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 void MemCheck::set(StepState& state) {
   // Extract the memory op
@@ -50,5 +49,4 @@ void MemCheck::set(StepState& state) {
   }
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/mem_check.cpp
+++ b/risc0/zkvm/circuit/mem_check.cpp
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 void MemCheck::set(StepState& state) {
   // Extract the memory op
@@ -49,4 +50,5 @@ void MemCheck::set(StepState& state) {
   }
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/mem_check.h
+++ b/risc0/zkvm/circuit/mem_check.h
@@ -18,6 +18,7 @@
 #include "risc0/zkvm/circuit/mem_io_regs.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct MemCheck {
   MemIORegs memIO;
@@ -30,4 +31,5 @@ struct MemCheck {
   void set(StepState& state);
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/mem_check.h
+++ b/risc0/zkvm/circuit/mem_check.h
@@ -17,8 +17,7 @@
 #include "risc0/zkvm/circuit/cycle.h"
 #include "risc0/zkvm/circuit/mem_io_regs.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct MemCheck {
   MemIORegs memIO;
@@ -31,5 +30,4 @@ struct MemCheck {
   void set(StepState& state);
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/mem_io_regs.cpp
+++ b/risc0/zkvm/circuit/mem_io_regs.cpp
@@ -15,6 +15,7 @@
 #include "risc0/zkvm/circuit/mem_io_regs.h"
 
 namespace risc0 {
+namespace circuit {
 
 void MemIORegs::doRead(Value cycle, Value addr) {
   address.set(addr);
@@ -33,4 +34,5 @@ void MemIORegs::doWrite(Value cycle, Value addr, ValueU32 val, Value isWOM) {
   value.set(val);
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/mem_io_regs.cpp
+++ b/risc0/zkvm/circuit/mem_io_regs.cpp
@@ -14,8 +14,7 @@
 
 #include "risc0/zkvm/circuit/mem_io_regs.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 void MemIORegs::doRead(Value cycle, Value addr) {
   address.set(addr);
@@ -34,5 +33,4 @@ void MemIORegs::doWrite(Value cycle, Value addr, ValueU32 val, Value isWOM) {
   value.set(val);
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/mem_io_regs.h
+++ b/risc0/zkvm/circuit/mem_io_regs.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/types.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct MemIORegs {
   Reg address;  /// The address being accessed
@@ -30,5 +29,4 @@ struct MemIORegs {
   void doWrite(Value cycle, Value address, ValueU32 val, Value isWOM);
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/mem_io_regs.h
+++ b/risc0/zkvm/circuit/mem_io_regs.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/types.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct MemIORegs {
   Reg address;  /// The address being accessed
@@ -29,4 +30,5 @@ struct MemIORegs {
   void doWrite(Value cycle, Value address, ValueU32 val, Value isWOM);
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/multiply_cycle.cpp
+++ b/risc0/zkvm/circuit/multiply_cycle.cpp
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 void MultiplyCycle::set(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -101,5 +100,4 @@ void MultiplyCycle::set(StepState& state) {
   resultInfo.pcRaw.set(final.pc + 4);
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/multiply_cycle.cpp
+++ b/risc0/zkvm/circuit/multiply_cycle.cpp
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 void MultiplyCycle::set(StepState& state) {
   Value cycle = state.code.cycle.get();
@@ -100,4 +101,5 @@ void MultiplyCycle::set(StepState& state) {
   resultInfo.pcRaw.set(final.pc + 4);
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/multiply_cycle.h
+++ b/risc0/zkvm/circuit/multiply_cycle.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/cycle.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct MultiplyCycle {
   template <size_t Size>
@@ -49,5 +48,4 @@ struct MultiplyCycle {
   RegDigits<1, 2> in1High;
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/multiply_cycle.h
+++ b/risc0/zkvm/circuit/multiply_cycle.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/cycle.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct MultiplyCycle {
   template <size_t Size>
@@ -48,4 +49,5 @@ struct MultiplyCycle {
   RegDigits<1, 2> in1High;
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/poly_context.cpp
+++ b/risc0/zkvm/circuit/poly_context.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 
 namespace risc0 {
+namespace circuit {
 
 namespace {
 
@@ -711,4 +712,5 @@ std::array<Context::ValPtr, 5> PolyContext::memCheck(SourceLoc loc) {
   throw std::runtime_error("Unimplemented");
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/poly_context.cpp
+++ b/risc0/zkvm/circuit/poly_context.cpp
@@ -22,8 +22,7 @@
 #include <set>
 #include <sstream>
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 namespace {
 
@@ -712,5 +711,4 @@ std::array<Context::ValPtr, 5> PolyContext::memCheck(SourceLoc loc) {
   throw std::runtime_error("Unimplemented");
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/poly_context.h
+++ b/risc0/zkvm/circuit/poly_context.h
@@ -18,8 +18,7 @@
 
 #include "risc0/zkvm/circuit/context.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 class PolyContext : public Context {
 public:
@@ -74,5 +73,4 @@ private:
   std::unique_ptr<Impl> impl;
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/poly_context.h
+++ b/risc0/zkvm/circuit/poly_context.h
@@ -19,6 +19,7 @@
 #include "risc0/zkvm/circuit/context.h"
 
 namespace risc0 {
+namespace circuit {
 
 class PolyContext : public Context {
 public:
@@ -73,4 +74,5 @@ private:
   std::unique_ptr<Impl> impl;
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/sha_cycle.cpp
+++ b/risc0/zkvm/circuit/sha_cycle.cpp
@@ -19,6 +19,7 @@
 #include <array>
 
 namespace risc0 {
+namespace circuit {
 
 static std::array<Value, 32> get(const RegDigits<1, 32>& reg) {
   std::array<Value, 32> ret;
@@ -410,4 +411,5 @@ void ShaCycle::setData(StepState& state) {
   BYZ_IF(state.code.p2.get()) { nextCycleType.set(DataCycleType::SHA_CONTROL); }
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/sha_cycle.cpp
+++ b/risc0/zkvm/circuit/sha_cycle.cpp
@@ -18,8 +18,7 @@
 
 #include <array>
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 static std::array<Value, 32> get(const RegDigits<1, 32>& reg) {
   std::array<Value, 32> ret;
@@ -411,5 +410,4 @@ void ShaCycle::setData(StepState& state) {
   BYZ_IF(state.code.p2.get()) { nextCycleType.set(DataCycleType::SHA_CONTROL); }
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/sha_cycle.h
+++ b/risc0/zkvm/circuit/sha_cycle.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/cycle.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct ShaCycle {
   ShaCycle(BufAlloc& alloc)
@@ -64,5 +63,4 @@ struct ShaCycle {
   Reg nextCycleType;
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/sha_cycle.h
+++ b/risc0/zkvm/circuit/sha_cycle.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/cycle.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct ShaCycle {
   ShaCycle(BufAlloc& alloc)
@@ -63,4 +64,5 @@ struct ShaCycle {
   Reg nextCycleType;
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/step_state.cpp
+++ b/risc0/zkvm/circuit/step_state.cpp
@@ -14,8 +14,7 @@
 
 #include "risc0/zkvm/circuit/step_state.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 DataRegs& StepState::getPrev(size_t size) {
   auto it = prev.find(size);
@@ -33,5 +32,4 @@ void StepState::setMemCheck() {
   data.setMemCheck(*this);
 }
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/step_state.cpp
+++ b/risc0/zkvm/circuit/step_state.cpp
@@ -15,6 +15,7 @@
 #include "risc0/zkvm/circuit/step_state.h"
 
 namespace risc0 {
+namespace circuit {
 
 DataRegs& StepState::getPrev(size_t size) {
   auto it = prev.find(size);
@@ -32,4 +33,5 @@ void StepState::setMemCheck() {
   data.setMemCheck(*this);
 }
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/step_state.h
+++ b/risc0/zkvm/circuit/step_state.h
@@ -19,8 +19,7 @@
 #include "risc0/zkvm/circuit/code_regs.h"
 #include "risc0/zkvm/circuit/data_regs.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 struct StepState {
   Buffer codeBuf;
@@ -39,5 +38,4 @@ struct StepState {
   void setMemCheck();
 };
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/step_state.h
+++ b/risc0/zkvm/circuit/step_state.h
@@ -20,6 +20,7 @@
 #include "risc0/zkvm/circuit/data_regs.h"
 
 namespace risc0 {
+namespace circuit {
 
 struct StepState {
   Buffer codeBuf;
@@ -38,4 +39,5 @@ struct StepState {
   void setMemCheck();
 };
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/circuit/types.h
+++ b/risc0/zkvm/circuit/types.h
@@ -16,8 +16,7 @@
 
 #include "risc0/zkvm/circuit/edsl.h"
 
-namespace risc0 {
-namespace circuit {
+namespace risc0::circuit {
 
 class BufAlloc {
 public:
@@ -248,5 +247,4 @@ struct NegU32Regs {
 
 struct StepState;
 
-} // namespace circuit
-} // namespace risc0
+} // namespace risc0::circuit

--- a/risc0/zkvm/circuit/types.h
+++ b/risc0/zkvm/circuit/types.h
@@ -17,6 +17,7 @@
 #include "risc0/zkvm/circuit/edsl.h"
 
 namespace risc0 {
+namespace circuit {
 
 class BufAlloc {
 public:
@@ -247,4 +248,5 @@ struct NegU32Regs {
 
 struct StepState;
 
+} // namespace circuit
 } // namespace risc0

--- a/risc0/zkvm/prove/step.h
+++ b/risc0/zkvm/prove/step.h
@@ -24,7 +24,7 @@
 
 namespace risc0 {
 
-using Buffer = std::vector<uint8_t>;
+using BufferU8 = std::vector<uint8_t>;
 using BufferU32 = std::vector<uint32_t>;
 
 struct MemoryEvent {
@@ -60,8 +60,8 @@ struct MemoryState {
 
 struct IoHandler {
   virtual void onInit(MemoryState& mem) {}
-  virtual void onWrite(const Buffer& data) {}
-  virtual void onCommit(const Buffer& data) {}
+  virtual void onWrite(const BufferU8& data) {}
+  virtual void onCommit(const BufferU8& data) {}
   virtual void onFault(const std::string& msg);
   virtual KeyStore& getKeyStore() = 0;
 };

--- a/risc0/zkvm/r0vm/r0vm.cpp
+++ b/risc0/zkvm/r0vm/r0vm.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
     // Run prover
     Receipt receipt = prover.run();
     // Write private output
-    const Buffer& out = prover.getOutput();
+    const BufferU8& out = prover.getOutput();
     size_t stdoutSize = fwrite(out.data(), 1, out.size(), stdout);
     if (stdoutSize != out.size()) {
       fprintf(stderr, "Failed on writing to stdout");

--- a/risc0/zkvm/sdk/cpp/host/receipt.h
+++ b/risc0/zkvm/sdk/cpp/host/receipt.h
@@ -25,24 +25,26 @@
 
 namespace risc0 {
 
+// CheckedStreamReader is a stream reader which reads from the given
+// BufferU8 and raises a std::runtime_error if an attempt is made to
+// read past the end of the buffer.
 class CheckedStreamReader {
 public:
-  CheckedStreamReader(const Buffer& buffer);
+  CheckedStreamReader(const BufferU8& buffer);
 
   uint32_t read_word();
   uint64_t read_dword();
   void read_buffer(void* buf, size_t len);
 
 private:
-  uint8_t read_byte();
-
-private:
-  const Buffer& buffer;
+  const BufferU8& buffer;
   size_t cursor;
 };
+static_assert(is_stream_reader<CheckedStreamReader>(),
+              "CheckedStreamReader must conform to the stream reader model");
 
 struct Receipt {
-  Buffer journal;
+  BufferU8 journal;
   BufferU32 seal;
 
   // Verify a receipt against some code, throws if invalid.
@@ -83,9 +85,9 @@ public:
 
   template <typename T> void writeInput(const T& obj) { getInputWriter().transfer(obj); }
 
-  const Buffer& getOutput();
+  const BufferU8& getOutput();
 
-  const Buffer& getCommit();
+  const BufferU8& getCommit();
 
   template <typename T> T readOutput() {
     T obj;


### PR DESCRIPTION
* Rename 2 of the 3 different types named "risc0::Buffer" to have different names
* Move the third type named "risc0::Buffer" along with all the other circuit code generation stuff into the new "risc0::circuit" namespace
* Comment stream buffer classes
* Enforce stream buffer classes conform to "stream reader" and "stream writer" models
* Change behavior of CheckedStreamReader to match the other stream readers and writers with respect to read_buffer where len is not a multiple of sizeof(uint32_t)
