### PR TITLE
rust: Implement cc wrapper

### DIFF
--- a/Cargo-guest.lock
+++ b/Cargo-guest.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",

--- a/Cargo-host.lock
+++ b/Cargo-host.lock
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5469a6f42296f4fd40789b397383718f9a0bd75d2f9b7cedbb249996811fba27"
+checksum = "b7c14d679239b1ccaad7acaf972a19b41b6c1d7a8cb942158294b4f11ec71bd8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777e4db0e12e17ef7033768fb911ee89097a7e3f2247dc1729fa76fb8cfd7388"
+checksum = "0fdbee15c52b8d9132c62c341d2046885717e4a180eb9d3cd34c5a78f2669257"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -460,15 +460,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fef2b4ffdc935c973bc7817d541fc936fdc8a85194cfdd9c761aca8387edd48"
+checksum = "2fdfa84261f05a9b69c0afe03270f9f26d6899ca7df6f442563908b646e8a376"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3a240a54f5526967ffae81fdcda1fc80564964220d90816960b2eae2eab7f4"
+checksum = "0269826813dfbda75223169c774fede73401793e9af3970e4edbe93879782c1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -562,12 +562,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -575,6 +591,17 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -600,8 +627,10 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -663,9 +692,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -869,6 +898,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cae2cd7ba2f3f63938b9c724475dfb7b9861b545a90324476324ed21dbc8c8"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -1081,9 +1120,32 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "password-hash"
@@ -1423,6 +1485,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cargo_metadata",
+ "cc",
  "cfg-if",
  "ctor",
  "cxx",
@@ -1436,6 +1499,7 @@ dependencies = [
  "risc0-zkvm-sys",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "xmas-elf",
@@ -1508,6 +1572,12 @@ checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
  "base64",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "ryu"
@@ -1642,6 +1712,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+dependencies = [
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1764,12 @@ name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"

--- a/cargo-bazel-lock-guest.json
+++ b/cargo-bazel-lock-guest.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "925e251f1481867aa17a2151382d60b039fd5b9a16dbdfc7a67cecf2129a5939",
+  "checksum": "8297fa8ae9a79038673c8b0dc170eb56327dc12f78382f54905584777352e668",
   "crates": {
     "anyhow 1.0.58": {
       "name": "anyhow",
@@ -320,13 +320,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crypto-common 0.1.5": {
+    "crypto-common 0.1.6": {
       "name": "crypto-common",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crypto-common/0.1.5/download",
-          "sha256": "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
+          "url": "https://crates.io/api/v1/crates/crypto-common/0.1.6/download",
+          "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
         }
       },
       "targets": [
@@ -362,7 +362,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.5"
+        "version": "0.1.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -406,7 +406,7 @@
               "target": "block_buffer"
             },
             {
-              "id": "crypto-common 0.1.5",
+              "id": "crypto-common 0.1.6",
               "target": "crypto_common"
             }
           ],

--- a/cargo-bazel-lock-host.json
+++ b/cargo-bazel-lock-host.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "48ccbaaf803a7eef96328b01d5d841ab5ddb0691647cd5f7df6bc1438c5c4997",
+  "checksum": "0c1c862b42266ae3a765dae1613e03d5844b2035a6a0984dc4d5fdcabc9d7b39",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -1398,7 +1398,7 @@
         "deps": {
           "common": [
             {
-              "id": "os_str_bytes 6.1.0",
+              "id": "os_str_bytes 6.2.0",
               "target": "os_str_bytes"
             }
           ],
@@ -2153,13 +2153,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crypto-common 0.1.5": {
+    "crypto-common 0.1.6": {
       "name": "crypto-common",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crypto-common/0.1.5/download",
-          "sha256": "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
+          "url": "https://crates.io/api/v1/crates/crypto-common/0.1.6/download",
+          "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
         }
       },
       "targets": [
@@ -2198,7 +2198,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.5"
+        "version": "0.1.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2351,13 +2351,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "cxx 1.0.71": {
+    "cxx 1.0.72": {
       "name": "cxx",
-      "version": "1.0.71",
+      "version": "1.0.72",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxx/1.0.71/download",
-          "sha256": "5469a6f42296f4fd40789b397383718f9a0bd75d2f9b7cedbb249996811fba27"
+          "url": "https://crates.io/api/v1/crates/cxx/1.0.72/download",
+          "sha256": "b7c14d679239b1ccaad7acaf972a19b41b6c1d7a8cb942158294b4f11ec71bd8"
         }
       },
       "targets": [
@@ -2399,7 +2399,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.71",
+              "id": "cxx 1.0.72",
               "target": "build_script_build"
             },
             {
@@ -2413,13 +2413,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "cxxbridge-macro 1.0.71",
+              "id": "cxxbridge-macro 1.0.72",
               "target": "cxxbridge_macro"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.71"
+        "version": "1.0.72"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2432,7 +2432,7 @@
               "target": "cc"
             },
             {
-              "id": "cxxbridge-flags 1.0.71",
+              "id": "cxxbridge-flags 1.0.72",
               "target": "cxxbridge_flags"
             }
           ],
@@ -2442,13 +2442,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxx-build 1.0.71": {
+    "cxx-build 1.0.72": {
       "name": "cxx-build",
-      "version": "1.0.71",
+      "version": "1.0.72",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxx-build/1.0.71/download",
-          "sha256": "777e4db0e12e17ef7033768fb911ee89097a7e3f2247dc1729fa76fb8cfd7388"
+          "url": "https://crates.io/api/v1/crates/cxx-build/1.0.72/download",
+          "sha256": "0fdbee15c52b8d9132c62c341d2046885717e4a180eb9d3cd34c5a78f2669257"
         }
       },
       "targets": [
@@ -2504,17 +2504,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.71"
+        "version": "1.0.72"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxxbridge-flags 1.0.71": {
+    "cxxbridge-flags 1.0.72": {
       "name": "cxxbridge-flags",
-      "version": "1.0.71",
+      "version": "1.0.72",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxxbridge-flags/1.0.71/download",
-          "sha256": "0fef2b4ffdc935c973bc7817d541fc936fdc8a85194cfdd9c761aca8387edd48"
+          "url": "https://crates.io/api/v1/crates/cxxbridge-flags/1.0.72/download",
+          "sha256": "2fdfa84261f05a9b69c0afe03270f9f26d6899ca7df6f442563908b646e8a376"
         }
       },
       "targets": [
@@ -2540,17 +2540,17 @@
           "default"
         ],
         "edition": "2018",
-        "version": "1.0.71"
+        "version": "1.0.72"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxxbridge-macro 1.0.71": {
+    "cxxbridge-macro 1.0.72": {
       "name": "cxxbridge-macro",
-      "version": "1.0.71",
+      "version": "1.0.72",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxxbridge-macro/1.0.71/download",
-          "sha256": "9d3a240a54f5526967ffae81fdcda1fc80564964220d90816960b2eae2eab7f4"
+          "url": "https://crates.io/api/v1/crates/cxxbridge-macro/1.0.72/download",
+          "sha256": "0269826813dfbda75223169c774fede73401793e9af3970e4edbe93879782c1d"
         }
       },
       "targets": [
@@ -2590,7 +2590,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.71"
+        "version": "1.0.72"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2638,7 +2638,7 @@
               "target": "block_buffer"
             },
             {
-              "id": "crypto-common 0.1.5",
+              "id": "crypto-common 0.1.6",
               "target": "crypto_common"
             },
             {
@@ -3077,6 +3077,78 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "futures 0.3.21": {
+      "name": "futures",
+      "version": "0.3.21",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/futures/0.3.21/download",
+          "sha256": "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "futures",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "futures",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc",
+          "executor",
+          "futures-executor",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "futures-channel 0.3.21",
+              "target": "futures_channel"
+            },
+            {
+              "id": "futures-core 0.3.21",
+              "target": "futures_core"
+            },
+            {
+              "id": "futures-executor 0.3.21",
+              "target": "futures_executor"
+            },
+            {
+              "id": "futures-io 0.3.21",
+              "target": "futures_io"
+            },
+            {
+              "id": "futures-sink 0.3.21",
+              "target": "futures_sink"
+            },
+            {
+              "id": "futures-task 0.3.21",
+              "target": "futures_task"
+            },
+            {
+              "id": "futures-util 0.3.21",
+              "target": "futures_util"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.21"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "futures-channel 0.3.21": {
       "name": "futures-channel",
       "version": "0.3.21",
@@ -3120,6 +3192,8 @@
         "crate_features": [
           "alloc",
           "default",
+          "futures-sink",
+          "sink",
           "std"
         ],
         "deps": {
@@ -3131,6 +3205,10 @@
             {
               "id": "futures-core 0.3.21",
               "target": "futures_core"
+            },
+            {
+              "id": "futures-sink 0.3.21",
+              "target": "futures_sink"
             }
           ],
           "selects": {}
@@ -3206,6 +3284,59 @@
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "futures-executor 0.3.21": {
+      "name": "futures-executor",
+      "version": "0.3.21",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/futures-executor/0.3.21/download",
+          "sha256": "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "futures_executor",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "futures_executor",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "futures-core 0.3.21",
+              "target": "futures_core"
+            },
+            {
+              "id": "futures-task 0.3.21",
+              "target": "futures_task"
+            },
+            {
+              "id": "futures-util 0.3.21",
+              "target": "futures_util"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.3.21"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3388,14 +3519,22 @@
         ],
         "crate_features": [
           "alloc",
+          "channel",
+          "futures-channel",
           "futures-io",
+          "futures-sink",
           "io",
           "memchr",
+          "sink",
           "slab",
           "std"
         ],
         "deps": {
           "common": [
+            {
+              "id": "futures-channel 0.3.21",
+              "target": "futures_channel"
+            },
             {
               "id": "futures-core 0.3.21",
               "target": "futures_core"
@@ -3403,6 +3542,10 @@
             {
               "id": "futures-io 0.3.21",
               "target": "futures_io"
+            },
+            {
+              "id": "futures-sink 0.3.21",
+              "target": "futures_sink"
             },
             {
               "id": "futures-task 0.3.21",
@@ -3722,13 +3865,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "hashbrown 0.12.2": {
+    "hashbrown 0.12.3": {
       "name": "hashbrown",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/hashbrown/0.12.2/download",
-          "sha256": "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+          "url": "https://crates.io/api/v1/crates/hashbrown/0.12.3/download",
+          "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
         }
       },
       "targets": [
@@ -3754,7 +3897,7 @@
           "raw"
         ],
         "edition": "2021",
-        "version": "0.12.2"
+        "version": "0.12.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4403,7 +4546,7 @@
         "deps": {
           "common": [
             {
-              "id": "hashbrown 0.12.2",
+              "id": "hashbrown 0.12.3",
               "target": "hashbrown"
             },
             {
@@ -4878,6 +5021,78 @@
           "selects": {}
         },
         "links": "cplusplus"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "lock_api 0.4.7": {
+      "name": "lock_api",
+      "version": "0.4.7",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/lock_api/0.4.7/download",
+          "sha256": "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "lock_api",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "lock_api",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "lock_api 0.4.7",
+              "target": "build_script_build"
+            },
+            {
+              "id": "scopeguard 1.1.0",
+              "target": "scopeguard"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.7"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "autocfg 1.1.0",
+              "target": "autocfg"
+            }
+          ],
+          "selects": {}
+        }
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -6138,13 +6353,13 @@
       },
       "license": "MIT"
     },
-    "os_str_bytes 6.1.0": {
+    "os_str_bytes 6.2.0": {
       "name": "os_str_bytes",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.1.0/download",
-          "sha256": "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.2.0/download",
+          "sha256": "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
         }
       },
       "targets": [
@@ -6169,8 +6384,143 @@
         "crate_features": [
           "raw_os_str"
         ],
+        "edition": "2021",
+        "version": "6.2.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "parking_lot 0.12.1": {
+      "name": "parking_lot",
+      "version": "0.12.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/parking_lot/0.12.1/download",
+          "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "parking_lot",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "parking_lot",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "lock_api 0.4.7",
+              "target": "lock_api"
+            },
+            {
+              "id": "parking_lot_core 0.9.3",
+              "target": "parking_lot_core"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2018",
-        "version": "6.1.0"
+        "version": "0.12.1"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "parking_lot_core 0.9.3": {
+      "name": "parking_lot_core",
+      "version": "0.9.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.9.3/download",
+          "sha256": "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "parking_lot_core",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "parking_lot_core",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "parking_lot_core 0.9.3",
+              "target": "build_script_build"
+            },
+            {
+              "id": "smallvec 1.9.0",
+              "target": "smallvec"
+            }
+          ],
+          "selects": {
+            "cfg(target_os = \"redox\")": [
+              {
+                "id": "redox_syscall 0.2.13",
+                "target": "syscall"
+              }
+            ],
+            "cfg(unix)": [
+              {
+                "id": "libc 0.2.126",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.36.1",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.9.3"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7833,7 +8183,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.71",
+              "id": "cxx 1.0.72",
               "target": "cxx"
             },
             {
@@ -7853,7 +8203,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx-build 1.0.71",
+              "id": "cxx-build 1.0.72",
               "target": "cxx_build"
             }
           ],
@@ -8040,7 +8390,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.71",
+              "id": "cxx 1.0.72",
               "target": "cxx"
             },
             {
@@ -8068,7 +8418,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx-build 1.0.71",
+              "id": "cxx-build 1.0.72",
               "target": "cxx_build"
             }
           ],
@@ -8087,6 +8437,18 @@
           "Library": {
             "crate_name": "risc0_zkvm",
             "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "Binary": {
+            "crate_name": "gcc-shim",
+            "crate_root": "src/bin/gcc-shim.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -8149,7 +8511,7 @@
           "selects": {
             "cfg(not(target_arch = \"riscv32\"))": [
               {
-                "id": "cxx 1.0.71",
+                "id": "cxx 1.0.72",
                 "target": "cxx"
               },
               {
@@ -8186,6 +8548,10 @@
         "deps_dev": {
           "common": [
             {
+              "id": "serial_test 0.8.0",
+              "target": "serial_test"
+            },
+            {
               "id": "tempfile 3.3.0",
               "target": "tempfile"
             }
@@ -8215,7 +8581,7 @@
           "selects": {
             "cfg(not(target_arch = \"riscv32\"))": [
               {
-                "id": "cxx-build 1.0.71",
+                "id": "cxx-build 1.0.72",
                 "target": "cxx_build"
               }
             ]
@@ -8321,7 +8687,7 @@
               "target": "anyhow"
             },
             {
-              "id": "cxx 1.0.71",
+              "id": "cxx 1.0.72",
               "target": "cxx"
             },
             {
@@ -8341,7 +8707,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx-build 1.0.71",
+              "id": "cxx-build 1.0.72",
               "target": "cxx_build"
             }
           ],
@@ -8443,7 +8809,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.71",
+              "id": "cxx 1.0.72",
               "target": "cxx"
             },
             {
@@ -8463,7 +8829,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx-build 1.0.71",
+              "id": "cxx-build 1.0.72",
               "target": "cxx_build"
             }
           ],
@@ -8511,7 +8877,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.71",
+              "id": "cxx 1.0.72",
               "target": "cxx"
             },
             {
@@ -8535,7 +8901,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx-build 1.0.71",
+              "id": "cxx-build 1.0.72",
               "target": "cxx_build"
             }
           ],
@@ -8668,6 +9034,65 @@
         "version": "1.0.0"
       },
       "license": "Apache-2.0/ISC/MIT"
+    },
+    "rustversion 1.0.8": {
+      "name": "rustversion",
+      "version": "1.0.8",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rustversion/1.0.8/download",
+          "sha256": "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "rustversion",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build/build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustversion",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "rustversion 1.0.8",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.8"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "ryu 1.0.10": {
       "name": "ryu",
@@ -9438,6 +9863,137 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "serial_test 0.8.0": {
+      "name": "serial_test",
+      "version": "0.8.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/serial_test/0.8.0/download",
+          "sha256": "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "serial_test",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "serial_test",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "log",
+          "logging"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "futures 0.3.21",
+              "target": "futures"
+            },
+            {
+              "id": "lazy_static 1.4.0",
+              "target": "lazy_static"
+            },
+            {
+              "id": "log 0.4.17",
+              "target": "log"
+            },
+            {
+              "id": "parking_lot 0.12.1",
+              "target": "parking_lot"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "serial_test_derive 0.8.0",
+              "target": "serial_test_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.8.0"
+      },
+      "license": "MIT"
+    },
+    "serial_test_derive 0.8.0": {
+      "name": "serial_test_derive",
+      "version": "0.8.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/serial_test_derive/0.8.0/download",
+          "sha256": "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "serial_test_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "serial_test_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro-error 1.0.4",
+              "target": "proc_macro_error"
+            },
+            {
+              "id": "proc-macro2 1.0.40",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.20",
+              "target": "quote"
+            },
+            {
+              "id": "syn 1.0.98",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "rustversion 1.0.8",
+              "target": "rustversion"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.8.0"
+      },
+      "license": "MIT"
+    },
     "sha1 0.10.1": {
       "name": "sha1",
       "version": "0.10.1",
@@ -9589,6 +10145,39 @@
         "version": "0.4.6"
       },
       "license": "MIT"
+    },
+    "smallvec 1.9.0": {
+      "name": "smallvec",
+      "version": "1.9.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/smallvec/1.9.0/download",
+          "sha256": "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "smallvec",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "smallvec",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "1.9.0"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "socket2 0.4.4": {
       "name": "socket2",
@@ -12125,8 +12714,10 @@
           "Win32_Storage_FileSystem",
           "Win32_System",
           "Win32_System_IO",
+          "Win32_System_LibraryLoader",
           "Win32_System_Memory",
           "Win32_System_Pipes",
+          "Win32_System_SystemServices",
           "Win32_System_WindowsProgramming",
           "default"
         ],

--- a/risc0/zkvm/sdk/rust/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/Cargo.toml
@@ -6,6 +6,7 @@ description = "RISC Zero zero-knowledge VM"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
+build = "build.rs"
 
 [dependencies]
 anyhow = "1.0"
@@ -14,9 +15,11 @@ cargo_metadata = "0.14"
 cfg-if = "1.0"
 risc0-zkp = { version = "0.10", path = "../../../zkp/rust", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+cc = { version = "1", optional = true }
 
 [dev-dependencies]
 tempfile = "3.3"
+serial_test = "0.8.0"
 
 # TODO(nils): Change these arch checks to vendor checks when we have a
 # real target triple.
@@ -46,6 +49,7 @@ bazel = []
 default = ["prove", "std", "verify"]
 doc = ["std"]
 prove = ["risc0-zkp/prove"]
+risc_cc = ["cc", "risc0-zkvm-methods/risc_cc"]
 # The pure feature enables the 'pure' rust implementation of this
 # crate without any of the FFI interfaces exposed for e.g. the prover.
 pure = []

--- a/risc0/zkvm/sdk/rust/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/Cargo.toml
@@ -12,14 +12,14 @@ build = "build.rs"
 anyhow = "1.0"
 bytemuck = "1.9"
 cargo_metadata = "0.14"
+cc = { version = "1", optional = true }
 cfg-if = "1.0"
 risc0-zkp = { version = "0.10", path = "../../../zkp/rust", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-cc = { version = "1", optional = true }
 
 [dev-dependencies]
-tempfile = "3.3"
 serial_test = "0.8.0"
+tempfile = "3.3"
 
 # TODO(nils): Change these arch checks to vendor checks when we have a
 # real target triple.
@@ -55,7 +55,6 @@ risc_cc = ["cc", "risc0-zkvm-methods/risc_cc"]
 pure = []
 std = ["risc0-zkp/std", "serde/std"]
 verify = ["risc0-zkp/verify"]
-
 
 [package.metadata.release]
 release = false

--- a/risc0/zkvm/sdk/rust/methods/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/methods/Cargo.toml
@@ -12,3 +12,6 @@ release = false
 [package.metadata.risc0]
 methods = ["inner"]
 
+[features]
+risc_cc = []
+

--- a/risc0/zkvm/sdk/rust/methods/build.rs
+++ b/risc0/zkvm/sdk/rust/methods/build.rs
@@ -2,12 +2,15 @@ use risc0_zkvm::build::{embed_methods_with_options, MethodOptions};
 use std::collections::HashMap;
 
 fn main() {
-    let inner_method_options = MethodOptions {
+    let mut _inner_method_options = MethodOptions {
         code_limit: 10,
         features: vec!["test_feature1".to_string(), "test_feature2".to_string()],
     };
 
-    let map = HashMap::from([("risc0-zkvm-methods-inner", inner_method_options)]);
+    #[cfg(feature = "risc_cc")]
+    _inner_method_options.features.push("risc_cc".to_string());
+
+    let map = HashMap::from([("risc0-zkvm-methods-inner", _inner_method_options)]);
 
     embed_methods_with_options(map);
 }

--- a/risc0/zkvm/sdk/rust/methods/inner/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/methods/inner/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 risc0-zkvm = { version = "0.10", path = "../..", default-features = false, features = ["std"] }
 risc0-zkp = { version = "0.10", path = "../../../../../zkp/rust", default-features = false, features = ["std"] }
+simple-c-pkg = { path = "../test-resources/simple-c-pkg", optional = true}
 
 [profile.release]
 lto = true
@@ -19,8 +20,17 @@ risc0-zkvm = { version = "0.10", path = "../.." }
 [package.metadata.release]
 release = false
 
+[[bin]]
+name = "cc_default"
+required-features = ["risc_cc"]
+
+[[bin]]
+name = "cc_release"
+required-features = ["risc_cc"]
+
 [features]
 default = ["std"]
 std = []
 test_feature1 = []
 test_feature2 = []
+risc_cc = ["simple-c-pkg"]

--- a/risc0/zkvm/sdk/rust/methods/inner/src/bin/cc_default.rs
+++ b/risc0/zkvm/sdk/rust/methods/inner/src/bin/cc_default.rs
@@ -1,0 +1,31 @@
+// Copyright 2022 Risc0, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+use simple_c_pkg::c_add_dev;
+use risc0_zkvm::guest::env;
+
+risc0_zkvm::entry!(main);
+
+pub fn main() {
+        let a: usize = env::read();
+        let b: usize = env::read();
+
+        let sum;
+        unsafe {
+            sum = c_add_dev(a, b);
+        }
+        env::commit(&sum);
+}

--- a/risc0/zkvm/sdk/rust/methods/inner/src/bin/cc_release.rs
+++ b/risc0/zkvm/sdk/rust/methods/inner/src/bin/cc_release.rs
@@ -1,0 +1,31 @@
+// Copyright 2022 Risc0, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+use simple_c_pkg::c_add_rel;
+use risc0_zkvm::guest::env;
+
+risc0_zkvm::entry!(main);
+
+pub fn main() {
+        let a: usize = env::read();
+        let b: usize = env::read();
+
+        let sum;
+        unsafe {
+            sum = c_add_rel(a, b);
+        }
+        env::commit(&sum);
+}

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/Cargo.toml
@@ -6,4 +6,4 @@ build = "build.rs"
 
 
 [build-dependencies]
-risc0-zkvm = { path = "../../.." , default-features = false, features = ["std"]}
+risc0-zkvm = { path = "../../.." , default-features = false, features = ["std", "risc_cc"]}

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "simple-c-pkg"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+
+[build-dependencies]
+risc0-zkvm = { path = "../../.." , default-features = false, features = ["std"]}

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/build.rs
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/build.rs
@@ -1,0 +1,16 @@
+use risc0_zkvm::build::rcc::Build;
+
+fn main() {
+    Build::new()
+        .compiler("/usr/bin/clang")
+        .include("depend/foo_dev.h")
+        .file("src/foo_dev.c")
+        .compile("foo_dev");
+
+    Build::new()
+        .compiler("/usr/bin/clang")
+        .include("depend/foo_rel.h")
+        .file("src/foo_rel.c")
+        .release(true)
+        .compile("foo_rel");
+}

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/depend/foo_dev.h
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/depend/foo_dev.h
@@ -1,0 +1,6 @@
+#ifndef RISC0_FOO_DEV_H
+#define RISC0_FOO_DEV_H
+
+unsigned int c_add_dev(unsigned int, unsigned int);
+
+#endif // RISC0_FOO_DEV_H

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/depend/foo_rel.h
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/depend/foo_rel.h
@@ -1,0 +1,6 @@
+#ifndef RISC0_FOO_REL_H
+#define RISC0_FOO_REL_H
+
+unsigned int c_add_rel(unsigned int, unsigned int);
+
+#endif // RISC0_FOO_REL_H

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/src/foo_dev.c
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/src/foo_dev.c
@@ -1,0 +1,5 @@
+#include "../depend/foo_dev.h"
+
+unsigned int c_add_dev(unsigned int a, unsigned int b) {
+  return a + b;
+}

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/src/foo_rel.c
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/src/foo_rel.c
@@ -1,0 +1,5 @@
+#include "../depend/foo_rel.h"
+
+unsigned int c_add_rel(unsigned int a, unsigned int b) {
+  return a + b;
+}

--- a/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/methods/test-resources/simple-c-pkg/src/lib.rs
@@ -1,0 +1,5 @@
+extern "C" {
+    pub fn c_add_dev(a: usize, b: usize) -> usize;
+
+    pub fn c_add_rel(a: usize, b: usize) -> usize;
+}

--- a/risc0/zkvm/sdk/rust/src/bin/gcc-shim.rs
+++ b/risc0/zkvm/sdk/rust/src/bin/gcc-shim.rs
@@ -1,9 +1,7 @@
 #![cfg_attr(test, allow(dead_code))]
 
-/*
-TESTING UTIL TAKEN FROM:
-https://github.com/rust-lang/cc-rs/blob/f2e1b1c9ff92ad063957382ec445bc54e9570c71/src/bin/gcc-shim.rs
-*/
+// TESTING UTIL TAKEN FROM:
+// https://github.com/rust-lang/cc-rs/blob/f2e1b1c9ff92ad063957382ec445bc54e9570c71/src/bin/gcc-shim.rs
 
 use std::env;
 use std::fs::File;
@@ -18,7 +16,8 @@ fn main() {
         env::var_os("GCCTEST_OUT_DIR").expect(&format!("{}: GCCTEST_OUT_DIR not found", program)),
     );
 
-    // Find the first nonexistent candidate file to which the program's args can be written.
+    // Find the first nonexistent candidate file to which the program's args can be
+    // written.
     for i in 0.. {
         let candidate = &out_dir.join(format!("out{}", i));
 

--- a/risc0/zkvm/sdk/rust/src/bin/gcc-shim.rs
+++ b/risc0/zkvm/sdk/rust/src/bin/gcc-shim.rs
@@ -1,0 +1,53 @@
+#![cfg_attr(test, allow(dead_code))]
+
+/*
+TESTING UTIL TAKEN FROM:
+https://github.com/rust-lang/cc-rs/blob/f2e1b1c9ff92ad063957382ec445bc54e9570c71/src/bin/gcc-shim.rs
+*/
+
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+
+fn main() {
+    let mut args = env::args();
+    let program = args.next().expect("Unexpected empty args");
+
+    let out_dir = PathBuf::from(
+        env::var_os("GCCTEST_OUT_DIR").expect(&format!("{}: GCCTEST_OUT_DIR not found", program)),
+    );
+
+    // Find the first nonexistent candidate file to which the program's args can be written.
+    for i in 0.. {
+        let candidate = &out_dir.join(format!("out{}", i));
+
+        // If the file exists, commands have already run. Try again.
+        if candidate.exists() {
+            continue;
+        }
+
+        // Create a file and record the args passed to the command.
+        let mut f = File::create(candidate).expect(&format!(
+            "{}: can't create candidate: {}",
+            program,
+            candidate.to_string_lossy()
+        ));
+        for arg in args {
+            writeln!(f, "{}", arg).expect(&format!(
+                "{}: can't write to candidate: {}",
+                program,
+                candidate.to_string_lossy()
+            ));
+        }
+        break;
+    }
+
+    // Create a file used by some tests.
+    let path = &out_dir.join("libfoo.a");
+    File::create(path).expect(&format!(
+        "{}: can't create libfoo.a: {}",
+        program,
+        path.to_string_lossy()
+    ));
+}

--- a/risc0/zkvm/sdk/rust/src/build/README.md
+++ b/risc0/zkvm/sdk/rust/src/build/README.md
@@ -3,4 +3,13 @@
 This crate contains helper functions to assist with building guest side code,
 and using it in host side code.
 
-[TODO: Examples]
+`risc0_zkvm::build::rcc::Build` is a wrapper for the `cc` crate that compiles to `riscv32im` 
+if the `CARGO_CFG_TARGET_ARCH` is set to `riscv32` with no boilerplate and reasonable defaults.
+
+If you want to change the defaults you can check out the methods for the given object, or set 
+via the environment flags below. Environment flags supersede the methods.
+
+- `RV_CC_INSTALL_PATH` sets the riscv32im cross-compiler gnu toolchain path. This can otherwise be set with the `Build::rv_cc_install_path` method. The default is `/opt/riscv`.
+- `RCC_COMPILER` sets the compiler that will be used for the build. This can otherwise be set with the `Build::compiler` method.
+- `CRATE_COMPILER_DEFAULTS` sets the compiler default flags. These default flags are turned off by default as compiler defaults usually don't account compiling for `riscv32im` architecture. This can otherwise be set with the `Build::compiler_default_flags` method.
+- `CRATE_NO_RISC0_DEFAULTS` allows you to turn off all the reasonable default flags set for `riscv32im`. This can otherwise be set with the `Build::no_risc0_default_flags` method.

--- a/risc0/zkvm/sdk/rust/src/build/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/build/mod.rs
@@ -15,8 +15,8 @@
 #![deny(missing_docs)]
 #![doc = include_str!("README.md")]
 
-/// A wrapper for the `cc` crate that compiles to `riscv32im` with no boilerplate and
-/// reasonable defaults.
+/// A wrapper for the `cc` crate that compiles to `riscv32im` with no
+/// boilerplate and reasonable defaults.
 ///
 /// ```no_run
 /// fn main() {
@@ -49,7 +49,6 @@
 ///         .compile("foo");
 /// }
 /// ```
-///
 #[cfg(feature = "risc_cc")]
 pub mod rcc;
 

--- a/risc0/zkvm/sdk/rust/src/build/rcc.rs
+++ b/risc0/zkvm/sdk/rust/src/build/rcc.rs
@@ -1,0 +1,599 @@
+#![cfg(feature = "risc_cc")]
+
+use std::{env, ffi::OsStr, path::Path};
+
+use cc;
+use cc::Error;
+
+#[allow(missing_docs)]
+pub const DEFAULT_RV_CC_INSTALL_PATH: &str = "/opt/riscv";
+
+#[derive(Debug)]
+/// A convenient wrapper around `cc::Build` with sensible defaults for building
+/// to `riscv32im` targets. See `./mod.rs` for further explanation.
+pub struct Build {
+    inner: cc::Build,
+    rv_cc_install_path: String,
+    no_risc0_default_flags: bool,
+    compiler_default_flags: bool,
+    release: bool,
+}
+
+impl Build {
+    /// Construct a new instance with the default riscv32 configuration.
+    ///
+    /// This builder is finished with the [`compile`] function.
+    ///
+    /// [`compile`]: struct.Build.html#method.compile
+    pub fn new() -> Self {
+        let is_riscv_env = env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32";
+
+        Self {
+            inner: cc::Build::new(),
+            rv_cc_install_path: DEFAULT_RV_CC_INSTALL_PATH.to_string(),
+            no_risc0_default_flags: !is_riscv_env,
+            compiler_default_flags: false,
+            release: false,
+        }
+    }
+
+    /// Add a directory to the `-I` or include path for headers
+    pub fn include<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.inner.include(dir);
+        self
+    }
+
+    /// Add multiple directories to the `-I` include path.
+    pub fn includes<P>(&mut self, dirs: P) -> &mut Self
+    where
+        P: IntoIterator,
+        P::Item: AsRef<Path>,
+    {
+        self.inner.includes(dirs);
+        self
+    }
+
+    /// Specify a `-D` variable with an optional value.
+    pub fn define<'a, V: Into<Option<&'a str>>>(&mut self, var: &str, val: V) -> &mut Self {
+        self.inner.define(var, val);
+        self
+    }
+
+    /// Add an arbitrary object file to link in
+    pub fn object<P: AsRef<Path>>(&mut self, obj: P) -> &mut Self {
+        self.inner.object(obj);
+        self
+    }
+
+    /// Add an arbitrary flag to the invocation of the compiler
+    pub fn flag(&mut self, flag: &str) -> &mut Self {
+        self.inner.flag(flag);
+        self
+    }
+
+    /// Add a flag to the invocation of the `ar`
+    pub fn ar_flag(&mut self, flag: &str) -> &mut Self {
+        self.inner.ar_flag(flag);
+        self
+    }
+
+    /// Run the compiler to test if it accepts the given flag.
+    ///
+    /// For a convenience method for setting flags conditionally, `see flag_if_supported()`.
+    ///
+    /// It may return error if it’s unable to run the compiler with a test file
+    /// (e.g. the compiler is missing or a write to the `out_dir` failed).
+    ///
+    /// Note: Once computed, the result of this call is stored in the `known_flag_support` field.
+    /// If `is_flag_supported(flag)` is called again, the result will be read from the hash table.
+    pub fn is_flag_supported(&self, flag: &str) -> Result<bool, Error> {
+        self.inner.is_flag_supported(flag)
+    }
+
+    /// Add an arbitrary flag to the invocation of the compiler if it supports it
+    pub fn flag_if_supported(&mut self, flag: &str) -> &mut Self {
+        self.inner.flag_if_supported(flag);
+        self
+    }
+
+    /// Set the `-shared` flag.
+    ///
+    /// When enabled, the compiler will produce a shared object which can then
+    /// be linked with other objects to form an executable.
+    pub fn shared_flag(&mut self, shared_flag: bool) -> &mut Self {
+        self.inner.shared_flag(shared_flag);
+        self
+    }
+
+    /// Set the `-static` flag.
+    ///
+    /// When enabled on systems that support dynamic linking, this prevents linking with the shared libraries.
+    pub fn static_flag(&mut self, static_flag: bool) -> &mut Self {
+        self.inner.static_flag(static_flag);
+        self
+    }
+
+    /// Enables the generation of default compiler flags by the inner `cc::Build`.
+    /// If this option is not set, this crate disables `cc`'s default flags
+    /// because they can cause issues when cross compiling.
+    ///
+    /// Setting the `CRATE_COMPILER_DEFAULTS` environment variable has the same
+    /// effect as setting this to `true`. The presence of the environment variable
+    /// and this value will be OR’d together.
+    pub fn compiler_default_flags(&mut self, compiler_default_flags: bool) -> &mut Self {
+        self.compiler_default_flags = compiler_default_flags;
+        self
+    }
+
+    /// Disables the generation of default risc0 flags.
+    ///
+    /// Setting the `CRATE_NO_RISC0_DEFAULTS` environment variable has the same
+    /// effect as setting this to `true`. The presence of the environment variable
+    /// and this value will be OR’d together.
+    pub fn no_risc0_default_flags(&mut self, no_risc0_default_flags: bool) -> &mut Self {
+        self.no_risc0_default_flags = no_risc0_default_flags;
+        self
+    }
+
+    /// Add a file which will be compiled
+    pub fn file<P: AsRef<Path>>(&mut self, p: P) -> &mut Self {
+        self.inner.file(p);
+        self
+    }
+
+    /// Add files which will be compiled
+    pub fn files<P>(&mut self, p: P) -> &mut Self
+    where
+        P: IntoIterator,
+        P::Item: AsRef<Path>,
+    {
+        self.inner.files(p);
+        self
+    }
+
+    /// Set C++ support.
+    ///
+    /// The other `cpp_*` options will only become active if this is set to `true`.
+    pub fn cpp(&mut self, cpp: bool) -> &mut Self {
+        self.inner.cpp(cpp);
+        self
+    }
+
+    /// Set CUDA C++ support.
+    ///
+    /// Enabling CUDA will pass the detected C/C++ toolchain as an argument to the CUDA compiler, NVCC.
+    /// NVCC itself accepts some limited GNU-like args; any other arguments for the C/C++ toolchain
+    /// will be redirected using "-Xcompiler" flags.
+    pub fn cuda(&mut self, cuda: bool) -> &mut Self {
+        self.inner.cuda(cuda);
+        self
+    }
+
+    /// Link CUDA run-time.
+    ///
+    /// This option mimics the `--cudart NVCC` command-line option. Just like the original it
+    /// accepts `{none|shared|static}`, with default being `static`. The method has to be invoked after `.cuda(true)`,
+    ///  or not at all, if the default is right for the project.
+    pub fn cudart(&mut self, cudart: &str) -> &mut Self {
+        self.inner.cudart(cudart);
+        self
+    }
+
+    /// Set warnings into errors flag.
+    ///
+    /// Disabled by default.
+    ///
+    /// Warning: turning warnings into errors only make sense
+    /// if you are a developer of the crate using cc-rs.
+    /// Some warnings only appear on some architecture or
+    /// specific version of the compiler. Any user of this crate,
+    /// or any other crate depending on it, could fail during
+    /// compile time.
+    pub fn warnings_into_errors(&mut self, warnings_into_errors: bool) -> &mut Self {
+        self.inner.warnings_into_errors(warnings_into_errors);
+        self
+    }
+
+    /// Set warnings flags.
+    ///
+    /// Adds some flags:
+    /// - "-Wall" for MSVC.
+    /// - "-Wall", "-Wextra" for GNU and Clang.
+    ///
+    /// Enabled by default.
+    pub fn warnings(&mut self, warnings: bool) -> &mut Self {
+        self.inner.warnings(warnings);
+        self
+    }
+
+    /// Set extra warnings flags.
+    ///
+    /// Adds some flags:
+    /// - nothing for MSVC.
+    /// - "-Wextra" for GNU and Clang.
+    ///
+    /// Enabled by default.
+    pub fn extra_warnings(&mut self, warnings: bool) -> &mut Self {
+        self.inner.extra_warnings(warnings);
+        self
+    }
+
+    /// Set the standard library to link against when compiling with C++
+    /// support.
+    ///
+    /// See [`get_cpp_link_stdlib`](cc::Build::get_cpp_link_stdlib) documentation
+    /// for the default value.
+    /// If the `CXXSTDLIB` environment variable is set, its value will
+    /// override the default value, but not the value explicitly set by calling
+    /// this function.
+    ///
+    /// A value of `None` indicates that no automatic linking should happen,
+    /// otherwise cargo will link against the specified library.
+    ///
+    /// The given library name must not contain the `lib` prefix.
+    ///
+    /// Common values:
+    /// - `stdc++` for GNU
+    /// - `c++` for Clang
+    /// - `c++_shared` or `c++_static` for Android
+    pub fn cpp_link_stdlib<'a, V: Into<Option<&'a str>>>(
+        &mut self,
+        cpp_link_stdlib: V,
+    ) -> &mut Self {
+        self.inner.cpp_link_stdlib(cpp_link_stdlib);
+        self
+    }
+
+    /// Force the C++ compiler to use the specified standard library.
+    ///
+    /// Setting this option will automatically set `cpp_link_stdlib` to the same
+    /// value.
+    ///
+    /// The default value of this option is always `None`.
+    ///
+    /// This option has no effect when compiling for a Visual Studio based
+    /// target.
+    ///
+    /// This option sets the `-stdlib` flag, which is only supported by some
+    /// compilers (clang, icc) but not by others (gcc). The library will not
+    /// detect which compiler is used, as such it is the responsibility of the
+    /// caller to ensure that this option is only used in conjunction with a
+    /// compiler which supports the `-stdlib` flag.
+    ///
+    /// A value of `None` indicates that no specific C++ standard library should
+    /// be used, otherwise `-stdlib` is added to the compile invocation.
+    ///
+    /// The given library name must not contain the `lib` prefix.
+    ///
+    /// Common values:
+    /// - `stdc++` for GNU
+    /// - `c++` for Clang
+    pub fn cpp_set_stdlib<'a, V: Into<Option<&'a str>>>(&mut self, cpp_set_stdlib: V) -> &mut Self {
+        self.inner.cpp_set_stdlib(cpp_set_stdlib);
+        self
+    }
+
+    /// Configures the target this configuration will be compiling for.
+    ///
+    /// This option is automatically scraped from the `TARGET` environment
+    /// variable by build scripts, so it's not required to call this function.
+    pub fn target(&mut self, target: &str) -> &mut Self {
+        self.inner.target(target);
+        self
+    }
+
+    /// Configures the host assumed by this configuration.
+    ///
+    /// This option is automatically scraped from the `HOST` environment
+    /// variable by build scripts, so it's not required to call this function.
+    pub fn host(&mut self, host: &str) -> &mut Self {
+        self.inner.host(host);
+        self
+    }
+
+    /// Configures the optimization level of the generated object files.
+    ///
+    /// This option is automatically scraped from the `OPT_LEVEL` environment
+    /// variable by build scripts, so it's not required to call this function.
+    pub fn opt_level(&mut self, opt_level: u32) -> &mut Self {
+        self.inner.opt_level(opt_level);
+        self
+    }
+
+    /// Configures the optimization level of the generated object files.
+    ///
+    /// This option is automatically scraped from the `OPT_LEVEL` environment
+    /// variable by build scripts, so it's not required to call this function.
+    pub fn opt_level_str(&mut self, opt_level: &str) -> &mut Self {
+        self.inner.opt_level_str(opt_level);
+        self
+    }
+
+    /// Configures whether the compiler will emit debug information when
+    /// generating object files.
+    ///
+    /// This option is automatically scraped from the `DEBUG` environment
+    /// variable by build scripts, so it's not required to call this function.
+    pub fn debug(&mut self, debug: bool) -> &mut Self {
+        self.inner.debug(debug);
+        self
+    }
+
+    /// Configures whether the compiler will emit instructions to store
+    /// frame pointers during codegen.
+    ///
+    /// This option is automatically enabled when debug information is emitted.
+    /// Otherwise the target platform compiler's default will be used.
+    /// You can use this option to force a specific setting.
+    pub fn force_frame_pointer(&mut self, force: bool) -> &mut Self {
+        self.inner.force_frame_pointer(force);
+        self
+    }
+
+    /// Configures the output directory where all object files and static
+    /// libraries will be located.
+    ///
+    /// This option is automatically scraped from the `OUT_DIR` environment
+    /// variable by build scripts, so it's not required to call this function.
+    pub fn out_dir<P: AsRef<Path>>(&mut self, out_dir: P) -> &mut Self {
+        self.inner.out_dir(out_dir);
+        self
+    }
+
+    /// Configures the compiler to be used to produce output.
+    ///
+    /// Setting the `RCC_COMPILER` makes this method call redundant. The presence of the
+    /// environment variable supersedes this value.
+    ///
+    /// If not set via this call or the env variable above, this option is automatically
+    /// determined from the target platform or a number of environment variables.
+    pub fn compiler<P: AsRef<Path>>(&mut self, compiler: P) -> &mut Self {
+        self.inner.compiler(compiler);
+        self
+    }
+
+    /// Configures the tool used to assemble archives.
+    ///
+    /// This option is automatically determined from the target platform or a
+    /// number of environment variables, so it's not required to call this
+    /// function.
+    pub fn archiver<P: AsRef<Path>>(&mut self, archiver: P) -> &mut Self {
+        self.inner.archiver(archiver);
+        self
+    }
+
+    /// Define whether metadata should be emitted for cargo allowing it to
+    /// automatically link the binary. Defaults to `true`.
+    ///
+    /// The emitted metadata is:
+    ///
+    ///  - `rustc-link-lib=static=`*compiled lib*
+    ///  - `rustc-link-search=native=`*target folder*
+    ///  - When target is MSVC, the ATL-MFC libs are added via `rustc-link-search=native=`
+    ///  - When C++ is enabled, the C++ stdlib is added via `rustc-link-lib`
+    ///
+    pub fn cargo_metadata(&mut self, cargo_metadata: bool) -> &mut Self {
+        self.inner.cargo_metadata(cargo_metadata);
+        self
+    }
+
+    /// Configures whether the compiler will emit position independent code.
+    ///
+    /// This option defaults to `false` for `windows-gnu` and bare metal targets and
+    /// to `true` for all other targets.
+    pub fn pic(&mut self, pic: bool) -> &mut Self {
+        self.inner.pic(pic);
+        self
+    }
+
+    /// Configures whether the Procedure Linkage Table is used for indirect
+    /// calls into shared libraries.
+    ///
+    /// The PLT is used to provide features like lazy binding, but introduces
+    /// a small performance loss due to extra pointer indirection. Setting
+    /// `use_plt` to `false` can provide a small performance increase.
+    ///
+    /// Note that skipping the PLT requires a recent version of GCC/Clang.
+    ///
+    /// This only applies to ELF targets. It has no effect on other platforms.
+    pub fn use_plt(&mut self, use_plt: bool) -> &mut Self {
+        self.inner.use_plt(use_plt);
+        self
+    }
+
+    /// Configures whether the /MT flag or the /MD flag will be passed to msvc build tools.
+    ///
+    /// This option defaults to `false`, and affect only msvc targets.
+    pub fn static_crt(&mut self, static_crt: bool) -> &mut Self {
+        self.inner.static_crt(static_crt);
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn __set_env<A, B>(&mut self, a: A, b: B) -> &mut Self
+    where
+        A: AsRef<OsStr>,
+        B: AsRef<OsStr>,
+    {
+        self.inner.__set_env(a, b);
+        self
+    }
+
+    /// Configures the riscv32 cross-compiler install path. The default value is "/opt/riscv"
+    ///
+    /// Setting the `RV_CC_INSTALL_PATH` makes this method call redundant. The presence of the
+    /// environment variable supersedes this or the default value.
+    pub fn rv_cc_install_path(&mut self, rv_cc_install_path: &str) -> &mut Self {
+        self.rv_cc_install_path = rv_cc_install_path.to_string();
+        self
+    }
+
+    /// If enabled, removes debug information from the compiled binary. This improves performance and
+    /// reduces binary size. This option is equivalent to:
+    /// ```no_run
+    ///  cc::Build::new()
+    ///             .flag("-feliminate-unused-debug-symbols")
+    ///             .flag("-feliminate-unused-debug-types")
+    ///             .flag("-fvirtual-function-elimination");
+    /// ```
+    pub fn release(&mut self, release: bool) -> &mut Self {
+        self.release = release;
+        self
+    }
+
+    /// Run the compiler, generating the file `output`
+    ///
+    /// This will return a result instead of panicing; see compile() for the complete description.
+    pub fn try_compile(&mut self, output: &str) -> Result<(), Error> {
+        self.add_flags();
+        self.inner.try_compile(output)
+    }
+
+    /// Run the compiler, generating the file `output`
+    ///
+    /// # Library name
+    ///
+    /// The `output` string argument determines the file name for the compiled
+    /// library. The Rust compiler will create an assembly named "lib"+output+".a".
+    /// MSVC will create a file named output+".lib".
+    ///
+    /// The choice of `output` is close to arbitrary, but:
+    ///
+    /// - must be nonempty,
+    /// - must not contain a path separator (`/`),
+    /// - must be unique across all `compile` invocations made by the same build
+    ///   script.
+    ///
+    /// If your build script compiles a single source file, the base name of
+    /// that source file would usually be reasonable:
+    ///
+    /// ```no_run
+    /// cc::Build::new().file("blobstore.c").compile("blobstore");
+    /// ```
+    ///
+    /// Compiling multiple source files, some people use their crate's name, or
+    /// their crate's name + "-cc".
+    ///
+    /// Otherwise, please use your imagination.
+    ///
+    /// For backwards compatibility, if `output` starts with "lib" *and* ends
+    /// with ".a", a second "lib" prefix and ".a" suffix do not get added on,
+    /// but this usage is deprecated; please omit `lib` and `.a` in the argument
+    /// that you pass.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `output` is not formatted correctly or if one of the underlying
+    /// compiler commands fails. It can also panic if it fails reading file names
+    /// or creating directories.
+    pub fn compile(&mut self, output: &str) {
+        self.add_flags();
+        self.inner.compile(output);
+    }
+
+    fn add_flags(&mut self) {
+        // Check and add compiler default flags if necessary
+        let compiler_default_flags_from_env = match env::var("CRATE_COMPILER_DEFAULTS").ok() {
+            Some(s) => s.to_lowercase() == "true",
+            None => false,
+        };
+        let compiler_default_flags = self.compiler_default_flags || compiler_default_flags_from_env;
+        self.inner.no_default_flags(!compiler_default_flags);
+
+        // Check and add no risc0 default flags if necessary
+        let no_risc0_default_flags_from_env = match env::var("CRATE_NO_RISC0_DEFAULTS").ok() {
+            Some(s) => s.to_lowercase() == "true",
+            None => false,
+        };
+        self.no_risc0_default_flags =
+            self.no_risc0_default_flags || no_risc0_default_flags_from_env;
+        if self.no_risc0_default_flags {
+            return;
+        }
+
+        // Set compiler from environment variable if it exists
+        env::var("RCC_COMPILER")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|s| self.inner.compiler(s));
+
+        // Set riscv32 cross-compiler from environment variable if it exists
+        env::var("RV_CC_INSTALL_PATH")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|s| self.rv_cc_install_path = s);
+
+        self.inner
+            .target("riscv32im-unknown-none-elf")
+            .opt_level(3)
+            .flag("-O3")
+            .flag("--target=riscv32-unknown-none-elf")
+            .flag("-mabi=ilp32")
+            .flag("-mcmodel=medany")
+            .flag("-fdata-sections")
+            .flag("-ffunction-sections")
+            .flag("-dead_strip")
+            .flag("-flto")
+            .flag("-march=rv32im")
+            .flag("-static")
+            .flag(&format!(
+                "--sysroot={}/riscv32-unknown-elf",
+                self.rv_cc_install_path
+            ))
+            .flag(&format!("--gcc-toolchain={}", self.rv_cc_install_path));
+
+        if !self.release {
+            return;
+        }
+
+        self.inner
+            .flag("-feliminate-unused-debug-symbols")
+            .flag("-feliminate-unused-debug-types")
+            .flag("-fvirtual-function-elimination");
+    }
+
+    /// This will return a result instead of panicing; see expand() for the complete description.
+    pub fn try_expand(&self) -> Result<Vec<u8>, Error> {
+        self.inner.try_expand()
+    }
+
+    /// Run the compiler, returning the macro-expanded version of the input files.
+    ///
+    /// This is only relevant for C and C++ files.
+    ///
+    /// # Panics
+    /// Panics if more than one file is present in the config, or if compiler
+    /// path has an invalid file name.
+    pub fn expand(&self) -> Vec<u8> {
+        self.inner.expand()
+    }
+
+    /// Get the compiler that's in use for this configuration.
+    ///
+    /// This function will return a `Tool` which represents the culmination
+    /// of this configuration at a snapshot in time. The returned compiler can
+    /// be inspected (e.g. the path, arguments, environment) to forward along to
+    /// other tools, or the `to_command` method can be used to invoke the
+    /// compiler itself.
+    ///
+    /// This method will take into account all configuration such as debug
+    /// information, optimization level, include directories, defines, etc.
+    /// Additionally, the compiler binary in use follows the standard
+    /// conventions for this path, e.g. looking at the explicitly set compiler,
+    /// environment variables (a number of which are inspected here), and then
+    /// falling back to the default configuration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an error occurred while determining the architecture.
+    pub fn get_compiler(&self) -> cc::Tool {
+        self.inner.get_compiler()
+    }
+
+    /// Get the compiler that's in use for this configuration.
+    ///
+    /// This will return a result instead of panicing; see get_compiler() for the complete description.
+    pub fn try_get_compiler(&self) -> Result<cc::Tool, Error> {
+        self.inner.try_get_compiler()
+    }
+}

--- a/risc0/zkvm/sdk/rust/src/build/rcc.rs
+++ b/risc0/zkvm/sdk/rust/src/build/rcc.rs
@@ -79,18 +79,21 @@ impl Build {
 
     /// Run the compiler to test if it accepts the given flag.
     ///
-    /// For a convenience method for setting flags conditionally, `see flag_if_supported()`.
+    /// For a convenience method for setting flags conditionally, `see
+    /// flag_if_supported()`.
     ///
     /// It may return error if it’s unable to run the compiler with a test file
     /// (e.g. the compiler is missing or a write to the `out_dir` failed).
     ///
-    /// Note: Once computed, the result of this call is stored in the `known_flag_support` field.
-    /// If `is_flag_supported(flag)` is called again, the result will be read from the hash table.
+    /// Note: Once computed, the result of this call is stored in the
+    /// `known_flag_support` field. If `is_flag_supported(flag)` is called
+    /// again, the result will be read from the hash table.
     pub fn is_flag_supported(&self, flag: &str) -> Result<bool, Error> {
         self.inner.is_flag_supported(flag)
     }
 
-    /// Add an arbitrary flag to the invocation of the compiler if it supports it
+    /// Add an arbitrary flag to the invocation of the compiler if it supports
+    /// it
     pub fn flag_if_supported(&mut self, flag: &str) -> &mut Self {
         self.inner.flag_if_supported(flag);
         self
@@ -107,19 +110,20 @@ impl Build {
 
     /// Set the `-static` flag.
     ///
-    /// When enabled on systems that support dynamic linking, this prevents linking with the shared libraries.
+    /// When enabled on systems that support dynamic linking, this prevents
+    /// linking with the shared libraries.
     pub fn static_flag(&mut self, static_flag: bool) -> &mut Self {
         self.inner.static_flag(static_flag);
         self
     }
 
-    /// Enables the generation of default compiler flags by the inner `cc::Build`.
-    /// If this option is not set, this crate disables `cc`'s default flags
-    /// because they can cause issues when cross compiling.
+    /// Enables the generation of default compiler flags by the inner
+    /// `cc::Build`. If this option is not set, this crate disables `cc`'s
+    /// default flags because they can cause issues when cross compiling.
     ///
     /// Setting the `CRATE_COMPILER_DEFAULTS` environment variable has the same
-    /// effect as setting this to `true`. The presence of the environment variable
-    /// and this value will be OR’d together.
+    /// effect as setting this to `true`. The presence of the environment
+    /// variable and this value will be OR’d together.
     pub fn compiler_default_flags(&mut self, compiler_default_flags: bool) -> &mut Self {
         self.compiler_default_flags = compiler_default_flags;
         self
@@ -128,8 +132,8 @@ impl Build {
     /// Disables the generation of default risc0 flags.
     ///
     /// Setting the `CRATE_NO_RISC0_DEFAULTS` environment variable has the same
-    /// effect as setting this to `true`. The presence of the environment variable
-    /// and this value will be OR’d together.
+    /// effect as setting this to `true`. The presence of the environment
+    /// variable and this value will be OR’d together.
     pub fn no_risc0_default_flags(&mut self, no_risc0_default_flags: bool) -> &mut Self {
         self.no_risc0_default_flags = no_risc0_default_flags;
         self
@@ -153,7 +157,8 @@ impl Build {
 
     /// Set C++ support.
     ///
-    /// The other `cpp_*` options will only become active if this is set to `true`.
+    /// The other `cpp_*` options will only become active if this is set to
+    /// `true`.
     pub fn cpp(&mut self, cpp: bool) -> &mut Self {
         self.inner.cpp(cpp);
         self
@@ -161,9 +166,10 @@ impl Build {
 
     /// Set CUDA C++ support.
     ///
-    /// Enabling CUDA will pass the detected C/C++ toolchain as an argument to the CUDA compiler, NVCC.
-    /// NVCC itself accepts some limited GNU-like args; any other arguments for the C/C++ toolchain
-    /// will be redirected using "-Xcompiler" flags.
+    /// Enabling CUDA will pass the detected C/C++ toolchain as an argument to
+    /// the CUDA compiler, NVCC. NVCC itself accepts some limited GNU-like
+    /// args; any other arguments for the C/C++ toolchain will be redirected
+    /// using "-Xcompiler" flags.
     pub fn cuda(&mut self, cuda: bool) -> &mut Self {
         self.inner.cuda(cuda);
         self
@@ -171,8 +177,9 @@ impl Build {
 
     /// Link CUDA run-time.
     ///
-    /// This option mimics the `--cudart NVCC` command-line option. Just like the original it
-    /// accepts `{none|shared|static}`, with default being `static`. The method has to be invoked after `.cuda(true)`,
+    /// This option mimics the `--cudart NVCC` command-line option. Just like
+    /// the original it accepts `{none|shared|static}`, with default being
+    /// `static`. The method has to be invoked after `.cuda(true)`,
     ///  or not at all, if the default is right for the project.
     pub fn cudart(&mut self, cudart: &str) -> &mut Self {
         self.inner.cudart(cudart);
@@ -221,8 +228,8 @@ impl Build {
     /// Set the standard library to link against when compiling with C++
     /// support.
     ///
-    /// See [`get_cpp_link_stdlib`](cc::Build::get_cpp_link_stdlib) documentation
-    /// for the default value.
+    /// See [`get_cpp_link_stdlib`](cc::Build::get_cpp_link_stdlib)
+    /// documentation for the default value.
     /// If the `CXXSTDLIB` environment variable is set, its value will
     /// override the default value, but not the value explicitly set by calling
     /// this function.
@@ -342,11 +349,12 @@ impl Build {
 
     /// Configures the compiler to be used to produce output.
     ///
-    /// Setting the `RCC_COMPILER` makes this method call redundant. The presence of the
-    /// environment variable supersedes this value.
+    /// Setting the `RCC_COMPILER` makes this method call redundant. The
+    /// presence of the environment variable supersedes this value.
     ///
-    /// If not set via this call or the env variable above, this option is automatically
-    /// determined from the target platform or a number of environment variables.
+    /// If not set via this call or the env variable above, this option is
+    /// automatically determined from the target platform or a number of
+    /// environment variables.
     pub fn compiler<P: AsRef<Path>>(&mut self, compiler: P) -> &mut Self {
         self.inner.compiler(compiler);
         self
@@ -369,9 +377,9 @@ impl Build {
     ///
     ///  - `rustc-link-lib=static=`*compiled lib*
     ///  - `rustc-link-search=native=`*target folder*
-    ///  - When target is MSVC, the ATL-MFC libs are added via `rustc-link-search=native=`
+    ///  - When target is MSVC, the ATL-MFC libs are added via
+    ///    `rustc-link-search=native=`
     ///  - When C++ is enabled, the C++ stdlib is added via `rustc-link-lib`
-    ///
     pub fn cargo_metadata(&mut self, cargo_metadata: bool) -> &mut Self {
         self.inner.cargo_metadata(cargo_metadata);
         self
@@ -379,8 +387,8 @@ impl Build {
 
     /// Configures whether the compiler will emit position independent code.
     ///
-    /// This option defaults to `false` for `windows-gnu` and bare metal targets and
-    /// to `true` for all other targets.
+    /// This option defaults to `false` for `windows-gnu` and bare metal targets
+    /// and to `true` for all other targets.
     pub fn pic(&mut self, pic: bool) -> &mut Self {
         self.inner.pic(pic);
         self
@@ -401,7 +409,8 @@ impl Build {
         self
     }
 
-    /// Configures whether the /MT flag or the /MD flag will be passed to msvc build tools.
+    /// Configures whether the /MT flag or the /MD flag will be passed to msvc
+    /// build tools.
     ///
     /// This option defaults to `false`, and affect only msvc targets.
     pub fn static_crt(&mut self, static_crt: bool) -> &mut Self {
@@ -419,18 +428,20 @@ impl Build {
         self
     }
 
-    /// Configures the riscv32 cross-compiler install path. The default value is "/opt/riscv"
+    /// Configures the riscv32 cross-compiler install path. The default value is
+    /// "/opt/riscv"
     ///
-    /// Setting the `RV_CC_INSTALL_PATH` makes this method call redundant. The presence of the
-    /// environment variable supersedes this or the default value.
+    /// Setting the `RV_CC_INSTALL_PATH` makes this method call redundant. The
+    /// presence of the environment variable supersedes this or the default
+    /// value.
     pub fn rv_cc_install_path(&mut self, rv_cc_install_path: &str) -> &mut Self {
         self.rv_cc_install_path = rv_cc_install_path.to_string();
         self
     }
 
-    /// If enabled, removes debug information from the compiled binary. This improves performance and
-    /// reduces binary size. This option is equivalent to:
-    /// ```no_run
+    /// If enabled, removes debug information from the compiled binary. This
+    /// improves performance and reduces binary size. This option is
+    /// equivalent to: ```no_run
     ///  cc::Build::new()
     ///             .flag("-feliminate-unused-debug-symbols")
     ///             .flag("-feliminate-unused-debug-types")
@@ -443,7 +454,8 @@ impl Build {
 
     /// Run the compiler, generating the file `output`
     ///
-    /// This will return a result instead of panicing; see compile() for the complete description.
+    /// This will return a result instead of panicing; see compile() for the
+    /// complete description.
     pub fn try_compile(&mut self, output: &str) -> Result<(), Error> {
         self.add_flags();
         self.inner.try_compile(output)
@@ -454,8 +466,8 @@ impl Build {
     /// # Library name
     ///
     /// The `output` string argument determines the file name for the compiled
-    /// library. The Rust compiler will create an assembly named "lib"+output+".a".
-    /// MSVC will create a file named output+".lib".
+    /// library. The Rust compiler will create an assembly named
+    /// "lib"+output+".a". MSVC will create a file named output+".lib".
     ///
     /// The choice of `output` is close to arbitrary, but:
     ///
@@ -483,9 +495,9 @@ impl Build {
     ///
     /// # Panics
     ///
-    /// Panics if `output` is not formatted correctly or if one of the underlying
-    /// compiler commands fails. It can also panic if it fails reading file names
-    /// or creating directories.
+    /// Panics if `output` is not formatted correctly or if one of the
+    /// underlying compiler commands fails. It can also panic if it fails
+    /// reading file names or creating directories.
     pub fn compile(&mut self, output: &str) {
         self.add_flags();
         self.inner.compile(output);
@@ -552,12 +564,14 @@ impl Build {
             .flag("-fvirtual-function-elimination");
     }
 
-    /// This will return a result instead of panicing; see expand() for the complete description.
+    /// This will return a result instead of panicing; see expand() for the
+    /// complete description.
     pub fn try_expand(&self) -> Result<Vec<u8>, Error> {
         self.inner.try_expand()
     }
 
-    /// Run the compiler, returning the macro-expanded version of the input files.
+    /// Run the compiler, returning the macro-expanded version of the input
+    /// files.
     ///
     /// This is only relevant for C and C++ files.
     ///
@@ -592,7 +606,8 @@ impl Build {
 
     /// Get the compiler that's in use for this configuration.
     ///
-    /// This will return a result instead of panicing; see get_compiler() for the complete description.
+    /// This will return a result instead of panicing; see get_compiler() for
+    /// the complete description.
     pub fn try_get_compiler(&self) -> Result<cc::Tool, Error> {
         self.inner.try_get_compiler()
     }

--- a/risc0/zkvm/sdk/rust/tests/cc_end_to_end_test.rs
+++ b/risc0/zkvm/sdk/rust/tests/cc_end_to_end_test.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "risc_cc")]
+
+use risc0_zkvm::host::Prover;
+use risc0_zkvm::serde::{from_slice, to_vec};
+use risc0_zkvm_methods::{CC_DEFAULT_ID, CC_DEFAULT_PATH, CC_RELEASE_ID, CC_RELEASE_PATH};
+
+use std::path::Path;
+
+fn test_cc_package<P: AsRef<Path>>(path: P, id: &[u8]) {
+    let a: u64 = 17;
+    let b: u64 = 23;
+
+    let mut prover = Prover::new(&std::fs::read(path).unwrap(), id).unwrap();
+
+    // Next we send a and b to the guest
+    prover.add_input(to_vec(&a).unwrap().as_slice()).unwrap();
+    prover.add_input(to_vec(&b).unwrap().as_slice()).unwrap();
+
+    let receipt = prover.run().unwrap();
+
+    // Extract journal of receipt (i.e. output c, where c = a + b)
+    let c: u64 = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
+
+    // Print an assertation
+    println!("The sum of a and b is {}, and I can prove it!", c);
+
+    receipt.verify(id).unwrap();
+}
+
+#[test]
+fn default() {
+    test_cc_package(CC_DEFAULT_PATH, CC_DEFAULT_ID);
+}
+
+#[test]
+fn release() {
+    test_cc_package(CC_RELEASE_PATH, CC_RELEASE_ID);
+}

--- a/risc0/zkvm/sdk/rust/tests/cc_unit_test.rs
+++ b/risc0/zkvm/sdk/rust/tests/cc_unit_test.rs
@@ -1,0 +1,217 @@
+#![cfg(feature = "risc_cc")]
+
+use crate::support::{Execution, Test};
+use risc0_zkvm::build::rcc;
+use serial_test::serial;
+
+mod support;
+
+#[test]
+#[serial]
+fn risc0_default_flags() {
+    reset_env();
+
+    let test = Test::gnu();
+    test.gcc().file("foo.c").compile("foo");
+
+    let e = test.cmd(0);
+
+    e.must_have("foo.c");
+    check_risc0_default_flags_exist(&e);
+    check_release_flags_do_not_exist(&e);
+
+    test.cmd(1).must_have(test.td.path().join("foo.o"));
+}
+
+#[test]
+#[serial]
+fn no_risc0_default_flags_via_function() {
+    reset_env();
+
+    let test = Test::gnu();
+    test.gcc()
+        .file("foo.c")
+        .no_risc0_default_flags(true)
+        .compile("foo");
+
+    let e = test.cmd(0);
+
+    check_risc0_default_flags_do_not_exist(&e);
+    check_release_flags_do_not_exist(&e);
+}
+
+#[test]
+#[serial]
+fn no_risc0_default_flags_via_flag() {
+    reset_env();
+    std::env::set_var("CRATE_NO_RISC0_DEFAULTS", "TRUE");
+
+    let test = Test::gnu();
+    test.gcc().file("foo.c").compile("foo");
+
+    let e = test.cmd(0);
+
+    check_risc0_default_flags_do_not_exist(&e);
+    check_release_flags_do_not_exist(&e);
+}
+
+#[test]
+#[serial]
+fn release() {
+    reset_env();
+
+    let test = Test::gnu();
+    test.gcc().file("foo.c").release(true).compile("foo");
+
+    let e = test.cmd(0);
+
+    check_risc0_default_flags_exist(&e);
+    check_release_flags_exist(&e);
+}
+
+#[test]
+#[serial]
+fn rv_cc_install_path_via_method() {
+    reset_env();
+
+    let some_install_path = "/stra/wqath";
+
+    let test = Test::gnu();
+    test.gcc()
+        .file("foo.c")
+        .rv_cc_install_path(some_install_path)
+        .compile("foo");
+
+    let e = test.cmd(0);
+
+    e.must_have(sysroot_flag(some_install_path));
+    e.must_have(gcc_toolchain_flag(some_install_path));
+}
+
+#[test]
+#[serial]
+fn rv_cc_install_path_via_flag() {
+    reset_env();
+
+    let install_path_via_flag = "/stra/wqath";
+    std::env::set_var("RV_CC_INSTALL_PATH", install_path_via_flag);
+
+    let install_path_via_method = "/abc";
+    let test = Test::gnu();
+    test.gcc()
+        .file("foo.c")
+        .rv_cc_install_path(install_path_via_method)
+        .compile("foo");
+
+    let e = test.cmd(0);
+
+    e.must_have(sysroot_flag(install_path_via_flag));
+    e.must_have(gcc_toolchain_flag(install_path_via_flag));
+
+    e.must_not_have(sysroot_flag(install_path_via_method));
+    e.must_not_have(gcc_toolchain_flag(install_path_via_method));
+}
+
+#[test]
+#[serial]
+fn compiler() {
+    reset_env();
+
+    let test = Test::gnu();
+
+    let compiler_name: &str = "bruv";
+    let compiler_path = test.td.path().join(compiler_name);
+    std::env::set_var("RCC_COMPILER", compiler_path);
+
+    let error_message = match test.gcc().file("foo.c").try_compile("foo") {
+        Ok(_) => panic!(
+            "{}",
+            format!(
+                "Should have panicd as compiler named {} does not exist",
+                compiler_name
+            )
+        ),
+        Err(e) => format!("{:?}", e),
+    };
+
+    assert!(error_message.contains(compiler_name));
+    assert!(error_message.contains("ToolNotFound"));
+}
+
+#[test]
+#[serial]
+fn architecture_detected_via_cargo_flag() {
+    reset_env();
+
+    std::env::set_var("CARGO_CFG_TARGET_ARCH", "");
+
+    let test = Test::gnu();
+    test.gcc().file("foo.c").compile("foo");
+
+    let e = test.cmd(0);
+
+    check_risc0_default_flags_do_not_exist(&e);
+}
+
+fn sysroot_flag(install_path: &str) -> String {
+    format!("--sysroot={}/riscv32-unknown-elf", install_path)
+}
+
+fn gcc_toolchain_flag(install_path: &str) -> String {
+    format!("--gcc-toolchain={}", install_path)
+}
+
+fn reset_env() {
+    // Some tests check that a flag is *not* present.  These tests might fail if the flag is set in the
+    // CFLAGS or CXXFLAGS environment variables.  This function clears the CFLAGS and CXXFLAGS
+    // variables to make sure that the tests can run correctly.
+    std::env::set_var("CFLAGS", "");
+    std::env::set_var("CXXFLAGS", "");
+
+    std::env::set_var("CRATE_NO_RISC0_DEFAULTS", "");
+    std::env::set_var("CARGO_CFG_TARGET_ARCH", "riscv32");
+    std::env::set_var("RV_CC_INSTALL_PATH", "");
+    std::env::set_var("RCC_COMPILER", "");
+}
+
+fn check_risc0_default_flags_exist(e: &Execution) -> &Execution {
+    e.must_have("-O3")
+        .must_have("--target=riscv32-unknown-none-elf")
+        .must_have("-mabi=ilp32")
+        .must_have("-mcmodel=medany")
+        .must_have("-fdata-sections")
+        .must_have("-ffunction-sections")
+        .must_have("-dead_strip")
+        .must_have("-flto")
+        .must_have("-march=rv32im")
+        .must_have("-static")
+        .must_have(sysroot_flag(rcc::DEFAULT_RV_CC_INSTALL_PATH))
+        .must_have(gcc_toolchain_flag(rcc::DEFAULT_RV_CC_INSTALL_PATH))
+}
+
+fn check_risc0_default_flags_do_not_exist(e: &Execution) -> &Execution {
+    e.must_not_have("-O3")
+        .must_not_have("--target=riscv32-unknown-none-elf")
+        .must_not_have("-mabi=ilp32")
+        .must_not_have("-mcmodel=medany")
+        .must_not_have("-fdata-sections")
+        .must_not_have("-ffunction-sections")
+        .must_not_have("-dead_strip")
+        .must_not_have("-flto")
+        .must_not_have("-march=rv32im")
+        .must_not_have("-static")
+        .must_not_have(sysroot_flag(rcc::DEFAULT_RV_CC_INSTALL_PATH))
+        .must_not_have(gcc_toolchain_flag(rcc::DEFAULT_RV_CC_INSTALL_PATH))
+}
+
+fn check_release_flags_exist(e: &Execution) -> &Execution {
+    e.must_have("-feliminate-unused-debug-symbols")
+        .must_have("-feliminate-unused-debug-types")
+        .must_have("-fvirtual-function-elimination")
+}
+
+fn check_release_flags_do_not_exist(e: &Execution) -> &Execution {
+    e.must_not_have("-feliminate-unused-debug-symbols")
+        .must_not_have("-feliminate-unused-debug-types")
+        .must_not_have("-fvirtual-function-elimination")
+}

--- a/risc0/zkvm/sdk/rust/tests/support/mod.rs
+++ b/risc0/zkvm/sdk/rust/tests/support/mod.rs
@@ -1,0 +1,141 @@
+#![allow(dead_code)]
+#![cfg(feature = "risc_cc")]
+
+/*
+TESTING UTIL ADAPTED FROM:
+https://github.com/rust-lang/cc-rs/blob/f2e1b1c9ff92ad063957382ec445bc54e9570c71/tests/support/mod.rs
+*/
+
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    fs::{self, File},
+    io,
+    io::prelude::*,
+    path::{Path, PathBuf},
+};
+
+use risc0_zkvm::build::rcc;
+
+use tempfile::{Builder, TempDir};
+
+pub struct Test {
+    pub td: TempDir,
+    pub gcc: PathBuf,
+}
+
+pub struct Execution {
+    args: Vec<String>,
+}
+
+impl Test {
+    pub fn new() -> Test {
+        // This is ugly: `sccache` needs to introspect the compiler it is
+        // executing, as it adjusts its behavior depending on the
+        // language/compiler. This crate's test driver uses mock compilers that
+        // are obviously not supported by sccache, so the tests fail if
+        // RUSTC_WRAPPER is set. rust doesn't build test dependencies with
+        // the `test` feature enabled, so we can't conditionally disable the
+        // usage of `sccache` if running in a test environment, at least not
+        // without setting an environment variable here and testing for it
+        // there. Explicitly deasserting RUSTC_WRAPPER here seems to be the
+        // lesser of the two evils.
+        env::remove_var("RUSTC_WRAPPER");
+
+        let mut gcc = PathBuf::from(env::current_exe().unwrap());
+        gcc.pop();
+        if gcc.ends_with("deps") {
+            gcc.pop();
+        }
+        let td = Builder::new().prefix("gcc-test").tempdir_in(&gcc).unwrap();
+        gcc.push(format!("gcc-shim{}", env::consts::EXE_SUFFIX));
+        Test { td, gcc }
+    }
+
+    pub fn gnu() -> Test {
+        let t = Test::new();
+        t.shim("cc").shim("c++").shim("ar");
+        t
+    }
+
+    pub fn shim(&self, name: &str) -> &Test {
+        let name = if name.ends_with(env::consts::EXE_SUFFIX) {
+            name.to_string()
+        } else {
+            format!("{}{}", name, env::consts::EXE_SUFFIX)
+        };
+        link_or_copy(&self.gcc, self.td.path().join(name)).unwrap();
+        self
+    }
+
+    pub fn gcc(&self) -> rcc::Build {
+        let mut cfg = rcc::Build::new();
+        let target = "x86_64-unknown-linux-gnu";
+
+        cfg.host(target)
+            .target(target)
+            .opt_level(2)
+            .out_dir(self.td.path())
+            .__set_env("PATH", self.path())
+            .__set_env("GCCTEST_OUT_DIR", self.td.path());
+        cfg
+    }
+
+    fn path(&self) -> OsString {
+        let mut path = env::split_paths(&env::var_os("PATH").unwrap()).collect::<Vec<_>>();
+        path.insert(0, self.td.path().to_owned());
+        env::join_paths(path).unwrap()
+    }
+
+    pub fn cmd(&self, i: u32) -> Execution {
+        let mut s = String::new();
+        File::open(self.td.path().join(format!("out{}", i)))
+            .unwrap()
+            .read_to_string(&mut s)
+            .unwrap();
+        Execution {
+            args: s.lines().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+impl Execution {
+    pub fn must_have<P: AsRef<OsStr>>(&self, p: P) -> &Execution {
+        if !self.has(p.as_ref()) {
+            panic!("didn't find {:?} in {:?}", p.as_ref(), self.args);
+        } else {
+            self
+        }
+    }
+
+    pub fn must_not_have<P: AsRef<OsStr>>(&self, p: P) -> &Execution {
+        if self.has(p.as_ref()) {
+            panic!("found {:?}", p.as_ref());
+        } else {
+            self
+        }
+    }
+
+    pub fn has(&self, p: &OsStr) -> bool {
+        self.args.iter().any(|arg| OsStr::new(arg) == p)
+    }
+}
+
+/// Hard link an executable or copy it if that fails.
+///
+/// We first try to hard link an executable to save space. If that fails (as on Windows with
+/// different mount points, issue #60), we copy.
+#[cfg(not(target_os = "macos"))]
+fn link_or_copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    fs::hard_link(from, to).or_else(|_| fs::copy(from, to).map(|_| ()))
+}
+
+/// Copy an executable.
+///
+/// On macOS, hard linking the executable leads to strange failures (issue #419), so we just copy.
+#[cfg(target_os = "macos")]
+fn link_or_copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
+    fs::copy(from, to).map(|_| ())
+}


### PR DESCRIPTION
This PR is for providing a wrapper for the `cc` crate that compiles to `riscv32im` if the `CARGO_CFG_TARGET_ARCH` is set to `riscv32` with no boilerplate and reasonable defaults. It's useful for libraries that depend on `c/cpp`.

e.g.
```
fn main() {
    risc0_zkvm::build::rcc::Build::new()
        .file("src/foo.c")
        .compile("foo");
}
```

is equivalent to...

```
fn main() {
     cc::Build::new() // The normal `cc` crate
         .target("riscv32im-unknown-none-elf")
         .no_default_flags(true)
         .flag("-O3")
         .flag("--target=riscv32-unknown-none-elf")
         .flag("-mabi=ilp32")
         .flag("-mcmodel=medany")
         .flag("-fdata-sections")
         .flag("-ffunction-sections")
         .flag("-dead_strip")
         .flag("-flto")
         .flag("-march=rv32im")
         .file("src/foo.c")
         .flag("-static")
         .flag("--sysroot=/opt/riscv/riscv32-unknown-elf")
         .flag("--gcc-toolchain=/opt/riscv")
         .compile("foo");
}
