### PR TITLE
Misc additional test vectors

### DIFF
--- a/risc0/zkp/src/core/sha.rs
+++ b/risc0/zkp/src/core/sha.rs
@@ -217,6 +217,7 @@ pub mod testutil {
     // behaves.
     pub fn test_sha_impl<S: Sha>(sha: &S) {
         test_hash_pair(sha);
+        test_hash_raw_pod_slice(sha);
         test_sha_basics(sha);
         test_elems(sha);
         test_extelems(sha);
@@ -320,6 +321,36 @@ pub mod testutil {
         let expected: Vec<Digest> = EXPECTED_STRS.iter().map(|x| Digest::from_str(x)).collect();
         let actual: Vec<Digest> = LENS.iter().map(|x| hash_extelems(sha, *x)).collect();
         assert_eq!(expected, actual);
+    }
+
+    fn test_hash_raw_pod_slice<S: Sha>(sha: &S) {
+        {
+            let items: &[u32] = &[1];
+            assert_eq!(
+                *sha.hash_raw_pod_slice(items),
+                Digest::from_str(
+                    "e3050856aac389661ae490656ad0ea57df6aff0ff6eef306f8cc2eed4f240249"
+                )
+            );
+        }
+        {
+            let items: &[u32] = &[1, 2];
+            assert_eq!(
+                *sha.hash_raw_pod_slice(items),
+                Digest::from_str(
+                    "4138ebae12299733cc677d1150c2a0139454662fc76ec95da75d2bf9efddc57a"
+                )
+            );
+        }
+        {
+            let items: &[u32] = &[0xffffffff];
+            assert_eq!(
+                *sha.hash_raw_pod_slice(items),
+                Digest::from_str(
+                    "a3dba037d56175209dfd4191f727e91c5feb67e65a6ab5ed4daf0893c89598c8"
+                )
+            );
+        }
     }
 
     fn test_hash_pair<S: Sha>(sha: &S) {

--- a/risc0/zkp/src/merkle.rs
+++ b/risc0/zkp/src/merkle.rs
@@ -60,3 +60,38 @@ impl MerkleTreeParams {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_merkle_tree_params_1() {
+        let row_size: usize = 1024;
+        let col_size: usize = 1234;
+        let queries: usize = 50;
+        let params = MerkleTreeParams::new(row_size, col_size, queries);
+
+        assert_eq!(params.row_size, row_size);
+        assert_eq!(params.col_size, col_size);
+        assert_eq!(params.queries, queries);
+        assert_eq!(params.layers, 10);
+        assert_eq!(params.top_layer, 5);
+        assert_eq!(params.top_size, 32);
+    }
+
+    #[test]
+    fn new_merkle_tree_params_2() {
+        let row_size: usize = 2048;
+        let col_size: usize = 31337;
+        let queries: usize = 128;
+        let params = MerkleTreeParams::new(row_size, col_size, queries);
+
+        assert_eq!(params.row_size, row_size);
+        assert_eq!(params.col_size, col_size);
+        assert_eq!(params.queries, queries);
+        assert_eq!(params.layers, 11);
+        assert_eq!(params.top_layer, 7);
+        assert_eq!(params.top_size, 128);
+    }
+}


### PR DESCRIPTION
Adds unit tests for `MerkleTreeParams::new()` and `Sha::hash_raw_pod_slice()`