### PR TITLE
Move zip download tmpdir to $HOME/.risc0

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -87,7 +87,7 @@ use risc0_zkp::adapter::TapsProvider;
 use risc0_zkvm::{MethodId, DEFAULT_METHOD_ID_LIMIT};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use tempfile::tempdir;
+use tempfile::tempdir_in;
 use zip::ZipArchive;
 
 const LINKER_SCRIPT: &str = include_str!("../risc0.ld");
@@ -338,12 +338,13 @@ fn download_zip_map<P>(zip_map: &[ZipMapEntry], dest_base: P)
 where
     P: AsRef<Path>,
 {
-    let cache_dir = risc0_root().join("cache");
+    let risc0_root = risc0_root();
+    let cache_dir = risc0_root.join("cache");
     if !cache_dir.is_dir() {
         fs::create_dir_all(&cache_dir).unwrap();
     }
 
-    let temp_dir = tempdir().unwrap();
+    let temp_dir = tempdir_in(risc0_root).unwrap();
     let mut downloader = Downloader::builder()
         .download_folder(&temp_dir.path())
         .build()


### PR DESCRIPTION
This fixes build issues with fs::rename() across filesystems when /tmp/ is mounted separately from the location of the repo. Hit error message `Invalid cross-device link` while trying to build `main` on Arch Linux.