### PR TITLE
Fix spelling of pseudo

### DIFF
--- a/risc0/core/rng.cpp
+++ b/risc0/core/rng.cpp
@@ -20,7 +20,7 @@ extern uint32_t get_random_u32();
 
 namespace risc0 {
 
-PsuedoRng::PsuedoRng() {
+PseudoRng::PseudoRng() {
   static uint64_t seed = CryptoRng::shared().generate();
   static bool logged = false;
   if (!logged) {

--- a/risc0/core/rng.h
+++ b/risc0/core/rng.h
@@ -29,13 +29,13 @@ namespace risc0 {
 /// Uses `std::mt19937_64` under the hood.
 /// Basically, only really used for tests.
 /// For this reason, when default constructed, it pick and log a per-process seed.
-class PsuedoRng {
+class PseudoRng {
 public:
   /// Seed with a process specific seed, log on first construction.
-  PsuedoRng();
+  PseudoRng();
 
   /// Construct a reproducable PRNG with a specific seed.
-  explicit PsuedoRng(uint64_t seed) : state_(seed) {}
+  explicit PseudoRng(uint64_t seed) : state_(seed) {}
 
   /// Generate a random 32-bit value uniformly selected over all values.
   uint32_t generate() { return static_cast<uint32_t>(state_()); }

--- a/risc0/zkp/accel/test/ntt.cpp
+++ b/risc0/zkp/accel/test/ntt.cpp
@@ -32,7 +32,7 @@ void testNTT(const char* name,
   std::vector<Fp> b(size * count);
   LOG(1, "Testing " << name);
   {
-    PsuedoRng rng(2);
+    PseudoRng rng(2);
     LOG(1, "Randomizing");
     AccelReadWriteLock cpuA(a);
     for (size_t i = 0; i < size * count; i++) {

--- a/risc0/zkp/accel/test/test_accel.h
+++ b/risc0/zkp/accel/test/test_accel.h
@@ -27,7 +27,7 @@ void testAccelUnary(const char* name, AccelFunc accelFunc, CpuFunc cpuFunc, size
   LOG(1, "Testing " << name);
   std::vector<T> goldenOut(count);
   {
-    PsuedoRng rng(2);
+    PseudoRng rng(2);
     LOG(1, "Randomizing");
     AccelReadWriteLock cpuA(a);
     for (size_t i = 0; i < count; i++) {
@@ -63,7 +63,7 @@ void testAccelBinary(const char* name, AccelFunc accelFunc, CpuFunc cpuFunc, siz
   LOG(1, "Testing " << name);
   std::vector<T> goldenOut(count);
   {
-    PsuedoRng rng(2);
+    PseudoRng rng(2);
     LOG(1, "Randomizing");
     AccelReadWriteLock cpuA(a);
     AccelReadWriteLock cpuB(b);

--- a/risc0/zkp/core/bench/benchmark.cpp
+++ b/risc0/zkp/core/bench/benchmark.cpp
@@ -24,7 +24,7 @@ static void BM_Interpolate_NTT(benchmark::State& state) {
   size_t size = 1 << n;
 
   std::vector<Fp> buf(size);
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   for (size_t i = 0; i < size; i++) {
     buf[i] = Fp::random(rng);
   }

--- a/risc0/zkp/core/test/fp.cpp
+++ b/risc0/zkp/core/test/fp.cpp
@@ -21,7 +21,7 @@ namespace risc0 {
 
 // Compare core operations against simple % P implementations
 TEST(Fp, FpCompareNative) {
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   for (size_t i = 0; i < 100000; i++) {
     Fp fa = Fp::random(rng);
     Fp fb = Fp::random(rng);

--- a/risc0/zkp/core/test/fp4.cpp
+++ b/risc0/zkp/core/test/fp4.cpp
@@ -20,7 +20,7 @@
 namespace risc0 {
 
 TEST(Fp4, IsaField) {
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   // Pick random sets of 3 elements of Fp4, and verify they meet the requirements of a field.
   for (size_t i = 0; i < 1000000; i++) {
     Fp4 a = Fp4::random(rng);

--- a/risc0/zkp/core/test/ntt.cpp
+++ b/risc0/zkp/core/test/ntt.cpp
@@ -27,7 +27,7 @@ TEST(NTT, CmpEvaluate) {
   size_t size = (1 << N);
   std::vector<Fp> in(size);
   // Randomly fill input
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   for (size_t i = 0; i < size; i++) {
     in[i] = Fp::random(rng);
   }
@@ -59,7 +59,7 @@ TEST(NTT, Roundtrip) {
   size_t size = (1 << N);
   std::vector<Fp> buf(size);
   // Randomly fill buffer
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   for (size_t i = 0; i < size; i++) {
     buf[i] = Fp::random(rng);
   }
@@ -82,7 +82,7 @@ TEST(NTT, Expand) {
   size_t sizeOut = (1 << N);
   std::vector<Fp> cmp(sizeIn);
   std::vector<Fp> buf(sizeOut);
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   for (size_t i = 0; i < sizeIn; i++) {
     cmp[i] = Fp::random(rng);
   }

--- a/risc0/zkp/core/test/sha256.cpp
+++ b/risc0/zkp/core/test/sha256.cpp
@@ -69,7 +69,7 @@ TEST(Sha256, TestVectors) {
 
 TEST(Sha256, compareFpVsBytes) {
   // Try sizes 0 - 100 for variety
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   for (size_t i = 0; i < 100; i++) {
     // Make a vector of fp values and their 'stringified' form
     std::vector<Fp> vals(i);

--- a/risc0/zkp/prove/test/fri.cpp
+++ b/risc0/zkp/prove/test/fri.cpp
@@ -40,7 +40,7 @@ TEST(Prove, FRI) {
   size_t deg = 8192;
   size_t domain = deg * kInvRate;
   // Make a random polynomial
-  PsuedoRng rng(3);
+  PseudoRng rng(3);
   LOG(1, "Making random poly, in 'colwise' Fp4");
   auto poly = AccelSlice<Fp>::allocate(deg * 4);
   {

--- a/risc0/zkp/prove/test/merkle.cpp
+++ b/risc0/zkp/prove/test/merkle.cpp
@@ -21,7 +21,7 @@
 
 namespace risc0 {
 
-void doTest(PsuedoRng& rng, size_t rowSize, size_t colSize, size_t queries) {
+void doTest(PseudoRng& rng, size_t rowSize, size_t colSize, size_t queries) {
   LOG(1, "Testing rowSize = " << rowSize << ", colSize = " << colSize << ", queries = " << queries);
   // Make some leaves
   auto leavesAccel = AccelSlice<Fp>::allocate(rowSize * colSize);
@@ -90,7 +90,7 @@ void doTest(PsuedoRng& rng, size_t rowSize, size_t colSize, size_t queries) {
 }
 
 TEST(Crypto, Merkle) {
-  PsuedoRng rng(2);
+  PseudoRng rng(2);
   doTest(rng, 1, 1, 1);
   doTest(rng, 4, 4, 2);
   auto logish = [&]() {


### PR DESCRIPTION
Fix the name of the class `PseudoRng` to be correctly spelled.