### PR TITLE
Eliminate copies in ReadIOP, merkle verifier

### DIFF
--- a/risc0/zkp/rust/src/prove/adapter.rs
+++ b/risc0/zkp/rust/src/prove/adapter.rs
@@ -52,7 +52,7 @@ impl<'a, C: CircuitDef<CS>, CS: CustomStep> Circuit for ProveAdapter<'a, C, CS> 
     }
 
     fn execute<S: Sha>(&mut self, iop: &mut WriteIOP<S>) {
-        iop.write_fp_slice(&self.exec.output);
+        iop.write_pod_slice(&self.exec.output);
         iop.write_u32_slice(&[self.exec.po2 as u32]);
     }
 

--- a/risc0/zkp/rust/src/prove/fri.rs
+++ b/risc0/zkp/rust/src/prove/fri.rs
@@ -102,7 +102,7 @@ where
     hal.batch_bit_reverse(&final_coeffs, EXT_SIZE);
     // Dump final polynomial + commit
     final_coeffs.view(|view| {
-        iop.write_fp_slice::<<<H as Hal>::Field as field::Field>::Elem>(view);
+        iop.write_pod_slice::<<<H as Hal>::Field as field::Field>::Elem>(view);
         let digest = iop.get_sha().hash_raw_pod_slice(view);
         iop.commit(&digest);
     });

--- a/risc0/zkp/rust/src/prove/merkle.rs
+++ b/risc0/zkp/rust/src/prove/merkle.rs
@@ -83,7 +83,7 @@ impl<H: Hal> MerkleTreeProver<H> {
         let mut proof_slice = self.tmp_proof.slice(0, top_size);
         hal.eltwise_copy_digest(&mut proof_slice, &self.nodes.slice(top_size, top_size));
         proof_slice.view(|view| {
-            iop.write_digest_slice(view);
+            iop.write_pod_slice(view);
         });
         iop.commit(self.root());
     }
@@ -114,14 +114,14 @@ impl<H: Hal> MerkleTreeProver<H> {
                 out.push(view[idx + i * self.params.row_size]);
             }
         });
-        iop.write_fp_slice::<<<H as Hal>::Field as Field>::Elem>(out.as_slice());
+        iop.write_pod_slice::<<<H as Hal>::Field as Field>::Elem>(out.as_slice());
         let mut idx = idx + self.params.row_size;
         self.nodes.view(|view| {
             while idx >= 2 * self.params.top_size {
                 let low_bit = idx % 2;
                 idx /= 2;
                 let other_idx = 2 * idx + (1 - low_bit);
-                iop.write_digest_slice(&[view[other_idx]]);
+                iop.write_pod_slice(&[view[other_idx]]);
             }
         });
         out
@@ -207,7 +207,7 @@ mod tests {
                         assert!(false, "Cannot test for bad query if there is only one row");
                     }
                     let r_idx = (r_idx + 1) % rows;
-                    let verification = verifier.verify(&mut r_iop, r_idx);
+                    let verification = verifier.verify::<BabyBear>(&mut r_iop, r_idx);
                     match verification {
                         Ok(_) => assert!(
                             false,
@@ -222,7 +222,7 @@ mod tests {
                     err = true;
                     break;
                 }
-                let col = verifier.verify(&mut r_iop, r_idx).unwrap();
+                let col = verifier.verify::<BabyBear>(&mut r_iop, r_idx).unwrap();
                 for c_idx in 0..cols {
                     assert_eq!(
                         col[c_idx],

--- a/risc0/zkp/rust/src/prove/mod.rs
+++ b/risc0/zkp/rust/src/prove/mod.rs
@@ -234,7 +234,7 @@ pub fn prove<H: Hal, S: Sha, C: Circuit, E: EvalCheck<H>>(
     });
 
     debug!("Size of U = {}", coeff_u.len());
-    iop.write_fp4_slice(&coeff_u);
+    iop.write_pod_slice(&coeff_u);
     let hash_u = sha.hash_raw_pod_slice(coeff_u.as_slice());
     iop.commit(&hash_u);
 

--- a/risc0/zkp/rust/src/prove/write_iop.rs
+++ b/risc0/zkp/rust/src/prove/write_iop.rs
@@ -15,11 +15,9 @@
 use alloc::vec::Vec;
 
 use crate::core::{
-    fp4::Fp4,
     sha::{Digest, Sha},
     sha_rng::ShaRng,
 };
-use crate::field::Elem;
 
 pub struct WriteIOP<S: Sha> {
     sha: S,
@@ -50,23 +48,8 @@ impl<S: Sha> WriteIOP<S> {
     }
 
     /// Called by the prover to write some data.
-    pub fn write_fp_slice<E: Elem>(&mut self, slice: &[E]) {
-        self.proof
-            .extend(slice.iter().flat_map(|x| x.to_u32_words()));
-    }
-
-    /// Called by the prover to write some data.
-    pub fn write_fp4_slice(&mut self, slice: &[Fp4]) {
-        for x in slice {
-            self.write_fp_slice(x.elems());
-        }
-    }
-
-    /// Called by the prover to write some data.
-    pub fn write_digest_slice(&mut self, digest: &[Digest]) {
-        for x in digest {
-            self.write_u32_slice(x.as_slice());
-        }
+    pub fn write_pod_slice<T: bytemuck::Pod>(&mut self, slice: &[T]) {
+        self.proof.extend(bytemuck::cast_slice(slice))
     }
 
     /// Called by the prover to commit to some hash (usually data written

--- a/risc0/zkp/rust/src/verify/merkle.rs
+++ b/risc0/zkp/rust/src/verify/merkle.rs
@@ -37,7 +37,7 @@ pub struct MerkleTreeVerifier<'a, S: Sha> {
     // contains the virtual indexes [top_size..top_size*2).
     top: &'a [Digest],
 
-    // These are the rest of the tree.  These have the virutal indexes [1, top_Size).
+    // These are the rest of the tree.  These have the virtual indexes [1, top_size).
     rest: Vec<S::DigestPtr>,
 }
 

--- a/risc0/zkp/rust/src/verify/merkle.rs
+++ b/risc0/zkp/rust/src/verify/merkle.rs
@@ -41,7 +41,7 @@ pub struct MerkleTreeVerifier<'a, S: Sha> {
     rest: Vec<S::DigestPtr>,
 }
 
-// Transltaes from virtual indexes to indexes in the "top" and "rest" arrays.
+// Translates from virtual indexes to indexes in the "top" and "rest" arrays.
 trait SplitMerkleIndex {
     fn idx_to_top(&self, idx: usize) -> usize;
     fn idx_to_rest(&self, idx: usize) -> usize;

--- a/risc0/zkp/rust/src/verify/merkle.rs
+++ b/risc0/zkp/rust/src/verify/merkle.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 
 use crate::{
-    core::{
-        fp::Fp,
-        sha::{Digest, Sha},
-    },
-    field::Elem,
+    core::sha::{Digest, Sha},
+    field::Field,
     merkle::MerkleTreeParams,
     verify::read_iop::ReadIOP,
     verify::VerificationError,
@@ -28,47 +25,115 @@ use crate::{
 /// A struct against which we verify merkle branches, consisting of the
 /// parameters of the Merkle tree and top - the vector of hash values in the top
 /// row of the tree, above which we verify only once.
-pub struct MerkleTreeVerifier {
+pub struct MerkleTreeVerifier<'a, S: Sha> {
     params: MerkleTreeParams,
-    top: Vec<Digest>,
+
+    // Conceptually, the merkle tree here is twice as long as the
+    // "top" row (params.top_size), minus element #0.  The children of
+    // the entry at virtual index i are stored at 2*i and 2*i+1.  The
+    // root of the tree is at virtual element #1.
+
+    // "top" is a reference, top_size long, to the top row.  This
+    // contains the virtual indexes [top_size..top_size*2).
+    top: &'a [Digest],
+
+    // These are the rest of the tree.  These have the virutal indexes [1, top_Size).
+    rest: Vec<S::DigestPtr>,
 }
 
-impl MerkleTreeVerifier {
+// Transltaes from virtual indexes to indexes in the "top" and "rest" arrays.
+trait SplitMerkleIndex {
+    fn idx_to_top(&self, idx: usize) -> usize;
+    fn idx_to_rest(&self, idx: usize) -> usize;
+}
+
+impl SplitMerkleIndex for MerkleTreeParams {
+    // Returns the index into "top" of the given element
+    #[track_caller]
+    fn idx_to_top(&self, idx: usize) -> usize {
+        debug_assert!(
+            idx >= self.top_size,
+            "idx = {idx}, top_size = {}",
+            self.top_size
+        );
+        debug_assert!(
+            idx < 2 * self.top_size,
+            "idx = {idx}, top_size = {}",
+            self.top_size
+        );
+        idx - self.top_size
+    }
+
+    // Returns the index into "rest" of the given element
+    #[track_caller]
+    fn idx_to_rest(&self, idx: usize) -> usize {
+        debug_assert!(
+            idx < self.top_size,
+            "idx = {idx}, top_size = {}",
+            self.top_size
+        );
+        debug_assert!(idx >= 1, "idx = {idx}, top_size = {}", self.top_size);
+        idx - 1
+    }
+}
+
+impl<'a, S: Sha> MerkleTreeVerifier<'a, S> {
     /// Constructs a new MerkleTreeVerifier by making the params, and then
     /// computing the root hashes from the top level hashes.
-    pub fn new<S: Sha>(
-        iop: &mut ReadIOP<S>,
-        row_size: usize,
-        col_size: usize,
-        queries: usize,
-    ) -> Self {
+    pub fn new(iop: &mut ReadIOP<'a, S>, row_size: usize, col_size: usize, queries: usize) -> Self {
         let params = MerkleTreeParams::new(row_size, col_size, queries);
-        // Initialize a vector to hold the digests.
-        // Vector is twice as long as the "top" row - the children of the entry at index
-        // i are stored at 2*i and 2*i+1.
-        let mut top = vec![Digest::default(); params.top_size * 2];
+
         // Fill top vector with digests from IOP.
-        iop.read_digests(&mut top[params.top_size..]);
+        let top = iop.read_pod_slice(params.top_size);
         // Populate hashes up to the root of the tree.
-        for i in (1..params.top_size).rev() {
-            top[i] = *iop.get_sha().hash_pair(&top[2 * i], &top[2 * i + 1]);
+        let mut rest = Vec::<S::DigestPtr>::with_capacity(params.top_size - 1);
+
+        let fill_rest = rest.spare_capacity_mut();
+
+        if !fill_rest.is_empty() {
+            for i in (params.top_size / 2..params.top_size).rev() {
+                let top_idx = params.idx_to_top(2 * i);
+                fill_rest[params.idx_to_rest(i)]
+                    .write(iop.get_sha().hash_pair(&top[top_idx], &top[top_idx + 1]));
+            }
         }
+        for i in (1..params.top_size / 2).rev() {
+            // SAFETY: We're working from the top down, so we will
+            // have already filled elements at upper_rest_idx.
+            let upper_rest_idx = params.idx_to_rest(i * 2);
+            fill_rest[params.idx_to_rest(i)].write(iop.get_sha().hash_pair(
+                unsafe { fill_rest[upper_rest_idx].assume_init_ref() },
+                unsafe { fill_rest[upper_rest_idx + 1].assume_init_ref() },
+            ));
+        }
+
+        // SAFETY: These are all the elements we just filled.
+        unsafe {
+            let filled = fill_rest.len();
+            rest.set_len(filled);
+        };
+
         // Commit to root (index 1).
-        iop.commit(&top[1]);
-        MerkleTreeVerifier { params, top }
+        let verifier = MerkleTreeVerifier { params, top, rest };
+        iop.commit(verifier.root());
+        verifier
     }
 
     /// Returns the root hash of the tree.
     pub fn root(&self) -> &Digest {
-        &self.top[1]
+        if self.rest.is_empty() {
+            &self.top[self.params.idx_to_top(1)]
+        } else {
+            &*self.rest[self.params.idx_to_rest(1)]
+        }
     }
 
     /// Verifies a branch provided by an IOP.
-    pub fn verify<S: Sha>(
+    pub fn verify<F: Field>(
         &self,
-        iop: &mut ReadIOP<S>,
+        iop: &mut ReadIOP<'a, S>,
         mut idx: usize,
-    ) -> Result<Vec<Fp>, VerificationError> {
+    ) -> Result<&'a [F::Elem], VerificationError> {
         if idx >= self.params.row_size {
             return Err(VerificationError::MerkleQueryOutOfRange {
                 idx: idx,
@@ -76,11 +141,9 @@ impl MerkleTreeVerifier {
             });
         }
         // Initialize a vector to hold field elements.
-        let mut out = vec![Fp::ZERO; self.params.col_size];
-        // Read out field elements from IOP.
-        iop.read_fps(&mut out);
+        let out: &[F::Elem] = iop.read_pod_slice(self.params.col_size);
         // Get the hash at the leaf of the tree by hashing these field elements.
-        let mut cur = *iop.get_sha().hash_raw_pod_slice(out.as_slice());
+        let mut cur: S::DigestPtr = iop.get_sha().hash_raw_pod_slice(out);
         // Shift idx to start of the row
         idx += self.params.row_size;
         while idx >= 2 * self.params.top_size {
@@ -88,19 +151,26 @@ impl MerkleTreeVerifier {
             // child.
             let low_bit = idx % 2;
             // Retrieve the other parent from the IOP.
-            let mut other = [Digest::default(); 1];
-            iop.read_digests(&mut other);
+            let other: &Digest = match iop.read_pod_slice(1) {
+                [other] => other,
+                _ => unreachable!(),
+            };
             // Now ascend to the parent index, and compute the hash there.
             idx /= 2;
             if low_bit == 1 {
-                cur = *iop.get_sha().hash_pair(&other[0], &cur);
+                cur = iop.get_sha().hash_pair(&other, &cur);
             } else {
-                cur = *iop.get_sha().hash_pair(&cur, &other[0]);
+                cur = iop.get_sha().hash_pair(&cur, &other);
             }
         }
         // Once we reduce to an index for which we have the hash, check that it's
         // correct.
-        if self.top[idx] == cur {
+        let present_hash: &Digest = if idx >= self.params.top_size {
+            &self.top[self.params.idx_to_top(idx)]
+        } else {
+            &self.rest[self.params.idx_to_rest(idx)]
+        };
+        if *present_hash == *cur {
             Ok(out)
         } else {
             Err(VerificationError::InvalidProof)


### PR DESCRIPTION
* ReadIOP is now field agnostic, and returns slices instead of copying.

* Merkle verifier now splits the merkle tree into "top", which is just referenced by slice, and "rest", which is hashed based on "top".
  It still passes the expanded merkle tests; thanks @tzerrell!