### PR TITLE
Added a more friendly error msg when nvcc fails

### DIFF
--- a/risc0/zkp/build.rs
+++ b/risc0/zkp/build.rs
@@ -101,7 +101,7 @@ fn build_cuda_kernels(out_dir: &Path) {
         .arg("-o")
         .arg(&out_path)
         .status()
-        .unwrap();
+        .expect("Failed to run 'nvcc' executable, do you have the 'cuda' package installed?");
     if result.success() {
         for src in src_paths {
             println!("cargo:rerun-if-changed={src}");


### PR DESCRIPTION
Triggered this .unwrap() while building on Arch Linux, adding context to the error might help the next person who forgets to install the cuda package first. 