### PR TITLE
Clean up Sha implementations in Zkp

### DIFF
--- a/Cargo-guest.lock
+++ b/Cargo-guest.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "array-init"
@@ -25,18 +25,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd2f4180c5721da6335cc9e9061cce522b87a35e51cc57636d28d22a9863c80"
+checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "log"

--- a/Cargo-host.lock
+++ b/Cargo-host.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "array-init"
@@ -127,24 +127,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "bytemuck"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd2f4180c5721da6335cc9e9061cce522b87a35e51cc57636d28d22a9863c80"
+checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -553,9 +553,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -997,9 +997,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "link-cplusplus"
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "oorandom"
@@ -1597,6 +1597,7 @@ dependencies = [
  "rand",
  "rand_core",
  "rayon",
+ "risc0-zkvm-platform",
  "serde",
  "sha2",
 ]

--- a/risc0/zkp/rust/BUILD.bazel
+++ b/risc0/zkp/rust/BUILD.bazel
@@ -9,6 +9,7 @@ risc0_rust_library_pair(
     crate_name = "risc0_zkp",
     data = glob(["**/README.md"]),
     guest_deps = [
+        "//risc0/zkvm/sdk/rust/platform:platform_guest",
         "@crates_guest//:anyhow",
         "@crates_guest//:bytemuck",
         "@crates_guest//:rand",

--- a/risc0/zkp/rust/Cargo.toml
+++ b/risc0/zkp/rust/Cargo.toml
@@ -25,6 +25,9 @@ rayon = { version = "1.5", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10", default-features = false, features = ["compress"] }
 
+[target.'cfg(target_os = "zkvm")'.dependencies]
+risc0-zkvm-platform = { version = "0.11", path = "../../zkvm/sdk/rust/platform" }
+
 [dev-dependencies]
 criterion = "0.3"
 rand = { version = "0.8", features = ["small_rng"] }

--- a/risc0/zkp/rust/src/core/mod.rs
+++ b/risc0/zkp/rust/src/core/mod.rs
@@ -37,9 +37,13 @@ pub mod fp4 {
 pub mod ntt;
 pub mod poly;
 pub mod rou;
-pub mod sha;
-pub mod sha_cpu;
 pub mod sha_rng;
+
+pub mod sha;
+#[cfg(not(target_os = "zkvm"))]
+pub(crate) mod sha_cpu;
+#[cfg(target_os = "zkvm")]
+mod sha_zkvm;
 
 /// For x = (1 << po2), given x, find po2.
 pub fn to_po2(x: usize) -> usize {

--- a/risc0/zkp/rust/src/core/sha.rs
+++ b/risc0/zkp/rust/src/core/sha.rs
@@ -14,30 +14,30 @@
 
 //! Simple SHA-256 wrappers.
 
-use alloc::{string::String, vec::Vec};
+use alloc::{borrow::Cow, string::String, vec::Vec};
 use core::{
     fmt::{Debug, Display, Formatter},
     mem,
-    ops::Deref,
 };
 
-use anyhow::{Error, Result};
+use anyhow::{bail, Error, Result};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
 
-use super::{fp::Fp, fp4::Fp4};
-
-/// The number of words represented by a [Digest].
-// We represent a SHA-256 digest as 8 32-bit words instead of the
-// traditional 32 8-bit bytes.
+/// The number of words represented by a [Digest].  We represent a
+/// SHA-256 digest as 8 32-bit words instead of the traditional 32
+/// 8-bit bytes.
 pub const DIGEST_WORDS: usize = 8;
 
 /// The size of a word within a [Digest] (32-bits = 4 bytes).
 pub const DIGEST_WORD_SIZE: usize = mem::size_of::<u32>();
 
+/// The number of words in a SHA block.  When using hash_raw_words,
+/// you can avoid a copy by making sure the number of words is a
+/// multiple of BLOCK_WORDS.
+pub const BLOCK_WORDS: usize = 16;
+
 /// The result of a SHA-256 hashing function.
-// TODO(nils): Remove 'Copy' trait on Digest; these are not small and
-// we don't want to copy them around accidentally.
 #[derive(Eq, PartialEq, Copy, Zeroable, Pod, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct Digest([u32; DIGEST_WORDS]);
@@ -93,20 +93,20 @@ impl Digest {
             .flat_map(|byte| [hex(byte >> 4), hex(byte & 0xF)])
             .collect()
     }
-
-    /// Converts a hexadecimal string into a [Digest].
-    pub fn from_str(s: &str) -> Digest {
-        s.into()
-    }
 }
 
-impl From<&str> for Digest {
-    fn from(s: &str) -> Digest {
-        let words: Vec<u32> = (0..DIGEST_WORDS)
+/// Converts a hexadecimal string into a [Digest].
+impl TryFrom<&str> for Digest {
+    type Error = anyhow::Error;
+    fn try_from(s: &str) -> Result<Digest> {
+        if s.len() != DIGEST_WORDS * DIGEST_WORD_SIZE * 2 {
+            bail!("Expected {DIGEST_WORDS} words in {s}");
+        }
+        let words: Result<Vec<u32>> = (0..DIGEST_WORDS)
             .into_iter()
-            .map(|x| u32::from_str_radix(&s[x * 8..(x + 1) * 8], 16).unwrap())
+            .map(|x| u32::from_str_radix(&s[x * 8..(x + 1) * 8], 16).map_err(Error::msg))
             .collect();
-        Digest::new(words.try_into().unwrap())
+        Self::try_from_slice(words?.as_slice())
     }
 }
 
@@ -140,47 +140,35 @@ impl Clone for Digest {
     }
 }
 
-/// An implementation that provides SHA-256 hashing services.
-pub trait Sha: Clone + Debug {
-    /// A pointer to the created digest.
-    ///
-    /// This may either be a Box<Digest> or some other pointer in case the
-    /// implementation wants to manage its own memory.
-    type DigestPtr: Deref<Target = Digest> + Debug;
+#[cfg(target_os = "zkvm")]
+use super::sha_zkvm as sha_impl;
 
-    /// Generate a SHA from a slice of bytes.
-    fn hash_bytes(&self, bytes: &[u8]) -> Self::DigestPtr;
+#[cfg(not(target_os = "zkvm"))]
+use super::sha_cpu as sha_impl;
 
-    /// Generate a SHA from a slice of words.
-    fn hash_words(&self, words: &[u32]) -> Self::DigestPtr {
-        self.hash_bytes(bytemuck::cast_slice(words) as &[u8])
-    }
-
-    /// Generate a SHA from a slice of words without adding padding or
-    /// length.
-    fn hash_raw_words(&self, words: &[u32]) -> Self::DigestPtr;
-
-    /// Generate a SHA from a pair of [Digests](Digest).
-    fn hash_pair(&self, a: &Digest, b: &Digest) -> Self::DigestPtr;
-
-    /// Generate a SHA from a slice of [Fps](Fp).
-    fn hash_fps(&self, fps: &[Fp]) -> Self::DigestPtr;
-
-    /// Generate a SHA from a slice of [Fp4s](Fp4).
-    fn hash_fp4s(&self, fp4s: &[Fp4]) -> Self::DigestPtr;
-
-    /// Generate a new digest by mixing two digests together via XOR,
-    /// and storing into the first digest.
-    fn mix(&self, pool: &mut Self::DigestPtr, val: &Digest);
+/// Generate a SHA from a slice of bytes.
+pub fn hash_bytes(bytes: &[u8]) -> Cow<Digest> {
+    sha_impl::hash_bytes(bytes)
 }
 
-// Default implementation is CPU-based.
-pub use super::sha_cpu::Impl as DefaultImplementation;
+/// Generate a SHA from a slice of words without adding the size at
+/// the end.  If needed, zero padding is still added to pad the data
+/// to a multiple of BLOCK_WORDS.
+pub fn hash_raw_words(words: &[u32]) -> Cow<'static, Digest> {
+    sha_impl::hash_raw_words(words)
+}
 
-/// Return the default implementation of a [Sha].
-pub fn default_implementation() -> &'static DefaultImplementation {
-    static DEFAULT_IMPLEMENTATION: DefaultImplementation = DefaultImplementation {};
-    &DEFAULT_IMPLEMENTATION
+/// Generate a SHA from a pair of [Digests](Digest).
+pub fn hash_pair(a: &Digest, b: &Digest) -> Cow<'static, Digest> {
+    sha_impl::hash_pair(a, b)
+}
+
+/// Generate a new digest by mixing two digests together via XOR,
+/// and stores it back in the pool.
+pub fn digest_mix(pool: &mut Digest, val: &Digest) {
+    for (pool_word, val_word) in pool.get_mut().iter_mut().zip(val.get()) {
+        *pool_word ^= *val_word;
+    }
 }
 
 #[cfg(test)]
@@ -190,7 +178,8 @@ mod tests {
     #[test]
     fn test_from_str() {
         assert_eq!(
-            Digest::from_str("00000077000000AA0000001200000034000000560000007a000000a900000009"),
+            Digest::try_from("00000077000000AA0000001200000034000000560000007a000000a900000009")
+                .unwrap(),
             Digest::new([119, 170, 18, 52, 86, 122, 169, 9])
         );
     }
@@ -198,44 +187,45 @@ mod tests {
 
 #[allow(missing_docs)]
 pub mod testutil {
-    use super::{Digest, Fp, Fp4, Sha};
-    use alloc::vec::Vec;
+    use alloc::{borrow::Cow, vec::Vec};
 
-    // Runs conformance test on a SHA implementation to make sure it properly
-    // behaves.
-    pub fn test_sha_impl<S: Sha>(sha: &S) {
-        test_hash_pair(sha);
-        test_sha_basics(sha);
-        test_fps(sha);
-        test_fp4s(sha);
+    use super::{hash_bytes, hash_pair, hash_raw_words, Digest};
 
-        crate::core::sha_rng::testutil::test_sha_rng_impl(sha);
+    // Runs conformance test on a SHA implementation to make sure it
+    // properly behaves.  This is purposefully not behind #[cfg(test)]
+    // so that it can be run in a zkvm guest.
+    pub fn test_sha_impl() {
+        test_hash_pair();
+        test_sha_basics();
+        test_raw_words();
+
+        crate::core::sha_rng::testutil::test_sha_rng_impl();
     }
 
-    fn test_sha_basics<S: Sha>(sha: &S) {
+    fn test_sha_basics() {
         // Standard test vectors
         assert_eq!(
-            *sha.hash_bytes("abc".as_bytes()),
+            *hash_bytes("abc".as_bytes()),
             Digest::new([
                 0xba7816bf, 0x8f01cfea, 0x414140de, 0x5dae2223, 0xb00361a3, 0x96177a9c, 0xb410ff61,
                 0xf20015ad
             ])
         );
         assert_eq!(
-            *sha.hash_bytes("".as_bytes()),
+            *hash_bytes("".as_bytes()),
             Digest::new([
                 0xe3b0c442, 0x98fc1c14, 0x9afbf4c8, 0x996fb924, 0x27ae41e4, 0x649b934c, 0xa495991b,
                 0x7852b855
             ])
         );
         assert_eq!(
-            *sha.hash_bytes("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_bytes()),
+            *hash_bytes("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_bytes()),
             Digest::new([
                 0x248d6a61, 0xd20638b8, 0xe5c02693, 0x0c3e6039, 0xa33ce459, 0x64ff2167, 0xf6ecedd4,
                 0x19db06c1
             ])
         );
-        assert_eq!(*sha.hash_bytes(
+        assert_eq!(*hash_bytes(
             "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" .as_bytes()),
             Digest::new([0xcf5b16a7,
                        0x78af8380,
@@ -250,32 +240,17 @@ pub mod testutil {
         // >>> hashlib.sha256("Byzantium").hexdigest()
         // 'f75c763b4a52709ac294fc7bd7cf14dd45718c3d50b36f4732b05b8c6017492a'
         assert_eq!(
-            sha.hash_bytes(&"Byzantium".as_bytes()).to_hex(),
+            hash_bytes(&"Byzantium".as_bytes()).to_hex(),
             "f75c763b4a52709ac294fc7bd7cf14dd45718c3d50b36f4732b05b8c6017492a"
         );
     }
 
-    fn hash_fpvec<S: Sha>(sha: &S, len: usize) -> Digest {
-        let items: Vec<Fp> = (0..len as u32).into_iter().map(|x| Fp::new(x)).collect();
-        *sha.hash_fps(items.as_slice())
+    fn hash_rawvec(len: usize) -> Cow<'static, Digest> {
+        let items: Vec<u32> = (0..len as u32).into_iter().collect();
+        hash_raw_words(items.as_slice())
     }
 
-    fn hash_fp4vec<S: Sha>(sha: &S, len: usize) -> Digest {
-        let items: Vec<Fp4> = (0..len as u32)
-            .into_iter()
-            .map(|x| {
-                Fp4::new(
-                    Fp::new(x * 4),
-                    Fp::new(x * 4 + 1),
-                    Fp::new(x * 4 + 2),
-                    Fp::new(x * 4 + 3),
-                )
-            })
-            .collect();
-        *sha.hash_fp4s(items.as_slice())
-    }
-
-    fn test_fps<S: Sha>(sha: &S) {
+    fn test_raw_words() {
         const LENS: &[usize] = &[0, 1, 7, 8, 9];
         const EXPECTED_STRS: &[&str] = &[
             "6a09e667bb67ae853c6ef372a54ff53a510e527f9b05688c1f83d9ab5be0cd19",
@@ -285,37 +260,28 @@ pub mod testutil {
             "ab57060d5b4b27718986483158dcf069e87ba7a52f6bf960d49f6d305b733281",
         ];
 
-        let expected: Vec<Digest> = EXPECTED_STRS.iter().map(|x| Digest::from_str(x)).collect();
-        let actual: Vec<Digest> = LENS.iter().map(|x| hash_fpvec(sha, *x)).collect();
+        let expected: Vec<Digest> = EXPECTED_STRS
+            .iter()
+            .map(|&x| Digest::try_from(x).unwrap())
+            .collect();
+        let actual: Vec<Digest> = LENS.iter().map(|x| *hash_rawvec(*x)).collect();
         assert_eq!(expected, actual);
     }
 
-    fn test_fp4s<S: Sha>(sha: &S) {
-        const LENS: &[usize] = &[0, 1, 7, 8, 9];
-        const EXPECTED_STRS: &[&str] = &[
-            "6a09e667bb67ae853c6ef372a54ff53a510e527f9b05688c1f83d9ab5be0cd19",
-            "04fcce36de1b9c057f7d11c89cd35fc7cec7fa8058764d15119ffdfb7c16d54b",
-            "d136c9e9616ef6dcc57dd20cc85a5df366177fe48b14a367a773c888b6382dc4",
-            "2f0b744a280f1700f6fa0ca5c51cbb51054ceb2c11460e1f04cb906b552e1e6d",
-            "08aa99c90d0cb74713d13f7451b0d2c0257a7716d5164b15f4a855fc54573ef1",
-        ];
-
-        let expected: Vec<Digest> = EXPECTED_STRS.iter().map(|x| Digest::from_str(x)).collect();
-        let actual: Vec<Digest> = LENS.iter().map(|x| hash_fp4vec(sha, *x)).collect();
-        assert_eq!(expected, actual);
-    }
-
-    fn test_hash_pair<S: Sha>(sha: &S) {
+    fn test_hash_pair() {
         assert_eq!(
-            *sha.hash_pair(
-                &Digest::from_str(
+            *hash_pair(
+                &Digest::try_from(
                     "6a09e667bb67ae853c6ef372a54ff53a510e527f9b05688c1f83d9ab5be0cd19"
-                ),
-                &Digest::from_str(
+                )
+                .unwrap(),
+                &Digest::try_from(
                     "ed375cadc653bb9078cee904acee6f7ff2bf7476c92dc92911bae27c41ebc015"
                 )
+                .unwrap()
             ),
-            Digest::from_str("3aa2c47c47cd9e5c5259fd1c3428c30b9608201f5e163061deea8d2d7c65f2c3")
+            Digest::try_from("3aa2c47c47cd9e5c5259fd1c3428c30b9608201f5e163061deea8d2d7c65f2c3")
+                .unwrap()
         );
     }
 }

--- a/risc0/zkp/rust/src/core/sha_zkvm.rs
+++ b/risc0/zkp/rust/src/core/sha_zkvm.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 Risc0, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::core::sha::{Digest, BLOCK_WORDS};
+use alloc::{borrow::Cow, vec::Vec};
+
+use bytemuck;
+
+// TODO: Figure out a better way to resolve this circular dependency.
+// Perhaps risc0_zkvm_guest should not have a dependency on zkp?  Or
+// maybe risc0_zkvm_guest::sha should move to risc0_zkvm_platform?
+extern "Rust" {
+    #[link_name = "zkvm_sha_raw_digest"]
+    pub fn raw_digest(data: &[u32]) -> &'static Digest;
+
+    #[link_name = "zkvm_sha_digest_u8_slice"]
+    pub fn digest_u8_slice(data: &[u8]) -> &'static Digest;
+}
+
+pub fn hash_bytes(bytes: &[u8]) -> Cow<'static, Digest> {
+    Cow::Borrowed(unsafe { digest_u8_slice(bytes) })
+}
+
+pub fn hash_raw_words(words: &[u32]) -> Cow<'static, Digest> {
+    let mut wordbuf: Vec<u32>;
+    // Add padding if necessary.
+    let words = if words.len() % 16 != 0 {
+        let padded_len = ((words.len() + BLOCK_WORDS - 1) / BLOCK_WORDS) * BLOCK_WORDS;
+        wordbuf = Vec::with_capacity(padded_len);
+        wordbuf.extend(words);
+        wordbuf.resize(padded_len, 0);
+        wordbuf.as_slice()
+    } else {
+        words
+    };
+
+    Cow::Borrowed(unsafe { raw_digest(words) })
+}
+
+pub fn hash_pair(a: &Digest, b: &Digest) -> Cow<'static, Digest> {
+    let block: [Digest; 2] = [*a, *b];
+    Cow::Borrowed(unsafe { raw_digest(bytemuck::cast_slice(&block)) })
+}

--- a/risc0/zkp/rust/src/prove/adapter.rs
+++ b/risc0/zkp/rust/src/prove/adapter.rs
@@ -23,7 +23,6 @@ use crate::{
         fp4::{Fp4, EXT_SIZE},
         log2_ceil,
         rou::ROU_FWD,
-        sha::Sha,
     },
     field::Elem,
     hal::Buffer,
@@ -58,12 +57,12 @@ impl<'a, C: CircuitDef<CS>, CS: CustomStep> Circuit for ProveAdapter<'a, C, CS> 
         self.exec.circuit.get_taps()
     }
 
-    fn execute<S: Sha>(&mut self, iop: &mut WriteIOP<S>) {
+    fn execute(&mut self, iop: &mut WriteIOP) {
         iop.write_fp_slice(&self.exec.output);
         iop.write_u32_slice(&[self.exec.po2 as u32]);
     }
 
-    fn accumulate<S: Sha>(&mut self, iop: &mut WriteIOP<S>) {
+    fn accumulate(&mut self, iop: &mut WriteIOP) {
         // Make the mixing values
         self.mix
             .resize_with(self.exec.circuit.mix_size(), || Fp::random(&mut iop.rng));

--- a/risc0/zkp/rust/src/prove/merkle.rs
+++ b/risc0/zkp/rust/src/prove/merkle.rs
@@ -18,10 +18,7 @@ use core::cmp;
 use log::debug;
 
 use crate::{
-    core::{
-        fp::Fp,
-        sha::{Digest, Sha},
-    },
+    core::{fp::Fp, sha::Digest},
     hal::{Buffer, Hal},
     merkle::MerkleTreeParams,
     prove::write_iop::WriteIOP,
@@ -85,7 +82,7 @@ impl MerkleTreeProver {
     }
 
     /// Write the 'top' of the merkle tree and commit to the root.
-    pub fn commit<H: Hal, S: Sha>(&self, hal: &H, iop: &mut WriteIOP<S>) {
+    pub fn commit<H: Hal>(&self, hal: &H, iop: &mut WriteIOP) {
         let top_size = self.params.top_size;
         let mut proof_slice = self.tmp_proof.slice(0, top_size);
         hal.eltwise_copy_digest(&mut proof_slice, &self.nodes.slice(top_size, top_size));
@@ -109,7 +106,7 @@ impl MerkleTreeProver {
     /// It is presumed the verifier is given the index of the row from other
     /// parts of the protocol, and verification will of course fail if the
     /// wrong row is specified.
-    pub fn prove<S: Sha>(&self, iop: &mut WriteIOP<S>, idx: usize) -> Vec<Fp> {
+    pub fn prove(&self, iop: &mut WriteIOP, idx: usize) -> Vec<Fp> {
         assert!(idx < self.params.row_size);
         let mut out = Vec::with_capacity(self.params.col_size);
         self.matrix.view(&mut |view| {

--- a/risc0/zkp/rust/src/prove/write_iop.rs
+++ b/risc0/zkp/rust/src/prove/write_iop.rs
@@ -14,31 +14,20 @@
 
 use alloc::vec::Vec;
 
-use crate::core::{
-    fp::Fp,
-    fp4::Fp4,
-    sha::{Digest, Sha},
-    sha_rng::ShaRng,
-};
+use crate::core::{fp::Fp, fp4::Fp4, sha::Digest, sha_rng::ShaRng};
 
-pub struct WriteIOP<S: Sha> {
-    sha: S,
+pub struct WriteIOP<'a> {
     pub proof: Vec<u32>,
-    pub rng: ShaRng<S>,
+    pub rng: ShaRng<'a>,
 }
 
-impl<S: Sha> WriteIOP<S> {
+impl<'a> WriteIOP<'a> {
     /// Create a new empty proof
-    pub fn new(sha: &S) -> Self {
+    pub fn new() -> Self {
         WriteIOP {
-            sha: sha.clone(),
             proof: Vec::new(),
-            rng: ShaRng::new(sha),
+            rng: ShaRng::new(),
         }
-    }
-
-    pub fn get_sha(&self) -> &S {
-        &self.sha
     }
 
     /// Called by the prover to write some data.

--- a/risc0/zkp/rust/src/verify/adapter.rs
+++ b/risc0/zkp/rust/src/verify/adapter.rs
@@ -16,11 +16,7 @@ use alloc::vec::Vec;
 
 use crate::{
     adapter::{CircuitInfo, PolyExt, PolyExtContext, TapsProvider},
-    core::{
-        fp::Fp,
-        fp4::Fp4,
-        sha::{Digest, Sha},
-    },
+    core::{fp::Fp, fp4::Fp4, sha::Digest},
     field::Elem,
     taps::TapSet,
     verify::{read_iop::ReadIOP, Circuit, VerificationError},
@@ -51,7 +47,7 @@ impl<'a, C: CircuitInfo + PolyExt + TapsProvider> Circuit for VerifyAdapter<'a, 
         self.circuit.get_taps()
     }
 
-    fn execute<S: Sha>(&mut self, iop: &mut ReadIOP<S>) {
+    fn execute(&mut self, iop: &mut ReadIOP) {
         // Read the outputs + size
         self.out.resize(self.circuit.output_size(), Fp::ZERO);
         iop.read_fps(&mut self.out);
@@ -61,7 +57,7 @@ impl<'a, C: CircuitInfo + PolyExt + TapsProvider> Circuit for VerifyAdapter<'a, 
         self.steps = 1 << self.po2;
     }
 
-    fn accumulate<S: Sha>(&mut self, iop: &mut ReadIOP<S>) {
+    fn accumulate(&mut self, iop: &mut ReadIOP) {
         // Fill in accum mix
         for _ in 0..self.circuit.mix_size() {
             self.mix.push(Fp::random(iop));

--- a/risc0/zkp/rust/src/verify/read_iop.rs
+++ b/risc0/zkp/rust/src/verify/read_iop.rs
@@ -17,28 +17,22 @@ use rand::{Error, RngCore};
 use crate::core::{
     fp::Fp,
     fp4::Fp4,
-    sha::{Digest, Sha, DIGEST_WORDS},
+    sha::{Digest, DIGEST_WORDS},
     sha_rng::ShaRng,
 };
 
 #[derive(Debug)]
-pub struct ReadIOP<'a, S: Sha> {
-    sha: S,
+pub struct ReadIOP<'a> {
     proof: &'a [u32],
-    rng: ShaRng<S>,
+    rng: ShaRng<'a>,
 }
 
-impl<'a, S: Sha> ReadIOP<'a, S> {
-    pub fn new(sha: &'a S, proof: &'a [u32]) -> Self {
+impl<'a> ReadIOP<'a> {
+    pub fn new(proof: &'a [u32]) -> Self {
         ReadIOP {
-            sha: sha.clone(),
             proof,
-            rng: ShaRng::new(sha),
+            rng: ShaRng::new(),
         }
-    }
-
-    pub fn get_sha(&self) -> &S {
-        &self.sha
     }
 
     pub fn read_u32s(&mut self, x: &mut [u32]) {
@@ -83,7 +77,7 @@ impl<'a, S: Sha> ReadIOP<'a, S> {
     }
 }
 
-impl<'a, S: Sha> RngCore for ReadIOP<'a, S> {
+impl<'a> RngCore for ReadIOP<'a> {
     fn next_u32(&mut self) -> u32 {
         self.rng.next_u32()
     }

--- a/risc0/zkvm/sdk/rust/build/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/build/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/risc0/risc0/"
 [dependencies]
 cargo_metadata = "0.15"
 reqwest = { version = "0.11", features = ["rustls-tls", "blocking"] }
-risc0-zkvm = { version = "0.11", path = ".." }
+risc0-zkvm = { version = "0.11", path = "..", default-features = false, features = ["host", "std", "circuit"] }
 risc0-zkvm-platform-sys = { version = "0.11", path = "../../../platform" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"

--- a/risc0/zkvm/sdk/rust/guest/BUILD.bazel
+++ b/risc0/zkvm/sdk/rust/guest/BUILD.bazel
@@ -12,6 +12,7 @@ rust_library(
     deps = [
         "//risc0/zkp/rust:zkp_guest",
         "//risc0/zkvm/sdk/rust:zkvm_guest",
+        "//risc0/zkvm/sdk/rust/platform:platform_guest",
         "@crates_guest//:bytemuck",
         "@crates_guest//:serde",
     ],

--- a/risc0/zkvm/sdk/rust/guest/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/guest/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/risc0/risc0/"
 bytemuck = "1.9"
 risc0-zkp = { version = "0.11", path = "../../../../zkp/rust", default-features = false }
 risc0-zkvm = { version = "0.11", path = "..", default-features = false }
+risc0-zkvm-platform = { version = "0.11", path = "../platform" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]

--- a/risc0/zkvm/sdk/rust/guest/src/abi.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/abi.rs
@@ -1,0 +1,20 @@
+/// Calls that the guest runtime provides.  These function signatures
+/// and symbols must match the ones in risc0_zkvm_platform::abi.
+
+// Number of u32 words in a SHA digest.
+const DIGEST_WORDS: usize = 8;
+
+#[export_name = "zkvm_sha_raw_digest"]
+pub fn sha_raw_digest(data: &[u32]) -> &'static [u32; DIGEST_WORDS] {
+    bytemuck::cast_ref(crate::sha::raw_digest(data))
+}
+
+#[export_name = "zkvm_sha_digest_u8_slice"]
+pub fn sha_digest_u8_slice(data: &[u8]) -> &'static [u32; DIGEST_WORDS] {
+    bytemuck::cast_ref(crate::sha::digest_u8_slice(data))
+}
+
+#[export_name = "zkvm_host_sendrecv"]
+pub fn host_sendrecv(channel: u32, buf: &[u8]) -> (&'static [u32], usize) {
+    crate::io::host_sendrecv(channel, buf)
+}

--- a/risc0/zkvm/sdk/rust/guest/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/lib.rs
@@ -34,6 +34,9 @@ pub mod sha;
 /// Functions for handling input and output
 pub mod io;
 
+// Implementations of runtime functions exposed in risc0_zkvm_platform::abi.
+mod abi;
+
 use core::{arch::asm, mem, panic::PanicInfo, ptr};
 
 extern "C" {

--- a/risc0/zkvm/sdk/rust/guest/src/sha.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/sha.rs
@@ -52,8 +52,6 @@ fn alloc_desc() -> *mut SHADescriptor {
 /// Computes a raw digest of the given slice.  For compatibility with
 /// the SHA specification, the data must already contain the end
 /// marker and the trailer
-// Exported manually to avoid circular dependency; see zkp/src/core/sha_zkvm.rs for details.
-#[export_name = "zkvm_sha_raw_digest"]
 pub fn raw_digest(data: &[u32]) -> &'static Digest {
     assert_eq!(data.len() % CHUNK_SIZE, 0);
     // Allocate fresh memory that's guaranteed to be uninitialized so
@@ -143,8 +141,6 @@ pub fn digest<T: Serialize>(val: &T) -> &'static Digest {
 /// Makes a digest for a slice of bytes.
 ///
 /// Since there are no guarantees on alignment, an internal copy is made.
-// Exported manually to avoid circular dependency; see zkp/src/core/sha_zkvm.rs for details.
-#[export_name = "zkvm_sha_digest_u8_slice"]
 pub fn digest_u8_slice(data: &[u8]) -> &'static Digest {
     let len_bytes = data.len();
     let cap = compute_capacity_needed(len_bytes);

--- a/risc0/zkvm/sdk/rust/methods/inner/src/bin/sha_accel.rs
+++ b/risc0/zkvm/sdk/rust/methods/inner/src/bin/sha_accel.rs
@@ -24,5 +24,5 @@ pub fn main() {
     let digest = sha::digest_u8_slice(data);
     env::commit(&digest);
 
-    risc0_zkp::core::sha::testutil::test_sha_impl(&risc0_zkvm_guest::sha::Impl {})
+    risc0_zkp::core::sha::testutil::test_sha_impl()
 }

--- a/risc0/zkvm/sdk/rust/platform/src/abi.rs
+++ b/risc0/zkvm/sdk/rust/platform/src/abi.rs
@@ -1,0 +1,42 @@
+/// Calls that the zkvm runtime provides.  These function signatures
+/// and symbols must match the ones in risc0_zkvm_guest::abi.
+
+// Number of u32 wors in a SHA digest.
+const DIGEST_WORDS: usize = 8;
+
+extern "Rust" {
+    #[link_name = "zkvm_sha_raw_digest"]
+    fn _sha_raw_digest(data: &[u32]) -> &'static [u32; DIGEST_WORDS];
+
+    #[link_name = "zkvm_sha_digest_u8_slice"]
+    fn _sha_digest_u8_slice(data: &[u8]) -> &'static [u32; DIGEST_WORDS];
+
+    #[link_name = "zkvm_host_sendrecv"]
+    fn _host_sendrecv(channel: u32, buf: &[u8]) -> (&'static [u32], usize);
+}
+
+// SAFETY: These functnion signatures defined above should exactly
+// match the ones defined in risc0_zkvm_guest::abi.
+
+/// Computes a raw digest of the given slice without adding a SHA end
+/// marker or trailer.
+pub fn sha_raw_digest(data: &[u32]) -> &'static [u32; DIGEST_WORDS] {
+    unsafe { _sha_raw_digest(data) }
+}
+
+/// Makes a digest for a slice of bytes, padding to SHA block length
+/// and adding the SHA end marker and trailer.
+pub fn sha_digest_u8_slice(data: &[u8]) -> &'static [u32; DIGEST_WORDS] {
+    unsafe { _sha_digest_u8_slice(data) }
+}
+
+/// Interacts with the host.  'channel' specifies the ZKVM channel to
+/// use, and 'buf' provides the data to tsend to the host.
+///
+/// The returned tuple contains a slice of 32-bit words from the host,
+/// and a size in bytes of the returned data.  The size in bytes might
+/// not match the length of the returned slice * WORD_SIZE in the case
+/// that the returned buffer does not fall on a word boundry.
+pub fn host_sendrecv(channel: u32, buf: &[u8]) -> (&'static [u32], usize) {
+    unsafe { _host_sendrecv(channel, buf) }
+}

--- a/risc0/zkvm/sdk/rust/platform/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/platform/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![no_std]
 
+pub mod abi;
 pub mod io;
 pub mod memory;
 

--- a/risc0/zkvm/sdk/rust/src/prove/exec.rs
+++ b/risc0/zkvm/sdk/rust/src/prove/exec.rs
@@ -21,10 +21,13 @@ use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 use anyhow::{bail, Result};
 use lazy_regex::{regex, Captures};
 use log::{debug, trace};
-use risc0_zkp::core::sha::Sha;
 use risc0_zkp::{
     adapter::{CircuitDef, CustomStep},
-    core::{fp::Fp, log2_ceil, sha::DIGEST_WORDS},
+    core::{
+        fp::Fp,
+        log2_ceil,
+        sha::{hash_raw_words, DIGEST_WORDS},
+    },
     field::Elem,
     prove::executor::Executor,
     MAX_CYCLES_PO2, ZK_CYCLES,
@@ -483,11 +486,10 @@ impl<'a, H: IoHandler> MachineContext<'a, H> {
             sha_type, count, desc.idx, desc.source, desc.digest
         );
 
-        let sha = risc0_zkp::core::sha::default_implementation();
         let words = self
             .memory
             .load_region_u32(desc.source as u32, (count * 64) as u32);
-        let digest = sha.hash_raw_words(bytemuck::cast_slice(words.as_slice()));
+        let digest = hash_raw_words(bytemuck::cast_slice(words.as_slice()));
 
         debug!("Digest result is {:X?}", digest.as_slice());
 

--- a/risc0/zkvm/sdk/rust/src/prove/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/prove/mod.rs
@@ -17,9 +17,7 @@ pub mod exec;
 use std::io::Write;
 
 use anyhow::Result;
-use risc0_zkp::{
-    core::sha::default_implementation, hal::cpu::CpuHal, prove::adapter::ProveAdapter,
-};
+use risc0_zkp::{hal::cpu::CpuHal, prove::adapter::ProveAdapter};
 
 use crate::{
     elf::Program,
@@ -75,13 +73,12 @@ impl<'a> Prover<'a> {
 
         let mut prover = ProveAdapter::new(&mut executor.executor);
         let hal = CpuHal {};
-        let sha = default_implementation();
 
         let seal = if skip_seal {
-            risc0_zkp::prove::prove_without_seal(&hal, sha, &mut prover);
+            risc0_zkp::prove::prove_without_seal(&hal, &mut prover);
             Vec::new()
         } else {
-            risc0_zkp::prove::prove(&hal, sha, &mut prover)
+            risc0_zkp::prove::prove(&hal, &mut prover)
         };
 
         // Attach the full version of the output journal & construct receipt object

--- a/risc0/zkvm/sdk/rust/src/receipt.rs
+++ b/risc0/zkvm/sdk/rust/src/receipt.rs
@@ -15,7 +15,6 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
-use risc0_zkp::core::sha::default_implementation;
 use risc0_zkp::verify::adapter::VerifyAdapter;
 use risc0_zkvm_circuit::CircuitImpl;
 
@@ -41,8 +40,7 @@ impl Receipt {
     {
         let circuit = CircuitImpl::new();
         let mut verifier = VerifyAdapter::new(&circuit);
-        let sha = default_implementation();
-        risc0_zkp::verify::verify(sha, &mut verifier, &self.seal)
+        risc0_zkp::verify::verify(&mut verifier, &self.seal)
             .map_err(|err| anyhow!("Verification failed: {:?}", err))
     }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+bazel/rules/rust/rustfmt.toml


### PR DESCRIPTION
* No more Sha trait to pass around everywhere; when we need to choose an accelerator we can use the more general "Hal".  zkp's verify does not use hal.
* sha implementations no longer care about "Fp" or "Fp4" types.
* sha implementations now return "Cow<'static, Digest>' which is a lot more efficient to copy in the guest.

Miscellaneous fixes:

* Trim zkvm features in risc0-build to speed compilation time
* Add "rustfmt.toml" in root of tree so that "cargo fmt" can find it.