### PR TITLE
Minimize deps for verify-only use cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       - run: cargo test --tests -- --ignored
         env:
           RUST_BACKTRACE: "1"
-      - run: cargo build -p risc0-zkvm -F verify-only --target=wasm32-unknown-unknown
+      - run: cargo build --manifest-path risc0/wasm/Cargo.toml --target wasm32-unknown-unknown
       - run: cargo check --benches
 
   doc:

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -11,7 +11,7 @@ repository = { workspace = true }
 cargo_metadata = "0.15"
 downloader = "0.2"
 home = "0.5"
-risc0-circuit-rv32im = { version = "1.0.0-rc.2", path = "../circuit/rv32im" }
+risc0-circuit-rv32im = { version = "1.0.0-rc.2", path = "../circuit/rv32im", default-features = false }
 risc0-zkp = { version = "1.0.0-rc.2", path = "../zkp" }
 risc0-zkvm = { version = "1.0.0-rc.2", path = "../zkvm" }
 risc0-zkvm-platform = { version = "1.0.0-rc.2", path = "../zkvm/platform" }

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -20,8 +20,8 @@ tracing = { version = "0.1", default-features = false, features = ["attributes"]
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
 fil-rustacuda = { version = "0.1", optional = true }
 log = "0.4"
-rand = "0.8"
-rayon = "1.5"
+rand = { version = "0.8", optional = true }
+rayon = { version = "1.5", optional = true }
 rustacuda_core = { version = "0.1", optional = true }
 rustacuda_derive = { version = "0.1", optional = true }
 
@@ -41,7 +41,7 @@ sha2 = "0.10"
 
 [features]
 cuda = ["dep:fil-rustacuda", "dep:rustacuda_core", "dep:rustacuda_derive", "risc0-zkp/cuda", "std"]
-default = ["std", "test"]
+default = ["prove", "test"]
+prove = ["dep:rand", "dep:rayon", "std"]
 std = ["risc0-zkp/std"]
 test = []
-verify-only = []

--- a/risc0/circuit/rv32im/build.rs
+++ b/risc0/circuit/rv32im/build.rs
@@ -24,9 +24,7 @@ use sha2::{Digest, Sha256};
 const KERNELS: &[&str] = &["eval_check"];
 
 fn main() {
-    if env::var("CARGO_CFG_TARGET_OS").unwrap().contains("zkvm")
-        || env::var("CARGO_FEATURE_VERIFY_ONLY").is_ok()
-    {
+    if !env::var("CARGO_FEATURE_PROVE").is_ok() {
         return;
     }
 

--- a/risc0/circuit/rv32im/src/lib.rs
+++ b/risc0/circuit/rv32im/src/lib.rs
@@ -14,16 +14,16 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 mod cpp;
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 pub mod cpu;
 #[cfg(feature = "cuda")]
 pub mod cuda;
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 mod ffi;
 mod info;
-#[cfg(all(target_os = "macos", not(feature = "verify-only")))]
+#[cfg(target_os = "macos")]
 pub mod metal;
 mod poly_ext;
 mod taps;

--- a/risc0/wasm/Cargo.toml
+++ b/risc0/wasm/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "risc0-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+risc0-zkvm = { version = "1.0.0-rc.2", path = "../zkvm", default-features = false }

--- a/risc0/wasm/src/main.rs
+++ b/risc0/wasm/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_main]
 
 use risc0_zkvm::{MethodId, Receipt};

--- a/risc0/wasm/src/main.rs
+++ b/risc0/wasm/src/main.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use risc0_zkvm::{MethodId, Receipt};
+
+// This binary is here as a way to check which deps are included
+// when building for the wasm32-unknown-unknown target.
+// Eventually this program should run a full verify with a real receipt.
+
+#[no_mangle]
+fn _start() {
+    // TODO: use a real receipt and method_id
+    let receipt = Receipt::new(&[], &[]);
+    let method_id = MethodId::from_slice(&[]).unwrap();
+    receipt.verify(method_id).unwrap();
+}

--- a/risc0/zeroio_derive/Cargo.toml
+++ b/risc0/zeroio_derive/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0" }
+syn = "1.0"
 
 [features]
 debug-derive = []

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = { version = "1.0", default-features = false }
 bytemuck = { version = "1.12", features = ["derive"] }
 fil-rustacuda = { version = "0.1", optional = true }
 paste = "1.0"
-rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 rand_core = "0.6"
 risc0-zeroio = { version = "1.0.0-rc.2", path = "../zeroio", default-features = false }
 rustacuda_core = { version = "0.1", optional = true }
@@ -27,18 +26,10 @@ tracing = { version = "0.1", default-features = false, features = ["attributes"]
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
 log = "0.4"
-ndarray = { version = "0.15", features = ["rayon"] }
-rayon = "1.5"
+ndarray = { version = "0.15", features = ["rayon"], optional = true }
+rand = { version = "0.8", optional = true }
+rayon = { version = "1.5", optional = true }
 sha2 = { version = "0.10", default-features = false, features = ["compress"] }
-
-[target.'cfg(target_os = "zkvm")'.dependencies]
-# Lots of things depend on getrandom, and it throws a compiler error
-# for environments it doesn't support.
-#
-# To actually use getrandom, one must provide a custom implementation per
-# https://docs.rs/getrandom/latest/getrandom/#custom-implementations or it
-# will panic.
-getrandom = { version = "0.2", features = ["custom"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = "0.24"
@@ -52,6 +43,12 @@ test-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-default = ["std"]
+default = ["prove"]
 cuda = ["dep:fil-rustacuda", "dep:rustacuda_core", "dep:rustacuda_derive"]
-std = ["anyhow/std", "risc0-zeroio/std", "rand/std", "rand/std_rng"]
+prove = [
+    "dep:ndarray",
+    "dep:rand",
+    "dep:rayon",
+    "std"
+]
+std = ["anyhow/std", "risc0-zeroio/std"]

--- a/risc0/zkp/src/core/mod.rs
+++ b/risc0/zkp/src/core/mod.rs
@@ -31,7 +31,7 @@ pub mod sha;
 pub mod sha_cpu;
 pub mod sha_rng;
 
-use rand::Rng;
+use rand_core::RngCore;
 
 /// For x = (1 << po2), given x, find po2.
 /// # Example
@@ -68,12 +68,12 @@ pub const fn log2_ceil(value: usize) -> usize {
 /// Generic trait for generating random values.
 pub trait Random {
     /// Generate a uniform random value.
-    fn random<R: Rng>(rng: &mut R) -> Self;
+    fn random<R: RngCore>(rng: &mut R) -> Self;
 }
 
 impl Random for u32 {
     /// Return a random u32 value.
-    fn random<R: Rng>(rng: &mut R) -> Self {
+    fn random<R: RngCore>(rng: &mut R) -> Self {
         rng.next_u32()
     }
 }

--- a/risc0/zkp/src/core/sha_rng.rs
+++ b/risc0/zkp/src/core/sha_rng.rs
@@ -14,8 +14,7 @@
 
 //! A SHA-256 based CRNG used in Fiat-Shamir.
 
-use rand::{Error, RngCore};
-use rand_core::impls;
+use rand_core::{impls, Error, RngCore};
 
 use super::sha::{Digest, Sha, DIGEST_WORDS};
 
@@ -78,7 +77,7 @@ impl<S: Sha> RngCore for ShaRng<S> {
 
 #[allow(missing_docs)]
 pub mod testutil {
-    use rand::RngCore;
+    use rand_core::RngCore;
 
     use super::ShaRng;
     use crate::core::sha::Sha;

--- a/risc0/zkp/src/field/baby_bear.rs
+++ b/risc0/zkp/src/field/baby_bear.rs
@@ -108,14 +108,14 @@ impl field::Elem for Elem {
     }
 
     /// Generate a random value within the Baby Bear field
-    fn random(rng: &mut impl rand::Rng) -> Self {
+    fn random(rng: &mut impl rand_core::RngCore) -> Self {
         // Reject the last modulo-P region of possible uint32_t values, since it's
         // uneven and will only return random values less than (2^32 % P).
         const REJECT_CUTOFF: u32 = (u32::MAX / P) * P;
-        let mut val: u32 = rng.gen();
+        let mut val: u32 = rng.next_u32();
 
         while val >= REJECT_CUTOFF {
-            val = rng.gen();
+            val = rng.next_u32();
         }
         Elem::from(val)
     }
@@ -357,7 +357,7 @@ impl field::Elem for ExtElem {
     const WORDS: usize = WORDS * EXT_SIZE;
 
     /// Generate a random field element uniformly.
-    fn random(rng: &mut impl rand::Rng) -> Self {
+    fn random(rng: &mut impl rand_core::RngCore) -> Self {
         Self([
             Elem::random(rng),
             Elem::random(rng),

--- a/risc0/zkp/src/field/goldilocks.rs
+++ b/risc0/zkp/src/field/goldilocks.rs
@@ -75,15 +75,15 @@ impl field::Elem for Elem {
     }
 
     /// Generate a random value within the Goldilocks field
-    fn random(rng: &mut impl rand::Rng) -> Self {
+    fn random(rng: &mut impl rand_core::RngCore) -> Self {
         // The range of possible RNG-generated u64 integers includes an uneven region
         // modulo P. We want to reject u64 values from this region because, if
         // mapped to finite field elements (wrapped), it leads to over-selection
         // of the wrapped values. Here, P happens to fit only once into a 64-bit
         // space, so we accept only RNG-generated u64 values less than P.
-        let mut val: u64 = rng.gen();
+        let mut val: u64 = rng.next_u64();
         while val >= P {
-            val = rng.gen();
+            val = rng.next_u64();
         }
         Elem::from(val)
     }
@@ -344,7 +344,7 @@ impl field::Elem for ExtElem {
     const WORDS: usize = 4;
 
     /// Generate a random [ExtElem] uniformly.
-    fn random(rng: &mut impl rand::Rng) -> Self {
+    fn random(rng: &mut impl rand_core::RngCore) -> Self {
         Self([Elem::random(rng), Elem::random(rng)])
     }
 

--- a/risc0/zkp/src/field/mod.rs
+++ b/risc0/zkp/src/field/mod.rs
@@ -85,7 +85,7 @@ pub trait Elem:
     }
 
     /// Returns a random valid field element.
-    fn random(rng: &mut impl rand::Rng) -> Self;
+    fn random(rng: &mut impl rand_core::RngCore) -> Self;
 
     /// Import a number into the field from the natural numbers.
     fn from_u64(val: u64) -> Self;

--- a/risc0/zkp/src/lib.rs
+++ b/risc0/zkp/src/lib.rs
@@ -20,10 +20,10 @@ extern crate alloc;
 pub mod adapter;
 pub mod core;
 pub mod field;
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 pub mod hal;
 mod merkle;
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 pub mod prove;
 pub mod taps;
 pub mod verify;

--- a/risc0/zkp/src/verify/fri.rs
+++ b/risc0/zkp/src/verify/fri.rs
@@ -14,7 +14,7 @@
 
 use alloc::vec::Vec;
 
-use rand::RngCore;
+use rand_core::RngCore;
 
 use super::VerifyHal;
 use crate::{

--- a/risc0/zkp/src/verify/read_iop.rs
+++ b/risc0/zkp/src/verify/read_iop.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::{Error, RngCore};
+use rand_core::{Error, RngCore};
 
 use crate::{
     core::{

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -36,30 +36,14 @@ tracing = { version = "0.1", default-features = false, features = ["attributes"]
 # Host dependencies
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
 addr2line = { version = "0.19", optional = true }
-elf = "0.7"
+elf = { version = "0.7", optional = true }
 gimli = { version = "0.27", optional = true }
-lazy-regex = "2.3"
+lazy-regex = { version = "2.3", optional = true }
 log = "0.4"
-num-traits = "0.2"
-num-derive = "0.3"
 prost = { version = "0.11", optional = true }
-rand = "0.8"
-rayon = "1.5"
-sha2 = "0.10"
-thiserror = "1.0"
-
-[target.'cfg(target_os = "zkvm")'.dependencies]
-# Lots of things depend on getrandom, and it throws a compiler error
-# for environments it doesn't support.  So, we depend on it here to
-# add the "custom" feature flag.
-#
-# To actually use getrandom, one must provide a custom implementation per
-# https://docs.rs/getrandom/latest/getrandom/#custom-implementations or it
-# will panic.
-getrandom = { version = "0.2", features = ["custom"] }
-
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+rand = { version = "0.8", optional = true }
+rayon = { version = "1.5", optional = true }
+sha2 = { version = "0.10", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
@@ -80,10 +64,19 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 cuda = ["risc0-circuit-rv32im/cuda", "risc0-zkp/cuda"]
-default = ["std"]
+default = ["prove"]
 dual = []
 insecure_skip_seal = []
 metal = []
 profiler = ["dep:addr2line", "dep:gimli", "dep:prost", "dep:prost-build", "dep:protobuf-src"]
+prove = [
+    "dep:elf",
+    "dep:lazy-regex",
+    "dep:rand",
+    "dep:rayon",
+    "dep:sha2",
+    "risc0-circuit-rv32im/prove",
+    "risc0-zkp/prove",
+    "std"
+]
 std = ["anyhow/std", "risc0-circuit-rv32im/std", "risc0-zeroio/std", "risc0-zkp/std", "serde/std"]
-verify-only = ["risc0-circuit-rv32im/verify-only"]

--- a/risc0/zkvm/methods/std/Cargo.toml
+++ b/risc0/zkvm/methods/std/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 bytemuck = "1.12"
 risc0-zkp = { path = "../../../zkp", default-features = false }
-risc0-zkvm = { path = "../.." }
+risc0-zkvm = { path = "../..", default-features = false, features = ["std"] }
 risc0-zkvm-methods = { path = "..", default-features = false }
 risc0-zkvm-platform = { path = "../../platform" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -40,7 +40,7 @@ extern crate alloc;
 #[cfg(any(target_os = "zkvm", doc))]
 pub mod guest;
 pub mod method_id;
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 pub mod prove;
 pub mod receipt;
 pub mod serde;
@@ -50,7 +50,7 @@ mod tests;
 
 pub use anyhow::Result;
 
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 pub use crate::prove::{Prover, ProverOpts};
 pub use crate::{
     method_id::{MethodId, DEFAULT_METHOD_ID_LIMIT},

--- a/risc0/zkvm/src/method_id.rs
+++ b/risc0/zkvm/src/method_id.rs
@@ -76,18 +76,18 @@ impl MethodId {
         Ok(MethodId { table })
     }
 
-    #[cfg(not(target_os = "zkvm"))]
+    #[cfg(feature = "prove")]
     pub fn compute(elf_contents: &[u8]) -> Result<Self> {
         MethodId::compute_with_limit(elf_contents, DEFAULT_METHOD_ID_LIMIT)
     }
 
-    #[cfg(not(target_os = "zkvm"))]
+    #[cfg(feature = "prove")]
     pub fn compute_with_limit(elf_contents: &[u8], limit: usize) -> Result<Self> {
         prove::compute_with_limit(elf_contents, limit)
     }
 }
 
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(feature = "prove")]
 mod prove {
     use anyhow::Result;
     use risc0_zkp::{

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{method_id::MethodId, CIRCUIT};
 
-#[cfg(not(target_os = "zkvm"))]
+#[cfg(all(feature = "std", not(target_os = "zkvm")))]
 pub fn insecure_skip_seal() -> bool {
     cfg!(feature = "insecure_skip_seal")
         && std::env::var("RISC0_INSECURE_SKIP_SEAL").unwrap_or_default() == "1"
@@ -68,6 +68,7 @@ where
         }
     };
 
+    #[cfg(any(feature = "std", target_os = "zkvm"))]
     if insecure_skip_seal() {
         return Ok(());
     }


### PR DESCRIPTION
* Drop explicit `getrandom` dep
* Use `default-features = false` when depending on `risc0-zkvm` to get verify-only behavior.
* Use `rand_core` to avoid `rand` dependency
* Drop `verify-only `feature
* Introduce `prove` feature (enabled by default)