### PR TITLE
Update copyright year and automatically check modified files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - run: |
           # Check that no source files updated this year have a missing or out-of-date copyright.
           set -e
-          MISSING_COPYRIGHT="$(comm -12 <(git log --since='Dec 31 2022' --name-only --pretty=format: | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
+          MISSING_COPYRIGHT="$(comm -12 <(git log --name-only --pretty=format: d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7... | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
           echo $MISSING_COPYRIGHT
           [ -z "$MISSING_COPYRIGHT" ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - run: |
           # Check that no source files updated this year have a missing or out-of-date copyright.
           set -e
-          MISSING_COPYRIGHT="$(comm -12 <(git log --since="Dec 31 2022" --name-only --pretty=format: | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
+          MISSING_COPYRIGHT="$(comm -12 <(git log --since='Dec 31 2022' --name-only --pretty=format: | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
           echo $MISSING_COPYRIGHT
           [ -z "$MISSING_COPYRIGHT" ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,12 @@ jobs:
           version: "1.0"
       - run: cargo fmt --all -- --check
       - run: cargo sort --workspace --check
-      - run: npx @kt3k/license-checker
+      - run: |
+          # Check that no source files updated this year have a missing or out-of-date copyright.
+          set -e
+          MISSING_COPYRIGHT="$(comm -12 <(git log --since="Dec 31 2022" --name-only --pretty=format: | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
+          echo $MISSING_COPYRIGHT
+          [ -z "$MISSING_COPYRIGHT" ]
 
   test:
     runs-on: [self-hosted, "${{ matrix.os }}", "${{ matrix.arch }}"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - run: |
           # Check that no source files updated this year have a missing or out-of-date copyright.
           set -e
-          MISSING_COPYRIGHT="$(comm -12 <(git log --name-only --pretty=format: d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7... | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
+          MISSING_COPYRIGHT="$(comm -12 <(git log --name-only --pretty=format: d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7..HEAD | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
           echo $MISSING_COPYRIGHT
           [ -z "$MISSING_COPYRIGHT" ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Fetch the merge commit and origin/HEAD.
+          fetch-depth: 2
       - uses: risc0/actions-rs-toolchain@v1
         with:
           toolchain: stable
@@ -26,7 +29,7 @@ jobs:
       - run: |
           # Check that no source files updated this year have a missing or out-of-date copyright.
           set -e
-          MISSING_COPYRIGHT="$(comm -12 <(git log --name-only --pretty=format: d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7..HEAD | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
+          MISSING_COPYRIGHT="$(comm -12 <(git diff --name-only --pretty=format: origin/HEAD | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
           echo $MISSING_COPYRIGHT
           [ -z "$MISSING_COPYRIGHT" ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,10 @@ jobs:
       - run: cargo sort --workspace --check
       - run: |
           # Check that no source files updated this year have a missing or out-of-date copyright.
+          # Locally, use the following command to check that copyrights have been updated.
+          # comm -12 <(git diff --name-only --pretty=format: origin/HEAD | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1)
           set -e
-          MISSING_COPYRIGHT="$(comm -12 <(git diff --name-only --pretty=format: origin/HEAD | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
+          MISSING_COPYRIGHT="$(comm -12 <(git diff --name-only --pretty=format: HEAD^ | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
           echo $MISSING_COPYRIGHT
           [ -z "$MISSING_COPYRIGHT" ]
 

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,6 +1,6 @@
 {
   "**/*.{cpp,h,rs}": [
-    "// Copyright 2022 RISC Zero, Inc.",
+    "// Copyright 2023 RISC Zero, Inc.",
     "//",
     "// Licensed under the Apache License, Version 2.0 (the \"License\");",
     "// you may not use this file except in compliance with the License.",

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/cxx/poly_fp.cpp
+++ b/risc0/circuit/rv32im/cxx/poly_fp.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/cxx/step_compute_accum.cpp
+++ b/risc0/circuit/rv32im/cxx/step_compute_accum.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/cxx/step_exec.cpp
+++ b/risc0/circuit/rv32im/cxx/step_exec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/cxx/step_verify_accum.cpp
+++ b/risc0/circuit/rv32im/cxx/step_verify_accum.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/cxx/step_verify_bytes.cpp
+++ b/risc0/circuit/rv32im/cxx/step_verify_bytes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/cxx/step_verify_mem.cpp
+++ b/risc0/circuit/rv32im/cxx/step_verify_mem.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/src/info.rs
+++ b/risc0/circuit/rv32im/src/info.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/src/poly_ext.rs
+++ b/risc0/circuit/rv32im/src/poly_ext.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/src/taps.rs
+++ b/risc0/circuit/rv32im/src/taps.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/circuit/rv32im/src/verify_taps_rv32im.rs
+++ b/risc0/circuit/rv32im/src/verify_taps_rv32im.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/r0vm/src/bin/r0vm.rs
+++ b/risc0/r0vm/src/bin/r0vm.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/r0vm/tests/standard_lib.rs
+++ b/risc0/r0vm/tests/standard_lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/tools/src/bin/make_id.rs
+++ b/risc0/tools/src/bin/make_id.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/wasm/src/main.rs
+++ b/risc0/wasm/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zeroio_derive/src/lib.rs
+++ b/risc0/zeroio_derive/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// DO NOT MERGE: Test copyright script
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{

--- a/risc0/zeroio_derive/src/lib.rs
+++ b/risc0/zeroio_derive/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// DO NOT MERGE: Test copyright script
-
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{

--- a/risc0/zkp/src/adapter.rs
+++ b/risc0/zkp/src/adapter.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/core/sha.rs
+++ b/risc0/zkp/src/core/sha.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/prove/accum.rs
+++ b/risc0/zkp/src/prove/accum.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/prove/adapter.rs
+++ b/risc0/zkp/src/prove/adapter.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/prove/executor.rs
+++ b/risc0/zkp/src/prove/executor.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/prove/mod.rs
+++ b/risc0/zkp/src/prove/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/verify/read_iop.rs
+++ b/risc0/zkp/src/verify/read_iop.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/methods/build.rs
+++ b/risc0/zkvm/methods/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/platform/src/lib.rs
+++ b/risc0/zkvm/platform/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/platform/src/memory.rs
+++ b/risc0/zkvm/platform/src/memory.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/guest/env.rs
+++ b/risc0/zkvm/src/guest/env.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/prove/exec.rs
+++ b/risc0/zkvm/src/prove/exec.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/prove/image.rs
+++ b/risc0/zkvm/src/prove/image.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/prove/loader.rs
+++ b/risc0/zkvm/src/prove/loader.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/prove/mod.rs
+++ b/risc0/zkvm/src/prove/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/prove/plonk.rs
+++ b/risc0/zkvm/src/prove/plonk.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/prove/profiler.rs
+++ b/risc0/zkvm/src/prove/profiler.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/tests.rs
+++ b/risc0/zkvm/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 RISC Zero, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the copyright year to 2023 in `.licenserc.json`, and in all files that have been modified since the start of the year.

Additionally, this PR includes a new copyright check command that ensures a PR will require an updated copyright on any files modified in the PR.

Opened this PR after running into the copyright check in https://github.com/risc0/risc0/pull/330
