### PR TITLE
Scoped the zkvm-platform dep to just guest builds

### DIFF
--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -14,7 +14,6 @@ harness = false
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
 risc0-zkp = { version = "1.0.0-rc.2", path = "../../../risc0/zkp", default-features = false }
-risc0-zkvm-platform = { version = "1.0.0-rc.2", path = "../../../risc0/zkvm/platform" }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
@@ -24,6 +23,9 @@ rand = { version = "0.8", optional = true }
 rayon = { version = "1.5", optional = true }
 rustacuda_core = { version = "0.1", optional = true }
 rustacuda_derive = { version = "0.1", optional = true }
+
+[target.'cfg(target_os = "zkvm")'.dependencies]
+risc0-zkvm-platform = { version = "1.0.0-rc.2", path = "../../../risc0/zkvm/platform" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = "0.24"


### PR DESCRIPTION
This removes additional dependency links with the circuit crate, should help with rebuild times in certain edit patterns of the src tree.