### PR TITLE
Change Merkle verify asserts to Result Errs

### DIFF
--- a/risc0/zkp/rust/src/verify/fri.rs
+++ b/risc0/zkp/rust/src/verify/fri.rs
@@ -26,7 +26,7 @@ use crate::{
         sha::Sha,
     },
     field::Elem,
-    verify::{merkle::MerkleTreeVerifier, read_iop::ReadIOP},
+    verify::{merkle::MerkleTreeVerifier, read_iop::ReadIOP, VerificationError},
     FRI_FOLD, FRI_MIN_DEGREE, INV_RATE, QUERIES,
 };
 
@@ -65,11 +65,11 @@ impl VerifyRoundInfo {
         }
     }
 
-    pub fn verify_query<S: Sha>(&mut self, iop: &mut ReadIOP<S>, pos: &mut usize, goal: &mut Fp4) {
+    pub fn verify_query<S: Sha>(&mut self, iop: &mut ReadIOP<S>, pos: &mut usize, goal: &mut Fp4) -> Result<(), VerificationError> {
         let quot = *pos / self.domain;
         let group = *pos % self.domain;
         // Get the column data
-        let data = self.merkle.verify(iop, group);
+        let data = self.merkle.verify(iop, group)?;
         let mut data4 = vec![];
         for i in 0..FRI_FOLD {
             data4.push(Fp4::new(
@@ -80,16 +80,18 @@ impl VerifyRoundInfo {
             ));
         }
         // Check the existing goal
+        // TODO: Return an error result instead
         assert_eq!(data4[quot], *goal);
         // Compute the new goal + pos
         *goal = fold_eval(&mut data4, self.mix, self.domain, group);
         *pos = group;
+        Ok(())
     }
 }
 
-pub fn fri_verify<S: Sha, F>(iop: &mut ReadIOP<S>, mut degree: usize, mut inner: F)
+pub fn fri_verify<S: Sha, F>(iop: &mut ReadIOP<S>, mut degree: usize, mut inner: F) -> Result<(), VerificationError>
 where
-    F: FnMut(&mut ReadIOP<S>, usize) -> Fp4,
+    F: FnMut(&mut ReadIOP<S>, usize) -> Result<Fp4, VerificationError>,
 {
     let orig_domain = INV_RATE * degree;
     let mut domain = orig_domain;
@@ -112,10 +114,10 @@ where
         let rng = iop.next_u32();
         let mut pos = rng as usize % orig_domain;
         // Do the 'inner' verification for this index
-        let mut goal = inner(iop, pos);
+        let mut goal = inner(iop, pos)?;
         // Verify the per-round proofs
         for round in &mut rounds {
-            round.verify_query(iop, &mut pos, &mut goal);
+            round.verify_query(iop, &mut pos, &mut goal)?;
         }
         // Do final verification
         let x = gen.pow(pos);
@@ -131,6 +133,8 @@ where
             fx += cur * coeff;
             cur *= x;
         }
+        // TODO: Return an error result instead
         assert_eq!(fx, goal)
     }
+    Ok(())
 }

--- a/risc0/zkp/rust/src/verify/fri.rs
+++ b/risc0/zkp/rust/src/verify/fri.rs
@@ -80,8 +80,9 @@ impl VerifyRoundInfo {
             ));
         }
         // Check the existing goal
-        // TODO: Return an error result instead
-        assert_eq!(data4[quot], *goal);
+        if data4[quot] != *goal {
+            return Err(VerificationError::InvalidProof);
+        }
         // Compute the new goal + pos
         *goal = fold_eval(&mut data4, self.mix, self.domain, group);
         *pos = group;
@@ -133,8 +134,9 @@ where
             fx += cur * coeff;
             cur *= x;
         }
-        // TODO: Return an error result instead
-        assert_eq!(fx, goal)
+        if fx != goal {
+            return Err(VerificationError::InvalidProof);
+        }
     }
     Ok(())
 }

--- a/risc0/zkp/rust/src/verify/fri.rs
+++ b/risc0/zkp/rust/src/verify/fri.rs
@@ -65,7 +65,12 @@ impl VerifyRoundInfo {
         }
     }
 
-    pub fn verify_query<S: Sha>(&mut self, iop: &mut ReadIOP<S>, pos: &mut usize, goal: &mut Fp4) -> Result<(), VerificationError> {
+    pub fn verify_query<S: Sha>(
+        &mut self,
+        iop: &mut ReadIOP<S>,
+        pos: &mut usize,
+        goal: &mut Fp4,
+    ) -> Result<(), VerificationError> {
         let quot = *pos / self.domain;
         let group = *pos % self.domain;
         // Get the column data
@@ -90,7 +95,11 @@ impl VerifyRoundInfo {
     }
 }
 
-pub fn fri_verify<S: Sha, F>(iop: &mut ReadIOP<S>, mut degree: usize, mut inner: F) -> Result<(), VerificationError>
+pub fn fri_verify<S: Sha, F>(
+    iop: &mut ReadIOP<S>,
+    mut degree: usize,
+    mut inner: F,
+) -> Result<(), VerificationError>
 where
     F: FnMut(&mut ReadIOP<S>, usize) -> Result<Fp4, VerificationError>,
 {

--- a/risc0/zkp/rust/src/verify/merkle.rs
+++ b/risc0/zkp/rust/src/verify/merkle.rs
@@ -65,8 +65,9 @@ impl MerkleTreeVerifier {
 
     /// Verifies a branch provided by an IOP.
     pub fn verify<S: Sha>(&self, iop: &mut ReadIOP<S>, mut idx: usize) -> Result<Vec<Fp>, VerificationError> {
-        // TODO: Return an error result instead
-        assert!(idx < self.params.row_size);
+        if idx >= self.params.row_size {
+            return Err(VerificationError::MerkleQueryOutOfRange{idx: idx, rows: self.params.row_size});
+        }
         // Initialize a vector to hold field elements.
         let mut out = vec![Fp::ZERO; self.params.col_size];
         // Read out field elements from IOP.
@@ -92,7 +93,6 @@ impl MerkleTreeVerifier {
         }
         // Once we reduce to an index for which we have the hash, check that it's
         // correct.
-        // TODO: Return an error result instead
         if self.top[idx] == cur {
             Ok(out)
         } else {

--- a/risc0/zkp/rust/src/verify/merkle.rs
+++ b/risc0/zkp/rust/src/verify/merkle.rs
@@ -96,7 +96,7 @@ impl MerkleTreeVerifier {
         if self.top[idx] == cur {
             Ok(out)
         } else {
-            Err(VerificationError::MerkleHashMismatchError(idx, self.top[idx], cur))
+            Err(VerificationError::InvalidProof)
         }
     }
 }

--- a/risc0/zkp/rust/src/verify/merkle.rs
+++ b/risc0/zkp/rust/src/verify/merkle.rs
@@ -64,9 +64,16 @@ impl MerkleTreeVerifier {
     }
 
     /// Verifies a branch provided by an IOP.
-    pub fn verify<S: Sha>(&self, iop: &mut ReadIOP<S>, mut idx: usize) -> Result<Vec<Fp>, VerificationError> {
+    pub fn verify<S: Sha>(
+        &self,
+        iop: &mut ReadIOP<S>,
+        mut idx: usize,
+    ) -> Result<Vec<Fp>, VerificationError> {
         if idx >= self.params.row_size {
-            return Err(VerificationError::MerkleQueryOutOfRange{idx: idx, rows: self.params.row_size});
+            return Err(VerificationError::MerkleQueryOutOfRange {
+                idx: idx,
+                rows: self.params.row_size,
+            });
         }
         // Initialize a vector to hold field elements.
         let mut out = vec![Fp::ZERO; self.params.col_size];

--- a/risc0/zkp/rust/src/verify/merkle.rs
+++ b/risc0/zkp/rust/src/verify/merkle.rs
@@ -22,6 +22,7 @@ use crate::{
     field::Elem,
     merkle::MerkleTreeParams,
     verify::read_iop::ReadIOP,
+    verify::VerificationError,
 };
 
 /// A struct against which we verify merkle branches, consisting of the
@@ -63,7 +64,8 @@ impl MerkleTreeVerifier {
     }
 
     /// Verifies a branch provided by an IOP.
-    pub fn verify<S: Sha>(&self, iop: &mut ReadIOP<S>, mut idx: usize) -> Vec<Fp> {
+    pub fn verify<S: Sha>(&self, iop: &mut ReadIOP<S>, mut idx: usize) -> Result<Vec<Fp>, VerificationError> {
+        // TODO: Return an error result instead
         assert!(idx < self.params.row_size);
         // Initialize a vector to hold field elements.
         let mut out = vec![Fp::ZERO; self.params.col_size];
@@ -90,7 +92,11 @@ impl MerkleTreeVerifier {
         }
         // Once we reduce to an index for which we have the hash, check that it's
         // correct.
-        assert_eq!(self.top[idx], cur);
-        out
+        // TODO: Return an error result instead
+        if self.top[idx] == cur {
+            Ok(out)
+        } else {
+            Err(VerificationError::MerkleHashMismatchError(idx, self.top[idx], cur))
+        }
     }
 }

--- a/risc0/zkp/rust/src/verify/mod.rs
+++ b/risc0/zkp/rust/src/verify/mod.rs
@@ -43,7 +43,7 @@ pub enum VerificationError {
     ReceiptFormatError,
     MethodVerificationError,
     MerkleHashMismatchError(usize, Digest, Digest),
-    MerkleQueryOutOfRange{idx: usize, rows: usize},
+    MerkleQueryOutOfRange { idx: usize, rows: usize },
     InvalidProof,
 }
 
@@ -52,8 +52,16 @@ impl fmt::Display for VerificationError {
         match self {
             VerificationError::ReceiptFormatError => write!(f, "invalid receipt format"),
             VerificationError::MethodVerificationError => write!(f, "method verification failed"),
-            VerificationError::MerkleHashMismatchError(idx, _, _) => write!(f, "Merkle validation failed with hash mismatch at index {}", idx),
-            VerificationError::MerkleQueryOutOfRange{idx, rows} => write!(f, "Requested Merkle validation on row {}, but only {} rows exist", idx, rows),
+            VerificationError::MerkleHashMismatchError(idx, _, _) => write!(
+                f,
+                "Merkle validation failed with hash mismatch at index {}",
+                idx
+            ),
+            VerificationError::MerkleQueryOutOfRange { idx, rows } => write!(
+                f,
+                "Requested Merkle validation on row {}, but only {} rows exist",
+                idx, rows
+            ),
             VerificationError::InvalidProof => write!(f, "Verification indicates proof is invalid"),
         }
     }
@@ -193,37 +201,41 @@ where
 
     let gen = Fp::new(ROU_FWD[log2_ceil(domain)]);
     // debug!("FRI-verify, size = {size}");
-    fri_verify(&mut iop, size, |iop: &mut ReadIOP<S>, idx: usize| -> Result<Fp4, VerificationError> {
-        let x = Fp4::from_fp(gen.pow(idx));
-        let mut rows = vec![];
-        rows.push(accum_merkle.verify(iop, idx)?);
-        rows.push(code_merkle.verify(iop, idx)?);
-        rows.push(data_merkle.verify(iop, idx)?);
-        let check_row = check_merkle.verify(iop, idx)?;
-        let mut cur = Fp4::ONE;
-        let mut tot = vec![Fp4::ZERO; combo_count + 1];
-        for reg in taps.regs() {
-            tot[reg.combo_id()] += cur * rows[reg.group() as usize][reg.offset()];
-            cur *= mix;
-        }
-        for i in 0..CHECK_SIZE {
-            tot[combo_count] += cur * check_row[i];
-            cur *= mix;
-        }
-        let mut ret = Fp4::ZERO;
-        for i in 0..combo_count {
-            let num = tot[i] - poly_eval(&combo_u[i], x);
-            let mut divisor = Fp4::ONE;
-            for back in taps.get_combo(i).slice() {
-                divisor *= x - z * back_one.pow(*back as usize);
+    fri_verify(
+        &mut iop,
+        size,
+        |iop: &mut ReadIOP<S>, idx: usize| -> Result<Fp4, VerificationError> {
+            let x = Fp4::from_fp(gen.pow(idx));
+            let mut rows = vec![];
+            rows.push(accum_merkle.verify(iop, idx)?);
+            rows.push(code_merkle.verify(iop, idx)?);
+            rows.push(data_merkle.verify(iop, idx)?);
+            let check_row = check_merkle.verify(iop, idx)?;
+            let mut cur = Fp4::ONE;
+            let mut tot = vec![Fp4::ZERO; combo_count + 1];
+            for reg in taps.regs() {
+                tot[reg.combo_id()] += cur * rows[reg.group() as usize][reg.offset()];
+                cur *= mix;
             }
-            ret += num * divisor.inv();
-        }
-        let check_num = tot[combo_count] - combo_u[combo_count][0];
-        let check_div = x - z.pow(INV_RATE);
-        ret += check_num * check_div.inv();
-        Ok(ret)
-    })?;
+            for i in 0..CHECK_SIZE {
+                tot[combo_count] += cur * check_row[i];
+                cur *= mix;
+            }
+            let mut ret = Fp4::ZERO;
+            for i in 0..combo_count {
+                let num = tot[i] - poly_eval(&combo_u[i], x);
+                let mut divisor = Fp4::ONE;
+                for back in taps.get_combo(i).slice() {
+                    divisor *= x - z * back_one.pow(*back as usize);
+                }
+                ret += num * divisor.inv();
+            }
+            let check_num = tot[combo_count] - combo_u[combo_count][0];
+            let check_div = x - z.pow(INV_RATE);
+            ret += check_num * check_div.inv();
+            Ok(ret)
+        },
+    )?;
     iop.verify_complete();
     Ok(())
 }

--- a/risc0/zkp/rust/src/verify/mod.rs
+++ b/risc0/zkp/rust/src/verify/mod.rs
@@ -42,7 +42,6 @@ const CHECK_SIZE: usize = INV_RATE * EXT_SIZE;
 pub enum VerificationError {
     ReceiptFormatError,
     MethodVerificationError,
-    MerkleHashMismatchError(usize, Digest, Digest),
     MerkleQueryOutOfRange { idx: usize, rows: usize },
     InvalidProof,
 }
@@ -52,11 +51,6 @@ impl fmt::Display for VerificationError {
         match self {
             VerificationError::ReceiptFormatError => write!(f, "invalid receipt format"),
             VerificationError::MethodVerificationError => write!(f, "method verification failed"),
-            VerificationError::MerkleHashMismatchError(idx, _, _) => write!(
-                f,
-                "Merkle validation failed with hash mismatch at index {}",
-                idx
-            ),
             VerificationError::MerkleQueryOutOfRange { idx, rows } => write!(
                 f,
                 "Requested Merkle validation on row {}, but only {} rows exist",


### PR DESCRIPTION
Replace assertion-based error handling in our Merkle verification code with Result-based error handling.

The intent is for `VerificationError::InvalidProof` to be used when we attempt to verify an alleged proof that is not actually a true proof, and to use other error types for issues not directly related to the validity of the proof.

Split off from #243 for clarity of purpose so that reviewers can more quickly give feedback on whether this is a good approach to handling verification errors.