### PR TITLE
support insecure_skip_seal feature in guest

### DIFF
--- a/risc0/r0vm/tests/standard_lib.rs
+++ b/risc0/r0vm/tests/standard_lib.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use anyhow::Result;
 use assert_cmd::Command;
 use assert_fs::{fixture::PathChild, TempDir};
-use risc0_zkvm::{prove::insecure_skip_seal, Receipt};
+use risc0_zkvm::{receipt::insecure_skip_seal, Receipt};
 
 static EXPECTED_STDOUT: &str = "Hello world on stdout!\n";
 static EXPECTED_STDERR: &str = "Hello world on stderr!\n";

--- a/risc0/zkvm/src/prove/mod.rs
+++ b/risc0/zkvm/src/prove/mod.rs
@@ -19,7 +19,7 @@ mod plonk;
 #[cfg(feature = "profiler")]
 pub mod profiler;
 
-use std::{collections::HashMap, env, fmt::Debug, io::Write, rc::Rc};
+use std::{collections::HashMap, fmt::Debug, io::Write, rc::Rc};
 
 use anyhow::{bail, Result};
 use risc0_zkp::{
@@ -33,12 +33,12 @@ use risc0_zkvm_platform::{
 };
 
 use self::elf::Program;
-use crate::{method_id::MethodId, receipt::Receipt, sha::sha, CIRCUIT};
-
-pub fn insecure_skip_seal() -> bool {
-    cfg!(feature = "insecure_skip_seal")
-        && env::var("RISC0_INSECURE_SKIP_SEAL").unwrap_or_default() == "1"
-}
+use crate::{
+    method_id::MethodId,
+    receipt::{insecure_skip_seal, Receipt},
+    sha::sha,
+    CIRCUIT,
+};
 
 /// Options available to modify the prover's behavior.
 pub struct ProverOpts<'a> {

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -21,6 +21,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::{method_id::MethodId, CIRCUIT};
 
+#[cfg(not(target_os = "zkvm"))]
+pub fn insecure_skip_seal() -> bool {
+    cfg!(feature = "insecure_skip_seal")
+        && std::env::var("RISC0_INSECURE_SKIP_SEAL").unwrap_or_default() == "1"
+}
+
+#[cfg(target_os = "zkvm")]
+pub fn insecure_skip_seal() -> bool {
+    cfg!(feature = "insecure_skip_seal")
+}
+
 #[derive(Deserialize, Serialize, ZeroioSerialize, ZeroioDeserialize, Clone, Debug)]
 pub struct Receipt {
     pub journal: Vec<u32>,
@@ -57,8 +68,7 @@ where
         }
     };
 
-    #[cfg(not(target_os = "zkvm"))]
-    if crate::prove::insecure_skip_seal() {
+    if insecure_skip_seal() {
         return Ok(());
     }
 


### PR DESCRIPTION
This is done by moving insecure_skip_seal() function from prover to receipt. This feature is used to faciliate development of the guest code and not intended for production use.