### PR TITLE
Memset and digest_u8_slice benchmark

### DIFF
--- a/risc0/zkvm/sdk/rust/benches/guest_run.rs
+++ b/risc0/zkvm/sdk/rust/benches/guest_run.rs
@@ -83,7 +83,6 @@ pub fn bench(c: &mut Criterion) {
         });
     }
     sha_group.finish();
-
     let mut api_sha_group = c.benchmark_group("api_sha");
     api_sha_group
         .sampling_mode(SamplingMode::Flat)
@@ -100,6 +99,7 @@ pub fn bench(c: &mut Criterion) {
     let mut memset_group = c.benchmark_group("memset");
     memset_group.sampling_mode(SamplingMode::Flat);
     for buf_bytes in [32u64, 64, 128, 256, 512, 1024, 2048, 4096] {
+        memset_group.throughput(Throughput::Bytes(buf_bytes));
         memset_group.bench_with_input(
             BenchmarkId::new("memset", buf_bytes),
             &buf_bytes,

--- a/risc0/zkvm/sdk/rust/benches/guest_run.rs
+++ b/risc0/zkvm/sdk/rust/benches/guest_run.rs
@@ -84,6 +84,19 @@ pub fn bench(c: &mut Criterion) {
     }
     sha_group.finish();
 
+    let mut api_sha_group = c.benchmark_group("api_sha");
+    api_sha_group
+        .sampling_mode(SamplingMode::Flat)
+        .measurement_time(Duration::new(20, 0));
+    for buf_bytes in [0u64, 64, 512, 2048, 8192] {
+        api_sha_group.throughput(Throughput::Bytes(buf_bytes));
+        api_sha_group.bench_function(BenchmarkId::from_parameter(buf_bytes), |b| {
+            let buf: Vec<u8> = rand_buffer(buf_bytes as usize);
+            guest_iter(b, BenchmarkSpec::ApiSha { buf: buf.clone() })
+        });
+    }
+    api_sha_group.finish();
+
     let mut memset_group = c.benchmark_group("memset");
     memset_group.sampling_mode(SamplingMode::Flat);
     for buf_bytes in [32u64, 64, 128, 256, 512, 1024, 2048, 4096] {

--- a/risc0/zkvm/sdk/rust/methods/inner/src/bin/bench.rs
+++ b/risc0/zkvm/sdk/rust/methods/inner/src/bin/bench.rs
@@ -27,6 +27,11 @@ pub fn main() {
                 memory_barrier(&i);
             }
         }
+        BenchmarkSpec::ApiSha { buf } => {
+            for _ in 0..iters {
+                memory_barrier(&sha::digest_u8_slice(&buf));
+            }
+        }
         BenchmarkSpec::RawSha { buf } => {
             for _ in 0..iters {
                 memory_barrier(&sha::raw_digest(&buf));

--- a/risc0/zkvm/sdk/rust/methods/src/bench.rs
+++ b/risc0/zkvm/sdk/rust/methods/src/bench.rs
@@ -10,6 +10,9 @@ pub enum BenchmarkSpec {
     RawSha {
         buf: Vec<u32>,
     },
+    ApiSha {
+        buf: Vec<u8>,
+    },
     Memcpy {
         src: Vec<u8>,
         src_align: usize,


### PR DESCRIPTION
Add a throughput measurement for memset and a benchmark that tests the sha::digest_u8_slice API performance which is quite dramatically worse than raw_sha throughput