### PR TITLE
Fix bug in decoding memory instructions

### DIFF
--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 cargo_metadata = "0.15"
 downloader = "0.2"
 home = "0.5"
+miniz_oxide = "=0.6.2"
 risc0-zkvm = { workspace = true, features = ["binfmt"] }
 risc0-zkvm-platform = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/risc0/zkp/src/lib.rs
+++ b/risc0/zkp/src/lib.rs
@@ -28,6 +28,8 @@ pub mod prove;
 pub mod taps;
 pub mod verify;
 
+pub use risc0_core::field;
+
 pub const MIN_CYCLES_PO2: usize = 11;
 pub const MIN_CYCLES: usize = 1 << MIN_CYCLES_PO2; // 1K
 pub const MAX_CYCLES_PO2: usize = 24;


### PR DESCRIPTION
This fixes https://github.com/risc0/risc0-rust-examples/issues/47

The bug is that when deocding a memory I/O instruction, the wrong address is computed which results in the wrong page being loaded in.