### PR TITLE
Allow building and running without Metal on MacOS

### DIFF
--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -24,9 +24,7 @@ rand = { version = "0.8", optional = true }
 rayon = { version = "1.5", optional = true }
 rustacuda_core = { version = "0.1", optional = true }
 rustacuda_derive = { version = "0.1", optional = true }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.24"
+metal = { version = "0.24", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"
@@ -40,8 +38,10 @@ glob = "0.3"
 sha2 = "0.10"
 
 [features]
+default = ["prove", "test", "metal"]
+
 cuda = ["dep:fil-rustacuda", "dep:rustacuda_core", "dep:rustacuda_derive", "risc0-zkp/cuda", "std"]
-default = ["prove", "test"]
+metal = ["dep:metal"]
 prove = ["dep:rand", "dep:rayon", "std"]
 std = ["risc0-zkp/std"]
 test = []

--- a/risc0/circuit/rv32im/src/lib.rs
+++ b/risc0/circuit/rv32im/src/lib.rs
@@ -23,7 +23,7 @@ pub mod cuda;
 #[cfg(feature = "prove")]
 mod ffi;
 mod info;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "metal"))]
 pub mod metal;
 pub mod poly_ext;
 mod taps;

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -30,9 +30,7 @@ ndarray = { version = "0.15", features = ["rayon"], optional = true }
 rand = { version = "0.8", optional = true }
 rayon = { version = "1.5", optional = true }
 sha2 = { version = "0.10", default-features = false, features = ["compress"] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.24"
+metal = { version = "0.24", optional = true }
 
 [dev-dependencies]
 criterion = "0.4"
@@ -43,7 +41,8 @@ test-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-default = ["prove"]
+default = ["prove", "metal"]
+metal = ["dep:metal"]
 cuda = ["dep:fil-rustacuda", "dep:rustacuda_core", "dep:rustacuda_derive"]
 prove = [
     "dep:ndarray",

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -64,10 +64,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 cuda = ["risc0-circuit-rv32im/cuda", "risc0-zkp/cuda"]
-default = ["prove"]
+default = ["prove", "metal"]
 dual = []
 insecure_skip_seal = []
-metal = []
+metal = ["risc0-circuit-rv32im/metal", "risc0-zkp/metal"]
 profiler = ["dep:addr2line", "dep:gimli", "dep:prost", "dep:prost-build", "dep:protobuf-src"]
 prove = [
     "dep:elf",

--- a/risc0/zkvm/src/method_id.rs
+++ b/risc0/zkvm/src/method_id.rs
@@ -116,7 +116,7 @@ mod prove {
     pub fn compute_with_limit(elf_contents: &[u8], limit: usize) -> Result<MethodId> {
         let code_size = CIRCUIT.code_size();
         cfg_if::cfg_if! {
-            if #[cfg(target_os = "macos")] {
+            if #[cfg(all(feature = "metal", target_os = "macos"))] {
                 let hal = risc0_zkp::hal::metal::MetalHal::new();
             } else {
                 let hal = risc0_zkp::hal::cpu::BabyBearCpuHal::new();


### PR DESCRIPTION
Metal is currently required as a build dependency on MacOS even if it will not be used. As a result,
the codebase cannot be built without it.

This PR refactors the use of Metal to gate building dependant code behind the "metal" feature flag.
As an alternative to the current method, this means users may have to explicitly enable "metal" as a
feature at build-time (if the turn off defeault features).
