### PR TITLE
Add constructor to Receipt (C++)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
     "fstream": "cpp",
     "ios": "cpp",
     "iosfwd": "cpp",
-    "vector": "cpp"
+    "vector": "cpp",
+    "charconv": "cpp"
   }
 }

--- a/risc0/zkvm/sdk/cpp/host/c_api.cpp
+++ b/risc0/zkvm/sdk/cpp/host/c_api.cpp
@@ -131,6 +131,18 @@ risc0_receipt* risc0_prover_run(risc0_error* err, risc0_prover* ptr) {
   });
 }
 
+risc0_receipt* risc0_receipt_new(risc0_error* err,
+                                 const uint8_t* journal,
+                                 const size_t journal_len,
+                                 const uint32_t* seal,
+                                 const size_t seal_len) {
+  return ffi_wrap<risc0_receipt*>(err, nullptr, [&] {
+    risc0::Receipt receipt{risc0::BufferU8{journal, journal + journal_len},
+                           risc0::BufferU32{seal, seal + seal_len}};
+    return new risc0_receipt{receipt};
+  });
+}
+
 void risc0_receipt_verify(risc0_error* err,
                           const risc0_receipt* ptr,
                           const uint8_t* method_id_buf,

--- a/risc0/zkvm/sdk/cpp/host/c_api.h
+++ b/risc0/zkvm/sdk/cpp/host/c_api.h
@@ -86,8 +86,14 @@ const void* risc0_prover_get_output(risc0_error* err, risc0_prover* ptr, size_t 
 risc0_receipt* risc0_prover_run(risc0_error* err, risc0_prover* ptr);
 
 //
-// Proof
+// Receipt
 //
+
+risc0_receipt* risc0_receipt_new(risc0_error* err,
+                                 const uint8_t* journal,
+                                 const size_t journal_len,
+                                 const uint32_t* seal,
+                                 const size_t seal_len);
 
 void risc0_receipt_verify(risc0_error* err,
                           const risc0_receipt* ptr,

--- a/risc0/zkvm/sdk/rust/host/src/ffi.rs
+++ b/risc0/zkvm/sdk/rust/host/src/ffi.rs
@@ -99,6 +99,14 @@ extern "C" {
     pub(crate) fn risc0_prover_run(err: *mut RawError, prover: *mut RawProver)
         -> *const RawReceipt;
 
+    pub(crate) fn risc0_receipt_new(
+        err: *mut RawError,
+        journal: *const u8,
+        journal_len: usize,
+        seal: *const u32,
+        seal_len: usize,
+    ) -> *const RawReceipt;
+
     pub(crate) fn risc0_receipt_verify(
         err: *mut RawError,
         receipt: *const RawReceipt,

--- a/risc0/zkvm/sdk/rust/host/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/host/src/lib.rs
@@ -94,6 +94,21 @@ impl Drop for MethodId {
 }
 
 impl Receipt {
+    /// Construct a new [Receipt] from individual journal and seal parts.
+    pub fn new(journal: &[u8], seal: &[u32]) -> Result<Self> {
+        let mut err = ffi::RawError::default();
+        let ptr = unsafe {
+            ffi::risc0_receipt_new(
+                &mut err,
+                journal.as_ptr(),
+                journal.len(),
+                seal.as_ptr(),
+                seal.len(),
+            )
+        };
+        ffi::check(err, || Receipt { ptr })
+    }
+
     /// Verify that the current [Receipt] is a valid result of executing the
     /// method associated with the given method ID in a ZKVM.
     pub fn verify(&self, method_id: &[u8]) -> Result<()> {


### PR DESCRIPTION
Add support for building a `Receipt` from individual `journal` and `seal` parts.