### PR TITLE
Add docs for ProveRoundInfo::new()

### DIFF
--- a/risc0/zkp/rust/src/prove/fri.rs
+++ b/risc0/zkp/rust/src/prove/fri.rs
@@ -38,13 +38,23 @@ struct ProveRoundInfo {
 }
 
 impl ProveRoundInfo {
+    /// Computes a round of the folding protocol. Takes in the coefficients of the current polynomial,
+    /// and interacts with the IOP verifier to produce the evaluations of the polynomial, the merkle tree
+    /// committing to the evaluation, and the coefficients of the folded polynomial.
     pub fn new<H: Hal, S: Sha>(hal: &H, iop: &mut WriteIOP<S>, coeffs: &Buffer<Fp>) -> Self {
         // LOG(1, "Doing FRI folding");
+        // Get the number of coefficients of the polynomial over the extension field.
         let size = coeffs.size() / EXT_SIZE;
+        // Get a larger domain to interpolate over.
         let domain = size * INV_RATE;
+        // Allocate space in which to put the interpolated values.
         let evaluated = hal.alloc(domain * EXT_SIZE);
+        // Put in the coefficients, padding out with zeros so that we are left with the same polynomial
+        // represented by a larger coefficient list
         hal.batch_expand(&evaluated, coeffs, EXT_SIZE);
+        // Evaluate the NTT in-place, filling the buffer with the evaluations of the polynomial.
         hal.batch_evaluate_ntt(&evaluated, EXT_SIZE, log2_ceil(INV_RATE));
+        // Compute a Merkle tree committing to the polynomial evaluations.
         let merkle = MerkleTreeProver::new(
             hal,
             &evaluated,
@@ -52,10 +62,14 @@ impl ProveRoundInfo {
             FRI_FOLD * EXT_SIZE,
             QUERIES,
         );
+        // Send the merkle tree (as a commitment) to the virtual IOP verifier
         merkle.commit(hal, iop);
+        // Retrieve from the IOP verifier a random value to mix the polynomial slices.
         let fold_mix = Fp4::random(&mut iop.rng);
+        // Create a buffer to hold the mixture of slices.
         let out_coeffs = hal.alloc(size / FRI_FOLD * EXT_SIZE);
         let mix = hal.copy_from([fold_mix].as_slice());
+        // Compute the folded polynomial
         hal.fri_fold(&out_coeffs, coeffs, &mix);
         ProveRoundInfo {
             size,

--- a/risc0/zkp/rust/src/prove/fri.rs
+++ b/risc0/zkp/rust/src/prove/fri.rs
@@ -38,9 +38,11 @@ struct ProveRoundInfo {
 }
 
 impl ProveRoundInfo {
-    /// Computes a round of the folding protocol. Takes in the coefficients of the current polynomial,
-    /// and interacts with the IOP verifier to produce the evaluations of the polynomial, the merkle tree
-    /// committing to the evaluation, and the coefficients of the folded polynomial.
+    /// Computes a round of the folding protocol. Takes in the coefficients of
+    /// the current polynomial, and interacts with the IOP verifier to
+    /// produce the evaluations of the polynomial, the merkle tree
+    /// committing to the evaluation, and the coefficients of the folded
+    /// polynomial.
     pub fn new<H: Hal, S: Sha>(hal: &H, iop: &mut WriteIOP<S>, coeffs: &Buffer<Fp>) -> Self {
         // LOG(1, "Doing FRI folding");
         // Get the number of coefficients of the polynomial over the extension field.
@@ -49,10 +51,11 @@ impl ProveRoundInfo {
         let domain = size * INV_RATE;
         // Allocate space in which to put the interpolated values.
         let evaluated = hal.alloc(domain * EXT_SIZE);
-        // Put in the coefficients, padding out with zeros so that we are left with the same polynomial
-        // represented by a larger coefficient list
+        // Put in the coefficients, padding out with zeros so that we are left with the
+        // same polynomial represented by a larger coefficient list
         hal.batch_expand(&evaluated, coeffs, EXT_SIZE);
-        // Evaluate the NTT in-place, filling the buffer with the evaluations of the polynomial.
+        // Evaluate the NTT in-place, filling the buffer with the evaluations of the
+        // polynomial.
         hal.batch_evaluate_ntt(&evaluated, EXT_SIZE, log2_ceil(INV_RATE));
         // Compute a Merkle tree committing to the polynomial evaluations.
         let merkle = MerkleTreeProver::new(


### PR DESCRIPTION
In keeping with what I was doing a few weeks ago, as I read the Rust code to understand the details of the protocol, I produce comments and docstrings.