### PR TITLE
Add constructor to Receipt

### DIFF
--- a/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
+++ b/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
@@ -35,6 +35,7 @@ impl Receipt {
             seal: seal,
         }
     }
+
     pub fn verify(&self, method_id: &MethodID) -> Result<bool, VerificationError> {
         let mut circuit = RV32Circuit::new(method_id);
         let sha = risc0_zkp_core::sha::default_implementation();

--- a/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
+++ b/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
@@ -29,6 +29,12 @@ pub struct Receipt {
 }
 
 impl Receipt {
+    pub fn new(journal: Vec<u8>, seal: Vec<u32>) -> Self {
+        Receipt {
+            journal: journal,
+            seal: seal,
+        }
+    }
     pub fn verify(&self, method_id: &MethodID) -> Result<bool, VerificationError> {
         let mut circuit = RV32Circuit::new(method_id);
         let sha = risc0_zkp_core::sha::default_implementation();

--- a/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
+++ b/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
@@ -31,8 +31,8 @@ pub struct Receipt {
 impl Receipt {
     pub fn new(journal: Vec<u8>, seal: Vec<u32>) -> Self {
         Receipt {
-            journal: journal,
-            seal: seal,
+            journal,
+            seal,
         }
     }
 

--- a/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
+++ b/risc0/zkvm/sdk/rust/verify/src/zkvm/receipt.rs
@@ -30,10 +30,7 @@ pub struct Receipt {
 
 impl Receipt {
     pub fn new(journal: Vec<u8>, seal: Vec<u32>) -> Self {
-        Receipt {
-            journal,
-            seal,
-        }
+        Receipt { journal, seal }
     }
 
     pub fn verify(&self, method_id: &MethodID) -> Result<bool, VerificationError> {


### PR DESCRIPTION
# Summary

The fields of the [Receipt](https://docs.rs/risc0-zkvm-verify/0.9.0/risc0_zkvm_verify/zkvm/struct.Receipt.html) structure are currently private. I do not actually know why this is the case - from reading the source, I would think that Rust would believe they are public. But it does not, and I need a way to build Receipts, so I wrote this PR.