### PR TITLE
Make risc0_zkvm_guest its own workspace

### DIFF
--- a/risc0/zkvm/sdk/rust/guest/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/guest/Cargo.toml
@@ -24,3 +24,5 @@ std = ["risc0-zkp/std", "serde/std"]
 
 [package.metadata.release]
 release = false
+
+[workspace]


### PR DESCRIPTION
The simplest possible change to enable building the risc0_zkvm_guest docs. I'm not sure whether I'm overlooking any implications of making guest its own workspace. That said, the tests are passing, and the docs are building. It is necessary to navigate to `risc0/zkvm/sdk/rust/guest` and build docs there to get the guest docs, but I think that's acceptable (again, unless I'm missing something).