### PR TITLE
fix: remove default features (std) from rand deps

### DIFF
--- a/risc0/zkp/rust/Cargo.toml
+++ b/risc0/zkp/rust/Cargo.toml
@@ -19,7 +19,7 @@ log = { version = "0.4", optional = true }
 ndarray = { version = "0.15", optional = true, features = ["rayon"] }
 paste = "1.0"
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
-rand_core = "0.6"
+rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.5", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10", optional = true, default-features = false, features = ["compress"] }

--- a/risc0/zkvm/sdk/rust/Cargo.toml
+++ b/risc0/zkvm/sdk/rust/Cargo.toml
@@ -31,7 +31,7 @@ ctor = "0.1"
 cxx = "1.0"
 gimli = { version = "0.26", optional = true }
 log = "0.4"
-rand = "0.8"
+rand = { version = "0.8", default-features = false }
 risc0-zkvm-sys = { version = "0.11", path = "../.." }
 sha2 = "0.10"
 xmas-elf = "0.8"


### PR DESCRIPTION
I didn't verify in-depth, just going off of intuition of what seems like would be a necessary step toward compatibility with more targets to solve issues like https://github.com/risc0/battleship-example/issues/15.