### PR TITLE
Write intro rust docs for zkVM, guest/build

### DIFF
--- a/risc0/zkvm/prove/make-id/src/main.rs
+++ b/risc0/zkvm/prove/make-id/src/main.rs
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Creates RISC Zero MethodIDs from ELF files
+//!
+//! A simple command line tool for creating
+//! [MethodID](risc0_zkvm::host::MethodId)s from RISC-V ELF files. It is
+//! intended for basic, low-level use cases. In particular, users looking to
+//! create MethodIDs for Rust code are advised to instead use our zkVM: visit
+//! our [Risc Zero Rust Starter repository](https://github.com/risc0/risc0-rust-starter)
+//! for help getting started.
+
 use clap::Parser;
 use std::fs;
 
 use risc0_zkvm::host::{MethodId, DEFAULT_METHOD_ID_LIMIT};
 
-/// Generates a MethodID for a given RISC-V ELF binary.
+/// The command line arguments necessary to run [main].
 #[derive(Parser)]
 #[clap(about, version, author)]
 struct Args {
@@ -32,6 +41,11 @@ struct Args {
     limit: u32,
 }
 
+/// Generates a MethodID for a given RISC-V ELF binary.
+///
+/// Must be provided command line arguments formatted according to [Args].
+/// Alternatively, command line help is available by running with the argument
+/// `--help`.
 fn main() {
     let args = Args::parse();
     let elf_contents = fs::read(args.elf).unwrap();

--- a/risc0/zkvm/prove/make-id/src/main.rs
+++ b/risc0/zkvm/prove/make-id/src/main.rs
@@ -26,7 +26,7 @@ use std::fs;
 
 use risc0_zkvm::host::{MethodId, DEFAULT_METHOD_ID_LIMIT};
 
-/// The command line arguments necessary to run [main].
+/// Generates a MethodID for a given RISC-V ELF binary.
 #[derive(Parser)]
 #[clap(about, version, author)]
 struct Args {

--- a/risc0/zkvm/sdk/rust/build/README.md
+++ b/risc0/zkvm/sdk/rust/build/README.md
@@ -9,14 +9,14 @@ In order for the host to execute guest code in the [RISC Zero zkVM](risc0_zkvm),
 Using this crate can be a bit delicate, so we encourage you to follow along in our [Risc Zero Rust Starter repository](https://github.com/risc0/risc0-rust-starter). In that repo, `risc0-build` is used in the [`methods` directory](https://github.com/risc0/risc0-rust-starter/tree/main/methods).
 
 Guest methods are embedded for the host to use by calling [embed_methods] (or [embed_methods_with_options]) in a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html). An example `build.rs` file would look like
-```
+```no_run
 fn main() {
     risc0_build::embed_methods();
 }
 ```
 
 This requires including `risc0-build` as a _build_ dependency. You will also need add a `[package.metadata.risc0]` section to your cargo file. In this section, put a `methods` field with a list of relative paths containing the guest code. For example, if your guest code is in the `guest` directory, then `Cargo.toml` might include
-```
+```ignore
 [build-dependencies]
 risc0-build = "0.10"
 
@@ -25,19 +25,19 @@ methods = ["guest"]
 ```
 
 This builds a file `methods.rs` in your cargo output directory which you must then include for the host to use. For example, you might make a file `src/lib.rs` containing
-```
+```ignore
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));
 ```
 
 Inside the guest code directory (so `guest` in the above example), you must again create a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html), this time calling [link] to link the embedded methods into the generated `methods.rs` build file. An example `build.rs` file for this is
-```
+```no_run
 fn main() {
     risc0_build::link();
 }
 ```
 
 Since you are again using `risc0-build` as a build script, remember to include it as a build dependency here just like before:
-```
+```ignore
 [build-dependencies]
 risc0-build = "0.10"
 ```
@@ -45,6 +45,6 @@ risc0-build = "0.10"
 Don't forget to write your guest code as well!
 
 This process will generate a method ID (`*_ID`) and a path to an ELF file (`*_PATH`). The names will be derived from the name of the file containing the guest method, which will be converted to ALL_CAPS to comply with rust naming conventions. Thus, in the [starter example](https://github.com/risc0/risc0-rust-starter), where the guest method is in [`multiply.rs`](https://github.com/risc0/risc0-rust-starter/blob/main/methods/guest/src/bin/multiply.rs), the method ID is named `methods::MULTIPLY_ID` and the path to the ELF file is named `methods::MULTIPLY_PATH`. These are included at the beginning of the [host code](https://github.com/risc0/risc0-rust-starter/blob/main/starter/src/main.rs):
-```
+```ignore
 use methods::{MULTIPLY_ID, MULTIPLY_PATH};
 ```

--- a/risc0/zkvm/sdk/rust/build/README.md
+++ b/risc0/zkvm/sdk/rust/build/README.md
@@ -2,7 +2,7 @@
 
 Build RISC Zero zkVM guest code and provide handles to the host side
 
-In order for the host to execute guest code in the [RISC Zero zkVM](risc0_zkvm), the host must be provided an ELF file with RISC-V source code and the corresponding [MethodID](risc0_zkvm::host::MethodId). This crate contains the functions needed to take zkVM guest code written in rust, build a corresponding ELF file and MethodID, and make the MethodID and a path to the ELF file available for the host to use.
+In order for the host to execute guest code in the [RISC Zero zkVM](risc0_zkvm), the host must be provided a compiled RISC-V ELF file and the corresponding [MethodID](risc0_zkvm::host::MethodId). This crate contains the functions needed to take zkVM guest code, build a corresponding ELF file and MethodID, and make the MethodID and a path to the ELF file available for the host to use.
 
 ## Using risc0-build to build guest methods
 

--- a/risc0/zkvm/sdk/rust/build/README.md
+++ b/risc0/zkvm/sdk/rust/build/README.md
@@ -1,6 +1,45 @@
 # risc0-build
 
-This crate contains helper functions to assist with building guest side code,
-and using it in host side code.
+Build RISC Zero zkVM guest code and provide handles to the host side
 
-[TODO: Examples]
+In order for the host to execute guest code in the [RISC Zero zkVM](risc0_zkvm), the host must be provided an ELF file with RISC-V source code and the corresponding [MethodID](risc0_zkvm::host::MethodId). This crate contains the functions needed to take zkVM guest code written in rust, build a corresponding ELF file and MethodID, and make the MethodID and a path to the ELF file available for the host to use.
+
+## Using risc0-build to build guest methods
+
+Using this crate can be a bit delicate, so we encourage you to follow along in our [Risc Zero Rust Starter repository](https://github.com/risc0/risc0-rust-starter). In that repo, `risc0-build` is used in the [`methods` directory](https://github.com/risc0/risc0-rust-starter/tree/main/methods).
+
+Guest methods are embedded for the host to use by calling [embed_methods] (or [embed_methods_with_options]) in a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html). An example `build.rs` file would look like
+```
+fn main() {
+    risc0_build::embed_methods();
+}
+```
+
+This requires including `risc0-build` as a _build_ dependency. You will also need add a `[package.metadata.risc0]` section to your cargo file. In this section, put a `methods` field with a list of relative paths containing the guest code. For example, if your guest code is in the `guest` directory, then `Cargo.toml` might include
+```
+[build-dependencies]
+risc0-build = "0.10"
+
+[package.metadata.risc0]
+methods = ["guest"]
+```
+
+This builds a file `methods.rs` in your cargo output directory which you must then include for the host to use. For example, you might make a file `src/lib.rs` containing
+```
+include!(concat!(env!("OUT_DIR"), "/methods.rs"));
+```
+
+Inside the guest code directory (so `guest` in the above example), you must again create a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html), this time calling [link] to link the embedded methods into the generated `methods.rs` build file. An example `build.rs` file for this is
+```
+fn main() {
+    risc0_build::link();
+}
+```
+
+Since you are again using `risc0-build` as a build script, remember to include it as a build dependency here just like before:
+```
+[build-dependencies]
+risc0-build = "0.10"
+```
+
+Don't forget to include your guest code as well! (If you're following the [starter repository](https://github.com/risc0/risc0-rust-starter) example, it's in `src/build`.)

--- a/risc0/zkvm/sdk/rust/build/README.md
+++ b/risc0/zkvm/sdk/rust/build/README.md
@@ -42,4 +42,9 @@ Since you are again using `risc0-build` as a build script, remember to include i
 risc0-build = "0.10"
 ```
 
-Don't forget to include your guest code as well! (If you're following the [starter repository](https://github.com/risc0/risc0-rust-starter) example, it's in `src/build`.)
+Don't forget to write your guest code as well!
+
+This process will generate a method ID (`*_ID`) and a path to an ELF file (`*_PATH`). The names will be derived from the name of the file containing the guest method, which will be converted to ALL_CAPS to comply with rust naming conventions. Thus, in the [starter example](https://github.com/risc0/risc0-rust-starter), where the guest method is in [`multiply.rs`](https://github.com/risc0/risc0-rust-starter/blob/main/methods/guest/src/bin/multiply.rs), the method ID is named `methods::MULTIPLY_ID` and the path to the ELF file is named `methods::MULTIPLY_PATH`. These are included at the beginning of the [host code](https://github.com/risc0/risc0-rust-starter/blob/main/starter/src/main.rs):
+```
+use methods::{MULTIPLY_ID, MULTIPLY_PATH};
+```

--- a/risc0/zkvm/sdk/rust/guest/README.md
+++ b/risc0/zkvm/sdk/rust/guest/README.md
@@ -1,3 +1,31 @@
 # risc0-zkvm-guest
 
-This crate provides access to guest-side RISC-V APIs provided by the RISC Zero ZKVM.
+The RISC Zero ZKVM's guest-side RISC-V APIs.
+
+Code that is validated by the [RISC Zero zkVM](risc0_zkvm) is run inside the guest. In the minimal case, an entrypoint (the guest's "`main`" function) must be provided by calling [entry]. The code executed when the entrypoint function is called is what will be proven by the zkVM and available for verification later. In almost all practical cases, the guest will want to read private input data using [env::read] and commit public output data using [env::commit]; additional I/O functionality is also available in [mod@env].
+
+[comment]: # (TODO: The following would ideally be a reference to the starter example guest code, not a copy of it)
+
+For example[^starter-ex], the following guest code proves a number is composite by multiplying two unsigned integers, and panicking if either is `1` or if the multiplication overflows:
+```
+use risc0_zkvm_guest::env;
+
+risc0_zkvm_guest::entry!(main);
+
+pub fn main() {
+    // Load the first number from the host
+    let a: u64 = env::read();
+    // Load the second number from the host
+    let b: u64 = env::read();
+    // Verify that neither of them are 1 (i.e. nontrivial factors)
+    if a == 1 || b == 1 {
+        panic!("Trivial factors")
+    }
+    // Compute the product while being careful with integer overflow
+    let product = a.checked_mul(b).expect("Integer overflow");
+    env::commit(&product);
+}
+```
+Notice how [entry] is used to indicate the entrypoint, [env::read] is used to load the two factors, and [env::commit] is used to make their composite product publically available.
+
+[^starter-ex]: The example is based on the [Risc Zero Rust Starter repository](https://github.com/risc0/risc0-rust-starter). 

--- a/risc0/zkvm/sdk/rust/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/src/lib.rs
@@ -12,6 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! A virtual machine to produces ZK proofs of computation
+//!
+//! The RISC Zero zkVM is a RISC-V virtual machine that produces
+//! [zero-knowledge proofs](https://en.wikipedia.org/wiki/Zero-knowledge_proof)
+//! of code it executes. By using the zkVM, a cryptographic
+//! [Receipt](host::Receipt) is produced which anyone can verify was produced by
+//! the zkVM's guest code. No additional information about the code execution
+//! (such as, for example, the inputs provided) is revealed by publishing the
+//! [Receipt](host::Receipt). A high-level overview of how the zkVM is
+//! structured to accomplish this is available in our
+//! [Overview of the zkVM](https://www.risczero.com/docs/explainers/zkvm/zkvm_overview)
+//! explainer.
+//!
+//! Developers new to RISC Zero are encouraged to get started with our
+//! [Risc Zero Rust Starter repository](https://github.com/risc0/risc0-rust-starter),
+//! which provides an example of producing a zero-knowledge proof that a number
+//! is composite, along with an introduction to key components of the RISC Zero
+//! zkVM.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;


### PR DESCRIPTION
Add introductions for the risc0-zkvm, risc0-zkvm-guest, risc0-build, and risc0-make-id crates. The risc0-build introduction is the most complex of these, as that's where I explain how to correctly embed/build/link guest methods and access them from the host.