### PR TITLE
rust: Add ability to embed methods with features

### DIFF
--- a/risc0/zkvm/sdk/rust/methods/build.rs
+++ b/risc0/zkvm/sdk/rust/methods/build.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+
 fn main() {
-    risc0_zkvm::build::embed_methods();
+    risc0_zkvm::build::embed_methods_with_features(HashMap::from([
+        ("risc0-zkvm-methods-inner".to_string(), vec!["test_feature1".to_string(),
+                                                      "test_feature2".to_string()])
+    ]));
 }

--- a/risc0/zkvm/sdk/rust/methods/inner/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/methods/inner/Cargo.toml
@@ -22,3 +22,5 @@ release = false
 [features]
 default = ["std"]
 std = []
+test_feature1 = []
+test_feature2 = []

--- a/risc0/zkvm/sdk/rust/methods/inner/src/bin/test_feature.rs
+++ b/risc0/zkvm/sdk/rust/methods/inner/src/bin/test_feature.rs
@@ -1,0 +1,24 @@
+// Copyright 2022 Risc0, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+use std::compile_error;
+
+risc0_zkvm::entry!(main);
+
+pub fn main() {
+
+    #[cfg(not(all(feature = "test_feature1", feature = "test_feature2")))]
+    compile_error!("Test feature was not found.");
+}


### PR DESCRIPTION
There is currently no way to pass features to build the guest packages with. 

Having an `embed_methods_with_features` allows user to build guest packages with specified features.