### PR TITLE
Move host_sendrecv back from zkvm_guest to zkvm_platform

### DIFF
--- a/risc0/zkvm/sdk/rust/guest/BUILD.bazel
+++ b/risc0/zkvm/sdk/rust/guest/BUILD.bazel
@@ -12,6 +12,7 @@ rust_library(
     deps = [
         "//risc0/zkp/rust:zkp_guest",
         "//risc0/zkvm/sdk/rust:zkvm_guest",
+        "//risc0/zkvm/sdk/rust/platform:platform_guest",
         "@crates_guest//:bytemuck",
         "@crates_guest//:serde",
     ],

--- a/risc0/zkvm/sdk/rust/guest/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/guest/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/risc0/risc0/"
 bytemuck = "1.9"
 risc0-zkp = { version = "0.11", path = "../../../../zkp/rust", default-features = false }
 risc0-zkvm = { version = "0.11", path = "..", default-features = false }
+risc0-zkvm-platform = { version = "0.11", path = "../platform" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [build-dependencies]

--- a/risc0/zkvm/sdk/rust/guest/src/alloc.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/alloc.rs
@@ -17,7 +17,7 @@ use core::{
     cell::UnsafeCell,
 };
 
-use risc0_zkvm::platform::{memory, WORD_SIZE};
+use risc0_zkvm_platform::{memory, WORD_SIZE};
 
 use crate::{_fault, align_up};
 

--- a/risc0/zkvm/sdk/rust/guest/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/lib.rs
@@ -20,7 +20,7 @@
 #![cfg_attr(target_arch = "riscv32", feature(alloc_error_handler))]
 #![cfg_attr(target_arch = "riscv32", feature(new_uninit))]
 
-extern crate alloc as _alloc;
+extern crate alloc as alloc_crate;
 
 #[cfg(not(feature = "std"))]
 mod alloc;
@@ -31,9 +31,6 @@ pub mod env;
 /// Functions for computing SHA-256 hashes.
 pub mod sha;
 
-/// Functions for handling input and output
-pub mod io;
-
 use core::{arch::asm, mem, panic::PanicInfo, ptr};
 
 extern "C" {
@@ -43,9 +40,9 @@ extern "C" {
 #[cfg(all(target_arch = "riscv32", not(feature = "std")))]
 #[panic_handler]
 unsafe fn panic_fault(panic_info: &PanicInfo<'static>) -> ! {
-    use risc0_zkvm::platform::io::GPIO_FAULT;
+    use risc0_zkvm_platform::io::GPIO_FAULT;
 
-    let msg = _alloc::format!("{}\0", panic_info);
+    let msg = alloc_crate::format!("{}\0", panic_info);
     let ptr = msg.as_ptr();
     memory_barrier(ptr);
     // A compliant host should fault when it receives this descriptor.

--- a/risc0/zkvm/sdk/rust/guest/src/sha.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/sha.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use _alloc::{boxed::Box, vec::Vec};
+use alloc_crate::{boxed::Box, vec::Vec};
 use core::{cell::UnsafeCell, mem};
 
 use risc0_zkp::core::{
@@ -20,12 +20,10 @@ use risc0_zkp::core::{
     fp4::Fp4,
     sha::{Digest, DIGEST_WORDS},
 };
-use risc0_zkvm::{
-    platform::{
-        io::{SHADescriptor, GPIO_SHA},
-        memory, WORD_SIZE,
-    },
-    serde::to_vec_with_capacity,
+use risc0_zkvm::serde::to_vec_with_capacity;
+use risc0_zkvm_platform::{
+    io::{SHADescriptor, GPIO_SHA},
+    memory, WORD_SIZE,
 };
 use serde::Serialize;
 

--- a/risc0/zkvm/sdk/rust/methods/inner/src/bin/sendrecv.rs
+++ b/risc0/zkvm/sdk/rust/methods/inner/src/bin/sendrecv.rs
@@ -15,7 +15,7 @@
 #![no_main]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use risc0_zkvm_guest::{env, io::host_sendrecv};
+use risc0_zkvm_guest::env;
 
 risc0_zkvm_guest::entry!(main);
 
@@ -27,7 +27,7 @@ pub fn main() {
     let mut input_len : usize = 0;
     
     for _ in 0..count {
-        let (host_data, host_len) = host_sendrecv(channel_id, &input[..input_len]);
+        let (host_data, host_len) = env::host_sendrecv(channel_id, &input[..input_len]);
 
         input = bytemuck::cast_slice(host_data);
         input_len = host_len;

--- a/risc0/zkvm/sdk/rust/platform/src/rt/host_sendrecv.rs
+++ b/risc0/zkvm/sdk/rust/platform/src/rt/host_sendrecv.rs
@@ -1,10 +1,21 @@
+// Copyright 2022 Risc0, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use core::cell::UnsafeCell;
 
-use risc0_zkvm::platform::{
-    io::{
-        IoDescriptor, GPIO_COMMIT, GPIO_SENDRECV_ADDR, GPIO_SENDRECV_CHANNEL, GPIO_SENDRECV_SIZE,
-        SENDRECV_CHANNEL_INITIAL_INPUT, SENDRECV_CHANNEL_STDOUT,
-    },
+use crate::{
+    io::{GPIO_SENDRECV_ADDR, GPIO_SENDRECV_CHANNEL, GPIO_SENDRECV_SIZE},
     memory, WORD_SIZE,
 };
 

--- a/risc0/zkvm/sdk/rust/platform/src/rt/mod.rs
+++ b/risc0/zkvm/sdk/rust/platform/src/rt/mod.rs
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_std]
+// Runtime routines to support the zkvm.
 
-pub mod io;
-pub mod memory;
+mod host_sendrecv;
 
-pub const WORD_SIZE: usize = core::mem::size_of::<u32>();
-
-#[cfg(target_os = "zkvm")]
-/// Runtime support for running on the ZKVM.  Provided here for the
-/// rust standard library to use.
-pub mod rt;
+pub use host_sendrecv::host_sendrecv;

--- a/risc0/zkvm/sdk/rust/src/host/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/host/mod.rs
@@ -83,15 +83,13 @@ pub use prove::{MethodId, Receipt};
 #[cfg(test)]
 mod test {
     use super::{MethodId, Prover, ProverOpts, Receipt};
-    use crate::{
-        platform::memory::{COMMIT, HEAP},
-        serde::{from_slice, to_vec},
-    };
+    use crate::serde::{from_slice, to_vec};
     use anyhow::Result;
     use risc0_zkp::core::sha::Digest;
     use risc0_zkvm_methods::{
         FAIL_ID, FAIL_PATH, IO_ID, IO_PATH, SENDRECV_ID, SENDRECV_PATH, SHA_ID, SHA_PATH,
     };
+    use risc0_zkvm_platform::memory::{COMMIT, HEAP};
     use std::sync::Mutex;
     use test_log::test;
 

--- a/risc0/zkvm/sdk/rust/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/src/lib.rs
@@ -50,7 +50,5 @@ pub mod serde;
 #[cfg(feature = "verify")]
 pub mod verify;
 
-pub use risc0_zkvm_platform as platform;
-
 // TODO: get this from the cirgen circuit
 const CODE_SIZE: usize = 16;

--- a/risc0/zkvm/sdk/rust/src/method_id.rs
+++ b/risc0/zkvm/sdk/rust/src/method_id.rs
@@ -65,12 +65,13 @@ impl MethodId {
 
     #[cfg(feature = "prove")]
     pub fn compute_with_limit(elf_contents: &[u8], limit: u32) -> Result<Self> {
-        use crate::{elf::Program, platform::memory::MEM_SIZE, prove::CIRCUIT, CODE_SIZE};
+        use crate::{elf::Program, prove::CIRCUIT, CODE_SIZE};
         use risc0_zkp::{
             hal::{cpu::CpuHal, Hal},
             prove::poly_group::PolyGroup,
         };
         use risc0_zkvm_circuit::CircuitImpl;
+        use risc0_zkvm_platform::memory::MEM_SIZE;
 
         let hal = CpuHal::<CircuitImpl>::new(&CIRCUIT);
         let program = Program::load_elf(elf_contents, MEM_SIZE as u32)?;

--- a/risc0/zkvm/sdk/rust/src/prove/exec.rs
+++ b/risc0/zkvm/sdk/rust/src/prove/exec.rs
@@ -38,11 +38,11 @@ use risc0_zkvm_platform::{
         },
         IoDescriptor, SHADescriptor,
     },
-    memory::INPUT,
+    memory::{INPUT, MEM_BITS},
     WORD_SIZE,
 };
 
-use crate::{elf::Program, platform::memory::MEM_BITS, CODE_SIZE};
+use crate::{elf::Program, CODE_SIZE};
 
 pub trait IoHandler {
     fn on_commit(&mut self, buf: &[u32]);

--- a/risc0/zkvm/sdk/rust/src/prove/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/prove/mod.rs
@@ -22,17 +22,12 @@ use risc0_zkp::{
     core::sha::default_implementation, hal::cpu::CpuHal, prove::adapter::ProveAdapter,
 };
 use risc0_zkvm_circuit::CircuitImpl;
-
-use crate::{
-    elf::Program,
-    host::ProverOpts,
-    method_id::MethodId,
-    platform::{
-        io::{SENDRECV_CHANNEL_INITIAL_INPUT, SENDRECV_CHANNEL_STDERR, SENDRECV_CHANNEL_STDOUT},
-        memory::MEM_SIZE,
-    },
-    receipt::Receipt,
+use risc0_zkvm_platform::{
+    io::{SENDRECV_CHANNEL_INITIAL_INPUT, SENDRECV_CHANNEL_STDERR, SENDRECV_CHANNEL_STDOUT},
+    memory::MEM_SIZE,
 };
+
+use crate::{elf::Program, host::ProverOpts, method_id::MethodId, receipt::Receipt};
 
 lazy_static! {
     pub static ref CIRCUIT: CircuitImpl = CircuitImpl::new();

--- a/risc0/zkvm/sdk/rust/tests/integration.rs
+++ b/risc0/zkvm/sdk/rust/tests/integration.rs
@@ -34,7 +34,7 @@ fn run_memio(pairs: &[(usize, usize)]) -> Result<Receipt> {
 mod integration {
     use test_log::test;
 
-    use risc0_zkvm::platform::memory::{COMMIT, HEAP};
+    use risc0_zkvm_platform::memory::{COMMIT, HEAP};
 
     use crate::run_memio;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+bazel/rules/rust/rustfmt.toml


### PR DESCRIPTION
* Now with comment as to why it needs to be in there for the standard library!
* clean up references to refer to platform directly instead of risc0_zkvm::platform
* Add rustfmt.toml to top level directory so "cargo fmt" can find it.