### PR TITLE
Minor build system fixes upstreamed from the risc0-sys crate work

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -426,7 +426,9 @@ impl Default for GuestOptions {
 /// Specify custom options for a guest package by defining its [GuestOptions].
 /// See [embed_methods].
 pub fn embed_methods_with_options(mut guest_pkg_to_options: HashMap<&str, GuestOptions>) {
-    if env::var("RISC0_SKIP_BUILD").is_ok() {
+    let skip_var_name = "RISC0_SKIP_BUILD";
+    println!("cargo:rerun-if-env-changed={}", skip_var_name);
+    if env::var(skip_var_name).is_ok() {
         return;
     }
 

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -23,12 +23,10 @@ rand = { version = "0.8", optional = true }
 rayon = { version = "1.5", optional = true }
 rustacuda_core = { version = "0.1", optional = true }
 rustacuda_derive = { version = "0.1", optional = true }
+metal = { version = "0.24", optional = true }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
 risc0-zkvm-platform = { workspace = true }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.24"
 
 [dev-dependencies]
 criterion = "0.4"
@@ -43,6 +41,7 @@ sha2 = "0.10"
 
 [features]
 cuda = ["dep:fil-rustacuda", "dep:rustacuda_core", "dep:rustacuda_derive", "risc0-zkp/cuda", "std"]
+metal = ["dep:metal"]
 default = ["prove", "test"]
 prove = ["dep:rand", "dep:rayon", "risc0-zkp/prove", "std"]
 std = ["risc0-zkp/std"]

--- a/risc0/circuit/rv32im/build.rs
+++ b/risc0/circuit/rv32im/build.rs
@@ -33,7 +33,7 @@ fn main() {
 
     build_cpu_kernels();
 
-    if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
+    if env::var("CARGO_FEATURE_METAL").is_ok() {
         build_metal_kernels(&out_dir);
     }
 

--- a/risc0/circuit/rv32im/src/lib.rs
+++ b/risc0/circuit/rv32im/src/lib.rs
@@ -24,7 +24,7 @@ pub mod cuda;
 #[cfg(feature = "prove")]
 mod ffi;
 mod info;
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 pub mod metal;
 pub mod poly_ext;
 mod taps;

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -16,6 +16,7 @@ harness = false
 anyhow = { version = "1.0", default-features = false }
 bytemuck = { version = "1.12", features = ["derive"] }
 fil-rustacuda = { version = "0.1", optional = true }
+metal = { version = "0.24", optional = true }
 paste = "1.0"
 rand_core = "0.6"
 risc0-zeroio = { workspace = true }
@@ -31,9 +32,6 @@ rand = { version = "0.8", optional = true }
 rayon = { version = "1.5", optional = true }
 sha2 = { version = "0.10", default-features = false, features = ["compress"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.24"
-
 [dev-dependencies]
 criterion = "0.4"
 env_logger = "0.10"
@@ -45,6 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [features]
 default = ["prove"]
 cuda = ["dep:fil-rustacuda", "dep:rustacuda_core", "dep:rustacuda_derive"]
+metal = ["dep:metal"]
 prove = [
     "dep:ndarray",
     "dep:rand",

--- a/risc0/zkp/build.rs
+++ b/risc0/zkp/build.rs
@@ -23,7 +23,7 @@ fn main() {
     let out_dir = Path::new(&out_dir);
     println!("cargo:include={}", env!("CARGO_MANIFEST_DIR"));
 
-    if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
+    if env::var("CARGO_FEATURE_METAL").is_ok() {
         build_metal_kernels(&out_dir);
     }
 

--- a/risc0/zkp/src/hal/mod.rs
+++ b/risc0/zkp/src/hal/mod.rs
@@ -18,7 +18,7 @@ pub mod cpu;
 #[cfg(feature = "cuda")]
 pub mod cuda;
 pub mod dual;
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 pub mod metal;
 
 use crate::{

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -66,10 +66,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 cuda = ["risc0-circuit-rv32im/cuda", "risc0-zkp/cuda"]
+metal = ["risc0-circuit-rv32im/metal", "risc0-zkp/metal"]
 default = ["prove"]
 dual = []
 insecure_skip_seal = []
-metal = []
 profiler = ["dep:addr2line", "dep:gimli", "dep:prost", "dep:prost-build", "dep:protobuf-src"]
 prove = [
     "dep:elf",


### PR DESCRIPTION
* Enabled rebuilds if the `RISC0_SKIP_BUILD` env var changes
* Moves metal builds behind a feature flag vs defaulting on `macos` platforms.