### PR TITLE
Increase resources available to ZKVM guest

### DIFF
--- a/risc0/zkp/core/constants.h
+++ b/risc0/zkp/core/constants.h
@@ -18,7 +18,7 @@
 
 namespace risc0 {
 
-CONSTSCALAR size_t kMaxCyclesPo2 = 20;
+CONSTSCALAR size_t kMaxCyclesPo2 = 24;
 CONSTSCALAR size_t kMaxCycles = size_t(1) << kMaxCyclesPo2;
 
 CONSTSCALAR size_t kQueries = 50; // ~100 bits of conjectured security

--- a/risc0/zkvm/circuit/constants.h
+++ b/risc0/zkvm/circuit/constants.h
@@ -60,7 +60,7 @@ enum {
 } // namespace ShaCycleType
 
 CONSTSCALAR size_t kCodeSize = 16;
-CONSTSCALAR size_t kDataSize = 160;
+CONSTSCALAR size_t kDataSize = 162;
 CONSTSCALAR size_t kAccumSize = 10;
 
 CONSTSCALAR size_t kOutputRegs = 9;

--- a/risc0/zkvm/circuit/data_regs.h
+++ b/risc0/zkvm/circuit/data_regs.h
@@ -26,7 +26,7 @@
 namespace risc0::circuit {
 
 struct DataRegs {
-  static constexpr size_t kMemCheckSize = 16;
+  static constexpr size_t kMemCheckSize = 18;
   static constexpr size_t kCycleRegs = 128;
   static constexpr size_t kNormalDigits = 100;
   static constexpr size_t kFinalDigits = 32;

--- a/risc0/zkvm/circuit/mem_check.cpp
+++ b/risc0/zkvm/circuit/mem_check.cpp
@@ -43,9 +43,9 @@ void MemCheck::set(StepState& state) {
         equate(memIO.value.low(), prev.memIO.value.low());
         equate(memIO.value.high(), prev.memIO.value.high());
       }
-      memDiff.setPartExact(cycle.get() - prev.cycle.get() - 1, 0, 20);
+      memDiff.setPartExact(cycle.get() - prev.cycle.get() - 1, 0, kMaxCyclesPo2);
     }
-    BYZ_IF(1 - sameAddr.get()) { memDiff.setPartExact(addr - prevAddr - 1, 0, 20); }
+    BYZ_IF(1 - sameAddr.get()) { memDiff.setPartExact(addr - prevAddr - 1, 0, kMaxCyclesPo2); }
   }
 }
 

--- a/risc0/zkvm/platform/io.h
+++ b/risc0/zkvm/platform/io.h
@@ -17,15 +17,15 @@
 namespace risc0 {
 
 // These must match the values in zkvm/sdk/rust/guest/src/gpio.rs
-constexpr size_t kGPIO_SHA = 0x001C0000;
-constexpr size_t kGPIO_Commit = 0x001C0004;
-constexpr size_t kGPIO_Fault = 0x001C0008;
-constexpr size_t kGPIO_Log = 0x001C000C;
-constexpr size_t kGPIO_GetKey = 0x001C010;
+constexpr size_t kGPIO_SHA = 0x01F00000;
+constexpr size_t kGPIO_Commit = 0x01F00004;
+constexpr size_t kGPIO_Fault = 0x01F00008;
+constexpr size_t kGPIO_Log = 0x01F0000C;
+constexpr size_t kGPIO_GetKey = 0x01F0010;
 
-constexpr size_t kGPIO_SendRecvChannel = 0X001C0014;
-constexpr size_t kGPIO_SendRecvSize = 0x001C0018;
-constexpr size_t kGPIO_SendRecvAddr = 0x001C001C;
+constexpr size_t kGPIO_SendRecvChannel = 0x01F00014;
+constexpr size_t kGPIO_SendRecvSize = 0x01F00018;
+constexpr size_t kGPIO_SendRecvAddr = 0x01F0001C;
 
 // Standard ZKVM channels; must match zkvm/sdk/rust/guest/src/gpio.rs.
 

--- a/risc0/zkvm/platform/memory.h
+++ b/risc0/zkvm/platform/memory.h
@@ -24,11 +24,9 @@ namespace risc0 {
   constexpr size_t kMem##name##End = start + len;                                                  \
   constexpr size_t kMem##name##Len = len;
 
-constexpr size_t kMemBits = 20;
+constexpr size_t kMemBits = 24;
 constexpr size_t kMemSize = (1 << kMemBits) * 4;
 
-constexpr size_t k256KB = 0x00040000;
-constexpr size_t k512KB = 0x00080000;
 constexpr size_t k1MB = 0x00100000;
 
 // Must match risc0.ld and zkvm/sdk/guest/src/mem_layout.rs.
@@ -38,16 +36,16 @@ constexpr size_t k1MB = 0x00100000;
 // in the upper half of the memory space.
 //
 // clang-format off
-MEM_REGION(Stack,  0x00000000, k256KB)
-MEM_REGION(Data,   0x00040000, k256KB)
-MEM_REGION(Heap,   0x00080000, k1MB)
-MEM_REGION(Input,  0x00180000, k256KB)
-MEM_REGION(GPIO,   0x001C0000, k256KB)
-MEM_REGION(Prog,   0x00200000, k1MB)
-MEM_REGION(SHA,    0x00300000, k256KB)
-MEM_REGION(WOM,    0x00340000, k256KB * 2)
-MEM_REGION(Output, 0x00340000, k256KB)
-MEM_REGION(Commit, 0x00380000, k256KB)
+MEM_REGION(Stack,  0x00000000, 9 * k1MB)
+MEM_REGION(Data,   0x00900000, k1MB)
+MEM_REGION(Heap,   0x00A00000, 20 * k1MB)
+MEM_REGION(Input,  0x01E00000, k1MB)
+MEM_REGION(GPIO,   0x01F00000, k1MB)
+MEM_REGION(Prog,   0x02000000, 10 * k1MB)
+MEM_REGION(SHA,    0x02A00000, k1MB)
+MEM_REGION(WOM,    0x02B00000, 21 * k1MB)
+MEM_REGION(Output, 0x02B00000, 20 * k1MB)
+MEM_REGION(Commit, 0x03F00000, k1MB)
 // clang-format on
 
 #define PTR_TO(type, name) reinterpret_cast<type*>(kMem##name##Start);

--- a/risc0/zkvm/platform/risc0.ld
+++ b/risc0/zkvm/platform/risc0.ld
@@ -22,14 +22,14 @@ EXTERN(__start)
 /* Must match risc0/zkvm/platform/memory.h and zkvm/sdk/guest/src/mem_layout.rs */
 /* Write-only section must match the range hardcoded in the circuit. */
 MEMORY {
-  stack        : ORIGIN = 0x00000000, LENGTH =  256K
-  data    (RW) : ORIGIN = 0x00040000, LENGTH =  256K
-  heap         : ORIGIN = 0x00080000, LENGTH =    1M
-  input        : ORIGIN = 0x00180000, LENGTH =  256K
-  gpio         : ORIGIN = 0x001C0000, LENGTH =  256K
-  prog    (X)  : ORIGIN = 0x00200000, LENGTH =    1M
-  sha          : ORIGIN = 0x00300000, LENGTH =  256K
-  wom          : ORIGIN = 0x00340000, LENGTH =  768K
+  stack        : ORIGIN = 0x00000000, LENGTH =   9M
+  data    (RW) : ORIGIN = 0x00900000, LENGTH =   1M
+  heap         : ORIGIN = 0x00A00000, LENGTH =  20M
+  input        : ORIGIN = 0x01E00000, LENGTH =   1M
+  gpio         : ORIGIN = 0x01F00000, LENGTH =   1M
+  prog    (X)  : ORIGIN = 0x02000000, LENGTH =  10M
+  sha          : ORIGIN = 0x02A00000, LENGTH =   1M
+  wom          : ORIGIN = 0x02B00000, LENGTH =  21M
 }
 
 SECTIONS {

--- a/risc0/zkvm/sdk/rust/guest/src/gpio.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/gpio.rs
@@ -14,15 +14,15 @@
 
 // These must match the values in zkvm/platform/io.h.  See this file
 // for documentation on these GPIO ports.
-pub(crate) const GPIO_SHA: *mut *const SHADescriptor = 0x001C_0000 as _;
-pub(crate) const GPIO_COMMIT: *mut *const IoDescriptor = 0x001C_0004 as _;
-pub(crate) const GPIO_FAULT: *mut *const u8 = 0x001C_0008 as _;
-pub(crate) const GPIO_LOG: *mut *const u8 = 0x001C_000C as _;
-pub(crate) const GPIO_GETKEY: *mut *const GetKeyDescriptor = 0x001C_0010 as _;
+pub(crate) const GPIO_SHA: *mut *const SHADescriptor = 0x01F0_0000 as _;
+pub(crate) const GPIO_COMMIT: *mut *const IoDescriptor = 0x01F0_0004 as _;
+pub(crate) const GPIO_FAULT: *mut *const u8 = 0x01F0_0008 as _;
+pub(crate) const GPIO_LOG: *mut *const u8 = 0x01F0_000C as _;
+pub(crate) const GPIO_GETKEY: *mut *const GetKeyDescriptor = 0x01F0_0010 as _;
 
-pub(crate) const GPIO_SENDRECV_CHANNEL: *mut u32 = 0x001C_0014 as _;
-pub(crate) const GPIO_SENDRECV_SIZE: *mut usize = 0x001C_0018 as _;
-pub(crate) const GPIO_SENDRECV_ADDR: *mut *const u8 = 0x001C_001C as _;
+pub(crate) const GPIO_SENDRECV_CHANNEL: *mut u32 = 0x01F0_0014 as _;
+pub(crate) const GPIO_SENDRECV_SIZE: *mut usize = 0x01F0_0018 as _;
+pub(crate) const GPIO_SENDRECV_ADDR: *mut *const u8 = 0x01F0_001C as _;
 
 #[repr(C)]
 pub(crate) struct IoDescriptor {

--- a/risc0/zkvm/sdk/rust/guest/src/mem_layout.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/mem_layout.rs
@@ -11,6 +11,10 @@ const fn kb(kb: usize) -> usize {
     kb * 1024
 }
 
+const fn mb(mb: usize) -> usize {
+    kb(mb * 1024)
+}
+
 impl Region {
     pub const fn new(start: usize, len_bytes: usize) -> Self {
         Self { start, len_bytes }
@@ -33,13 +37,13 @@ impl Region {
 
 // These should match zkvm/platform/memory.h and zkvm/platform/risc0.ld.
 // Write-only section must match the range hardcoded in the circuit.
-pub const STACK: Region = Region::new(0x0000_0000, kb(256));
-pub const DATA: Region = Region::new(0x0004_0000, kb(1024));
-pub const HEAP: Region = Region::new(0x0008_0000, kb(256));
-pub const INPUT: Region = Region::new(0x0018_0000, kb(256));
-pub const GPIO: Region = Region::new(0x001C_0000, kb(256));
-pub const PROG: Region = Region::new(0x0020_0000, kb(1024));
-pub const SHA: Region = Region::new(0x0030_0000, kb(256));
-pub const WOM: Region = Region::new(0x0034_0000, kb(256));
-pub const OUTPUT: Region = Region::new(0x0038_0000, kb(256));
-pub const COMMIT: Region = Region::new(0x0038_0000, kb(256));
+pub const STACK: Region = Region::new(0x0000_0000, mb(9));
+pub const DATA: Region = Region::new(0x0090_0000, mb(1));
+pub const HEAP: Region = Region::new(0x00A0_0000, mb(20));
+pub const INPUT: Region = Region::new(0x01E0_0000, mb(1));
+pub const GPIO: Region = Region::new(0x01F0_0000, mb(1));
+pub const PROG: Region = Region::new(0x0200_0000, mb(10));
+pub const SHA: Region = Region::new(0x02A0_0000, mb(1));
+pub const WOM: Region = Region::new(0x02B0_0000, mb(21));
+pub const OUTPUT: Region = Region::new(0x02B0_0000, mb(20));
+pub const COMMIT: Region = Region::new(0x03F0_0000, mb(1));

--- a/risc0/zkvm/sdk/rust/host/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/host/src/lib.rs
@@ -327,8 +327,8 @@ mod test {
     fn memory_io() {
         // TODO(nils): Move these constants into something both the guest and host can
         // depend on
-        const HEAP_START: u32 = 0x0008_0000;
-        const COMMIT_START: u32 = 0x0038_0000;
+        const HEAP_START: u32 = 0x00A0_0000;
+        const COMMIT_START: u32 = 0x03F0_0000;
 
         // Double write to WOM are fine
         assert!(run_memio(&[(COMMIT_START, 1), (COMMIT_START, 1)]).is_ok());
@@ -370,7 +370,7 @@ mod test {
     fn receipt_serde() {
         // TODO(nils): Move this constant into something both the guest and host can
         // depend on
-        const HEAP_START: u32 = 0x0008_0000;
+        const HEAP_START: u32 = 0x00A0_0000;
 
         let receipt: Receipt = run_memio(&[(HEAP_START, 0)]).unwrap();
         let ser: Vec<u32> = risc0_zkvm_serde::to_vec(&receipt).unwrap();


### PR DESCRIPTION
Guest now has 2^24 words (64 MB) of memory and 2^24 possible execution steps, both up from 2^20.

Patch adapted from PR by @preston-evans98.  Thanks @preston-evans98!

Fixes #165