### PR TITLE
"the zkvm" -> "a zkvm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the case of RISC Zero, the prover can show they correctly executed some code
 (known to both parties), while only revealing to the verifier the output of the
 code, not any of its inputs or any state during execution.
 
-The code runs in a special virtual machine, called the *ZKVM*.  The RISC Zero
+The code runs in a special virtual machine, called a *ZKVM*.  The RISC Zero
 ZKVM emulates a small RISC-V computer, allowing it to run arbitrary code in any
 language, so long as a compiler toolchain exists that targets RISC-V.
 Currently, SDK support exists for Rust, C, and C++.


### PR DESCRIPTION
@jbruestle 

Context: https://discord.com/channels/953703904086994974/953703904086994977/991749904647077938

> So ZKVM is a generic term.  Cario, Miden and all of the ZKEVM projects are also ZKVM's.  So ours is more officially called the RISC Zero ZKVM, but we often just call it 'the ZKVM' when the context is clear.  A ZKVM is distinguished by running 'code' of some sort, as opposed to ZK circuits (like what Zcash use, or what LEO compiles down to).  As far as I know though, our ZKVM is the only one that emulates an existing general purpose ISA (the others being either EVM or bespoke architectures).