### PR TITLE
Bump rust-toolchain to nightly-2022-06-20

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-06-13"
+channel = "nightly-2022-06-20"
 components = [ "rustfmt", "rust-src" ]
 profile = "minimal"


### PR DESCRIPTION
This is necessary to deal with `camino = 1.0.10` that just landed, which relies on some features that appear in rust `1.63`, but weren't added until at least `2022-06-15`