### PR TITLE
Group imports by Std External Crate 

### DIFF
--- a/bazel/rules/rust/rustfmt.toml
+++ b/bazel/rules/rust/rustfmt.toml
@@ -1,2 +1,3 @@
 wrap_comments = true
 normalize_comments = true
+group_imports = "StdExternalCrate"

--- a/risc0/zkp/rust/src/core/ntt.rs
+++ b/risc0/zkp/rust/src/core/ntt.rs
@@ -23,7 +23,6 @@ use super::{
     log2_ceil,
     rou::{ROU_FWD, ROU_REV},
 };
-
 use crate::field::Elem;
 
 /// Reverses the bits in a 32-bit number.
@@ -323,7 +322,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::field::Elem;
     use rand::thread_rng;
 
     use crate::core::{
@@ -331,6 +329,7 @@ mod tests {
         ntt::{bit_reverse, evaluate_ntt, interpolate_ntt},
         rou::ROU_FWD,
     };
+    use crate::field::Elem;
 
     // Compare the complex version to the naive version
     #[test]

--- a/risc0/zkp/rust/src/core/sha.rs
+++ b/risc0/zkp/rust/src/core/sha.rs
@@ -223,8 +223,9 @@ mod tests {
 
 #[allow(missing_docs)]
 pub mod testutil {
-    use super::{Digest, Fp, Fp4, Sha};
     use alloc::vec::Vec;
+
+    use super::{Digest, Fp, Fp4, Sha};
 
     // Runs conformance test on a SHA implementation to make sure it properly
     // behaves.

--- a/risc0/zkp/rust/src/core/sha_rng.rs
+++ b/risc0/zkp/rust/src/core/sha_rng.rs
@@ -78,9 +78,10 @@ impl<S: Sha> RngCore for ShaRng<S> {
 
 #[allow(missing_docs)]
 pub mod testutil {
+    use rand::RngCore;
+
     use super::ShaRng;
     use crate::core::sha::Sha;
-    use rand::RngCore;
 
     // Runs conformance test on a SHA implementation to make sure it
     // properly behaves for generating pseudo-random numbers.

--- a/risc0/zkp/rust/src/field/baby_bear.rs
+++ b/risc0/zkp/rust/src/field/baby_bear.rs
@@ -579,10 +579,12 @@ impl From<Elem> for ExtElem {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
+
+    use rand::{Rng, SeedableRng};
+
     use super::{field, Elem, ExtElem, P, P_U64};
     use crate::field::Elem as FieldElem;
-    use alloc::{vec, vec::Vec};
-    use rand::{Rng, SeedableRng};
 
     #[test]
     pub fn roots_of_unity() {

--- a/risc0/zkp/rust/src/field/goldilocks.rs
+++ b/risc0/zkp/rust/src/field/goldilocks.rs
@@ -569,10 +569,12 @@ impl From<Elem> for ExtElem {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
+
+    use rand::{Rng, SeedableRng};
+
     use super::{field, Elem, ExtElem, P};
     use crate::field::Elem as FieldElem;
-    use alloc::{vec, vec::Vec};
-    use rand::{Rng, SeedableRng};
 
     #[test]
     /// Roots of unity tests common to all fields under test

--- a/risc0/zkp/rust/src/field/mod.rs
+++ b/risc0/zkp/rust/src/field/mod.rs
@@ -125,9 +125,11 @@ pub trait RootsOfUnity: Sized + 'static {
 
 #[cfg(test)]
 pub mod test {
-    use super::{Elem, RootsOfUnity};
     use core::fmt::Debug;
+
     use rand::Rng;
+
+    use super::{Elem, RootsOfUnity};
 
     pub fn test_roots_of_unity<F: Elem + RootsOfUnity + Debug>() {
         let mut cur: Option<F> = None;

--- a/risc0/zkp/rust/src/hal/cpu.rs
+++ b/risc0/zkp/rust/src/hal/cpu.rs
@@ -420,10 +420,10 @@ impl<F: Field> Hal for CpuHal<F> {
 
 #[cfg(test)]
 mod test {
-    use crate::field::baby_bear::BabyBear;
     use rand::thread_rng;
 
     use super::*;
+    use crate::field::baby_bear::BabyBear;
 
     #[test]
     #[should_panic]

--- a/risc0/zkp/rust/src/prove/merkle.rs
+++ b/risc0/zkp/rust/src/prove/merkle.rs
@@ -14,6 +14,7 @@
 
 use alloc::vec::Vec;
 use core::cmp;
+
 #[allow(unused_imports)]
 use log::debug;
 
@@ -130,15 +131,15 @@ impl<H: Hal> MerkleTreeProver<H> {
 
 #[cfg(test)]
 mod tests {
+    use rand::{Rng, RngCore};
+
+    use super::*;
     use crate::{
         core::{fp::Fp, sha_cpu},
         field::{baby_bear::BabyBear, Elem},
         hal::cpu::CpuHal,
         verify::{merkle::MerkleTreeVerifier, read_iop::ReadIOP, VerificationError},
     };
-    use rand::{Rng, RngCore};
-
-    use super::*;
 
     fn init_prover<H: Hal>(
         hal: &H,

--- a/risc0/zkp/rust/src/verify/mod.rs
+++ b/risc0/zkp/rust/src/verify/mod.rs
@@ -18,7 +18,8 @@ pub(crate) mod merkle;
 pub mod read_iop;
 
 use alloc::vec;
-use core::{fmt, iter::zip};
+use core::fmt;
+use core::iter::zip;
 
 // use log::debug;
 use crate::{

--- a/risc0/zkp/rust/src/verify/mod.rs
+++ b/risc0/zkp/rust/src/verify/mod.rs
@@ -19,8 +19,8 @@ pub mod read_iop;
 
 use alloc::vec;
 use core::fmt;
-// use log::debug;
 
+// use log::debug;
 use crate::{
     core::{
         fp::Fp,

--- a/risc0/zkp/rust/src/verify/mod.rs
+++ b/risc0/zkp/rust/src/verify/mod.rs
@@ -17,7 +17,7 @@ mod fri;
 pub(crate) mod merkle;
 pub mod read_iop;
 
-use alloc::vec;
+use alloc::{vec, vec::Vec};
 use core::fmt;
 use core::iter::zip;
 

--- a/risc0/zkp/rust/src/verify/mod.rs
+++ b/risc0/zkp/rust/src/verify/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod merkle;
 pub mod read_iop;
 
 use alloc::vec;
-use core::fmt;
+use core::{fmt, iter::zip};
 
 // use log::debug;
 use crate::{
@@ -30,7 +30,7 @@ use crate::{
         rou::{ROU_FWD, ROU_REV},
         sha::{Digest, Sha},
     },
-    field::Elem,
+    field::{baby_bear::BabyBear, Elem},
     taps::{RegisterGroup, TapSet},
     verify::{fri::fri_verify, merkle::MerkleTreeVerifier, read_iop::ReadIOP},
     CHECK_SIZE, INV_RATE, MAX_CYCLES_PO2, QUERIES,
@@ -59,23 +59,23 @@ impl fmt::Display for VerificationError {
     }
 }
 
-pub trait Circuit {
+pub trait Circuit<'a> {
     fn taps(&self) -> &'static TapSet<'static>;
-    fn execute<S: Sha>(&mut self, iop: &mut ReadIOP<S>);
-    fn accumulate<S: Sha>(&mut self, iop: &mut ReadIOP<S>);
+    fn execute<S: Sha>(&mut self, iop: &mut ReadIOP<'a, S>);
+    fn accumulate<S: Sha>(&mut self, iop: &mut ReadIOP<'a, S>);
     fn po2(&self) -> u32;
     fn compute_polynomial(&self, u: &[Fp4], mix: Fp4) -> Fp4;
 }
 
-pub fn verify<S, C, F>(
-    sha: &S,
+pub fn verify<'a, S, C, F>(
+    sha: &'a S,
     circuit: &mut C,
-    seal: &[u32],
+    seal: &'a [u32],
     check_code: F,
 ) -> Result<(), VerificationError>
 where
     S: Sha,
-    C: Circuit,
+    C: Circuit<'a>,
     F: Fn(u32, &Digest) -> bool,
 {
     if seal.len() == 0 {
@@ -131,14 +131,13 @@ where
 
     // Read the U coeffs + commit their hash
     let num_taps = taps.tap_size();
-    let mut coeff_u = vec![Fp4::ZERO; num_taps + CHECK_SIZE];
-    iop.read_fp4s(&mut coeff_u);
-    let hash_u = *sha.hash_raw_pod_slice(coeff_u.as_slice());
+    let coeff_u = iop.read_pod_slice(num_taps + CHECK_SIZE);
+    let hash_u = *sha.hash_raw_pod_slice(coeff_u);
     iop.commit(&hash_u);
 
     // Now, convert to evaluated values
     let mut cur_pos = 0;
-    let mut eval_u = vec![];
+    let mut eval_u = Vec::with_capacity(num_taps);
     for reg in taps.regs() {
         for i in 0..reg.size() {
             let x = back_one.pow(reg.back(i)) * z;
@@ -147,6 +146,7 @@ where
         }
         cur_pos += reg.size();
     }
+    assert_eq!(eval_u.len(), num_taps, "Miscalculated capacity for eval_us");
 
     // Compute the core polynomial
     let result = circuit.compute_polynomial(&eval_u, poly_mix);
@@ -175,27 +175,48 @@ where
     // debug!("mix = {mix:?}");
 
     // Make the mixed U polynomials
-    let mut combo_u = vec![];
-    for i in 0..combo_count {
-        combo_u.push(vec![Fp4::ZERO; taps.get_combo(i).size()]);
-    }
+    let mut combo_u: Vec<Vec<Fp4>> = Vec::with_capacity(combo_count + 1);
+    combo_u.extend(
+        (0..combo_count)
+            .into_iter()
+            .map(|i| vec![Fp4::ZERO; taps.get_combo(i).size()]),
+    );
     let mut cur_mix = Fp4::ONE;
     cur_pos = 0;
+    let mut tap_mix_pows = Vec::with_capacity(taps.reg_count());
     for reg in taps.regs() {
         for i in 0..reg.size() {
             combo_u[reg.combo_id()][i] += cur_mix * coeff_u[cur_pos + i];
         }
+        tap_mix_pows.push(cur_mix);
         cur_mix *= mix;
         cur_pos += reg.size();
     }
+    assert_eq!(
+        tap_mix_pows.len(),
+        taps.reg_count(),
+        "Miscalculated capacity for tap_mix_pows"
+    );
     // debug!("cur_mix: {cur_mix:?}, cur_pos: {cur_pos}");
     // Handle check group
     combo_u.push(vec![Fp4::ZERO]);
+    assert_eq!(
+        combo_u.len(),
+        combo_count + 1,
+        "Miscalculated capacity for combo_u"
+    );
+    let mut check_mix_pows = Vec::with_capacity(CHECK_SIZE);
     for _ in 0..CHECK_SIZE {
         combo_u[combo_count][0] += cur_mix * coeff_u[cur_pos];
         cur_pos += 1;
+        check_mix_pows.push(cur_mix);
         cur_mix *= mix;
     }
+    assert_eq!(
+        check_mix_pows.len(),
+        CHECK_SIZE,
+        "Miscalculated capacity for check_mix_pows"
+    );
     // debug!("cur_mix: {cur_mix:?}");
 
     let gen = Fp::new(ROU_FWD[log2_ceil(domain)]);
@@ -205,20 +226,18 @@ where
         size,
         |iop: &mut ReadIOP<S>, idx: usize| -> Result<Fp4, VerificationError> {
             let x = Fp4::from_fp(gen.pow(idx));
-            let mut rows = vec![];
-            rows.push(accum_merkle.verify(iop, idx)?);
-            rows.push(code_merkle.verify(iop, idx)?);
-            rows.push(data_merkle.verify(iop, idx)?);
-            let check_row = check_merkle.verify(iop, idx)?;
-            let mut cur = Fp4::ONE;
+            let rows = [
+                accum_merkle.verify::<BabyBear>(iop, idx)?,
+                code_merkle.verify::<BabyBear>(iop, idx)?,
+                data_merkle.verify::<BabyBear>(iop, idx)?,
+            ];
+            let check_row = check_merkle.verify::<BabyBear>(iop, idx)?;
             let mut tot = vec![Fp4::ZERO; combo_count + 1];
-            for reg in taps.regs() {
-                tot[reg.combo_id()] += cur * rows[reg.group() as usize][reg.offset()];
-                cur *= mix;
+            for (reg, cur) in zip(taps.regs(), tap_mix_pows.iter()) {
+                tot[reg.combo_id()] += *cur * rows[reg.group() as usize][reg.offset()];
             }
-            for i in 0..CHECK_SIZE {
-                tot[combo_count] += cur * check_row[i];
-                cur *= mix;
+            for (i, cur) in zip(0..CHECK_SIZE, check_mix_pows.iter()) {
+                tot[combo_count] += *cur * check_row[i];
             }
             let mut ret = Fp4::ZERO;
             for i in 0..combo_count {

--- a/risc0/zkp/rust/src/verify/mod.rs
+++ b/risc0/zkp/rust/src/verify/mod.rs
@@ -18,8 +18,7 @@ pub(crate) mod merkle;
 pub mod read_iop;
 
 use alloc::{vec, vec::Vec};
-use core::fmt;
-use core::iter::zip;
+use core::{fmt, iter::zip};
 
 // use log::debug;
 use crate::{

--- a/risc0/zkvm/prove/make-id/src/main.rs
+++ b/risc0/zkvm/prove/make-id/src/main.rs
@@ -21,9 +21,9 @@
 //! our [Risc Zero Rust Starter repository](https://github.com/risc0/risc0-rust-starter)
 //! for help getting started.
 
-use clap::Parser;
 use std::fs;
 
+use clap::Parser;
 use risc0_zkvm::host::{MethodId, DEFAULT_METHOD_ID_LIMIT};
 
 /// Generates a MethodID for a given RISC-V ELF binary.

--- a/risc0/zkvm/r0vm/src/bin/r0vm.rs
+++ b/risc0/zkvm/r0vm/src/bin/r0vm.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::Parser;
 use std::default::Default;
 use std::{fs, io::Write};
 
+use clap::Parser;
 use risc0_zkvm::host::{MethodId, Prover, ProverOpts, Receipt, DEFAULT_METHOD_ID_LIMIT};
 
 /// Generates a MethodID for a given RISC-V ELF binary.

--- a/risc0/zkvm/r0vm/tests/standard_lib.rs
+++ b/risc0/zkvm/r0vm/tests/standard_lib.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use anyhow::Result;
 use assert_cmd::Command;
 use assert_fs::{fixture::PathChild, TempDir};
-
 use risc0_zkvm::host::Receipt;
 
 static EXPECTED_STDOUT: &str = "Hello world on stdout!\n";

--- a/risc0/zkvm/sdk/rust/benches/guest_run.rs
+++ b/risc0/zkvm/sdk/rust/benches/guest_run.rs
@@ -19,6 +19,8 @@
 //! are not indicitive of performance with cryptographically secure
 //! proofs.
 
+use std::time::{Duration, Instant};
+
 use criterion::{
     black_box, criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, SamplingMode,
     Throughput,
@@ -27,8 +29,6 @@ use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-use std::time::{Duration, Instant};
-
 use risc0_zkvm::host::{Prover, ProverOpts};
 use risc0_zkvm::serde::to_vec;
 use risc0_zkvm_methods::{

--- a/risc0/zkvm/sdk/rust/circuit/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/circuit/src/lib.rs
@@ -42,8 +42,9 @@ impl CircuitInfo for CircuitImpl {
 
 #[cfg(test)]
 mod test {
-    use super::taps;
     use risc0_zkp::taps::{TapSet, TapSetOwned};
+
+    use super::taps;
 
     #[test]
     fn generated_tapset_matches() {

--- a/risc0/zkvm/sdk/rust/guest/src/env.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/env.rs
@@ -16,6 +16,9 @@ use core::{cell::UnsafeCell, mem::MaybeUninit, slice};
 
 use risc0_zkp::core::sha::Digest;
 use risc0_zkvm::serde::{Deserializer, Serializer, Slice};
+// Re-export for easy use by user programs.
+#[cfg(target_os = "zkvm")]
+pub use risc0_zkvm_platform::rt::host_io::host_sendrecv;
 use risc0_zkvm_platform::{
     io::{
         IoDescriptor, GPIO_COMMIT, GPIO_CYCLECOUNT, SENDRECV_CHANNEL_INITIAL_INPUT,
@@ -28,10 +31,6 @@ use risc0_zkvm_platform::{
 use serde::{Deserialize, Serialize};
 
 use crate::{align_up, memory_barrier, sha};
-
-// Re-export for easy use by user programs.
-#[cfg(target_os = "zkvm")]
-pub use risc0_zkvm_platform::rt::host_io::host_sendrecv;
 
 #[cfg(not(target_os = "zkvm"))]
 // Bazel really wants to compile this file for the host too, so provide a stub.

--- a/risc0/zkvm/sdk/rust/guest/src/sha.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/sha.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc_crate::{boxed::Box, vec::Vec};
 use core::{cell::UnsafeCell, mem};
 
+use alloc_crate::{boxed::Box, vec::Vec};
 use risc0_zkp::core::{
     fp::Fp,
     fp4::Fp4,

--- a/risc0/zkvm/sdk/rust/guest/src/sha_insecure.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/sha_insecure.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use alloc_crate::vec::Vec;
-
 use risc0_zkp::core::sha::{Digest, DIGEST_WORDS, SHA256_INIT};
 use risc0_zkvm_platform::{
     io::{

--- a/risc0/zkvm/sdk/rust/methods/build.rs
+++ b/risc0/zkvm/sdk/rust/methods/build.rs
@@ -1,5 +1,6 @@
-use risc0_build::{embed_methods_with_options, GuestOptions};
 use std::{collections::HashMap, env};
+
+use risc0_build::{embed_methods_with_options, GuestOptions};
 
 fn main() {
     if env::var("CARGO_CFG_TARGET_OS").unwrap().contains("zkvm") {

--- a/risc0/zkvm/sdk/rust/methods/src/bench.rs
+++ b/risc0/zkvm/sdk/rust/methods/src/bench.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
 use alloc::vec::Vec;
+
 use serde::{Deserialize, Serialize};
 
 // Benchmark support structures for communication between host and guest.

--- a/risc0/zkvm/sdk/rust/src/host/ffi.rs
+++ b/risc0/zkvm/sdk/rust/src/host/ffi.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{ffi::CStr, mem, os::raw::c_char};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::exception::Exception;
 use super::ProverOpts;

--- a/risc0/zkvm/sdk/rust/src/host/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/host/mod.rs
@@ -25,10 +25,9 @@ mod prove;
 
 use std::collections::HashMap;
 
+pub use exception::Exception;
 #[cfg(not(feature = "pure-prove"))]
 use ffi as prove;
-
-pub use exception::Exception;
 pub use prove::{MethodId, Prover, Receipt};
 
 /// The default digest count when generating a MethodId.
@@ -78,8 +77,8 @@ impl<'a> Default for ProverOpts<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::{MethodId, Prover, ProverOpts, Receipt};
-    use crate::serde::{from_slice, to_vec};
+    use std::sync::Mutex;
+
     use anyhow::Result;
     use risc0_zkp::core::sha::Digest;
     use risc0_zkvm_methods::{
@@ -87,8 +86,10 @@ mod test {
         SHA_ACCEL_PATH, SHA_ID, SHA_PATH,
     };
     use risc0_zkvm_platform::memory::{COMMIT, HEAP};
-    use std::sync::Mutex;
     use test_log::test;
+
+    use super::{MethodId, Prover, ProverOpts, Receipt};
+    use crate::serde::{from_slice, to_vec};
 
     #[test]
     fn sha() {

--- a/risc0/zkvm/sdk/rust/src/method_id.rs
+++ b/risc0/zkvm/sdk/rust/src/method_id.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use alloc::vec::Vec;
+
 use anyhow::Result;
 use risc0_zkp::{
     core::{
@@ -94,9 +95,8 @@ mod prove {
     };
     use risc0_zkvm_platform::memory::MEM_SIZE;
 
-    use crate::{elf::Program, prove::exec, CODE_SIZE};
-
     use super::{MethodId, MAX_CODE_DIGEST_COUNT};
+    use crate::{elf::Program, prove::exec, CODE_SIZE};
 
     pub fn compute_with_limit(elf_contents: &[u8], limit: u32) -> Result<MethodId> {
         let code_size = *CODE_SIZE;

--- a/risc0/zkvm/sdk/rust/src/prove/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/prove/mod.rs
@@ -29,9 +29,8 @@ use risc0_zkvm_platform::{
     memory::MEM_SIZE,
 };
 
-use crate::{elf::Program, host::ProverOpts, method_id::MethodId, receipt::Receipt, CIRCUIT};
-
 use self::cpu_eval::CpuEvalCheck;
+use crate::{elf::Program, host::ProverOpts, method_id::MethodId, receipt::Receipt, CIRCUIT};
 
 pub struct Prover<'a> {
     elf: Program,

--- a/risc0/zkvm/sdk/rust/src/receipt.rs
+++ b/risc0/zkvm/sdk/rust/src/receipt.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use alloc::vec::Vec;
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 

--- a/risc0/zkvm/sdk/rust/src/serde/deserializer.rs
+++ b/risc0/zkvm/sdk/rust/src/serde/deserializer.rs
@@ -432,6 +432,7 @@ impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
 #[cfg(test)]
 mod test {
     use alloc::string::String;
+
     use serde::{Deserialize, Serialize};
 
     use super::*;

--- a/risc0/zkvm/sdk/rust/src/serde/mod.rs
+++ b/risc0/zkvm/sdk/rust/src/serde/mod.rs
@@ -28,8 +28,9 @@ fn align_up(addr: usize, align: usize) -> usize {
 
 #[cfg(test)]
 mod test {
-    use crate::serde::{from_slice, to_vec};
     use std::collections::HashMap;
+
+    use crate::serde::{from_slice, to_vec};
 
     #[test]
     fn test_vec_round_trip() {

--- a/risc0/zkvm/sdk/rust/src/serde/serializer.rs
+++ b/risc0/zkvm/sdk/rust/src/serde/serializer.rs
@@ -497,9 +497,11 @@ impl StreamWriter for AllocVec {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use alloc::string::String;
+
     use serde::Serialize;
+
+    use super::*;
 
     #[test]
     fn test_struct() {


### PR DESCRIPTION
Use [group_imports = "StdExternalCrate"](https://rust-lang.github.io/rustfmt/?search=&version=v1.5.1#StdExternalCrate%5C%3A) to format and group imports by:

[std, core, malloc, etc]

[extern]

[crate, super]