### PR TITLE
Adjust visibility of Receipt fields

### DIFF
--- a/risc0/zkvm/sdk/rust/verify/src/zkvm/mod.rs
+++ b/risc0/zkvm/sdk/rust/verify/src/zkvm/mod.rs
@@ -29,8 +29,8 @@ use crate::zkvm::circuit::Risc0Circuit;
 
 #[derive(Deserialize, Serialize)]
 pub struct Receipt {
-    journal: Vec<u8>,
-    seal: Vec<u32>,
+    pub journal: Vec<u8>,
+    pub seal: Vec<u32>,
 }
 
 impl Receipt {


### PR DESCRIPTION
This is needed for conversion of `risc0_zkvm_host::Receipt` into `risc0_zkvm_verify::zkvm::Receipt`.

TODO: unify the two types once the pure rust implementation is complete.