### PR TITLE
Add "Field" as an associated type in a Hal.

### DIFF
--- a/risc0/zkp/rust/src/hal/cpu.rs
+++ b/risc0/zkp/rust/src/hal/cpu.rs
@@ -15,6 +15,7 @@
 //! Hardware abstraction layer for RISC Zero zkVM
 use core::{
     cell::{Ref, RefMut},
+    marker::PhantomData,
     ops::Range,
     slice::{from_raw_parts, from_raw_parts_mut},
 };
@@ -27,22 +28,24 @@ use rayon::prelude::*;
 use super::{Buffer, Hal};
 use crate::{
     core::{
-        fp::Fp,
-        fp4::{Fp4, EXT_SIZE},
         log2_ceil,
         ntt::{bit_rev_32, bit_reverse, evaluate_ntt, expand, interpolate_ntt},
         sha::{Digest, Sha},
         sha_cpu,
     },
-    field::Elem,
+    field::{Elem, ExtElem, Field},
     FRI_FOLD,
 };
 
-pub struct CpuHal {}
+pub struct CpuHal<F: Field> {
+    _phantom: PhantomData<F>,
+}
 
-impl CpuHal {
+impl<F: Field> CpuHal<F> {
     pub fn new() -> Self {
-        CpuHal {}
+        CpuHal {
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -133,25 +136,27 @@ impl<T: Pod> Buffer<T> for CpuBuffer<T> {
     }
 }
 
-impl Hal for CpuHal {
-    type BufferFp = CpuBuffer<Fp>;
-    type BufferFp4 = CpuBuffer<Fp4>;
+impl<F: Field> Hal for CpuHal<F> {
+    type Field = F;
+
+    type BufferFp = CpuBuffer<F::Elem>;
+    type BufferFp4 = CpuBuffer<F::ExtElem>;
     type BufferDigest = CpuBuffer<Digest>;
     type BufferU32 = CpuBuffer<u32>;
 
-    fn alloc_fp(&self, size: usize) -> CpuBuffer<Fp> {
+    fn alloc_fp(&self, size: usize) -> CpuBuffer<F::Elem> {
         CpuBuffer::new(size)
     }
 
-    fn copy_fp_from(&self, slice: &[Fp]) -> CpuBuffer<Fp> {
+    fn copy_fp_from(&self, slice: &[F::Elem]) -> CpuBuffer<F::Elem> {
         CpuBuffer::copy_from(slice)
     }
 
-    fn alloc_fp4(&self, size: usize) -> CpuBuffer<Fp4> {
+    fn alloc_fp4(&self, size: usize) -> CpuBuffer<F::ExtElem> {
         CpuBuffer::new(size)
     }
 
-    fn copy_fp4_from(&self, slice: &[Fp4]) -> CpuBuffer<Fp4> {
+    fn copy_fp4_from(&self, slice: &[F::ExtElem]) -> CpuBuffer<F::ExtElem> {
         CpuBuffer::copy_from(slice)
     }
 
@@ -171,7 +176,7 @@ impl Hal for CpuHal {
         CpuBuffer::copy_from(slice)
     }
 
-    fn batch_expand(&self, output: &CpuBuffer<Fp>, input: &CpuBuffer<Fp>, count: usize) {
+    fn batch_expand(&self, output: &CpuBuffer<F::Elem>, input: &CpuBuffer<F::Elem>, count: usize) {
         let out_size = output.size() / count;
         let in_size = input.size() / count;
         let expand_bits = log2_ceil(out_size / in_size);
@@ -187,27 +192,27 @@ impl Hal for CpuHal {
             });
     }
 
-    fn batch_evaluate_ntt(&self, io: &CpuBuffer<Fp>, count: usize, expand_bits: usize) {
+    fn batch_evaluate_ntt(&self, io: &CpuBuffer<F::Elem>, count: usize, expand_bits: usize) {
         let row_size = io.size() / count;
         assert_eq!(row_size * count, io.size());
         io.as_slice_mut()
             .par_chunks_exact_mut(row_size)
             .for_each(|row| {
-                evaluate_ntt(row, expand_bits);
+                evaluate_ntt(Self::to_baby_bear_fp_slice_mut(row), expand_bits);
             });
     }
 
-    fn batch_interpolate_ntt(&self, io: &CpuBuffer<Fp>, count: usize) {
+    fn batch_interpolate_ntt(&self, io: &CpuBuffer<F::Elem>, count: usize) {
         let row_size = io.size() / count;
         assert_eq!(row_size * count, io.size());
         io.as_slice_mut()
             .par_chunks_exact_mut(row_size)
             .for_each(|row| {
-                interpolate_ntt(row);
+                interpolate_ntt(Self::to_baby_bear_fp_slice_mut(row));
             });
     }
 
-    fn batch_bit_reverse(&self, io: &CpuBuffer<Fp>, count: usize) {
+    fn batch_bit_reverse(&self, io: &CpuBuffer<F::Elem>, count: usize) {
         let row_size = io.size() / count;
         assert_eq!(row_size * count, io.size());
         io.as_slice_mut()
@@ -219,11 +224,11 @@ impl Hal for CpuHal {
 
     fn batch_evaluate_any(
         &self,
-        coeffs: &CpuBuffer<Fp>,
+        coeffs: &CpuBuffer<F::Elem>,
         poly_count: usize,
         which: &CpuBuffer<u32>,
-        xs: &CpuBuffer<Fp4>,
-        out: &CpuBuffer<Fp4>,
+        xs: &CpuBuffer<F::ExtElem>,
+        out: &CpuBuffer<F::ExtElem>,
     ) {
         let po2 = log2_ceil(coeffs.size() / poly_count);
         assert_eq!(poly_count * (1 << po2), coeffs.size());
@@ -237,8 +242,8 @@ impl Hal for CpuHal {
         (&which[..], &xs[..], &mut out[..])
             .into_par_iter()
             .for_each(|(id, x, out)| {
-                let mut tot = Fp4::ZERO;
-                let mut cur = Fp4::new(Fp::ONE, Fp::ZERO, Fp::ZERO, Fp::ZERO);
+                let mut tot = F::ExtElem::ZERO;
+                let mut cur = F::ExtElem::ONE;
                 let id = *id as usize;
                 let count = 1 << po2;
                 let local = &coeffs[count * id..count * id + count];
@@ -250,7 +255,7 @@ impl Hal for CpuHal {
             });
     }
 
-    fn zk_shift(&self, io: &CpuBuffer<Fp>, poly_count: usize) {
+    fn zk_shift(&self, io: &CpuBuffer<F::Elem>, poly_count: usize) {
         let bits = log2_ceil(io.size() / poly_count);
         let count = io.size();
         assert_eq!(io.size(), poly_count * (1 << bits));
@@ -260,17 +265,17 @@ impl Hal for CpuHal {
             .for_each(|(io, idx)| {
                 let pos = idx & ((1 << bits) - 1);
                 let rev = bit_rev_32(pos as u32) >> (32 - bits);
-                let pow3 = Fp::new(3).pow(rev as usize);
+                let pow3 = F::Elem::from_u64(3).pow(rev as usize);
                 *io = *io * pow3;
             });
     }
 
     fn mix_poly_coeffs(
         &self,
-        output: &CpuBuffer<Fp4>,
-        mix_start: &Fp4,
-        mix: &Fp4,
-        input: &CpuBuffer<Fp>,
+        output: &CpuBuffer<F::ExtElem>,
+        mix_start: &F::ExtElem,
+        mix: &F::ExtElem,
+        input: &CpuBuffer<F::Elem>,
         combos: &CpuBuffer<u32>,
         input_size: usize,
         count: usize,
@@ -291,9 +296,9 @@ impl Hal for CpuHal {
 
     fn eltwise_add_fp(
         &self,
-        output: &CpuBuffer<Fp>,
-        input1: &CpuBuffer<Fp>,
-        input2: &CpuBuffer<Fp>,
+        output: &CpuBuffer<F::Elem>,
+        input1: &CpuBuffer<F::Elem>,
+        input2: &CpuBuffer<F::Elem>,
     ) {
         assert_eq!(output.size(), input1.size());
         assert_eq!(output.size(), input2.size());
@@ -307,29 +312,30 @@ impl Hal for CpuHal {
             });
     }
 
-    fn eltwise_sum_fp4(&self, output: &CpuBuffer<Fp>, input: &CpuBuffer<Fp4>) {
-        let count = output.size() / EXT_SIZE;
+    fn eltwise_sum_fp4(&self, output: &CpuBuffer<F::Elem>, input: &CpuBuffer<F::ExtElem>) {
+        let count = output.size() / F::ExtElem::EXT_SIZE;
         let to_add = input.size() / count;
-        assert_eq!(output.size(), count * EXT_SIZE);
+        assert_eq!(output.size(), count * F::ExtElem::EXT_SIZE);
         assert_eq!(input.size(), count * to_add);
         let mut output = output.as_slice_mut();
-        let mut output = ArrayViewMut::from_shape((EXT_SIZE, count), &mut output).unwrap();
+        let mut output =
+            ArrayViewMut::from_shape((F::ExtElem::EXT_SIZE, count), &mut output).unwrap();
         let output = output.axis_iter_mut(Axis(1)).into_par_iter();
         let input = input.as_slice();
         let input = ArrayView::from_shape((to_add, count), &input).unwrap();
         let input = input.axis_iter(Axis(1)).into_par_iter();
         output.zip(input).for_each(|(mut output, input)| {
-            let mut sum = Fp4::ZERO;
+            let mut sum = F::ExtElem::ZERO;
             for i in input {
                 sum += *i;
             }
-            for i in 0..EXT_SIZE {
-                output[i] = sum.elems()[i];
+            for i in 0..F::ExtElem::EXT_SIZE {
+                output[i] = sum.subelems()[i]
             }
         });
     }
 
-    fn eltwise_copy_fp(&self, output: &CpuBuffer<Fp>, input: &CpuBuffer<Fp>) {
+    fn eltwise_copy_fp(&self, output: &CpuBuffer<F::Elem>, input: &CpuBuffer<F::Elem>) {
         let count = output.size();
         assert_eq!(count, input.size());
         let mut output = output.as_slice_mut();
@@ -353,44 +359,42 @@ impl Hal for CpuHal {
             });
     }
 
-    fn fri_fold(&self, output: &CpuBuffer<Fp>, input: &CpuBuffer<Fp>, mix: &Fp4) {
-        let count = output.size() / EXT_SIZE;
-        assert_eq!(output.size(), count * EXT_SIZE);
+    fn fri_fold(&self, output: &CpuBuffer<F::Elem>, input: &CpuBuffer<F::Elem>, mix: &F::ExtElem) {
+        let count = output.size() / F::ExtElem::EXT_SIZE;
+        assert_eq!(output.size(), count * F::ExtElem::EXT_SIZE);
         assert_eq!(input.size(), output.size() * FRI_FOLD);
         let mut output = output.as_slice_mut();
         let input = input.as_slice();
 
         // TODO: parallelize
         for idx in 0..count {
-            let mut tot = Fp4::ZERO;
-            let mut cur_mix = Fp4::from_u32(1);
+            let mut tot = F::ExtElem::ZERO;
+            let mut cur_mix = F::ExtElem::ONE;
             for i in 0..FRI_FOLD {
                 let rev_i = bit_rev_32(i as u32) >> (32 - log2_ceil(FRI_FOLD));
                 let rev_idx = rev_i as usize * count + idx;
-                let factor = Fp4::new(
-                    input[0 * count * FRI_FOLD + rev_idx],
-                    input[1 * count * FRI_FOLD + rev_idx],
-                    input[2 * count * FRI_FOLD + rev_idx],
-                    input[3 * count * FRI_FOLD + rev_idx],
+                let factor = F::ExtElem::from_subelems(
+                    (0..F::ExtElem::EXT_SIZE).map(|i| input[i * count * FRI_FOLD + rev_idx]),
                 );
                 tot += cur_mix * factor;
                 cur_mix *= *mix;
             }
-            for i in 0..EXT_SIZE {
-                output[count * i + idx] = tot.elems()[i];
+            for i in 0..F::ExtElem::EXT_SIZE {
+                output[count * i + idx] = tot.subelems()[i];
             }
         }
     }
 
-    fn sha_rows(&self, output: &CpuBuffer<Digest>, matrix: &CpuBuffer<Fp>) {
+    fn sha_rows(&self, output: &CpuBuffer<Digest>, matrix: &CpuBuffer<F::Elem>) {
         let count = output.size();
         let col_size = matrix.size() / output.size();
         assert_eq!(matrix.size(), col_size * count);
         let mut output = output.as_slice_mut();
         let matrix = matrix.as_slice().to_vec(); // TODO: avoid copy
+        let fp_matrix = CpuHal::<F>::to_baby_bear_fp_slice(matrix.as_slice());
         let sha = sha_cpu::Impl {};
         output.par_iter_mut().enumerate().for_each(|(idx, output)| {
-            *output = *sha.hash_fps_stride(&matrix, idx, col_size, count);
+            *output = *sha.hash_fps_stride(fp_matrix, idx, col_size, count);
         });
     }
 
@@ -415,6 +419,7 @@ impl Hal for CpuHal {
 
 #[cfg(test)]
 mod test {
+    use crate::field::baby_bear::BabyBear;
     use rand::thread_rng;
 
     use super::*;
@@ -422,7 +427,7 @@ mod test {
     #[test]
     #[should_panic]
     fn check_req() {
-        let hal = CpuHal::new();
+        let hal = CpuHal::<BabyBear>::new();
         let a = hal.alloc_fp(10);
         let b = hal.alloc_fp(20);
         hal.eltwise_add_fp(&a, &b, &b);
@@ -430,7 +435,7 @@ mod test {
 
     #[test]
     fn fp() {
-        let hal = CpuHal::new();
+        let hal = CpuHal::<BabyBear>::new();
         const COUNT: usize = 1024 * 1024;
         test_binary(
             &hal,
@@ -446,7 +451,7 @@ mod test {
     where
         H: Hal,
         HF: Fn(&H::BufferFp, &H::BufferFp, &H::BufferFp),
-        CF: Fn(&Fp, &Fp) -> Fp,
+        CF: Fn(&<H::Field as Field>::Elem, &<H::Field as Field>::Elem) -> <H::Field as Field>::Elem,
     {
         let a = hal.alloc_fp(count);
         let b = hal.alloc_fp(count);
@@ -456,8 +461,8 @@ mod test {
         a.view_mut(|a| {
             b.view_mut(|b| {
                 for i in 0..count {
-                    a[i] = Fp::random(&mut rng);
-                    b[i] = Fp::random(&mut rng);
+                    a[i] = <H::Field as Field>::Elem::random(&mut rng);
+                    b[i] = <H::Field as Field>::Elem::random(&mut rng);
                 }
                 for i in 0..count {
                     golden.push(cpu_fn(&a[i], &b[i]));

--- a/risc0/zkp/rust/src/hal/mod.rs
+++ b/risc0/zkp/rust/src/hal/mod.rs
@@ -15,7 +15,10 @@
 //! Hardware abstraction layer for RISC Zero zkVM
 pub mod cpu;
 
-use crate::core::{fp::Fp, fp4::Fp4, sha::Digest};
+use crate::{
+    core::sha::Digest,
+    field::{self, baby_bear::BabyBear},
+};
 
 pub trait Buffer<T>: Clone {
     fn size(&self) -> usize;
@@ -27,10 +30,64 @@ pub trait Buffer<T>: Clone {
     fn view_mut<F: FnOnce(&mut [T])>(&self, f: F);
 }
 
+// Baby bear adapters to facilitate migration to generics.  They
+// convert between a genericizied baby bear type and a concreate baby
+// bear type.  Once everything uses genericized types, we can get rid
+// of these.
+//
+// If called with a non-baby-bear field, they will produce an error at
+// runtime.
+//
+// TODO: Make it so these aren't necessary anymore.
+macro_rules! baby_bear_adapter {
+    ($fn_name:ident, $slice_fn_name:ident, $mut_slice_fn_name:ident, $from_ty:ty, $to_ty: ty $(,)?) => {
+        fn $fn_name(val: $from_ty) -> $to_ty {
+            let val_any = &val as &dyn core::any::Any;
+            if let Some(val) = val_any.downcast_ref::<$to_ty>() {
+                *val
+            } else {
+                panic!("Unable to convert between baby bear types {} and {}; other fields not supported yet.",
+                       core::any::type_name::<$from_ty>(),
+                       core::any::type_name::<$to_ty>());
+            }
+        }
+
+        // Rust doesn't let us put a reference in an any, so we have
+        // to resort to unsafe.  Specify lifetimes explicitly here
+        // to avoid any confusion.
+        fn $slice_fn_name<'a>(val: &'a [$from_ty]) -> &'a [$to_ty] {
+            let len = val.len();
+            if core::any::TypeId::of::<$from_ty>() == core::any::TypeId::of::<$to_ty>() {
+                let ptr: *const $from_ty = val.as_ptr();
+                let out: *const $to_ty = ptr.cast();
+                unsafe { core::slice::from_raw_parts(out, len) }
+            } else {
+                panic!("Unable to convert between baby bear types &[{}] and &[{}]; other fields not supported yet.",
+                       core::any::type_name::<$from_ty>(),
+                       core::any::type_name::<$to_ty>());
+            }
+        }
+
+        fn $mut_slice_fn_name<'a>(val: &'a mut [$from_ty]) -> &'a mut [$to_ty] {
+            let len = val.len();
+            if core::any::TypeId::of::<$from_ty>() == core::any::TypeId::of::<$to_ty>() {
+                let ptr: *mut $from_ty = val.as_mut_ptr();
+                let out: *mut $to_ty = ptr.cast();
+                unsafe { core::slice::from_raw_parts_mut(out, len) }
+            } else {
+                panic!("Unable to convert between baby bear types &mut [{}] and &mut [{}]; other fields not supported yet.",
+                       core::any::type_name::<$from_ty>(),
+                       core::any::type_name::<$to_ty>());
+            }
+        }
+    };
+}
+
 pub trait Hal {
+    type Field: field::Field;
     type BufferDigest: Buffer<Digest>;
-    type BufferFp: Buffer<Fp>;
-    type BufferFp4: Buffer<Fp4>;
+    type BufferFp: Buffer<<Self::Field as field::Field>::Elem>;
+    type BufferFp4: Buffer<<Self::Field as field::Field>::ExtElem>;
     type BufferU32: Buffer<u32>;
 
     fn alloc_digest(&self, size: usize) -> Self::BufferDigest;
@@ -39,8 +96,8 @@ pub trait Hal {
     fn alloc_u32(&self, size: usize) -> Self::BufferU32;
 
     fn copy_digest_from(&self, slice: &[Digest]) -> Self::BufferDigest;
-    fn copy_fp_from(&self, slice: &[Fp]) -> Self::BufferFp;
-    fn copy_fp4_from(&self, slice: &[Fp4]) -> Self::BufferFp4;
+    fn copy_fp_from(&self, slice: &[<Self::Field as field::Field>::Elem]) -> Self::BufferFp;
+    fn copy_fp4_from(&self, slice: &[<Self::Field as field::Field>::ExtElem]) -> Self::BufferFp4;
     fn copy_u32_from(&self, slice: &[u32]) -> Self::BufferU32;
 
     fn batch_expand(&self, output: &Self::BufferFp, input: &Self::BufferFp, count: usize);
@@ -65,8 +122,8 @@ pub trait Hal {
     fn mix_poly_coeffs(
         &self,
         out: &Self::BufferFp4,
-        mix_start: &Fp4,
-        mix: &Fp4,
+        mix_start: &<Self::Field as field::Field>::ExtElem,
+        mix: &<Self::Field as field::Field>::ExtElem,
         input: &Self::BufferFp,
         combos: &Self::BufferU32,
         input_size: usize,
@@ -86,11 +143,46 @@ pub trait Hal {
 
     fn eltwise_copy_digest(&self, output: &Self::BufferDigest, input: &Self::BufferDigest);
 
-    fn fri_fold(&self, output: &Self::BufferFp, input: &Self::BufferFp, mix: &Fp4);
+    fn fri_fold(
+        &self,
+        output: &Self::BufferFp,
+        input: &Self::BufferFp,
+        mix: &<Self::Field as field::Field>::ExtElem,
+    );
 
     fn sha_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferFp);
 
     fn sha_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize);
+
+    // Adapters to convert to/from baby bear field until all code is migrated.
+    baby_bear_adapter!(
+        to_baby_bear_fp,
+        to_baby_bear_fp_slice,
+        to_baby_bear_fp_slice_mut,
+        <Self::Field as field::Field>::Elem,
+        <BabyBear as field::Field>::Elem,
+    );
+    baby_bear_adapter!(
+        to_baby_bear_fp4,
+        to_baby_bear_fp4_slice,
+        to_baby_bear_fp4_slice_mut,
+        <Self::Field as field::Field>::ExtElem,
+        <BabyBear as field::Field>::ExtElem,
+    );
+    baby_bear_adapter!(
+        from_baby_bear_fp,
+        from_baby_bear_fp_slice,
+        from_baby_bear_fp_slice_mut,
+        <BabyBear as field::Field>::Elem,
+        <Self::Field as field::Field>::Elem,
+    );
+    baby_bear_adapter!(
+        from_baby_bear_fp4,
+        from_baby_bear_fp4_slice,
+        from_baby_bear_fp4_slice_mut,
+        <BabyBear as field::Field>::ExtElem,
+        <Self::Field as field::Field>::ExtElem,
+    );
 }
 
 pub trait EvalCheck<H: Hal> {
@@ -103,7 +195,7 @@ pub trait EvalCheck<H: Hal> {
         accum: &H::BufferFp,
         mix: &H::BufferFp,
         out: &H::BufferFp,
-        poly_mix: Fp4,
+        poly_mix: <H::Field as field::Field>::ExtElem,
         po2: usize,
         steps: usize,
     );

--- a/risc0/zkp/rust/src/prove/fri.rs
+++ b/risc0/zkp/rust/src/prove/fri.rs
@@ -70,7 +70,7 @@ impl<H: Hal> ProveRoundInfo<H> {
         // Create a buffer to hold the mixture of slices.
         let out_coeffs = hal.alloc_fp(size / FRI_FOLD * EXT_SIZE);
         // Compute the folded polynomial
-        hal.fri_fold(&out_coeffs, coeffs, &fold_mix);
+        hal.fri_fold(&out_coeffs, coeffs, &H::from_baby_bear_fp4(fold_mix));
         ProveRoundInfo {
             domain,
             coeffs: out_coeffs,
@@ -106,6 +106,7 @@ where
     hal.batch_bit_reverse(&final_coeffs, EXT_SIZE);
     // Dump final polynomial + commit
     final_coeffs.view(|view| {
+        let view = H::to_baby_bear_fp_slice(view);
         iop.write_fp_slice(view);
         let digest = iop.get_sha().hash_fps(view);
         iop.commit(&digest);

--- a/risc0/zkvm/sdk/rust/src/method_id.rs
+++ b/risc0/zkvm/sdk/rust/src/method_id.rs
@@ -22,6 +22,7 @@ use risc0_zkp::{
         log2_ceil,
         sha::{Digest, DIGEST_WORDS, DIGEST_WORD_SIZE},
     },
+    field::baby_bear::BabyBear,
     MAX_CYCLES, MIN_CYCLES, ZK_CYCLES,
 };
 
@@ -72,7 +73,7 @@ impl MethodId {
         };
         use risc0_zkvm_platform::memory::MEM_SIZE;
 
-        let hal = CpuHal::new();
+        let hal: CpuHal<BabyBear> = CpuHal::new();
         let program = Program::load_elf(elf_contents, MEM_SIZE as u32)?;
 
         // Start with an empty table

--- a/risc0/zkvm/sdk/rust/src/prove/cpu_eval.rs
+++ b/risc0/zkvm/sdk/rust/src/prove/cpu_eval.rs
@@ -20,7 +20,7 @@ use risc0_zkp::{
         log2_ceil,
         rou::ROU_FWD,
     },
-    field::Elem,
+    field::{baby_bear::BabyBear, Elem},
     hal::{
         cpu::{CpuBuffer, CpuHal},
         EvalCheck,
@@ -38,7 +38,7 @@ impl<'a, C: PolyFp> CpuEvalCheck<'a, C> {
     }
 }
 
-impl<'a, C: PolyFp> EvalCheck<CpuHal> for CpuEvalCheck<'a, C> {
+impl<'a, C: PolyFp> EvalCheck<CpuHal<BabyBear>> for CpuEvalCheck<'a, C> {
     fn eval_check(
         &self,
         check: &CpuBuffer<Fp>,


### PR DESCRIPTION
This PR cuts off the head of the hydra, and adds calls in a bunch
of places to convert between the BabyBear field (e.g.  Fp and Fp4)
and the type-erased version of it (Hal::Field::{Elem,ExtElem}).

As other things get genericized, we can remove these conversion
calls.