### PR TITLE
Use memcpy and memset from musl for performance benefit

### DIFF
--- a/risc0/zkvm/sdk/rust/guest/BUILD.bazel
+++ b/risc0/zkvm/sdk/rust/guest/BUILD.bazel
@@ -8,7 +8,7 @@ rust_library(
     name = "guest",
     srcs = glob(["src/**/*.rs"]),
     crate_name = "risc0_zkvm_guest",
-    data = ["README.md"],
+    data = ["README.md", "src/memset.s", "src/memcpy.s"],
     deps = [
         "//risc0/zkp/rust:zkp_guest",
         "//risc0/zkvm/sdk/rust:zkvm_guest",

--- a/risc0/zkvm/sdk/rust/guest/src/lib.rs
+++ b/risc0/zkvm/sdk/rust/guest/src/lib.rs
@@ -34,7 +34,12 @@ pub mod sha;
 #[cfg(feature = "pure-prove")]
 pub mod sha_insecure;
 
-use core::{arch::asm, mem, ptr};
+use core::{arch::asm, arch::global_asm, mem, ptr};
+
+#[cfg(target_arch = "riscv32")]
+global_asm!(include_str!("memset.s"));
+#[cfg(target_arch = "riscv32")]
+global_asm!(include_str!("memcpy.s"));
 
 extern "C" {
     fn _fault() -> !;

--- a/risc0/zkvm/sdk/rust/guest/src/memcpy.s
+++ b/risc0/zkvm/sdk/rust/guest/src/memcpy.s
@@ -1,0 +1,498 @@
+// This is musl-libc commit 37e18b7bf307fa4a8c745feebfcba54a0ba74f30:
+// 
+// src/string/memcpy.c
+// 
+// This was compiled into assembly with:
+// 
+// clang-14 -target riscv32 -march=rv32im -O3 -S memcpy.c -nostdlib -fno-builtin -funroll-loops
+// 
+// and labels manually updated to not conflict.
+// 
+// musl as a whole is licensed under the following standard MIT license:
+// 
+// ----------------------------------------------------------------------
+// Copyright © 2005-2020 Rich Felker, et al.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ----------------------------------------------------------------------
+// 
+// Authors/contributors include:
+// 
+// A. Wilcox
+// Ada Worcester
+// Alex Dowad
+// Alex Suykov
+// Alexander Monakov
+// Andre McCurdy
+// Andrew Kelley
+// Anthony G. Basile
+// Aric Belsito
+// Arvid Picciani
+// Bartosz Brachaczek
+// Benjamin Peterson
+// Bobby Bingham
+// Boris Brezillon
+// Brent Cook
+// Chris Spiegel
+// Clément Vasseur
+// Daniel Micay
+// Daniel Sabogal
+// Daurnimator
+// David Carlier
+// David Edelsohn
+// Denys Vlasenko
+// Dmitry Ivanov
+// Dmitry V. Levin
+// Drew DeVault
+// Emil Renner Berthing
+// Fangrui Song
+// Felix Fietkau
+// Felix Janda
+// Gianluca Anzolin
+// Hauke Mehrtens
+// He X
+// Hiltjo Posthuma
+// Isaac Dunham
+// Jaydeep Patil
+// Jens Gustedt
+// Jeremy Huntwork
+// Jo-Philipp Wich
+// Joakim Sindholt
+// John Spencer
+// Julien Ramseier
+// Justin Cormack
+// Kaarle Ritvanen
+// Khem Raj
+// Kylie McClain
+// Leah Neukirchen
+// Luca Barbato
+// Luka Perkov
+// M Farkas-Dyck (Strake)
+// Mahesh Bodapati
+// Markus Wichmann
+// Masanori Ogino
+// Michael Clark
+// Michael Forney
+// Mikhail Kremnyov
+// Natanael Copa
+// Nicholas J. Kain
+// orc
+// Pascal Cuoq
+// Patrick Oppenlander
+// Petr Hosek
+// Petr Skocik
+// Pierre Carrier
+// Reini Urban
+// Rich Felker
+// Richard Pennington
+// Ryan Fairfax
+// Samuel Holland
+// Segev Finer
+// Shiz
+// sin
+// Solar Designer
+// Stefan Kristiansson
+// Stefan O'Rear
+// Szabolcs Nagy
+// Timo Teräs
+// Trutz Behn
+// Valentin Ochs
+// Will Dietz
+// William Haddon
+// William Pitcock
+// 
+// Portions of this software are derived from third-party works licensed
+// under terms compatible with the above MIT license:
+// 
+// The TRE regular expression implementation (src/regex/reg* and
+// src/regex/tre*) is Copyright © 2001-2008 Ville Laurikari and licensed
+// under a 2-clause BSD license (license text in the source files). The
+// included version has been heavily modified by Rich Felker in 2012, in
+// the interests of size, simplicity, and namespace cleanliness.
+// 
+// Much of the math library code (src/math/* and src/complex/*) is
+// Copyright © 1993,2004 Sun Microsystems or
+// Copyright © 2003-2011 David Schultz or
+// Copyright © 2003-2009 Steven G. Kargl or
+// Copyright © 2003-2009 Bruce D. Evans or
+// Copyright © 2008 Stephen L. Moshier or
+// Copyright © 2017-2018 Arm Limited
+// and labelled as such in comments in the individual source files. All
+// have been licensed under extremely permissive terms.
+// 
+// The ARM memcpy code (src/string/arm/memcpy.S) is Copyright © 2008
+// The Android Open Source Project and is licensed under a two-clause BSD
+// license. It was taken from Bionic libc, used on Android.
+// 
+// The AArch64 memcpy and memset code (src/string/aarch64/*) are
+// Copyright © 1999-2019, Arm Limited.
+// 
+// The implementation of DES for crypt (src/crypt/crypt_des.c) is
+// Copyright © 1994 David Burren. It is licensed under a BSD license.
+// 
+// The implementation of blowfish crypt (src/crypt/crypt_blowfish.c) was
+// originally written by Solar Designer and placed into the public
+// domain. The code also comes with a fallback permissive license for use
+// in jurisdictions that may not recognize the public domain.
+// 
+// The smoothsort implementation (src/stdlib/qsort.c) is Copyright © 2011
+// Valentin Ochs and is licensed under an MIT-style license.
+// 
+// The x86_64 port was written by Nicholas J. Kain and is licensed under
+// the standard MIT terms.
+// 
+// The mips and microblaze ports were originally written by Richard
+// Pennington for use in the ellcc project. The original code was adapted
+// by Rich Felker for build system and code conventions during upstream
+// integration. It is licensed under the standard MIT terms.
+// 
+// The mips64 port was contributed by Imagination Technologies and is
+// licensed under the standard MIT terms.
+// 
+// The powerpc port was also originally written by Richard Pennington,
+// and later supplemented and integrated by John Spencer. It is licensed
+// under the standard MIT terms.
+// 
+// All other files which have no copyright comments are original works
+// produced specifically for use as part of this library, written either
+// by Rich Felker, the main author of the library, or by one or more
+// contibutors listed above. Details on authorship of individual files
+// can be found in the git version control history of the project. The
+// omission of copyright and license comments in each file is in the
+// interest of source tree size.
+// 
+// In addition, permission is hereby granted for all public header files
+// (include/* and arch/* /bits/* ) and crt files intended to be linked into
+// applications (crt/*, ldso/dlstart.c, and arch/* /crt_arch.h) to omit
+// the copyright notice and permission notice otherwise required by the
+// license, and to use these files without any requirement of
+// attribution. These files include substantial contributions from:
+// 
+// Bobby Bingham
+// John Spencer
+// Nicholas J. Kain
+// Rich Felker
+// Richard Pennington
+// Stefan Kristiansson
+// Szabolcs Nagy
+// 
+// all of whom have explicitly granted such permission.
+// 
+// This file previously contained text expressing a belief that most of
+// the files covered by the above exception were sufficiently trivial not
+// to be subject to copyright, resulting in confusion over whether it
+// negated the permissions granted in the license. In the spirit of
+// permissive licensing, and of not having licensing issues being an
+// obstacle to adoption, that text has been removed.
+	.text
+	.attribute	4, 16
+	.attribute	5, "rv32i2p0_m2p0"
+	.file	"musl_memcpy.c"
+	.globl	memcpy
+	.p2align	2
+	.type	memcpy,@function
+memcpy:
+	andi	a3, a1, 3
+	seqz	a3, a3
+	seqz	a4, a2
+	or	a3, a3, a4
+	bnez	a3, .LBBmemcpy0_11
+	addi	a5, a1, 1
+	mv	a6, a0
+.LBBmemcpy0_2:
+	lb	a7, 0(a1)
+	addi	a4, a1, 1
+	addi	a3, a6, 1
+	sb	a7, 0(a6)
+	addi	a2, a2, -1
+	andi	a1, a5, 3
+	snez	a1, a1
+	snez	a6, a2
+	and	a7, a1, a6
+	addi	a5, a5, 1
+	mv	a1, a4
+	mv	a6, a3
+	bnez	a7, .LBBmemcpy0_2
+	andi	a1, a3, 3
+	beqz	a1, .LBBmemcpy0_12
+.LBBmemcpy0_4:
+	li	a5, 32
+	bltu	a2, a5, .LBBmemcpy0_26
+	li	a5, 3
+	beq	a1, a5, .LBBmemcpy0_19
+	li	a5, 2
+	beq	a1, a5, .LBBmemcpy0_22
+	li	a5, 1
+	bne	a1, a5, .LBBmemcpy0_26
+	lw	a5, 0(a4)
+	sb	a5, 0(a3)
+	srli	a1, a5, 8
+	sb	a1, 1(a3)
+	srli	a6, a5, 16
+	addi	a1, a3, 3
+	sb	a6, 2(a3)
+	addi	a2, a2, -3
+	addi	a3, a4, 16
+	li	a4, 16
+.LBBmemcpy0_9:
+	lw	a6, -12(a3)
+	srli	a5, a5, 24
+	slli	a7, a6, 8
+	lw	t0, -8(a3)
+	or	a5, a7, a5
+	sw	a5, 0(a1)
+	srli	a5, a6, 24
+	slli	a6, t0, 8
+	lw	a7, -4(a3)
+	or	a5, a6, a5
+	sw	a5, 4(a1)
+	srli	a6, t0, 24
+	slli	t0, a7, 8
+	lw	a5, 0(a3)
+	or	a6, t0, a6
+	sw	a6, 8(a1)
+	srli	a6, a7, 24
+	slli	a7, a5, 8
+	or	a6, a7, a6
+	sw	a6, 12(a1)
+	addi	a1, a1, 16
+	addi	a2, a2, -16
+	addi	a3, a3, 16
+	bltu	a4, a2, .LBBmemcpy0_9
+	addi	a4, a3, -13
+	j	.LBBmemcpy0_25
+.LBBmemcpy0_11:
+	mv	a3, a0
+	mv	a4, a1
+	andi	a1, a3, 3
+	bnez	a1, .LBBmemcpy0_4
+.LBBmemcpy0_12:
+	li	a1, 16
+	bltu	a2, a1, .LBBmemcpy0_15
+	li	a1, 15
+.LBBmemcpy0_14:
+	lw	a5, 0(a4)
+	lw	a6, 4(a4)
+	lw	a7, 8(a4)
+	lw	t0, 12(a4)
+	sw	a5, 0(a3)
+	sw	a6, 4(a3)
+	sw	a7, 8(a3)
+	sw	t0, 12(a3)
+	addi	a4, a4, 16
+	addi	a2, a2, -16
+	addi	a3, a3, 16
+	bltu	a1, a2, .LBBmemcpy0_14
+.LBBmemcpy0_15:
+	andi	a1, a2, 8
+	beqz	a1, .LBBmemcpy0_17
+	lw	a1, 0(a4)
+	lw	a5, 4(a4)
+	sw	a1, 0(a3)
+	sw	a5, 4(a3)
+	addi	a3, a3, 8
+	addi	a4, a4, 8
+.LBBmemcpy0_17:
+	andi	a1, a2, 4
+	beqz	a1, .LBBmemcpy0_30
+	lw	a1, 0(a4)
+	sw	a1, 0(a3)
+	addi	a3, a3, 4
+	addi	a4, a4, 4
+	j	.LBBmemcpy0_30
+.LBBmemcpy0_19:
+	lw	a5, 0(a4)
+	addi	a1, a3, 1
+	sb	a5, 0(a3)
+	addi	a2, a2, -1
+	addi	a3, a4, 16
+	li	a4, 18
+.LBBmemcpy0_20:
+	lw	a6, -12(a3)
+	srli	a5, a5, 8
+	slli	a7, a6, 24
+	lw	t0, -8(a3)
+	or	a5, a7, a5
+	sw	a5, 0(a1)
+	srli	a5, a6, 8
+	slli	a6, t0, 24
+	lw	a7, -4(a3)
+	or	a5, a6, a5
+	sw	a5, 4(a1)
+	srli	a6, t0, 8
+	slli	t0, a7, 24
+	lw	a5, 0(a3)
+	or	a6, t0, a6
+	sw	a6, 8(a1)
+	srli	a6, a7, 8
+	slli	a7, a5, 24
+	or	a6, a7, a6
+	sw	a6, 12(a1)
+	addi	a1, a1, 16
+	addi	a2, a2, -16
+	addi	a3, a3, 16
+	bltu	a4, a2, .LBBmemcpy0_20
+	addi	a4, a3, -15
+	j	.LBBmemcpy0_25
+.LBBmemcpy0_22:
+	lw	a5, 0(a4)
+	sb	a5, 0(a3)
+	srli	a6, a5, 8
+	addi	a1, a3, 2
+	sb	a6, 1(a3)
+	addi	a2, a2, -2
+	addi	a3, a4, 16
+	li	a4, 17
+.LBBmemcpy0_23:
+	lw	a6, -12(a3)
+	srli	a5, a5, 16
+	slli	a7, a6, 16
+	lw	t0, -8(a3)
+	or	a5, a7, a5
+	sw	a5, 0(a1)
+	srli	a5, a6, 16
+	slli	a6, t0, 16
+	lw	a7, -4(a3)
+	or	a5, a6, a5
+	sw	a5, 4(a1)
+	srli	a6, t0, 16
+	slli	t0, a7, 16
+	lw	a5, 0(a3)
+	or	a6, t0, a6
+	sw	a6, 8(a1)
+	srli	a6, a7, 16
+	slli	a7, a5, 16
+	or	a6, a7, a6
+	sw	a6, 12(a1)
+	addi	a1, a1, 16
+	addi	a2, a2, -16
+	addi	a3, a3, 16
+	bltu	a4, a2, .LBBmemcpy0_23
+	addi	a4, a3, -14
+.LBBmemcpy0_25:
+	mv	a3, a1
+.LBBmemcpy0_26:
+	andi	a1, a2, 16
+	bnez	a1, .LBBmemcpy0_35
+	andi	a1, a2, 8
+	bnez	a1, .LBBmemcpy0_36
+.LBBmemcpy0_28:
+	andi	a1, a2, 4
+	beqz	a1, .LBBmemcpy0_30
+.LBBmemcpy0_29:
+	lb	a1, 0(a4)
+	lb	a5, 1(a4)
+	lb	a6, 2(a4)
+	sb	a1, 0(a3)
+	sb	a5, 1(a3)
+	lb	a1, 3(a4)
+	sb	a6, 2(a3)
+	addi	a4, a4, 4
+	addi	a5, a3, 4
+	sb	a1, 3(a3)
+	mv	a3, a5
+.LBBmemcpy0_30:
+	andi	a1, a2, 2
+	bnez	a1, .LBBmemcpy0_33
+	andi	a1, a2, 1
+	bnez	a1, .LBBmemcpy0_34
+.LBBmemcpy0_32:
+	ret
+.LBBmemcpy0_33:
+	lb	a1, 0(a4)
+	lb	a5, 1(a4)
+	sb	a1, 0(a3)
+	addi	a4, a4, 2
+	addi	a1, a3, 2
+	sb	a5, 1(a3)
+	mv	a3, a1
+	andi	a1, a2, 1
+	beqz	a1, .LBBmemcpy0_32
+.LBBmemcpy0_34:
+	lb	a1, 0(a4)
+	sb	a1, 0(a3)
+	ret
+.LBBmemcpy0_35:
+	lb	a1, 0(a4)
+	lb	a5, 1(a4)
+	lb	a6, 2(a4)
+	sb	a1, 0(a3)
+	sb	a5, 1(a3)
+	lb	a1, 3(a4)
+	sb	a6, 2(a3)
+	lb	a5, 4(a4)
+	lb	a6, 5(a4)
+	sb	a1, 3(a3)
+	lb	a1, 6(a4)
+	sb	a5, 4(a3)
+	sb	a6, 5(a3)
+	lb	a5, 7(a4)
+	sb	a1, 6(a3)
+	lb	a1, 8(a4)
+	lb	a6, 9(a4)
+	sb	a5, 7(a3)
+	lb	a5, 10(a4)
+	sb	a1, 8(a3)
+	sb	a6, 9(a3)
+	lb	a1, 11(a4)
+	sb	a5, 10(a3)
+	lb	a5, 12(a4)
+	lb	a6, 13(a4)
+	sb	a1, 11(a3)
+	lb	a1, 14(a4)
+	sb	a5, 12(a3)
+	sb	a6, 13(a3)
+	lb	a5, 15(a4)
+	sb	a1, 14(a3)
+	addi	a4, a4, 16
+	addi	a1, a3, 16
+	sb	a5, 15(a3)
+	mv	a3, a1
+	andi	a1, a2, 8
+	beqz	a1, .LBBmemcpy0_28
+.LBBmemcpy0_36:
+	lb	a1, 0(a4)
+	lb	a5, 1(a4)
+	lb	a6, 2(a4)
+	sb	a1, 0(a3)
+	sb	a5, 1(a3)
+	lb	a1, 3(a4)
+	sb	a6, 2(a3)
+	lb	a5, 4(a4)
+	lb	a6, 5(a4)
+	sb	a1, 3(a3)
+	lb	a1, 6(a4)
+	sb	a5, 4(a3)
+	sb	a6, 5(a3)
+	lb	a5, 7(a4)
+	sb	a1, 6(a3)
+	addi	a4, a4, 8
+	addi	a1, a3, 8
+	sb	a5, 7(a3)
+	mv	a3, a1
+	andi	a1, a2, 4
+	bnez	a1, .LBBmemcpy0_29
+	j	.LBBmemcpy0_30
+.Lfuncmemcpy_end0:
+	.size	memcpy, .Lfuncmemcpy_end0-memcpy
+
+	.ident	"Ubuntu clang version 14.0.6-++20220622053131+f28c006a5895-1~exp1~20220622173215.157"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig

--- a/risc0/zkvm/sdk/rust/guest/src/memset.s
+++ b/risc0/zkvm/sdk/rust/guest/src/memset.s
@@ -1,0 +1,281 @@
+// This is musl-libc memset commit 37e18b7bf307fa4a8c745feebfcba54a0ba74f30:
+// 
+// src/string/memset.c
+// 
+// This was compiled into assembly with:
+// 
+// clang-14 -target riscv32 -march=rv32im -O3 -S memset.c -nostdlib -fno-builtin -funroll-loops
+// 
+// and labels manually updated to not conflict.
+// 
+// musl as a whole is licensed under the following standard MIT license:
+// 
+// ----------------------------------------------------------------------
+// Copyright © 2005-2020 Rich Felker, et al.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ----------------------------------------------------------------------
+// 
+// Authors/contributors include:
+// 
+// A. Wilcox
+// Ada Worcester
+// Alex Dowad
+// Alex Suykov
+// Alexander Monakov
+// Andre McCurdy
+// Andrew Kelley
+// Anthony G. Basile
+// Aric Belsito
+// Arvid Picciani
+// Bartosz Brachaczek
+// Benjamin Peterson
+// Bobby Bingham
+// Boris Brezillon
+// Brent Cook
+// Chris Spiegel
+// Clément Vasseur
+// Daniel Micay
+// Daniel Sabogal
+// Daurnimator
+// David Carlier
+// David Edelsohn
+// Denys Vlasenko
+// Dmitry Ivanov
+// Dmitry V. Levin
+// Drew DeVault
+// Emil Renner Berthing
+// Fangrui Song
+// Felix Fietkau
+// Felix Janda
+// Gianluca Anzolin
+// Hauke Mehrtens
+// He X
+// Hiltjo Posthuma
+// Isaac Dunham
+// Jaydeep Patil
+// Jens Gustedt
+// Jeremy Huntwork
+// Jo-Philipp Wich
+// Joakim Sindholt
+// John Spencer
+// Julien Ramseier
+// Justin Cormack
+// Kaarle Ritvanen
+// Khem Raj
+// Kylie McClain
+// Leah Neukirchen
+// Luca Barbato
+// Luka Perkov
+// M Farkas-Dyck (Strake)
+// Mahesh Bodapati
+// Markus Wichmann
+// Masanori Ogino
+// Michael Clark
+// Michael Forney
+// Mikhail Kremnyov
+// Natanael Copa
+// Nicholas J. Kain
+// orc
+// Pascal Cuoq
+// Patrick Oppenlander
+// Petr Hosek
+// Petr Skocik
+// Pierre Carrier
+// Reini Urban
+// Rich Felker
+// Richard Pennington
+// Ryan Fairfax
+// Samuel Holland
+// Segev Finer
+// Shiz
+// sin
+// Solar Designer
+// Stefan Kristiansson
+// Stefan O'Rear
+// Szabolcs Nagy
+// Timo Teräs
+// Trutz Behn
+// Valentin Ochs
+// Will Dietz
+// William Haddon
+// William Pitcock
+// 
+// Portions of this software are derived from third-party works licensed
+// under terms compatible with the above MIT license:
+// 
+// The TRE regular expression implementation (src/regex/reg* and
+// src/regex/tre*) is Copyright © 2001-2008 Ville Laurikari and licensed
+// under a 2-clause BSD license (license text in the source files). The
+// included version has been heavily modified by Rich Felker in 2012, in
+// the interests of size, simplicity, and namespace cleanliness.
+// 
+// Much of the math library code (src/math/* and src/complex/*) is
+// Copyright © 1993,2004 Sun Microsystems or
+// Copyright © 2003-2011 David Schultz or
+// Copyright © 2003-2009 Steven G. Kargl or
+// Copyright © 2003-2009 Bruce D. Evans or
+// Copyright © 2008 Stephen L. Moshier or
+// Copyright © 2017-2018 Arm Limited
+// and labelled as such in comments in the individual source files. All
+// have been licensed under extremely permissive terms.
+// 
+// The ARM memcpy code (src/string/arm/memcpy.S) is Copyright © 2008
+// The Android Open Source Project and is licensed under a two-clause BSD
+// license. It was taken from Bionic libc, used on Android.
+// 
+// The AArch64 memcpy and memset code (src/string/aarch64/*) are
+// Copyright © 1999-2019, Arm Limited.
+// 
+// The implementation of DES for crypt (src/crypt/crypt_des.c) is
+// Copyright © 1994 David Burren. It is licensed under a BSD license.
+// 
+// The implementation of blowfish crypt (src/crypt/crypt_blowfish.c) was
+// originally written by Solar Designer and placed into the public
+// domain. The code also comes with a fallback permissive license for use
+// in jurisdictions that may not recognize the public domain.
+// 
+// The smoothsort implementation (src/stdlib/qsort.c) is Copyright © 2011
+// Valentin Ochs and is licensed under an MIT-style license.
+// 
+// The x86_64 port was written by Nicholas J. Kain and is licensed under
+// the standard MIT terms.
+// 
+// The mips and microblaze ports were originally written by Richard
+// Pennington for use in the ellcc project. The original code was adapted
+// by Rich Felker for build system and code conventions during upstream
+// integration. It is licensed under the standard MIT terms.
+// 
+// The mips64 port was contributed by Imagination Technologies and is
+// licensed under the standard MIT terms.
+// 
+// The powerpc port was also originally written by Richard Pennington,
+// and later supplemented and integrated by John Spencer. It is licensed
+// under the standard MIT terms.
+// 
+// All other files which have no copyright comments are original works
+// produced specifically for use as part of this library, written either
+// by Rich Felker, the main author of the library, or by one or more
+// contibutors listed above. Details on authorship of individual files
+// can be found in the git version control history of the project. The
+// omission of copyright and license comments in each file is in the
+// interest of source tree size.
+// 
+// In addition, permission is hereby granted for all public header files
+// (include/* and arch/* /bits/* ) and crt files intended to be linked into
+// applications (crt/*, ldso/dlstart.c, and arch/* /crt_arch.h) to omit
+// the copyright notice and permission notice otherwise required by the
+// license, and to use these files without any requirement of
+// attribution. These files include substantial contributions from:
+// 
+// Bobby Bingham
+// John Spencer
+// Nicholas J. Kain
+// Rich Felker
+// Richard Pennington
+// Stefan Kristiansson
+// Szabolcs Nagy
+// 
+// all of whom have explicitly granted such permission.
+// 
+// This file previously contained text expressing a belief that most of
+// the files covered by the above exception were sufficiently trivial not
+// to be subject to copyright, resulting in confusion over whether it
+// negated the permissions granted in the license. In the spirit of
+// permissive licensing, and of not having licensing issues being an
+// obstacle to adoption, that text has been removed.
+	.text
+	.attribute	4, 16
+	.attribute	5, "rv32i2p0_m2p0"
+	.file	"musl_memset.c"
+	.globl	memset
+	.p2align	2
+	.type	memset,@function
+memset:
+	beqz	a2, .LBB0_9memset
+	sb	a1, 0(a0)
+	add	a3, a2, a0
+	li	a4, 3
+	sb	a1, -1(a3)
+	bltu	a2, a4, .LBB0_9memset
+	sb	a1, 1(a0)
+	sb	a1, 2(a0)
+	sb	a1, -2(a3)
+	li	a4, 7
+	sb	a1, -3(a3)
+	bltu	a2, a4, .LBB0_9memset
+	sb	a1, 3(a0)
+	li	a5, 9
+	sb	a1, -4(a3)
+	bltu	a2, a5, .LBB0_9memset
+	neg	a3, a0
+	andi	a4, a3, 3
+	add	a3, a0, a4
+	sub	a2, a2, a4
+	andi	a2, a2, -4
+	andi	a1, a1, 255
+	lui	a4, 4112
+	addi	a4, a4, 257
+	mul	a1, a1, a4
+	sw	a1, 0(a3)
+	add	a4, a3, a2
+	sw	a1, -4(a4)
+	bltu	a2, a5, .LBB0_9memset
+	sw	a1, 4(a3)
+	sw	a1, 8(a3)
+	sw	a1, -12(a4)
+	li	a5, 25
+	sw	a1, -8(a4)
+	bltu	a2, a5, .LBB0_9memset
+	sw	a1, 12(a3)
+	sw	a1, 16(a3)
+	sw	a1, 20(a3)
+	sw	a1, 24(a3)
+	sw	a1, -28(a4)
+	sw	a1, -24(a4)
+	sw	a1, -20(a4)
+	andi	a5, a3, 4
+	ori	a5, a5, 24
+	sub	a2, a2, a5
+	li	a6, 32
+	sw	a1, -16(a4)
+	bltu	a2, a6, .LBB0_9memset
+	add	a3, a3, a5
+	li	a4, 31
+.LBB0_8memset:
+	sw	a1, 0(a3)
+	sw	a1, 4(a3)
+	sw	a1, 8(a3)
+	sw	a1, 12(a3)
+	sw	a1, 16(a3)
+	sw	a1, 20(a3)
+	sw	a1, 24(a3)
+	sw	a1, 28(a3)
+	addi	a2, a2, -32
+	addi	a3, a3, 32
+	bltu	a4, a2, .LBB0_8memset
+.LBB0_9memset:
+	ret
+.Lfunc_end0memset:
+	.size	memset, .Lfunc_end0memset-memset
+
+	.ident	"Ubuntu clang version 14.0.6-++20220622053131+f28c006a5895-1~exp1~20220622173215.157"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig


### PR DESCRIPTION
Base: commit 37e18b7bf307fa4a8c745feebfcba54a0ba74f30
- src/string/memcpy.c
- src/string/memset.c

This was compiled into assembly with:

 clang-14 -target riscv32 -march=rv32im -O3 -S memcpy.c -nostdlib -fno-builtin -funroll-loops

and labels manually updated to not conflict.

License is MIT, see https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT

This work was prompted by slow performance seen in compiler-builtins in Rust being the memcpy/memset: 

https://github.com/rust-lang/compiler-builtins/blob/master/src/mem/mod.rs#L25

cargo bench output from risc0/zkvm/sdk/rust, initially ran on baseline of f99fe08babce1f679fbf6b660028b89d99d35eb0 / current main at the time, with all CPUs in performance governor on a Intel(R) Xeon(R) CPU E3-1275 v5 @ 3.60GHz - please confirm independently (impact seen in memset and memcpy benchmarks):

```Benchmarking raw_sha/0
Benchmarking raw_sha/0: Warming up for 3.0000 s
Benchmarking raw_sha/0: Collecting 100 samples in estimated 20.002 s (20k iterations)
Benchmarking raw_sha/0: Analyzing
raw_sha/0               time:   [1.0618 ms 1.0627 ms 1.0640 ms]
                        thrpt:  [0.0000   B/s 0.0000   B/s 0.0000   B/s]
                 change:
                        time:   [+0.1294% +0.2691% +0.4031%] (p = 0.00 < 0.05)
                        thrpt:  [-0.4015% -0.2684% -0.1293%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking raw_sha/64
Benchmarking raw_sha/64: Warming up for 3.0000 s
Benchmarking raw_sha/64: Collecting 100 samples in estimated 20.049 s (20k iterations)
Benchmarking raw_sha/64: Analyzing
raw_sha/64              time:   [1.1025 ms 1.1036 ms 1.1051 ms]
                        thrpt:  [56.555 KiB/s 56.633 KiB/s 56.691 KiB/s]
                 change:
                        time:   [+1.1370% +1.3065% +1.4829%] (p = 0.00 < 0.05)
                        thrpt:  [-1.4612% -1.2897% -1.1242%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking raw_sha/512
Benchmarking raw_sha/512: Warming up for 3.0000 s
Benchmarking raw_sha/512: Collecting 100 samples in estimated 20.061 s (18k iterations)
Benchmarking raw_sha/512: Analyzing
raw_sha/512             time:   [1.3080 ms 1.3089 ms 1.3103 ms]
                        thrpt:  [381.59 KiB/s 382.00 KiB/s 382.28 KiB/s]
                 change:
                        time:   [-1.1905% -1.0083% -0.8434%] (p = 0.00 < 0.05)
                        thrpt:  [+0.8506% +1.0186% +1.2049%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
Benchmarking raw_sha/2048
Benchmarking raw_sha/2048: Warming up for 3.0000 s
Benchmarking raw_sha/2048: Collecting 100 samples in estimated 20.134 s (6600 iterations)
Benchmarking raw_sha/2048: Analyzing
raw_sha/2048            time:   [4.0441 ms 4.0465 ms 4.0500 ms]
                        thrpt:  [493.83 KiB/s 494.25 KiB/s 494.54 KiB/s]
                 change:
                        time:   [+0.0022% +0.0709% +0.1631%] (p = 0.08 > 0.05)
                        thrpt:  [-0.1628% -0.0708% -0.0022%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking raw_sha/8192
Benchmarking raw_sha/8192: Warming up for 3.0000 s
Benchmarking raw_sha/8192: Collecting 100 samples in estimated 22.252 s (200 iterations)
Benchmarking raw_sha/8192: Analyzing
raw_sha/8192            time:   [342.26 ms 342.38 ms 342.53 ms]
                        thrpt:  [23.356 KiB/s 23.366 KiB/s 23.374 KiB/s]
                 change:
                        time:   [+0.5052% +0.5480% +0.5962%] (p = 0.00 < 0.05)
                        thrpt:  [-0.5927% -0.5450% -0.5027%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking memset/memset/32
Benchmarking memset/memset/32: Warming up for 3.0000 s
Benchmarking memset/memset/32: Collecting 100 samples in estimated 5.1077 s (4400 iterations)
Benchmarking memset/memset/32: Analyzing
memset/memset/32        time:   [1.4813 ms 1.4826 ms 1.4848 ms]
                        change: [+5.8207% +6.0225% +6.2050%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
Benchmarking memset/memset/64
Benchmarking memset/memset/64: Warming up for 3.0000 s
Benchmarking memset/memset/64: Collecting 100 samples in estimated 5.1182 s (3900 iterations)
Benchmarking memset/memset/64: Analyzing
memset/memset/64        time:   [1.7197 ms 1.7215 ms 1.7244 ms]
                        change: [-14.422% -14.312% -14.160%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Benchmarking memset/memset/128
Benchmarking memset/memset/128: Warming up for 3.0000 s
Benchmarking memset/memset/128: Collecting 100 samples in estimated 5.0341 s (2500 iterations)
Benchmarking memset/memset/128: Analyzing
memset/memset/128       time:   [2.4919 ms 2.4948 ms 2.4990 ms]
                        change: [-18.771% -18.663% -18.531%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
Benchmarking memset/memset/256
Benchmarking memset/memset/256: Warming up for 3.0000 s
Benchmarking memset/memset/256: Collecting 100 samples in estimated 5.0387 s (2000 iterations)
Benchmarking memset/memset/256: Analyzing
memset/memset/256       time:   [3.3286 ms 3.3320 ms 3.3372 ms]
                        change: [-39.949% -39.831% -39.715%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
Benchmarking memset/memset/512
Benchmarking memset/memset/512: Warming up for 3.0000 s
Benchmarking memset/memset/512: Collecting 100 samples in estimated 5.2650 s (1200 iterations)
Benchmarking memset/memset/512: Analyzing
memset/memset/512       time:   [5.5545 ms 5.5604 ms 5.5694 ms]
                        change: [-49.845% -49.787% -49.692%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking memset/memset/1024
Benchmarking memset/memset/1024: Warming up for 3.0000 s
Benchmarking memset/memset/1024: Collecting 100 samples in estimated 5.7669 s (700 iterations)
Benchmarking memset/memset/1024: Analyzing
memset/memset/1024      time:   [9.9648 ms 9.9737 ms 9.9878 ms]
                        change: [-60.101% -60.002% -59.921%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking memset/memset/2048
Benchmarking memset/memset/2048: Warming up for 3.0000 s
Benchmarking memset/memset/2048: Collecting 100 samples in estimated 6.3538 s (400 iterations)
Benchmarking memset/memset/2048: Analyzing
memset/memset/2048      time:   [24.343 ms 24.416 ms 24.524 ms]
                        change: [-54.541% -54.365% -54.156%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
Benchmarking memset/memset/4096
Benchmarking memset/memset/4096: Warming up for 3.0000 s
Benchmarking memset/memset/4096: Collecting 100 samples in estimated 6.2785 s (200 iterations)
Benchmarking memset/memset/4096: Analyzing
memset/memset/4096      time:   [51.883 ms 51.952 ms 52.065 ms]
                        change: [-58.149% -58.049% -57.944%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

Benchmarking memcpy/memcpy-aligned/32
Benchmarking memcpy/memcpy-aligned/32: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-aligned/32: Collecting 100 samples in estimated 5.0745 s (4400 iterations)
Benchmarking memcpy/memcpy-aligned/32: Analyzing
memcpy/memcpy-aligned/32
                        time:   [1.5943 ms 1.5958 ms 1.5980 ms]
                        thrpt:  [19.555 KiB/s 19.583 KiB/s 19.601 KiB/s]
                 change:
                        time:   [-36.552% -36.378% -36.236%] (p = 0.00 < 0.05)
                        thrpt:  [+56.828% +57.179% +57.610%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/32
Benchmarking memcpy/memcpy-src-unaligned/32: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-src-unaligned/32: Collecting 100 samples in estimated 5.1645 s (2000 iterations)
Benchmarking memcpy/memcpy-src-unaligned/32: Analyzing
memcpy/memcpy-src-unaligned/32
                        time:   [4.7691 ms 4.7752 ms 4.7859 ms]
                        thrpt:  [6.5296 KiB/s 6.5442 KiB/s 6.5525 KiB/s]
                 change:
                        time:   [+48.326% +48.690% +49.060%] (p = 0.00 < 0.05)
                        thrpt:  [-32.913% -32.746% -32.581%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-dst-unaligned/32
Benchmarking memcpy/memcpy-dst-unaligned/32: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-dst-unaligned/32: Collecting 100 samples in estimated 5.1212 s (2300 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/32: Analyzing
memcpy/memcpy-dst-unaligned/32
                        time:   [3.0566 ms 3.0613 ms 3.0676 ms]
                        thrpt:  [10.187 KiB/s 10.208 KiB/s 10.224 KiB/s]
                 change:
                        time:   [-9.7214% -9.5813% -9.3898%] (p = 0.00 < 0.05)
                        thrpt:  [+10.363% +10.597% +10.768%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/32
Benchmarking memcpy/memcpy-both-unaligned/32: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-both-unaligned/32: Collecting 100 samples in estimated 5.1614 s (2000 iterations)
Benchmarking memcpy/memcpy-both-unaligned/32: Analyzing
memcpy/memcpy-both-unaligned/32
                        time:   [4.7674 ms 4.7749 ms 4.7871 ms]
                        thrpt:  [6.5279 KiB/s 6.5446 KiB/s 6.5549 KiB/s]
                 change:
                        time:   [+47.505% +47.852% +48.250%] (p = 0.00 < 0.05)
                        thrpt:  [-32.546% -32.365% -32.206%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-aligned/64
Benchmarking memcpy/memcpy-aligned/64: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-aligned/64: Collecting 100 samples in estimated 5.0931 s (2600 iterations)
Benchmarking memcpy/memcpy-aligned/64: Analyzing
memcpy/memcpy-aligned/64
                        time:   [3.6453 ms 3.6504 ms 3.6589 ms]
                        thrpt:  [17.082 KiB/s 17.121 KiB/s 17.145 KiB/s]
                 change:
                        time:   [-18.152% -17.915% -17.676%] (p = 0.00 < 0.05)
                        thrpt:  [+21.471% +21.826% +22.177%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/64
Benchmarking memcpy/memcpy-src-unaligned/64: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-src-unaligned/64: Collecting 100 samples in estimated 5.3355 s (1300 iterations)
Benchmarking memcpy/memcpy-src-unaligned/64: Analyzing
memcpy/memcpy-src-unaligned/64
                        time:   [7.5037 ms 7.5145 ms 7.5318 ms]
                        thrpt:  [8.2981 KiB/s 8.3173 KiB/s 8.3292 KiB/s]
                 change:
                        time:   [-0.1381% +0.1473% +0.4127%] (p = 0.36 > 0.05)
                        thrpt:  [-0.4111% -0.1470% +0.1383%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
Benchmarking memcpy/memcpy-dst-unaligned/64
Benchmarking memcpy/memcpy-dst-unaligned/64: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-dst-unaligned/64: Collecting 100 samples in estimated 5.2836 s (1600 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/64: Analyzing
memcpy/memcpy-dst-unaligned/64
                        time:   [6.1180 ms 6.1255 ms 6.1388 ms]
                        thrpt:  [10.181 KiB/s 10.203 KiB/s 10.216 KiB/s]
                 change:
                        time:   [-24.664% -24.449% -24.218%] (p = 0.00 < 0.05)
                        thrpt:  [+31.958% +32.362% +32.738%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/64
Benchmarking memcpy/memcpy-both-unaligned/64: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-both-unaligned/64: Collecting 100 samples in estimated 5.3421 s (1300 iterations)
Benchmarking memcpy/memcpy-both-unaligned/64: Analyzing
memcpy/memcpy-both-unaligned/64
                        time:   [7.4843 ms 7.4940 ms 7.5110 ms]
                        thrpt:  [8.3211 KiB/s 8.3400 KiB/s 8.3508 KiB/s]
                 change:
                        time:   [-1.4076% -1.1277% -0.8816%] (p = 0.00 < 0.05)
                        thrpt:  [+0.8895% +1.1405% +1.4277%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-aligned/128
Benchmarking memcpy/memcpy-aligned/128: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-aligned/128: Collecting 100 samples in estimated 5.1577 s (2000 iterations)
Benchmarking memcpy/memcpy-aligned/128: Analyzing
memcpy/memcpy-aligned/128
                        time:   [5.5651 ms 5.5719 ms 5.5830 ms]
                        thrpt:  [22.389 KiB/s 22.434 KiB/s 22.461 KiB/s]
                 change:
                        time:   [-38.617% -38.458% -38.303%] (p = 0.00 < 0.05)
                        thrpt:  [+62.082% +62.491% +62.910%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/128
Benchmarking memcpy/memcpy-src-unaligned/128: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-src-unaligned/128: Collecting 100 samples in estimated 5.4060 s (900 iterations)
Benchmarking memcpy/memcpy-src-unaligned/128: Analyzing
memcpy/memcpy-src-unaligned/128
                        time:   [12.341 ms 12.356 ms 12.380 ms]
                        thrpt:  [10.097 KiB/s 10.117 KiB/s 10.129 KiB/s]
                 change:
                        time:   [-20.704% -20.500% -20.288%] (p = 0.00 < 0.05)
                        thrpt:  [+25.451% +25.786% +26.109%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-dst-unaligned/128
Benchmarking memcpy/memcpy-dst-unaligned/128: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-dst-unaligned/128: Collecting 100 samples in estimated 5.0109 s (1000 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/128: Analyzing
memcpy/memcpy-dst-unaligned/128
                        time:   [11.045 ms 11.059 ms 11.082 ms]
                        thrpt:  [11.280 KiB/s 11.303 KiB/s 11.317 KiB/s]
                 change:
                        time:   [-29.840% -29.640% -29.454%] (p = 0.00 < 0.05)
                        thrpt:  [+41.751% +42.126% +42.532%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/128
Benchmarking memcpy/memcpy-both-unaligned/128: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-both-unaligned/128: Collecting 100 samples in estimated 5.3790 s (900 iterations)
Benchmarking memcpy/memcpy-both-unaligned/128: Analyzing
memcpy/memcpy-both-unaligned/128
                        time:   [12.246 ms 12.259 ms 12.283 ms]
                        thrpt:  [10.177 KiB/s 10.196 KiB/s 10.208 KiB/s]
                 change:
                        time:   [-21.285% -21.079% -20.869%] (p = 0.00 < 0.05)
                        thrpt:  [+26.373% +26.709% +27.040%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking memcpy/memcpy-aligned/256
Benchmarking memcpy/memcpy-aligned/256: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-aligned/256: Collecting 100 samples in estimated 5.0056 s (1000 iterations)
Benchmarking memcpy/memcpy-aligned/256: Analyzing
memcpy/memcpy-aligned/256
                        time:   [13.227 ms 13.248 ms 13.277 ms]
                        thrpt:  [18.830 KiB/s 18.871 KiB/s 18.900 KiB/s]
                 change:
                        time:   [-39.723% -39.590% -39.432%] (p = 0.00 < 0.05)
                        thrpt:  [+65.104% +65.534% +65.902%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/256
Benchmarking memcpy/memcpy-src-unaligned/256: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-src-unaligned/256: Collecting 100 samples in estimated 5.1123 s (500 iterations)
Benchmarking memcpy/memcpy-src-unaligned/256: Analyzing
memcpy/memcpy-src-unaligned/256
                        time:   [26.605 ms 26.630 ms 26.673 ms]
                        thrpt:  [9.3727 KiB/s 9.3880 KiB/s 9.3969 KiB/s]
                 change:
                        time:   [-21.295% -21.217% -21.078%] (p = 0.00 < 0.05)
                        thrpt:  [+26.707% +26.931% +27.056%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe
Benchmarking memcpy/memcpy-dst-unaligned/256
Benchmarking memcpy/memcpy-dst-unaligned/256: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-dst-unaligned/256: Collecting 100 samples in estimated 5.8625 s (600 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/256: Analyzing
memcpy/memcpy-dst-unaligned/256
                        time:   [22.837 ms 22.867 ms 22.911 ms]
                        thrpt:  [10.912 KiB/s 10.933 KiB/s 10.947 KiB/s]
                 change:
                        time:   [-33.115% -32.968% -32.809%] (p = 0.00 < 0.05)
                        thrpt:  [+48.830% +49.182% +49.509%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/256
Benchmarking memcpy/memcpy-both-unaligned/256: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-both-unaligned/256: Collecting 100 samples in estimated 5.1244 s (500 iterations)
Benchmarking memcpy/memcpy-both-unaligned/256: Analyzing
memcpy/memcpy-both-unaligned/256
                        time:   [26.658 ms 26.683 ms 26.726 ms]
                        thrpt:  [9.3541 KiB/s 9.3691 KiB/s 9.3779 KiB/s]
                 change:
                        time:   [-21.284% -21.205% -21.085%] (p = 0.00 < 0.05)
                        thrpt:  [+26.718% +26.912% +27.039%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-aligned/512
Benchmarking memcpy/memcpy-aligned/512: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-aligned/512: Collecting 100 samples in estimated 5.4270 s (400 iterations)
Benchmarking memcpy/memcpy-aligned/512: Analyzing
memcpy/memcpy-aligned/512
                        time:   [58.562 ms 58.599 ms 58.660 ms]
                        thrpt:  [8.5237 KiB/s 8.5325 KiB/s 8.5380 KiB/s]
                 change:
                        time:   [-26.740% -26.685% -26.612%] (p = 0.00 < 0.05)
                        thrpt:  [+36.262% +36.398% +36.500%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/512
Benchmarking memcpy/memcpy-src-unaligned/512: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-src-unaligned/512: Collecting 100 samples in estimated 5.0885 s (200 iterations)
Benchmarking memcpy/memcpy-src-unaligned/512: Analyzing
memcpy/memcpy-src-unaligned/512
                        time:   [116.51 ms 116.60 ms 116.72 ms]
                        thrpt:  [4.2836 KiB/s 4.2882 KiB/s 4.2916 KiB/s]
                 change:
                        time:   [-4.5735% -4.4402% -4.3179%] (p = 0.00 < 0.05)
                        thrpt:  [+4.5128% +4.6465% +4.7926%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
Benchmarking memcpy/memcpy-dst-unaligned/512
Benchmarking memcpy/memcpy-dst-unaligned/512: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-dst-unaligned/512: Collecting 100 samples in estimated 5.0658 s (200 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/512: Analyzing
memcpy/memcpy-dst-unaligned/512
                        time:   [116.91 ms 116.99 ms 117.11 ms]
                        thrpt:  [4.2697 KiB/s 4.2739 KiB/s 4.2767 KiB/s]
                 change:
                        time:   [-3.6594% -3.5414% -3.4122%] (p = 0.00 < 0.05)
                        thrpt:  [+3.5328% +3.6715% +3.7983%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/512
Benchmarking memcpy/memcpy-both-unaligned/512: Warming up for 3.0000 s
Benchmarking memcpy/memcpy-both-unaligned/512: Collecting 100 samples in estimated 5.1402 s (200 iterations)
Benchmarking memcpy/memcpy-both-unaligned/512: Analyzing
memcpy/memcpy-both-unaligned/512
                        time:   [117.23 ms 117.30 ms 117.42 ms]
                        thrpt:  [4.2581 KiB/s 4.2625 KiB/s 4.2653 KiB/s]
                 change:
                        time:   [-3.9466% -3.8320% -3.7054%] (p = 0.00 < 0.05)
                        thrpt:  [+3.8480% +3.9847% +4.1087%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking memcpy/memcpy-aligned/1024
Benchmarking memcpy/memcpy-aligned/1024: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.4s, or reduce sample count to 90.
Benchmarking memcpy/memcpy-aligned/1024: Collecting 100 samples in estimated 5.3572 s (100 iterations)
Benchmarking memcpy/memcpy-aligned/1024: Analyzing
memcpy/memcpy-aligned/1024
                        time:   [440.01 ms 440.35 ms 440.77 ms]
                        thrpt:  [2.2688 KiB/s 2.2709 KiB/s 2.2727 KiB/s]
                 change:
                        time:   [-2.4192% -2.3331% -2.2312%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2821% +2.3888% +2.4791%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/1024
Benchmarking memcpy/memcpy-src-unaligned/1024: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.6s, or reduce sample count to 70.
Benchmarking memcpy/memcpy-src-unaligned/1024: Collecting 100 samples in estimated 6.5826 s (100 iterations)
Benchmarking memcpy/memcpy-src-unaligned/1024: Analyzing
memcpy/memcpy-src-unaligned/1024
                        time:   [452.05 ms 452.93 ms 453.83 ms]
                        thrpt:  [2.2035 KiB/s 2.2079 KiB/s 2.2121 KiB/s]
                 change:
                        time:   [-2.0596% -1.8762% -1.6849%] (p = 0.00 < 0.05)
                        thrpt:  [+1.7138% +1.9120% +2.1029%]
                        Performance has improved.
Benchmarking memcpy/memcpy-dst-unaligned/1024
Benchmarking memcpy/memcpy-dst-unaligned/1024: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.5s, or reduce sample count to 70.
Benchmarking memcpy/memcpy-dst-unaligned/1024: Collecting 100 samples in estimated 6.5283 s (100 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/1024: Analyzing
memcpy/memcpy-dst-unaligned/1024
                        time:   [446.84 ms 447.56 ms 448.34 ms]
                        thrpt:  [2.2305 KiB/s 2.2343 KiB/s 2.2379 KiB/s]
                 change:
                        time:   [-3.0021% -2.8397% -2.6701%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7434% +2.9227% +3.0950%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  18 (18.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/1024
Benchmarking memcpy/memcpy-both-unaligned/1024: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.6s, or reduce sample count to 70.
Benchmarking memcpy/memcpy-both-unaligned/1024: Collecting 100 samples in estimated 6.6369 s (100 iterations)
Benchmarking memcpy/memcpy-both-unaligned/1024: Analyzing
memcpy/memcpy-both-unaligned/1024
                        time:   [449.23 ms 449.67 ms 450.19 ms]
                        thrpt:  [2.2213 KiB/s 2.2238 KiB/s 2.2260 KiB/s]
                 change:
                        time:   [-2.0304% -1.9207% -1.8147%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8482% +1.9584% +2.0725%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
Benchmarking memcpy/memcpy-aligned/2048
Benchmarking memcpy/memcpy-aligned/2048: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 21.6s, or reduce sample count to 20.
Benchmarking memcpy/memcpy-aligned/2048: Collecting 100 samples in estimated 21.553 s (100 iterations)
Benchmarking memcpy/memcpy-aligned/2048: Analyzing
memcpy/memcpy-aligned/2048
                        time:   [646.24 ms 646.77 ms 647.37 ms]
                        thrpt:  [3.0894 KiB/s 3.0923 KiB/s 3.0948 KiB/s]
                 change:
                        time:   [-3.0802% -2.9934% -2.8965%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9829% +3.0858% +3.1781%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/2048
Benchmarking memcpy/memcpy-src-unaligned/2048: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 24.9s, or reduce sample count to 20.
Benchmarking memcpy/memcpy-src-unaligned/2048: Collecting 100 samples in estimated 24.893 s (100 iterations)
Benchmarking memcpy/memcpy-src-unaligned/2048: Analyzing
memcpy/memcpy-src-unaligned/2048
                        time:   [665.93 ms 666.16 ms 666.45 ms]
                        thrpt:  [3.0010 KiB/s 3.0023 KiB/s 3.0033 KiB/s]
                 change:
                        time:   [-28.022% -27.973% -27.926%] (p = 0.00 < 0.05)
                        thrpt:  [+38.746% +38.838% +38.932%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Benchmarking memcpy/memcpy-dst-unaligned/2048
Benchmarking memcpy/memcpy-dst-unaligned/2048: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 24.9s, or reduce sample count to 20.
Benchmarking memcpy/memcpy-dst-unaligned/2048: Collecting 100 samples in estimated 24.890 s (100 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/2048: Analyzing
memcpy/memcpy-dst-unaligned/2048
                        time:   [665.98 ms 666.25 ms 666.59 ms]
                        thrpt:  [3.0003 KiB/s 3.0019 KiB/s 3.0031 KiB/s]
                 change:
                        time:   [-28.079% -28.039% -27.998%] (p = 0.00 < 0.05)
                        thrpt:  [+38.885% +38.964% +39.041%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/2048
Benchmarking memcpy/memcpy-both-unaligned/2048: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 24.8s, or reduce sample count to 20.
Benchmarking memcpy/memcpy-both-unaligned/2048: Collecting 100 samples in estimated 24.759 s (100 iterations)
Benchmarking memcpy/memcpy-both-unaligned/2048: Analyzing
memcpy/memcpy-both-unaligned/2048
                        time:   [661.32 ms 661.56 ms 661.87 ms]
                        thrpt:  [3.0217 KiB/s 3.0231 KiB/s 3.0243 KiB/s]
                 change:
                        time:   [-28.640% -28.583% -28.529%] (p = 0.00 < 0.05)
                        thrpt:  [+39.918% +40.023% +40.134%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe
Benchmarking memcpy/memcpy-aligned/4096
Benchmarking memcpy/memcpy-aligned/4096: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 64.2s, or reduce sample count to 10.
Benchmarking memcpy/memcpy-aligned/4096: Collecting 100 samples in estimated 64.241 s (100 iterations)
Benchmarking memcpy/memcpy-aligned/4096: Analyzing
memcpy/memcpy-aligned/4096
                        time:   [1.2954 s 1.2960 s 1.2966 s]
                        thrpt:  [3.0850 KiB/s 3.0865 KiB/s 3.0878 KiB/s]
                 change:
                        time:   [-3.0484% -2.9906% -2.9388%] (p = 0.00 < 0.05)
                        thrpt:  [+3.0278% +3.0827% +3.1442%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
Benchmarking memcpy/memcpy-src-unaligned/4096
Benchmarking memcpy/memcpy-src-unaligned/4096: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 106.8s, or reduce sample count to 10.
Benchmarking memcpy/memcpy-src-unaligned/4096: Collecting 100 samples in estimated 106.82 s (100 iterations)
Benchmarking memcpy/memcpy-src-unaligned/4096: Analyzing
memcpy/memcpy-src-unaligned/4096
                        time:   [1.3275 s 1.3279 s 1.3283 s]
                        thrpt:  [3.0113 KiB/s 3.0123 KiB/s 3.0132 KiB/s]
                 change:
                        time:   [-27.869% -27.840% -27.808%] (p = 0.00 < 0.05)
                        thrpt:  [+38.520% +38.582% +38.638%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking memcpy/memcpy-dst-unaligned/4096
Benchmarking memcpy/memcpy-dst-unaligned/4096: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 107.3s, or reduce sample count to 10.
Benchmarking memcpy/memcpy-dst-unaligned/4096: Collecting 100 samples in estimated 107.30 s (100 iterations)
Benchmarking memcpy/memcpy-dst-unaligned/4096: Analyzing
memcpy/memcpy-dst-unaligned/4096
                        time:   [1.3365 s 1.3369 s 1.3374 s]
                        thrpt:  [2.9909 KiB/s 2.9919 KiB/s 2.9929 KiB/s]
                 change:
                        time:   [-27.403% -27.369% -27.332%] (p = 0.00 < 0.05)
                        thrpt:  [+37.613% +37.682% +37.746%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
Benchmarking memcpy/memcpy-both-unaligned/4096
Benchmarking memcpy/memcpy-both-unaligned/4096: Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 107.7s, or reduce sample count to 10.
Benchmarking memcpy/memcpy-both-unaligned/4096: Collecting 100 samples in estimated 107.74 s (100 iterations)
Benchmarking memcpy/memcpy-both-unaligned/4096: Analyzing
memcpy/memcpy-both-unaligned/4096
                        time:   [1.3384 s 1.3388 s 1.3392 s]
                        thrpt:  [2.9868 KiB/s 2.9878 KiB/s 2.9887 KiB/s]
                 change:
                        time:   [-27.310% -27.276% -27.243%] (p = 0.00 < 0.05)
                        thrpt:  [+37.443% +37.506% +37.571%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```

Signed-off-by: Carsten Munk <carsten@zippie.com>

