### PR TITLE
Increase max guest execution to 2^24 steps

### DIFF
--- a/risc0/zkp/core/constants.h
+++ b/risc0/zkp/core/constants.h
@@ -18,7 +18,7 @@
 
 namespace risc0 {
 
-CONSTSCALAR size_t kMaxCyclesPo2 = 20;
+CONSTSCALAR size_t kMaxCyclesPo2 = 24;
 CONSTSCALAR size_t kMaxCycles = size_t(1) << kMaxCyclesPo2;
 
 CONSTSCALAR size_t kQueries = 50; // ~100 bits of conjectured security

--- a/risc0/zkvm/circuit/constants.h
+++ b/risc0/zkvm/circuit/constants.h
@@ -59,7 +59,7 @@ enum {
 } // namespace ShaCycleType
 
 CONSTSCALAR size_t kCodeSize = 16;
-CONSTSCALAR size_t kDataSize = 160;
+CONSTSCALAR size_t kDataSize = 162;
 CONSTSCALAR size_t kAccumSize = 10;
 
 CONSTSCALAR size_t kOutputRegs = 9;

--- a/risc0/zkvm/circuit/data_regs.h
+++ b/risc0/zkvm/circuit/data_regs.h
@@ -26,7 +26,7 @@
 namespace risc0::circuit {
 
 struct DataRegs {
-  static constexpr size_t kMemCheckSize = 16;
+  static constexpr size_t kMemCheckSize = 18;
   static constexpr size_t kCycleRegs = 128;
   static constexpr size_t kNormalDigits = 100;
   static constexpr size_t kFinalDigits = 32;

--- a/risc0/zkvm/circuit/mem_check.cpp
+++ b/risc0/zkvm/circuit/mem_check.cpp
@@ -43,9 +43,9 @@ void MemCheck::set(StepState& state) {
         equate(memIO.value.low(), prev.memIO.value.low());
         equate(memIO.value.high(), prev.memIO.value.high());
       }
-      memDiff.setPartExact(cycle.get() - prev.cycle.get() - 1, 0, 20);
+      memDiff.setPartExact(cycle.get() - prev.cycle.get() - 1, 0, kMaxCyclesPo2);
     }
-    BYZ_IF(1 - sameAddr.get()) { memDiff.setPartExact(addr - prevAddr - 1, 0, 20); }
+    BYZ_IF(1 - sameAddr.get()) { memDiff.setPartExact(addr - prevAddr - 1, 0, kMaxCyclesPo2); }
   }
 }
 

--- a/risc0/zkvm/platform/memory.h
+++ b/risc0/zkvm/platform/memory.h
@@ -24,25 +24,23 @@ namespace risc0 {
   constexpr size_t kMem##name##End = start + len;                                                  \
   constexpr size_t kMem##name##Len = len;
 
-constexpr size_t kMemBits = 20;
+constexpr size_t kMemBits = 24;
 constexpr size_t kMemSize = (1 << kMemBits) * 4;
 
-constexpr size_t k256KB = 0x00040000;
-constexpr size_t k512KB = 0x00080000;
 constexpr size_t k1MB = 0x00100000;
 
 // Must match riscv.ld
 // clang-format off
-MEM_REGION(Stack,  0x00000000, k256KB)
-MEM_REGION(Data,   0x00040000, k256KB)
-MEM_REGION(Heap,   0x00080000, k1MB)
-MEM_REGION(Input,  0x00180000, k256KB)
-MEM_REGION(GPIO,   0x001C0000, k256KB)
-MEM_REGION(Prog,   0x00200000, k1MB)
-MEM_REGION(SHA,    0x00300000, k256KB)
-MEM_REGION(WOM,    0x00340000, k256KB * 2)
-MEM_REGION(Output, 0x00340000, k256KB)
-MEM_REGION(Commit, 0x00380000, k256KB)
+MEM_REGION(Stack,  0x00000000, 9 * k1MB)
+MEM_REGION(Data,   0x00900000, k1MB)
+MEM_REGION(Heap,   0x00a00000, 20 * k1MB)
+MEM_REGION(Input,  0x01e00000, k1MB)
+MEM_REGION(GPIO,   0x01f00000, k1MB)
+MEM_REGION(Prog,   0x02000000, 10 * k1MB)
+MEM_REGION(SHA,    0x02a00000, k1MB)
+MEM_REGION(WOM,    0x02b00000, 21 * k1MB)
+MEM_REGION(Output, 0x02b00000, 20 * k1MB)
+MEM_REGION(Commit, 0x03f00000, k1MB)
 // clang-format on
 
 #define PTR_TO(type, name) reinterpret_cast<type*>(kMem##name##Start);

--- a/risc0/zkvm/platform/risc0.ld
+++ b/risc0/zkvm/platform/risc0.ld
@@ -21,14 +21,14 @@ EXTERN(__start)
 
 /* Must match risc0/zkvm/platform/memory.h */
 MEMORY {
-  stack        : ORIGIN = 0x00000000, LENGTH =  256K
-  data    (RW) : ORIGIN = 0x00040000, LENGTH =  256K
-  heap         : ORIGIN = 0x00080000, LENGTH =    1M
-  input        : ORIGIN = 0x00180000, LENGTH =  256K
-  gpio         : ORIGIN = 0x001C0000, LENGTH =  256K
-  prog    (X)  : ORIGIN = 0x00200000, LENGTH =    1M
-  sha          : ORIGIN = 0x00300000, LENGTH =  256K
-  wom          : ORIGIN = 0x00340000, LENGTH =  768K
+  stack        : ORIGIN = 0x00000000, LENGTH =   9M
+  data    (RW) : ORIGIN = 0x00900000, LENGTH =   1M
+  heap         : ORIGIN = 0x00a00000, LENGTH =  20M
+  input        : ORIGIN = 0x01e00000, LENGTH =   1M
+  gpio         : ORIGIN = 0x01f00000, LENGTH =   1M
+  prog    (X)  : ORIGIN = 0x02000000, LENGTH =  10M
+  sha          : ORIGIN = 0x02a00000, LENGTH =   1M
+  wom          : ORIGIN = 0x02b00000, LENGTH =  21M
 }
 
 SECTIONS {


### PR DESCRIPTION
## Notes
The guest previously had a soft cap of 2^20 execution steps and 2^20 words of memory. This change increases both limits to 2^24 steps, which is the hard cap for the current circuit. 

Per conversations with @jbruestle, increasing the cap will slow down proving by about 5% for all programs. 

## Changes
- Increase kMaxCyclesPo2 from 20 to 24
- Increase kMemBits from 20 to 24
- Increase kDataSize from 160 to 162
- Modify memory layout in memory.h and risc0.ld
- Replace hardcoded `20` with kMemBits in mem_check.cpp