### PR TITLE
verify: use hash_raw_pod_slice to hash journal without trailer

### DIFF
--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -306,7 +306,7 @@ where
                 }
             }
         } else {
-            let journal_digest = hal.sha().hash_words(journal);
+            let journal_digest = hal.sha().hash_raw_pod_slice(journal);
             let journal_hash = journal_digest.as_slice();
             for i in 0..journal_hash.len() {
                 if journal_hash[i]

--- a/risc0/zkvm/methods/std/src/bin/hello_commit.rs
+++ b/risc0/zkvm/methods/std/src/bin/hello_commit.rs
@@ -1,0 +1,24 @@
+// Copyright 2022 Risc0, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+#![no_main]
+
+use risc0_zkvm::guest::env;
+
+risc0_zkvm::entry!(main);
+
+pub fn main() {
+    env::commit(b"hello world");
+}

--- a/risc0/zkvm/src/tests.rs
+++ b/risc0/zkvm/src/tests.rs
@@ -18,7 +18,8 @@ use anyhow::Result;
 use risc0_zeroio::{from_slice, to_vec};
 use risc0_zkp::core::sha::Digest;
 use risc0_zkvm_methods::{
-    multi_test::MultiTestSpec, FIB_CONTENTS, FIB_ID, MULTI_TEST_CONTENTS, MULTI_TEST_ID,
+    multi_test::MultiTestSpec, FIB_CONTENTS, FIB_ID, HELLO_COMMIT_CONTENTS, HELLO_COMMIT_ID,
+    MULTI_TEST_CONTENTS, MULTI_TEST_ID,
 };
 use risc0_zkvm_platform::{
     memory::{COMMIT, HEAP},
@@ -193,6 +194,19 @@ fn long_fib() {
             .to_string(),
         "Verification failed: Method execution cycle exceeded code limit. Increase code limit to at least 15."
     );
+}
+
+#[test]
+#[cfg_attr(feature = "insecure_skip_seal", ignore)]
+fn commit_hello_world() {
+    let receipt = {
+        let mut prover = Prover::new(HELLO_COMMIT_CONTENTS, HELLO_COMMIT_ID).unwrap();
+        prover.run().expect("Could not get receipt")
+    };
+
+    receipt
+        .verify(HELLO_COMMIT_ID)
+        .expect("Could not verify receipt");
 }
 
 #[test]


### PR DESCRIPTION
Previously, the verifier used hash_words() to create a hash of the journal. Unintentionally, this resulted in a "trailer" being appended to the hashed journal when the input length was not a multiple of 16. In the guest, the data that was committed gets hashed without a trailer if the data exceeds 32 bytes. The verifier needs the hash of the journal to match the seal root so the divergent behavior between the verifier and guest causes unintended verification errors for guest code that commits more than 32 bytes of data that are not divisible by 16. Fix this by using a hashing function in the verifier that does not add a trailer. Also, add a "hello world" test case as a regression test.