### PR TITLE
Add option to run guest without generating a seal.

### DIFF
--- a/Cargo-host.lock
+++ b/Cargo-host.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +53,20 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf09bb72e00da477c2596865e8873227e2196d263cca35414048875dbbeea1be"
+dependencies = [
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
 ]
 
 [[package]]
@@ -669,6 +692,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "globset"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +863,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1348,6 +1413,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1465,6 +1532,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "assert_fs",
  "bytemuck",
  "clap 3.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "risc0-zkvm",
@@ -1857,6 +1925,15 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "time"

--- a/cargo-bazel-lock-host.json
+++ b/cargo-bazel-lock-host.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f529aee02e8e040e504620a7abd977429be1e1b2060221d6817406624097f4ad",
+  "checksum": "70f8671ac6ca1cdf0badd788634b77171a178fcf12f5ffb55fbc14c2c26f0a8e",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -90,6 +90,52 @@
         "version": "0.7.5"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "aho-corasick 0.7.18": {
+      "name": "aho-corasick",
+      "version": "0.7.18",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.18/download",
+          "sha256": "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "aho_corasick",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "aho_corasick",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "memchr 2.5.0",
+              "target": "memchr"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.7.18"
+      },
+      "license": "Unlicense/MIT"
     },
     "anyhow 1.0.58": {
       "name": "anyhow",
@@ -258,6 +304,68 @@
         },
         "edition": "2018",
         "version": "2.0.4"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "assert_fs 1.0.7": {
+      "name": "assert_fs",
+      "version": "1.0.7",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/assert_fs/1.0.7/download",
+          "sha256": "cf09bb72e00da477c2596865e8873227e2196d263cca35414048875dbbeea1be"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "assert_fs",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "assert_fs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "doc-comment 0.3.3",
+              "target": "doc_comment"
+            },
+            {
+              "id": "globwalk 0.8.1",
+              "target": "globwalk"
+            },
+            {
+              "id": "predicates 2.1.1",
+              "target": "predicates"
+            },
+            {
+              "id": "predicates-core 1.0.3",
+              "target": "predicates_core"
+            },
+            {
+              "id": "predicates-tree 1.0.5",
+              "target": "predicates_tree"
+            },
+            {
+              "id": "tempfile 3.3.0",
+              "target": "tempfile"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3773,6 +3881,118 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "globset 0.4.9": {
+      "name": "globset",
+      "version": "0.4.9",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/globset/0.4.9/download",
+          "sha256": "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "globset",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "globset",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "log"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "aho-corasick 0.7.18",
+              "target": "aho_corasick"
+            },
+            {
+              "id": "bstr 0.2.17",
+              "target": "bstr"
+            },
+            {
+              "id": "fnv 1.0.7",
+              "target": "fnv"
+            },
+            {
+              "id": "log 0.4.17",
+              "target": "log"
+            },
+            {
+              "id": "regex 1.6.0",
+              "target": "regex"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.9"
+      },
+      "license": "Unlicense OR MIT"
+    },
+    "globwalk 0.8.1": {
+      "name": "globwalk",
+      "version": "0.8.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/globwalk/0.8.1/download",
+          "sha256": "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "globwalk",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "globwalk",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 1.3.2",
+              "target": "bitflags"
+            },
+            {
+              "id": "ignore 0.4.18",
+              "target": "ignore"
+            },
+            {
+              "id": "walkdir 2.3.2",
+              "target": "walkdir"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2015",
+        "version": "0.8.1"
+      },
+      "license": "MIT"
+    },
     "h2 0.3.13": {
       "name": "h2",
       "version": "0.3.13",
@@ -4522,6 +4742,87 @@
         "version": "0.2.3"
       },
       "license": "MIT/Apache-2.0"
+    },
+    "ignore 0.4.18": {
+      "name": "ignore",
+      "version": "0.4.18",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ignore/0.4.18/download",
+          "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ignore",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "ignore",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "crossbeam-utils 0.8.11",
+              "target": "crossbeam_utils"
+            },
+            {
+              "id": "globset 0.4.9",
+              "target": "globset"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "log 0.4.17",
+              "target": "log"
+            },
+            {
+              "id": "memchr 2.5.0",
+              "target": "memchr"
+            },
+            {
+              "id": "regex 1.6.0",
+              "target": "regex"
+            },
+            {
+              "id": "same-file 1.0.6",
+              "target": "same_file"
+            },
+            {
+              "id": "thread_local 1.1.4",
+              "target": "thread_local"
+            },
+            {
+              "id": "walkdir 2.3.2",
+              "target": "walkdir"
+            }
+          ],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "winapi-util 0.1.5",
+                "target": "winapi_util"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.4.18"
+      },
+      "license": "Unlicense/MIT"
     },
     "indexmap 1.9.1": {
       "name": "indexmap",
@@ -7655,10 +7956,34 @@
           "**"
         ],
         "crate_features": [
-          "std"
+          "aho-corasick",
+          "default",
+          "memchr",
+          "perf",
+          "perf-cache",
+          "perf-dfa",
+          "perf-inline",
+          "perf-literal",
+          "std",
+          "unicode",
+          "unicode-age",
+          "unicode-bool",
+          "unicode-case",
+          "unicode-gencat",
+          "unicode-perl",
+          "unicode-script",
+          "unicode-segment"
         ],
         "deps": {
           "common": [
+            {
+              "id": "aho-corasick 0.7.18",
+              "target": "aho_corasick"
+            },
+            {
+              "id": "memchr 2.5.0",
+              "target": "memchr"
+            },
             {
               "id": "regex-syntax 0.6.27",
               "target": "regex_syntax"
@@ -7731,6 +8056,17 @@
       "common_attrs": {
         "compile_data_glob": [
           "**"
+        ],
+        "crate_features": [
+          "default",
+          "unicode",
+          "unicode-age",
+          "unicode-bool",
+          "unicode-case",
+          "unicode-gencat",
+          "unicode-perl",
+          "unicode-script",
+          "unicode-segment"
         ],
         "edition": "2018",
         "version": "0.6.27"
@@ -8301,6 +8637,10 @@
             {
               "id": "assert_cmd 2.0.4",
               "target": "assert_cmd"
+            },
+            {
+              "id": "assert_fs 1.0.7",
+              "target": "assert_fs"
             }
           ],
           "selects": {}
@@ -10559,6 +10899,48 @@
         "version": "0.15.0"
       },
       "license": "MIT"
+    },
+    "thread_local 1.1.4": {
+      "name": "thread_local",
+      "version": "1.1.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/thread_local/1.1.4/download",
+          "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "thread_local",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "thread_local",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "once_cell 1.13.0",
+              "target": "once_cell"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.1.4"
+      },
+      "license": "Apache-2.0/MIT"
     },
     "time 0.3.11": {
       "name": "time",

--- a/risc0/zkp/prove/prove.cpp
+++ b/risc0/zkp/prove/prove.cpp
@@ -39,6 +39,11 @@ static AccelSlice<Fp> makeCoeffs(const std::vector<Fp>& vec, size_t count) {
   return ret;
 }
 
+void runWithoutSeal(ProveCircuit& circuit) {
+  WriteIOP iop;
+  circuit.execute(iop);
+}
+
 // NOLINTNEXTLINE(readability-function-size)
 std::vector<uint32_t> prove(ProveCircuit& circuit) {
   // Get taps

--- a/risc0/zkp/prove/prove.h
+++ b/risc0/zkp/prove/prove.h
@@ -56,4 +56,6 @@ public:
 
 std::vector<uint32_t> prove(ProveCircuit& circuit);
 
+void runWithoutSeal(ProveCircuit& circuit);
+
 } // namespace risc0

--- a/risc0/zkvm/r0vm/Cargo.toml
+++ b/risc0/zkvm/r0vm/Cargo.toml
@@ -11,4 +11,5 @@ risc0-zkvm = { version = "0.10", path = "../sdk/rust" }
 [dev-dependencies]
 anyhow = "1.0"
 assert_cmd = "2.0"
+assert_fs = "1.0"
 risc0-zkvm-methods = { path = "../sdk/rust/methods" }

--- a/risc0/zkvm/r0vm/tests/standard_lib.rs
+++ b/risc0/zkvm/r0vm/tests/standard_lib.rs
@@ -1,15 +1,95 @@
+use std::path::Path;
+
 use anyhow::Result;
 use assert_cmd::Command;
+use assert_fs::{fixture::PathChild, TempDir};
+
+use risc0_zkvm::host::Receipt;
+
+static EXPECTED_STDOUT: &str = "Hello world on stdout!\n";
+static EXPECTED_STDERR: &str = "Hello world on stderr!\n";
 
 #[test]
 fn stdio_outputs() -> Result<()> {
+    let temp = TempDir::new().unwrap();
+    let method_id_file = temp.child("method_id.dat");
+    let mut cmd = Command::cargo_bin("r0vm")?;
+    std::fs::write(&method_id_file, risc0_zkvm_methods::STANDARD_LIB_ID).unwrap();
+
+    cmd.arg("--elf")
+        .arg(risc0_zkvm_methods::STANDARD_LIB_PATH)
+        .arg("--method-id")
+        .arg(&*method_id_file);
+
+    cmd.assert()
+        .stderr(EXPECTED_STDERR)
+        .stdout(EXPECTED_STDOUT)
+        .success();
+
+    Ok(())
+}
+
+fn load_receipt(p: &Path) -> Receipt {
+    const WORD_SIZE: usize = std::mem::size_of::<u32>();
+    let data = std::fs::read(p).unwrap();
+    let as_u32: Vec<u32> = data
+        .chunks(WORD_SIZE)
+        .map(|bytes| u32::from_le_bytes(<[u8; WORD_SIZE]>::try_from(bytes).unwrap()))
+        .collect();
+    risc0_zkvm::serde::from_slice(&as_u32).unwrap()
+}
+
+#[test]
+fn stdio_outputs_in_receipt() -> Result<()> {
+    let temp = TempDir::new().unwrap();
+    let receipt_file = temp.child("receipt.dat");
+    let method_id_file = temp.child("method_id.dat");
+    std::fs::write(&method_id_file, risc0_zkvm_methods::STANDARD_LIB_ID).unwrap();
+
     let mut cmd = Command::cargo_bin("r0vm")?;
 
-    cmd.arg("--elf").arg(risc0_zkvm_methods::STANDARD_LIB_PATH);
+    cmd.arg("--elf")
+        .arg(risc0_zkvm_methods::STANDARD_LIB_PATH)
+        .arg("--method-id")
+        .arg(&*method_id_file)
+        .arg("--receipt")
+        .arg(&*receipt_file);
     cmd.assert()
-        .stderr("Hello world on stderr!\n")
-        .stdout("Hello world on stdout!\n")
+        .stderr(EXPECTED_STDERR)
+        .stdout(EXPECTED_STDOUT)
         .success();
+
+    let receipt = load_receipt(&receipt_file);
+    assert!(receipt.get_seal().unwrap().len() > 0);
+    receipt.verify(risc0_zkvm_methods::STANDARD_LIB_ID).unwrap();
+
+    Ok(())
+}
+
+#[test]
+fn stdio_outputs_in_receipt_without_seal() -> Result<()> {
+    let temp = TempDir::new().unwrap();
+    let receipt_file = temp.child("receipt.dat");
+    let method_id_file = temp.child("method_id.dat");
+    std::fs::write(&method_id_file, risc0_zkvm_methods::STANDARD_LIB_ID).unwrap();
+
+    let mut cmd = Command::cargo_bin("r0vm")?;
+
+    cmd.arg("--elf")
+        .arg(risc0_zkvm_methods::STANDARD_LIB_PATH)
+        .arg("--method-id")
+        .arg(&*method_id_file)
+        .arg("--receipt")
+        .arg(&*receipt_file)
+        .arg("--skip-seal");
+    cmd.assert()
+        .stderr(EXPECTED_STDERR)
+        .stdout(EXPECTED_STDOUT)
+        .success();
+
+    let receipt = load_receipt(&receipt_file);
+    assert_eq!(receipt.get_seal().unwrap().len(), 0);
+    assert!(receipt.verify(risc0_zkvm_methods::STANDARD_LIB_ID).is_err());
 
     Ok(())
 }

--- a/risc0/zkvm/sdk/cpp/host/c_api.cpp
+++ b/risc0/zkvm/sdk/cpp/host/c_api.cpp
@@ -141,6 +141,13 @@ risc0_receipt* risc0_prover_run(risc0_error* err, risc0_prover* ptr) {
   });
 }
 
+risc0_receipt* risc0_prover_run_without_seal(risc0_error* err, risc0_prover* ptr) {
+  return ffi_wrap<risc0_receipt*>(err, nullptr, [&] {
+    risc0::Receipt receipt = ptr->prover->runWithoutSeal();
+    return new risc0_receipt{receipt};
+  });
+}
+
 risc0_receipt* risc0_receipt_new(risc0_error* err,
                                  const uint8_t* journal,
                                  const size_t journal_len,

--- a/risc0/zkvm/sdk/cpp/host/c_api.h
+++ b/risc0/zkvm/sdk/cpp/host/c_api.h
@@ -91,6 +91,8 @@ size_t risc0_prover_get_output_len(risc0_error* err, const risc0_prover* ptr);
 
 risc0_receipt* risc0_prover_run(risc0_error* err, risc0_prover* ptr);
 
+risc0_receipt* risc0_prover_run_without_seal(risc0_error* err, risc0_prover* ptr);
+
 //
 // Receipt
 //

--- a/risc0/zkvm/sdk/cpp/host/receipt.h
+++ b/risc0/zkvm/sdk/cpp/host/receipt.h
@@ -104,7 +104,15 @@ public:
     return obj;
   }
 
+  // Run the method and generate a zero-knowledge proof that the
+  // method was run correctly.
   Receipt run();
+
+  // Run the method without generating a seal containing the proof of
+  // correct execution.  This is significantly faster than run(), but
+  // does not provide any of the cryptographic guarantees so should
+  // only be used for testing.
+  Receipt runWithoutSeal();
 
 private:
   Prover() = default;

--- a/risc0/zkvm/sdk/rust/src/host/ffi.rs
+++ b/risc0/zkvm/sdk/rust/src/host/ffi.rs
@@ -107,6 +107,11 @@ extern "C" {
     pub(crate) fn risc0_prover_run(err: *mut RawError, prover: *mut RawProver)
         -> *const RawReceipt;
 
+    pub(crate) fn risc0_prover_run_without_seal(
+        err: *mut RawError,
+        prover: *mut RawProver,
+    ) -> *const RawReceipt;
+
     pub(crate) fn risc0_receipt_new(
         err: *mut RawError,
         journal: *const u8,


### PR DESCRIPTION
riscv guest now runs about 200x faster!*

*: Cryptographic proof of correctness not supported, but very useful for testing.