### PR TITLE
Expose "sendrecv" in rust SDK on both host and guest side

### DIFF
--- a/risc0/zkvm/r0vm/src/bin/r0vm.rs
+++ b/risc0/zkvm/r0vm/src/bin/r0vm.rs
@@ -115,8 +115,8 @@ fn main() {
         })
     };
 
-    let mut opts: ProverOpts = Default::default();
-    opts.skip_seal = args.skip_seal || args.receipt.is_none();
+    let opts: ProverOpts =
+        ProverOpts::default().with_skip_seal(args.skip_seal || args.receipt.is_none());
 
     let mut prover =
         Prover::new_with_opts(&elf_contents, method_id.as_slice().unwrap(), opts).unwrap();

--- a/risc0/zkvm/sdk/cpp/host/c_api.h
+++ b/risc0/zkvm/sdk/cpp/host/c_api.h
@@ -34,6 +34,7 @@ typedef struct risc0_string risc0_string;
 typedef struct risc0_prover risc0_prover;
 typedef struct risc0_receipt risc0_receipt;
 typedef struct risc0_method_id risc0_method_id;
+typedef struct risc0_u8buffer risc0_u8buffer;
 
 //
 // Error
@@ -50,6 +51,11 @@ typedef struct {
 const char* risc0_string_ptr(risc0_string* str);
 
 void risc0_string_free(risc0_string* str);
+
+//
+// U8buffer
+
+risc0_u8buffer* risc0_u8buffer_new(const uint8_t* bytes, size_t len);
 
 //
 // Library
@@ -91,7 +97,14 @@ size_t risc0_prover_get_output_len(risc0_error* err, const risc0_prover* ptr);
 
 risc0_receipt* risc0_prover_run(risc0_error* err, risc0_prover* ptr);
 
-risc0_receipt* risc0_prover_run_without_seal(risc0_error* err, risc0_prover* ptr);
+void risc0_prover_set_skip_seal(risc0_error* err, risc0_prover* ptr, bool skip_seal);
+
+void risc0_prover_set_sendrecv_handler(
+    risc0_error* err,
+    risc0_prover* ptr,
+    uint32_t channel_id,
+    risc0_u8buffer* (*callback)(uint32_t channel_id, const uint8_t* buf, size_t len, void* cbdata),
+    void* cbdata);
 
 //
 // Receipt

--- a/risc0/zkvm/sdk/cpp/host/receipt.h
+++ b/risc0/zkvm/sdk/cpp/host/receipt.h
@@ -21,6 +21,7 @@
 #include "risc0/zkvm/prove/step.h"
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -76,7 +77,7 @@ class Prover {
 public:
   Prover(const uint8_t* bytes, size_t len, const MethodId& methodId);
   Prover(std::vector<uint8_t> elfContents, const MethodId& methodId);
-  Prover(const std::string& elfFile, const MethodId& method_id);
+  Prover(const std::string& elfFile, const MethodId& methodId);
   ~Prover();
 
   // Allows access to key store to get/set keys
@@ -108,11 +109,10 @@ public:
   // method was run correctly.
   Receipt run();
 
-  // Run the method without generating a seal containing the proof of
-  // correct execution.  This is significantly faster than run(), but
-  // does not provide any of the cryptographic guarantees so should
-  // only be used for testing.
-  Receipt runWithoutSeal();
+  void setSkipSeal(bool skipSeal) { skip_seal = skipSeal; }
+  void setSendRecvHandler(
+      uint32_t channelId,
+      const std::function<BufferU8(uint32_t /* channelId*/, const BufferU8&)>& handler);
 
 private:
   Prover() = default;
@@ -124,6 +124,7 @@ private:
 private:
   struct Impl;
   std::unique_ptr<Impl> impl;
+  bool skip_seal = false;
 };
 
 } // namespace risc0

--- a/risc0/zkvm/sdk/rust/benches/guest_run.rs
+++ b/risc0/zkvm/sdk/rust/benches/guest_run.rs
@@ -39,10 +39,12 @@ use risc0_zkvm_methods::{
 fn run_guest(spec: SpecWithIters) -> Duration {
     let input_data: Vec<u32> = to_vec(&spec).unwrap();
 
-    let mut opts: ProverOpts = ProverOpts::default();
-    opts.skip_seal = true;
-    let mut prover =
-        Prover::new_with_opts(&std::fs::read(BENCH_PATH).unwrap(), BENCH_ID, opts).unwrap();
+    let mut prover = Prover::new_with_opts(
+        &std::fs::read(BENCH_PATH).unwrap(),
+        BENCH_ID,
+        ProverOpts::default().with_skip_seal(true),
+    )
+    .unwrap();
     prover.add_input(input_data.as_slice()).unwrap();
 
     let start = Instant::now();

--- a/risc0/zkvm/sdk/rust/guest/src/env.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/env.rs
@@ -17,17 +17,14 @@ use core::{cell::UnsafeCell, mem::MaybeUninit, slice};
 use risc0_zkp::core::sha::Digest;
 use risc0_zkvm::{
     platform::{
-        io::{
-            host_sendrecv, IoDescriptor, GPIO_COMMIT, SENDRECV_CHANNEL_INITIAL_INPUT,
-            SENDRECV_CHANNEL_STDOUT,
-        },
+        io::{IoDescriptor, GPIO_COMMIT, SENDRECV_CHANNEL_INITIAL_INPUT, SENDRECV_CHANNEL_STDOUT},
         memory, WORD_SIZE,
     },
     serde::{Deserializer, Serializer, Slice},
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{align_up, memory_barrier, sha};
+use crate::{align_up, io::host_sendrecv, memory_barrier, sha};
 
 struct Env {
     output: Serializer<Slice<'static>>,

--- a/risc0/zkvm/sdk/rust/guest/src/io.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/io.rs
@@ -1,0 +1,46 @@
+use core::cell::UnsafeCell;
+
+use risc0_zkvm::platform::{
+    io::{
+        IoDescriptor, GPIO_COMMIT, GPIO_SENDRECV_ADDR, GPIO_SENDRECV_CHANNEL, GPIO_SENDRECV_SIZE,
+        SENDRECV_CHANNEL_INITIAL_INPUT, SENDRECV_CHANNEL_STDOUT,
+    },
+    memory, WORD_SIZE,
+};
+
+// Current offset in number of words from the INPUT memory region that
+// we're reading,
+static mut READ_PTR: UnsafeCell<usize> = UnsafeCell::new(0);
+
+/// Interacts with the host.  'channel' specifies the ZKVM channel to
+/// use, and 'buf' provides the data to tsend to the host.
+///
+/// The returned tuple contains a slice of 32-bit words from the host,
+/// and a size in bytes of the returned data.  The size in bytes might
+/// not match the length of the returned slice * WORD_SIZE in the case
+/// that the returned buffer does not fall on a word boundry.
+pub fn host_sendrecv(channel: u32, buf: &[u8]) -> (&'static [u32], usize) {
+    // SAFETY: Single threaded, so it's ok to borrow READ_PTR while in this routine.
+    let read_ptr: &mut usize = unsafe { &mut *READ_PTR.get() };
+
+    // Tell the host to execute the sendrecv.
+    unsafe {
+        GPIO_SENDRECV_CHANNEL.as_ptr().write_volatile(channel);
+        GPIO_SENDRECV_SIZE.as_ptr().write_volatile(buf.len());
+        GPIO_SENDRECV_ADDR.as_ptr().write_volatile(buf.as_ptr());
+    }
+
+    // Receive
+    let read_start: *const u32 = memory::INPUT.start() as _;
+    let response_nbytes = unsafe { read_start.add(*read_ptr).read_volatile() } as usize;
+    *read_ptr += 1;
+    let response_nwords = (response_nbytes + WORD_SIZE - 1) / WORD_SIZE;
+
+    assert!(*read_ptr + response_nwords < memory::INPUT.len_words());
+    // SAFETY: This region is in the INPUT region and we just did a bounds check.
+    let response_data =
+        unsafe { core::slice::from_raw_parts(read_start.add(*read_ptr), response_nwords) };
+    *read_ptr += response_nwords;
+
+    (response_data, response_nbytes)
+}

--- a/risc0/zkvm/sdk/rust/guest/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/lib.rs
@@ -31,6 +31,9 @@ pub mod env;
 /// Functions for computing SHA-256 hashes.
 pub mod sha;
 
+/// Functions for handling input and output
+pub mod io;
+
 use core::{arch::asm, mem, panic::PanicInfo, ptr};
 
 extern "C" {

--- a/risc0/zkvm/sdk/rust/methods/inner/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/methods/inner/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bytemuck = "1.11.0"
 risc0-zkp = { version = "0.10", path = "../../../../../zkp/rust", default-features = false }
 risc0-zkvm-guest = { version = "0.10", path = "../../guest", default-features = false, features = ["std"] }
 risc0-zkvm-methods = { version = "0.1", path = "..", default-features = false }

--- a/risc0/zkvm/sdk/rust/methods/inner/src/bin/sendrecv.rs
+++ b/risc0/zkvm/sdk/rust/methods/inner/src/bin/sendrecv.rs
@@ -1,0 +1,35 @@
+// Copyright 2022 Risc0, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use risc0_zkvm_guest::{env, io::host_sendrecv};
+
+risc0_zkvm_guest::entry!(main);
+
+pub fn main() {
+    let channel_id = env::read();
+    let count = env::read();
+
+    let mut input : &[u8] = &[];
+    let mut input_len : usize = 0;
+    
+    for _ in 0..count {
+        let (host_data, host_len) = host_sendrecv(channel_id, &input[..input_len]);
+
+        input = bytemuck::cast_slice(host_data);
+        input_len = host_len;
+    }
+}

--- a/risc0/zkvm/sdk/rust/platform/src/io.rs
+++ b/risc0/zkvm/sdk/rust/platform/src/io.rs
@@ -15,6 +15,8 @@
 // These must match the values in zkvm/platform/io.h.  See this file
 // for documentation on these GPIO ports.
 
+use core::marker::PhantomData;
+
 pub struct Gpio<T> {
     addr: u32,
     _marker: PhantomData<T>,
@@ -84,61 +86,3 @@ pub struct GetKeyDescriptor {
 pub const SENDRECV_CHANNEL_INITIAL_INPUT: u32 = 0;
 pub const SENDRECV_CHANNEL_STDOUT: u32 = 1;
 pub const SENDRECV_CHANNEL_STDERR: u32 = 2;
-
-#[cfg(target_os = "zkvm")]
-mod guest {
-    use crate::{memory, WORD_SIZE};
-    use core::cell::UnsafeCell;
-
-    // Current offset in number of words from the INPUT memory region that
-    // we're reading,
-    static mut READ_PTR: UnsafeCell<usize> = UnsafeCell::new(0);
-
-    /// Interacts with the host.  'channel' specifies the ZKVM channel to
-    /// use, and 'buf' provides the data to tsend to the host.
-    ///
-    /// The returned tuple contains a slice of 32-bit words from the host,
-    /// and a size in bytes of the returned data.  The size in bytes might
-    /// not match the length of the returned slice * WORD_SIZE in the case
-    /// that the returned buffer does not fall on a word boundry.
-    pub fn host_sendrecv(channel: u32, buf: &[u8]) -> (&'static [u32], usize) {
-        // SAFETY: Single threaded, so it's ok to borrow READ_PTR while in this routine.
-        let read_ptr: &mut usize = unsafe { &mut *READ_PTR.get() };
-
-        // Tell the host to execute the sendrecv.
-        unsafe {
-            super::GPIO_SENDRECV_CHANNEL
-                .as_ptr()
-                .write_volatile(channel);
-            super::GPIO_SENDRECV_SIZE.as_ptr().write_volatile(buf.len());
-            super::GPIO_SENDRECV_ADDR
-                .as_ptr()
-                .write_volatile(buf.as_ptr());
-        }
-
-        // Receive
-        let read_start: *const u32 = memory::INPUT.start() as _;
-        let response_nbytes = unsafe { read_start.add(*read_ptr).read_volatile() } as usize;
-        *read_ptr += 1;
-        let response_nwords = (response_nbytes + WORD_SIZE - 1) / WORD_SIZE;
-
-        assert!(*read_ptr + response_nwords < memory::INPUT.len_words());
-        // SAFETY: This region is in the INPUT region and we just did a bounds check.
-        let response_data =
-            unsafe { core::slice::from_raw_parts(read_start.add(*read_ptr), response_nwords) };
-        *read_ptr += response_nwords;
-
-        (response_data, response_nbytes)
-    }
-}
-
-#[cfg(not(target_os = "zkvm"))]
-mod guest {
-    pub fn host_sendrecv(_channel: u32, _buf: &[u8]) -> (&'static [u32], usize) {
-        unimplemented!()
-    }
-}
-
-use core::marker::PhantomData;
-
-pub use guest::*;

--- a/risc0/zkvm/sdk/rust/src/prove/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/prove/mod.rs
@@ -23,6 +23,7 @@ use risc0_zkp::{
 
 use crate::{
     elf::Program,
+    host::ProverOpts,
     method_id::MethodId,
     platform::{
         io::{SENDRECV_CHANNEL_INITIAL_INPUT, SENDRECV_CHANNEL_STDERR, SENDRECV_CHANNEL_STDOUT},
@@ -33,19 +34,19 @@ use crate::{
 
 use self::exec::{IoHandler, RV32Executor};
 
-pub struct Prover {
+pub struct Prover<'a> {
     elf: Program,
     inner: ProverImpl,
     method_id: MethodId,
-    opts: ProverOpts,
+    opts: ProverOpts<'a>,
 }
 
-impl Prover {
+impl<'a> Prover<'a> {
     pub fn new(elf: &[u8], method_id: &[u8]) -> Result<Self> {
         Self::new_with_opts(elf, method_id, ProverOpts::default())
     }
 
-    pub fn new_with_opts(elf: &[u8], method_id: &[u8], opts: ProverOpts) -> Result<Self> {
+    pub fn new_with_opts(elf: &[u8], method_id: &[u8], opts: ProverOpts<'a>) -> Result<Self> {
         Ok(Prover {
             elf: Program::load_elf(&elf, MEM_SIZE as u32)?,
             inner: ProverImpl::new(),
@@ -135,14 +136,4 @@ impl IoHandler for ProverImpl {
     fn on_fault(&mut self, msg: &str) {
         panic!("{}", msg);
     }
-}
-
-/// Options available to modify the prover's behavior.
-#[non_exhaustive]
-#[derive(Default, Debug, Clone, Copy)]
-pub struct ProverOpts {
-    /// Skip generating the seal in receipt.  This should only be used
-    /// for testing.  In this case, performace will be much better but
-    /// we will not be able to cryptographically verify the execution.
-    pub skip_seal: bool,
 }


### PR DESCRIPTION
* ProverOpts now uses builder pattern