### PR TITLE
Remove mention of non-existent C support (328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ output of the code, not any of its inputs or any state during execution.
 The code runs in a special virtual machine, called a *zkVM*.  The RISC Zero zkVM
 emulates a small [RISC-V] computer, allowing it to run arbitrary code in any
 language, so long as a compiler toolchain exists that targets RISC-V. Currently,
-SDK support exists for Rust, C, and C++.
+SDK support exists for Rust.
 
 ## Protocol overview and terminology
 


### PR DESCRIPTION
https://github.com/risc0/risc0/issues/328 says that C support doesn't work at the moment.