### PR TITLE
Simplify copyright check for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,7 @@ jobs:
           version: "1.0"
       - run: cargo fmt --all -- --check
       - run: cargo sort --workspace --check
-      - run: |
-          # Check that no source files updated this year have a missing or out-of-date copyright.
-          # Locally, use the following command to check that copyrights have been updated.
-          # comm -12 <(git diff --name-only --pretty=format: origin/HEAD | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1)
-          set -e
-          MISSING_COPYRIGHT="$(comm -12 <(git diff --name-only --pretty=format: HEAD^ | sort | uniq) <(npx @kt3k/license-checker | grep 'missing copyright' | sort | cut -d ' ' -f 1))"
-          echo $MISSING_COPYRIGHT
-          [ -z "$MISSING_COPYRIGHT" ]
+      - run: npx @kt3k/license-checker
 
   test:
     runs-on: [self-hosted, "${{ matrix.os }}", "${{ matrix.arch }}"]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts


### PR DESCRIPTION
Since https://github.com/risc0/risc0/pull/336 we no longer need the more complicated copyright check
introduced in https://github.com/risc0/risc0/pull/331. This PR reverts those changes and
additionally specifies the version of nodejs to use in a `.tool-versions` file.
