### PR TITLE
[NFC] Refactor code in advance of adding support for alternate hashes

### DIFF
--- a/risc0/circuit/rv32im/benches/eval_check.rs
+++ b/risc0/circuit/rv32im/benches/eval_check.rs
@@ -18,7 +18,7 @@ use risc0_circuit_rv32im::{
     testutil::{eval_check_impl, EvalCheckParams},
     CircuitImpl,
 };
-use risc0_zkp::hal::cpu::BabyBearCpuHal;
+use risc0_zkp::hal::cpu::BabyBearSha256CpuHal;
 
 pub fn eval_check(c: &mut Criterion) {
     let mut group = c.benchmark_group("eval_check");
@@ -26,7 +26,7 @@ pub fn eval_check(c: &mut Criterion) {
     for po2 in [2, 8, 16].iter() {
         let params = EvalCheckParams::new(*po2);
         let circuit = CircuitImpl::new();
-        let hal = BabyBearCpuHal::new();
+        let hal = BabyBearSha256CpuHal::new();
         let eval = CpuEvalCheck::new(&circuit);
         group.bench_function(BenchmarkId::new("cpu", po2), |b| {
             b.iter(|| {

--- a/risc0/circuit/rv32im/src/cpu.rs
+++ b/risc0/circuit/rv32im/src/cpu.rs
@@ -21,7 +21,7 @@ use risc0_zkp::{
     adapter::PolyFp,
     core::log2_ceil,
     hal::{
-        cpu::{BabyBearCpuHal, CpuBuffer},
+        cpu::{BabyBearSha256CpuHal, CpuBuffer},
         EvalCheck,
     },
     INV_RATE,
@@ -41,7 +41,7 @@ impl<'a, C: PolyFp<BabyBear>> CpuEvalCheck<'a, C> {
     }
 }
 
-impl<'a, C: PolyFp<BabyBear> + Sync> EvalCheck<BabyBearCpuHal> for CpuEvalCheck<'a, C> {
+impl<'a, C: PolyFp<BabyBear> + Sync> EvalCheck<BabyBearSha256CpuHal> for CpuEvalCheck<'a, C> {
     #[tracing::instrument(skip_all)]
     fn eval_check(
         &self,

--- a/risc0/circuit/rv32im/src/cuda.rs
+++ b/risc0/circuit/rv32im/src/cuda.rs
@@ -109,7 +109,7 @@ impl<'a> EvalCheck<CudaHal> for CudaEvalCheck {
 mod tests {
     use std::rc::Rc;
 
-    use risc0_zkp::hal::{cpu::BabyBearCpuHal, cuda::CudaHal};
+    use risc0_zkp::hal::{cpu::BabyBearSha256CpuHal, cuda::CudaHal};
     use test_log::test;
 
     use crate::cpu::CpuEvalCheck;
@@ -118,7 +118,7 @@ mod tests {
     fn eval_check() {
         const PO2: usize = 4;
         let circuit = crate::CircuitImpl::new();
-        let cpu_hal = BabyBearCpuHal::new();
+        let cpu_hal = BabyBearSha256CpuHal::new();
         let cpu_eval = CpuEvalCheck::new(&circuit);
         let gpu_hal = Rc::new(CudaHal::new());
         let gpu_eval = super::CudaEvalCheck::new(gpu_hal.clone());

--- a/risc0/circuit/rv32im/src/metal.rs
+++ b/risc0/circuit/rv32im/src/metal.rs
@@ -94,7 +94,7 @@ impl EvalCheck<MetalHal> for MetalEvalCheck {
 mod tests {
     use std::rc::Rc;
 
-    use risc0_zkp::hal::{cpu::BabyBearCpuHal, metal::MetalHal};
+    use risc0_zkp::hal::{cpu::BabyBearSha256CpuHal, metal::MetalHal};
     use test_log::test;
 
     use crate::cpu::CpuEvalCheck;
@@ -106,7 +106,7 @@ mod tests {
         // The number of cycles, choose a number that doesn't make tests take too long.
         const PO2: usize = 4;
         let circuit = crate::CircuitImpl::new();
-        let cpu_hal = BabyBearCpuHal::new();
+        let cpu_hal = BabyBearSha256CpuHal::new();
         let cpu_eval = CpuEvalCheck::new(&circuit);
         let gpu_hal = Rc::new(MetalHal::new());
         let gpu_eval = super::MetalEvalCheck::new(gpu_hal.clone());

--- a/risc0/zkp/src/core/config.rs
+++ b/risc0/zkp/src/core/config.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Traits to configure which cryptographic primitives the ZKP uses
+
+use core::{fmt::Debug, ops::DerefMut};
+
+use risc0_core::field::Field;
+
+use super::digest::Digest;
+
+/// A trait that sets the hashes and encodings used by the ZKP.
+pub trait ConfigHash {
+    /// A pointer to the digest created as the result of a hashing operation.
+    ///
+    /// This may either be a `Box<Digest>` or some other pointer in case the
+    /// implementation wants to manage its own memory. Semantically, holding the
+    /// `DigestPtr` denotes ownership of the underlying value. (e.g. `DigestPtr`
+    /// does not implement `Copy` and the owner of `DigestPtr` can create a
+    /// mutable reference to the underlying digest).
+    type DigestPtr: DerefMut<Target = Digest> + Debug;
+
+    /// Generate a hash from a pair of [Digest].   
+    fn hash_pair(a: &Digest, b: &Digest) -> Self::DigestPtr;
+
+    /// Generate a hash from a slice of anything that can be represented as
+    /// plain old data.
+    fn hash_raw_pod_slice<T: bytemuck::Pod>(slice: &[T]) -> Self::DigestPtr;
+}
+
+/// A trait that sets the PRNG used by Fiat-Shamir.  We allow specialization at
+/// this level rather than at RngCore because some hashes such as Posidon have
+/// elements distributed uniformly over the field natively.
+pub trait ConfigRNG<F: Field> {
+    /// Create a new RNG is a standard state, mix before using!
+    fn new() -> Self;
+    /// Mix in randomness from a Fiat-Shamir commitment.
+    fn mix(&mut self, val: &Digest);
+    /// Get a cryptographically uniform u32
+    fn next_u32(&mut self) -> u32;
+    /// Get a cryptographically uniform field element
+    fn next_elem(&mut self) -> F::Elem;
+    /// Get a cryptographically uniform extension field element
+    fn next_ext_elem(&mut self) -> F::ExtElem;
+}

--- a/risc0/zkp/src/core/config.rs
+++ b/risc0/zkp/src/core/config.rs
@@ -42,15 +42,15 @@ pub trait ConfigHash {
 /// A trait that sets the PRNG used by Fiat-Shamir.  We allow specialization at
 /// this level rather than at RngCore because some hashes such as Posidon have
 /// elements distributed uniformly over the field natively.
-pub trait ConfigRNG<F: Field> {
+pub trait ConfigRng<F: Field> {
     /// Create a new RNG is a standard state, mix before using!
     fn new() -> Self;
     /// Mix in randomness from a Fiat-Shamir commitment.
     fn mix(&mut self, val: &Digest);
     /// Get a cryptographically uniform u32
-    fn next_u32(&mut self) -> u32;
+    fn random_u32(&mut self) -> u32;
     /// Get a cryptographically uniform field element
-    fn next_elem(&mut self) -> F::Elem;
+    fn random_elem(&mut self) -> F::Elem;
     /// Get a cryptographically uniform extension field element
-    fn next_ext_elem(&mut self) -> F::ExtElem;
+    fn random_ext_elem(&mut self) -> F::ExtElem;
 }

--- a/risc0/zkp/src/core/digest.rs
+++ b/risc0/zkp/src/core/digest.rs
@@ -1,0 +1,270 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A generic (cross hash) digest, which is always 256 bits and composed of 8
+//! words
+
+use alloc::format;
+use alloc::vec::Vec;
+use core::fmt::{Debug, Display, Formatter};
+
+use bytemuck::{Pod, PodCastError, Zeroable};
+use hex::{FromHex, FromHexError};
+use risc0_zeroio::{Deserialize as ZeroioDeserialize, Serialize as ZeroioSerialize};
+pub use risc0_zkvm_platform::WORD_SIZE;
+use serde::{Deserialize, Serialize};
+
+/// The number of words in the representation of a [Digest].
+pub const DIGEST_WORDS: usize = 8;
+
+/// Size of the [Digest] representation in bytes.
+///
+/// Note that digests are stored in memory as words instead of bytes.
+pub const DIGEST_BYTES: usize = DIGEST_WORDS * WORD_SIZE;
+
+/// Digest represents the results of a hashing function.  It is always 256 bits
+/// of storage although depending on the hash it may have additional structure
+/// (for example Poseidon's output is actually composed of field elements).  The
+/// storage is in u32's in part to simiplify alignment requirements, especially
+/// in the zkVM.
+#[derive(
+    Copy,
+    Clone,
+    Eq,
+    Ord,
+    PartialOrd,
+    PartialEq,
+    Pod,
+    Zeroable,
+    Serialize,
+    Deserialize,
+    ZeroioSerialize,
+    ZeroioDeserialize,
+)]
+#[repr(transparent)]
+pub struct Digest([u32; DIGEST_WORDS]);
+
+impl Digest {
+    /// Constant constructor
+    pub const fn new(data: [u32; DIGEST_WORDS]) -> Self {
+        Self(data)
+    }
+    /// Returns a reference to the [Digest] as a slice of words.
+    pub fn as_words(&self) -> &[u32] {
+        &self.0
+    }
+
+    /// Returns a reference to the [Digest] as a slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        bytemuck::cast_slice(&self.0)
+    }
+
+    /// Returns a mutable slice of words.
+    pub fn as_mut_words(&mut self) -> &mut [u32] {
+        &mut self.0
+    }
+
+    /// Returns a mutable slice of bytes.
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        bytemuck::cast_slice_mut(&mut self.0)
+    }
+}
+
+impl Default for Digest {
+    fn default() -> Digest {
+        Digest([0; DIGEST_WORDS])
+    }
+}
+
+/// Create a new [Digest] from an array of words.
+impl From<[u32; DIGEST_WORDS]> for Digest {
+    fn from(data: [u32; DIGEST_WORDS]) -> Self {
+        Self(data)
+    }
+}
+
+/// Create a new [Digest] from an array of bytes.
+impl From<[u8; DIGEST_BYTES]> for Digest {
+    fn from(data: [u8; DIGEST_BYTES]) -> Self {
+        match bytemuck::try_cast(data) {
+            Ok(digest) => digest,
+            Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
+                // Bytes are not aligned. Copy the byte array into a new digest.
+                bytemuck::pod_read_unaligned(&data)
+            }
+            Err(e) => unreachable!("failed to cast [u8; DIGEST_BYTES] to Digest: {}", e),
+        }
+    }
+}
+
+impl<'a> From<&'a [u32; DIGEST_WORDS]> for &'a Digest {
+    fn from(data: &'a [u32; DIGEST_WORDS]) -> Self {
+        bytemuck::cast_ref(data)
+    }
+}
+
+impl FromHex for Digest {
+    type Error = FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        Ok(<[u8; DIGEST_BYTES]>::from_hex(hex)?.into())
+    }
+}
+
+impl TryFrom<&[u8]> for Digest {
+    type Error = core::array::TryFromSliceError;
+
+    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+        Ok(<[u8; DIGEST_BYTES]>::try_from(data)?.into())
+    }
+}
+
+impl TryFrom<&[u32]> for Digest {
+    type Error = core::array::TryFromSliceError;
+
+    fn try_from(data: &[u32]) -> Result<Self, Self::Error> {
+        Ok(<[u32; DIGEST_WORDS]>::try_from(data)?.into())
+    }
+}
+
+impl<'a> TryFrom<&'a [u32]> for &'a Digest {
+    type Error = PodCastError;
+
+    fn try_from(data: &'a [u32]) -> Result<Self, Self::Error> {
+        match bytemuck::try_cast_slice(data) {
+            Ok(&[ref digest]) => Ok(digest),
+            Ok(_) => Err(PodCastError::SizeMismatch),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for Digest {
+    type Error = Vec<u8>;
+
+    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(<[u8; DIGEST_BYTES]>::try_from(data)?.into())
+    }
+}
+
+impl TryFrom<Vec<u32>> for Digest {
+    type Error = Vec<u32>;
+
+    fn try_from(data: Vec<u32>) -> Result<Self, Self::Error> {
+        Ok(<[u32; DIGEST_WORDS]>::try_from(data)?.into())
+    }
+}
+
+impl From<Digest> for [u8; DIGEST_BYTES] {
+    fn from(digest: Digest) -> Self {
+        bytemuck::cast(digest)
+    }
+}
+
+impl From<Digest> for [u32; DIGEST_WORDS] {
+    fn from(digest: Digest) -> Self {
+        digest.0
+    }
+}
+
+impl AsRef<[u8; DIGEST_BYTES]> for Digest {
+    fn as_ref(&self) -> &[u8; DIGEST_BYTES] {
+        bytemuck::cast_ref(&self.0)
+    }
+}
+
+impl AsMut<[u8; DIGEST_BYTES]> for Digest {
+    fn as_mut(&mut self) -> &mut [u8; DIGEST_BYTES] {
+        bytemuck::cast_mut(&mut self.0)
+    }
+}
+
+impl AsRef<[u32; DIGEST_WORDS]> for Digest {
+    fn as_ref(&self) -> &[u32; DIGEST_WORDS] {
+        &self.0
+    }
+}
+
+impl AsMut<[u32; DIGEST_WORDS]> for Digest {
+    fn as_mut(&mut self) -> &mut [u32; DIGEST_WORDS] {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for Digest {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl AsMut<[u8]> for Digest {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_bytes()
+    }
+}
+
+impl AsRef<[u32]> for Digest {
+    fn as_ref(&self) -> &[u32] {
+        self.as_words()
+    }
+}
+
+impl AsMut<[u32]> for Digest {
+    fn as_mut(&mut self) -> &mut [u32] {
+        self.as_mut_words()
+    }
+}
+
+impl Display for Digest {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        f.write_str(&hex::encode(&self))
+    }
+}
+
+impl Debug for Digest {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        f.write_str(&format!("Digest({})", &hex::encode(&self)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hex::FromHex;
+
+    use super::Digest;
+
+    #[test]
+    fn test_from_hex() {
+        assert_eq!(
+            Digest::from_hex("00000077000000AA0000001200000034000000560000007a000000a900000009")
+                .unwrap(),
+            Digest::from([
+                0x77_u32.to_be(),
+                0xaa_u32.to_be(),
+                0x12_u32.to_be(),
+                0x34_u32.to_be(),
+                0x56_u32.to_be(),
+                0x7a_u32.to_be(),
+                0xa9_u32.to_be(),
+                0x09_u32.to_be(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        const HEX: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        assert_eq!(hex::encode(Digest::from_hex(HEX).unwrap()), HEX);
+    }
+}

--- a/risc0/zkp/src/core/mod.rs
+++ b/risc0/zkp/src/core/mod.rs
@@ -24,6 +24,7 @@
 
 extern crate alloc;
 
+pub mod digest;
 pub mod ntt;
 pub mod poly;
 pub mod sha;

--- a/risc0/zkp/src/core/mod.rs
+++ b/risc0/zkp/src/core/mod.rs
@@ -24,6 +24,7 @@
 
 extern crate alloc;
 
+pub mod config;
 pub mod digest;
 pub mod ntt;
 pub mod poly;

--- a/risc0/zkp/src/core/sha.rs
+++ b/risc0/zkp/src/core/sha.rs
@@ -27,13 +27,7 @@ use risc0_zeroio::{Deserialize as ZeroioDeserialize, Serialize as ZeroioSerializ
 pub use risc0_zkvm_platform::WORD_SIZE;
 use serde::{Deserialize, Serialize};
 
-/// The number of words in the representation of a [Digest].
-pub const DIGEST_WORDS: usize = 8;
-
-/// Size of the [Digest] representation in bytes.
-///
-/// Note that digests are stored in memory as words instead of bytes.
-pub const DIGEST_BYTES: usize = DIGEST_WORDS * WORD_SIZE;
+pub use super::digest::{Digest, DIGEST_BYTES, DIGEST_WORDS};
 
 /// The number of words in the representation of a [Block].
 ///
@@ -47,7 +41,7 @@ pub const BLOCK_WORDS: usize = DIGEST_WORDS * 2;
 pub const BLOCK_BYTES: usize = DIGEST_BYTES * 2;
 
 /// Standard SHA-256 initialization vector.
-pub static SHA256_INIT: Digest = Digest([
+pub static SHA256_INIT: Digest = Digest::new([
     0x6a09e667_u32.to_be(),
     0xbb67ae85_u32.to_be(),
     0x3c6ef372_u32.to_be(),
@@ -113,207 +107,6 @@ pub trait Sha256 {
     /// add the standard SHA-256 trailer and so is not a standards compliant
     /// hash.
     fn hash_raw_pod_slice<T: bytemuck::Pod>(slice: &[T]) -> Self::DigestPtr;
-}
-
-/// The result of the SHA-256 hash algorithm.
-///
-/// NOTE: Bytes in the [Digest] type are stored in big-endian order regardless
-/// of the host architecture. When interpreted as words, the numerical result
-/// will depend on the architecture.
-#[derive(
-    Copy,
-    Clone,
-    Eq,
-    Ord,
-    PartialOrd,
-    PartialEq,
-    Pod,
-    Zeroable,
-    Serialize,
-    Deserialize,
-    ZeroioSerialize,
-    ZeroioDeserialize,
-)]
-#[repr(transparent)]
-pub struct Digest([u32; DIGEST_WORDS]);
-
-impl Digest {
-    /// Returns a reference to the [Digest] as a slice of words.
-    pub fn as_words(&self) -> &[u32] {
-        &self.0
-    }
-
-    /// Returns a reference to the [Digest] as a slice of bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        bytemuck::cast_slice(&self.0)
-    }
-
-    /// Returns a mutable slice of words.
-    pub fn as_mut_words(&mut self) -> &mut [u32] {
-        &mut self.0
-    }
-
-    /// Returns a mutable slice of bytes.
-    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
-        bytemuck::cast_slice_mut(&mut self.0)
-    }
-}
-
-impl Default for Digest {
-    fn default() -> Digest {
-        Digest([0; DIGEST_WORDS])
-    }
-}
-
-/// Create a new [Digest] from an array of words.
-impl From<[u32; DIGEST_WORDS]> for Digest {
-    fn from(data: [u32; DIGEST_WORDS]) -> Self {
-        Self(data)
-    }
-}
-
-/// Create a new [Digest] from an array of bytes.
-impl From<[u8; DIGEST_BYTES]> for Digest {
-    fn from(data: [u8; DIGEST_BYTES]) -> Self {
-        match bytemuck::try_cast(data) {
-            Ok(digest) => digest,
-            Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
-                // Bytes are not aligned. Copy the byte array into a new digest.
-                bytemuck::pod_read_unaligned(&data)
-            }
-            Err(e) => unreachable!("failed to cast [u8; DIGEST_BYTES] to Digest: {}", e),
-        }
-    }
-}
-
-impl<'a> From<&'a [u32; DIGEST_WORDS]> for &'a Digest {
-    fn from(data: &'a [u32; DIGEST_WORDS]) -> Self {
-        bytemuck::cast_ref(data)
-    }
-}
-
-impl FromHex for Digest {
-    type Error = FromHexError;
-
-    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        Ok(<[u8; DIGEST_BYTES]>::from_hex(hex)?.into())
-    }
-}
-
-impl TryFrom<&[u8]> for Digest {
-    type Error = core::array::TryFromSliceError;
-
-    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        Ok(<[u8; DIGEST_BYTES]>::try_from(data)?.into())
-    }
-}
-
-impl TryFrom<&[u32]> for Digest {
-    type Error = core::array::TryFromSliceError;
-
-    fn try_from(data: &[u32]) -> Result<Self, Self::Error> {
-        Ok(<[u32; DIGEST_WORDS]>::try_from(data)?.into())
-    }
-}
-
-impl<'a> TryFrom<&'a [u32]> for &'a Digest {
-    type Error = PodCastError;
-
-    fn try_from(data: &'a [u32]) -> Result<Self, Self::Error> {
-        match bytemuck::try_cast_slice(data) {
-            Ok(&[ref digest]) => Ok(digest),
-            Ok(_) => Err(PodCastError::SizeMismatch),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-impl TryFrom<Vec<u8>> for Digest {
-    type Error = Vec<u8>;
-
-    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(<[u8; DIGEST_BYTES]>::try_from(data)?.into())
-    }
-}
-
-impl TryFrom<Vec<u32>> for Digest {
-    type Error = Vec<u32>;
-
-    fn try_from(data: Vec<u32>) -> Result<Self, Self::Error> {
-        Ok(<[u32; DIGEST_WORDS]>::try_from(data)?.into())
-    }
-}
-
-impl From<Digest> for [u8; DIGEST_BYTES] {
-    fn from(digest: Digest) -> Self {
-        bytemuck::cast(digest)
-    }
-}
-
-impl From<Digest> for [u32; DIGEST_WORDS] {
-    fn from(digest: Digest) -> Self {
-        digest.0
-    }
-}
-
-impl AsRef<[u8; DIGEST_BYTES]> for Digest {
-    fn as_ref(&self) -> &[u8; DIGEST_BYTES] {
-        bytemuck::cast_ref(&self.0)
-    }
-}
-
-impl AsMut<[u8; DIGEST_BYTES]> for Digest {
-    fn as_mut(&mut self) -> &mut [u8; DIGEST_BYTES] {
-        bytemuck::cast_mut(&mut self.0)
-    }
-}
-
-impl AsRef<[u32; DIGEST_WORDS]> for Digest {
-    fn as_ref(&self) -> &[u32; DIGEST_WORDS] {
-        &self.0
-    }
-}
-
-impl AsMut<[u32; DIGEST_WORDS]> for Digest {
-    fn as_mut(&mut self) -> &mut [u32; DIGEST_WORDS] {
-        &mut self.0
-    }
-}
-
-impl AsRef<[u8]> for Digest {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl AsMut<[u8]> for Digest {
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.as_mut_bytes()
-    }
-}
-
-impl AsRef<[u32]> for Digest {
-    fn as_ref(&self) -> &[u32] {
-        self.as_words()
-    }
-}
-
-impl AsMut<[u32]> for Digest {
-    fn as_mut(&mut self) -> &mut [u32] {
-        self.as_mut_words()
-    }
-}
-
-impl Display for Digest {
-    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        f.write_str(&hex::encode(&self))
-    }
-}
-
-impl Debug for Digest {
-    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        f.write_str(&format!("Digest({})", &hex::encode(&self)))
-    }
 }
 
 /// Input block to the SHA-256 hashing algorithm. SHA-256 consumes blocks in
@@ -669,37 +462,6 @@ pub mod rust_crypto {
 
     /// SHA-256 implementation cross-compatible with `sha2::Sha256`.
     pub type Sha256<S> = CoreWrapper<CtVariableCoreWrapper<Sha256VarCore<S>, U32>>;
-}
-
-#[cfg(test)]
-mod tests {
-    use hex::FromHex;
-
-    use super::Digest;
-
-    #[test]
-    fn test_from_hex() {
-        assert_eq!(
-            Digest::from_hex("00000077000000AA0000001200000034000000560000007a000000a900000009")
-                .unwrap(),
-            Digest::from([
-                0x77_u32.to_be(),
-                0xaa_u32.to_be(),
-                0x12_u32.to_be(),
-                0x34_u32.to_be(),
-                0x56_u32.to_be(),
-                0x7a_u32.to_be(),
-                0xa9_u32.to_be(),
-                0x09_u32.to_be(),
-            ])
-        );
-    }
-
-    #[test]
-    fn test_roundtrip() {
-        const HEX: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
-        assert_eq!(hex::encode(Digest::from_hex(HEX).unwrap()), HEX);
-    }
 }
 
 #[allow(missing_docs)]

--- a/risc0/zkp/src/core/sha_rng.rs
+++ b/risc0/zkp/src/core/sha_rng.rs
@@ -17,8 +17,10 @@
 use core::marker::PhantomData;
 
 use rand_core::{impls, Error, RngCore};
+//use risc0_core::field::{Field};
 
 use super::sha::{Digest, Sha256, DIGEST_WORDS};
+//use super::config::ConfigRNG;
 
 /// A random number generator driven by a [Sha256].
 #[derive(Clone, Debug)]
@@ -80,6 +82,11 @@ impl<S: Sha256> RngCore for ShaRng<S> {
         Ok(self.fill_bytes(dest))
     }
 }
+
+/*
+impl<S: Sha256, F: Field> ConfigRNG<F> for ShaRng<S> {
+}
+*/
 
 #[allow(missing_docs)]
 pub mod testutil {

--- a/risc0/zkp/src/hal/cpu.rs
+++ b/risc0/zkp/src/hal/cpu.rs
@@ -458,7 +458,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn check_req() {
-        let hal = BabyBearCpuHal::new();
+        let hal = BabyBearSha256CpuHal::new();
         let a = hal.alloc_elem("a", 10);
         let b = hal.alloc_elem("b", 20);
         hal.eltwise_add_elem(&a, &b, &b);
@@ -466,7 +466,7 @@ mod tests {
 
     #[test]
     fn fp() {
-        let hal: BabyBearCpuHal = CpuHal::new();
+        let hal: BabyBearSha256CpuHal = CpuHal::new();
         const COUNT: usize = 1024 * 1024;
         test_binary(
             &hal,
@@ -507,7 +507,7 @@ mod tests {
     }
 
     fn do_hash_rows(rows: usize, cols: usize, expected: &[&str]) {
-        let hal: BabyBearCpuHal = CpuHal::new();
+        let hal: BabyBearSha256CpuHal = CpuHal::new();
         let matrix_size = rows * cols;
         let matrix = hal.alloc_elem("matrix", matrix_size);
         let output = hal.alloc_digest("output", rows);

--- a/risc0/zkp/src/hal/cpu.rs
+++ b/risc0/zkp/src/hal/cpu.rs
@@ -423,7 +423,7 @@ where
     }
 
     #[tracing::instrument(skip_all)]
-    fn sha_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
+    fn hash_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
         let row_size = output.size();
         let col_size = matrix.size() / output.size();
         assert_eq!(matrix.size(), col_size * row_size);
@@ -434,7 +434,7 @@ where
         });
     }
 
-    fn sha_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
+    fn hash_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
         assert_eq!(input_size, 2 * output_size);
         let mut io = io.as_slice_mut();
         let (output, input) = unsafe {
@@ -510,12 +510,12 @@ mod tests {
         });
     }
 
-    fn do_sha_rows(rows: usize, cols: usize, expected: &[&str]) {
+    fn do_hash_rows(rows: usize, cols: usize, expected: &[&str]) {
         let hal: BabyBearCpuHal = CpuHal::new();
         let matrix_size = rows * cols;
         let matrix = hal.alloc_elem("matrix", matrix_size);
         let output = hal.alloc_digest("output", rows);
-        hal.sha_rows(&output, &matrix);
+        hal.hash_rows(&output, &matrix);
         output.view(|view| {
             assert_eq!(expected.len(), view.len());
             for (expected, actual) in expected.iter().zip(view) {
@@ -525,8 +525,8 @@ mod tests {
     }
 
     #[test]
-    fn sha_rows() {
-        do_sha_rows(
+    fn hash_rows() {
+        do_hash_rows(
             1,
             16,
             &["da5698be17b9b46962335799779fbeca8ce5d491c0d26243bafef9ea1837a9d8"],

--- a/risc0/zkp/src/hal/cuda.rs
+++ b/risc0/zkp/src/hal/cuda.rs
@@ -17,7 +17,7 @@ use std::{cell::RefCell, ffi::CString, marker::PhantomData, rc::Rc};
 use bytemuck::Pod;
 use fil_rustacuda as rustacuda;
 use risc0_core::field::{
-    baby_bear::{BabyBearElem, BabyBearExtElem},
+    baby_bear::{BabyBear, BabyBearElem, BabyBearExtElem},
     Elem, ExtElem, RootsOfUnity,
 };
 use rustacuda::{
@@ -29,7 +29,7 @@ use rustacuda::{
 use rustacuda_core::UnifiedPointer;
 
 use crate::{
-    core::{log2_ceil, sha::Digest},
+    core::{config::ConfigHashSha256, log2_ceil, sha::Digest, sha_cpu, sha_rng::ShaRng},
     hal::{Buffer, Hal},
     FRI_FOLD,
 };
@@ -200,11 +200,15 @@ impl CudaHal {
 impl Hal for CudaHal {
     type Elem = BabyBearElem;
     type ExtElem = BabyBearExtElem;
+    type Field = BabyBear;
 
     type BufferDigest = BufferImpl<Digest>;
     type BufferElem = BufferImpl<Self::Elem>;
     type BufferExtElem = BufferImpl<Self::ExtElem>;
     type BufferU32 = BufferImpl<u32>;
+
+    type Hash = ConfigHashSha256<sha_cpu::Impl>;
+    type Rng = ShaRng<sha_cpu::Impl>;
 
     fn alloc_elem(&self, name: &'static str, size: usize) -> Self::BufferElem {
         BufferImpl::new(name, size)

--- a/risc0/zkp/src/hal/cuda.rs
+++ b/risc0/zkp/src/hal/cuda.rs
@@ -546,13 +546,13 @@ impl Hal for CudaHal {
     }
 
     #[tracing::instrument(skip_all)]
-    fn sha_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
+    fn hash_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
         let row_size = output.size();
         let col_size = matrix.size() / output.size();
         assert_eq!(matrix.size(), col_size * row_size);
 
         let stream = Stream::new(StreamFlags::DEFAULT, None).unwrap();
-        let kernel_name = CString::new("sha_rows").unwrap();
+        let kernel_name = CString::new("hash_rows").unwrap();
         let kernel = self.module.get_function(&kernel_name).unwrap();
         let params = self.compute_simple_params(row_size);
         unsafe {
@@ -567,7 +567,7 @@ impl Hal for CudaHal {
         stream.synchronize().unwrap();
     }
 
-    fn sha_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
+    fn hash_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
         assert_eq!(input_size, 2 * output_size);
 
         let stream = Stream::new(StreamFlags::DEFAULT, None).unwrap();
@@ -633,14 +633,14 @@ mod tests {
 
     #[test]
     #[serial]
-    fn sha_rows() {
+    fn hash_rows() {
         testutil::sha_rows(CudaHal::new());
     }
 
     #[test]
     #[serial]
-    fn sha_fold() {
-        testutil::sha_fold(CudaHal::new());
+    fn hash_fold() {
+        testutil::hash_fold(CudaHal::new());
     }
 
     #[test]

--- a/risc0/zkp/src/hal/dual.rs
+++ b/risc0/zkp/src/hal/dual.rs
@@ -99,10 +99,13 @@ where
 {
     type Elem = U::Elem;
     type ExtElem = U::ExtElem;
+    type Field = U::Field;
     type BufferDigest = BufferImpl<Digest, U::BufferDigest, V::BufferDigest>;
     type BufferElem = BufferImpl<Self::Elem, U::BufferElem, V::BufferElem>;
     type BufferExtElem = BufferImpl<Self::ExtElem, U::BufferExtElem, V::BufferExtElem>;
     type BufferU32 = BufferImpl<u32, U::BufferU32, V::BufferU32>;
+    type Hash = U::Hash;
+    type Rng = U::Rng;
 
     fn alloc_digest(&self, name: &'static str, size: usize) -> Self::BufferDigest {
         let buf1 = self.hal1.alloc_digest(name, size);

--- a/risc0/zkp/src/hal/dual.rs
+++ b/risc0/zkp/src/hal/dual.rs
@@ -284,15 +284,15 @@ where
         output.assert_eq();
     }
 
-    fn sha_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
-        self.hal1.sha_rows(&output.buf1, &matrix.buf1);
-        self.hal2.sha_rows(&output.buf2, &matrix.buf2);
+    fn hash_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
+        self.hal1.hash_rows(&output.buf1, &matrix.buf1);
+        self.hal2.hash_rows(&output.buf2, &matrix.buf2);
         output.assert_eq();
     }
 
-    fn sha_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
-        self.hal1.sha_fold(&io.buf1, input_size, output_size);
-        self.hal2.sha_fold(&io.buf2, input_size, output_size);
+    fn hash_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
+        self.hal1.hash_fold(&io.buf1, input_size, output_size);
+        self.hal2.hash_fold(&io.buf2, input_size, output_size);
         io.assert_eq();
     }
 }

--- a/risc0/zkp/src/hal/metal.rs
+++ b/risc0/zkp/src/hal/metal.rs
@@ -488,7 +488,7 @@ impl Hal for MetalHal {
         self.dispatch_by_name("mix_poly_coeffs", args, count as u64);
     }
 
-    fn sha_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
+    fn hash_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize) {
         assert_eq!(input_size, 2 * output_size);
         let args = &[
             io.as_arg_with_offset(output_size),
@@ -498,7 +498,7 @@ impl Hal for MetalHal {
     }
 
     #[tracing::instrument(skip_all)]
-    fn sha_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
+    fn hash_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem) {
         let row_size = output.size();
         let col_size = matrix.size() / output.size();
         assert_eq!(matrix.size(), col_size * row_size);
@@ -619,13 +619,13 @@ mod tests {
     }
 
     #[test]
-    fn sha_fold() {
-        testutil::sha_fold(MetalHal::new());
+    fn hash_fold() {
+        testutil::hash_fold(MetalHal::new());
     }
 
     #[test]
-    fn sha_rows() {
-        testutil::sha_rows(MetalHal::new());
+    fn hash_rows() {
+        testutil::hash_rows(MetalHal::new());
     }
 
     #[test]

--- a/risc0/zkp/src/hal/metal.rs
+++ b/risc0/zkp/src/hal/metal.rs
@@ -19,13 +19,13 @@ use metal::{
     MTLSize, NSRange,
 };
 use risc0_core::field::{
-    baby_bear::{BabyBearElem, BabyBearExtElem},
+    baby_bear::{BabyBear, BabyBearElem, BabyBearExtElem},
     Elem, ExtElem, RootsOfUnity,
 };
 
 use super::{Buffer, Hal};
 use crate::{
-    core::{log2_ceil, sha::Digest},
+    core::{config::ConfigHashSha256, log2_ceil, sha::Digest, sha_cpu, sha_rng::ShaRng},
     FRI_FOLD,
 };
 
@@ -242,11 +242,15 @@ impl MetalHal {
 impl Hal for MetalHal {
     type Elem = BabyBearElem;
     type ExtElem = BabyBearExtElem;
+    type Field = BabyBear;
 
     type BufferDigest = BufferImpl<Digest>;
     type BufferElem = BufferImpl<Self::Elem>;
     type BufferExtElem = BufferImpl<Self::ExtElem>;
     type BufferU32 = BufferImpl<u32>;
+
+    type Hash = ConfigHashSha256<sha_cpu::Impl>;
+    type Rng = ShaRng<sha_cpu::Impl>;
 
     fn alloc_elem(&self, _name: &'static str, size: usize) -> Self::BufferElem {
         BufferImpl::new(&self.device, self.cmd_queue.clone(), size)

--- a/risc0/zkp/src/hal/mod.rs
+++ b/risc0/zkp/src/hal/mod.rs
@@ -21,9 +21,13 @@ pub mod dual;
 #[cfg(feature = "metal")]
 pub mod metal;
 
-use risc0_core::field::{Elem, ExtElem, RootsOfUnity};
+use risc0_core::field::{Elem, ExtElem, Field, RootsOfUnity};
 
-use crate::{core::sha::Digest, INV_RATE};
+use crate::{
+    core::config::{ConfigHash, ConfigRng},
+    core::digest::Digest,
+    INV_RATE,
+};
 
 pub trait Buffer<T>: Clone {
     fn size(&self) -> usize;
@@ -38,10 +42,13 @@ pub trait Buffer<T>: Clone {
 pub trait Hal {
     type Elem: Elem + RootsOfUnity;
     type ExtElem: ExtElem<SubElem = Self::Elem>;
+    type Field: Field<Elem = Self::Elem, ExtElem = Self::ExtElem>;
     type BufferDigest: Buffer<Digest>;
     type BufferElem: Buffer<Self::Elem>;
     type BufferExtElem: Buffer<Self::ExtElem>;
     type BufferU32: Buffer<u32>;
+    type Hash: ConfigHash;
+    type Rng: ConfigRng<Self::Field>;
 
     const CHECK_SIZE: usize = INV_RATE * Self::ExtElem::EXT_SIZE;
 

--- a/risc0/zkp/src/hal/mod.rs
+++ b/risc0/zkp/src/hal/mod.rs
@@ -99,9 +99,9 @@ pub trait Hal {
 
     fn fri_fold(&self, output: &Self::BufferElem, input: &Self::BufferElem, mix: &Self::ExtElem);
 
-    fn sha_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem);
+    fn hash_rows(&self, output: &Self::BufferDigest, matrix: &Self::BufferElem);
 
-    fn sha_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize);
+    fn hash_fold(&self, io: &Self::BufferDigest, input_size: usize, output_size: usize);
 }
 
 pub trait EvalCheck<H: Hal> {
@@ -506,7 +506,7 @@ mod testutil {
         });
     }
 
-    pub(crate) fn sha_fold<H: Hal>(hal_gpu: H) {
+    pub(crate) fn hash_fold<H: Hal>(hal_gpu: H) {
         const INPUTS: usize = 16;
         const OUTPUTS: usize = INPUTS / 2;
         let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
@@ -531,8 +531,8 @@ mod testutil {
                 }
             });
         });
-        hal_cpu.sha_fold(&cpu_io, INPUTS, OUTPUTS);
-        hal_gpu.sha_fold(&gpu_io, INPUTS, OUTPUTS);
+        hal_cpu.hash_fold(&cpu_io, INPUTS, OUTPUTS);
+        hal_gpu.hash_fold(&gpu_io, INPUTS, OUTPUTS);
 
         gpu_io.view(|g| {
             cpu_io.view(|c| {
@@ -543,7 +543,7 @@ mod testutil {
         });
     }
 
-    pub(crate) fn sha_rows<H: Hal<Elem = BabyBearElem>>(hal_gpu: H) {
+    pub(crate) fn hash_rows<H: Hal<Elem = BabyBearElem>>(hal_gpu: H) {
         let mut rng = thread_rng();
         let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
         let rows = [1, 2, 3, 4, 10];
@@ -564,8 +564,8 @@ mod testutil {
                 });
                 let output_gpu = hal_gpu.alloc_digest("output", row_count);
                 let output_cpu = hal_cpu.alloc_digest("output", row_count);
-                hal_gpu.sha_rows(&output_gpu, &matrix_gpu);
-                hal_cpu.sha_rows(&output_cpu, &matrix_cpu);
+                hal_gpu.hash_rows(&output_gpu, &matrix_gpu);
+                hal_cpu.hash_rows(&output_cpu, &matrix_cpu);
                 output_gpu.view(|g| {
                     output_cpu.view(|c| {
                         for i in 0..g.len() {
@@ -601,8 +601,8 @@ mod testutil {
             });
         });
 
-        hal_cpu.sha_rows(&cpu_nodes.slice(rows, rows), &cpu_matrix);
-        hal_gpu.sha_rows(&gpu_nodes.slice(rows, rows), &gpu_matrix);
+        hal_cpu.hash_rows(&cpu_nodes.slice(rows, rows), &cpu_matrix);
+        hal_gpu.hash_rows(&gpu_nodes.slice(rows, rows), &gpu_matrix);
 
         cpu_nodes.view(|c| {
             gpu_nodes.view(|g| {

--- a/risc0/zkp/src/hal/mod.rs
+++ b/risc0/zkp/src/hal/mod.rs
@@ -136,7 +136,7 @@ mod testutil {
 
     use super::{EvalCheck, Hal};
     use crate::{
-        core::{log2_ceil, sha::Digest, config::HashSuiteSha256, sha_cpu},
+        core::{config::HashSuiteSha256, log2_ceil, sha::Digest, sha_cpu},
         hal::{cpu::CpuHal, Buffer},
         FRI_FOLD, INV_RATE,
     };

--- a/risc0/zkp/src/hal/mod.rs
+++ b/risc0/zkp/src/hal/mod.rs
@@ -129,13 +129,14 @@ pub trait EvalCheck<H: Hal> {
 #[cfg(test)]
 #[allow(unused)]
 mod testutil {
+    // TODO: Not fully generic over hash
     use rand::thread_rng;
     use rand::RngCore;
     use risc0_core::field::{baby_bear::BabyBearElem, Elem, ExtElem};
 
     use super::{EvalCheck, Hal};
     use crate::{
-        core::{log2_ceil, sha::Digest},
+        core::{log2_ceil, sha::Digest, config::HashSuiteSha256, sha_cpu},
         hal::{cpu::CpuHal, Buffer},
         FRI_FOLD, INV_RATE,
     };
@@ -144,7 +145,7 @@ mod testutil {
 
     pub(crate) fn batch_bit_reverse<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let steps = 1 << 12;
         let count = 203; // data_size
@@ -178,7 +179,7 @@ mod testutil {
 
     pub(crate) fn batch_evaluate_any<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let steps = 1 << 12;
         let domain = steps * INV_RATE;
@@ -225,7 +226,7 @@ mod testutil {
 
     pub(crate) fn batch_evaluate_ntt<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let count = 203; // data_size
         let expand_bits = 2;
@@ -260,7 +261,7 @@ mod testutil {
 
     pub(crate) fn batch_expand<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let poly_count = 203; // data_size
         let steps = 1 << 16;
@@ -298,7 +299,7 @@ mod testutil {
 
     pub(crate) fn batch_interpolate_ntt<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let count = 203; // data_size
         let steps = 1 << 16;
@@ -388,7 +389,7 @@ mod testutil {
     pub(crate) fn eltwise_sum_extelem<H: Hal>(hal_gpu: H) {
         const COUNT: usize = 1024 * 1024;
 
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let hal_in = hal_gpu.alloc_extelem("in", COUNT);
         let cpu_in = hal_cpu.alloc_extelem("in", COUNT);
@@ -422,7 +423,7 @@ mod testutil {
 
     pub(crate) fn fri_fold<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
         for count in COUNTS {
             let output_size = count * H::ExtElem::EXT_SIZE;
             let input_size = output_size * FRI_FOLD;
@@ -457,7 +458,7 @@ mod testutil {
 
     pub(crate) fn mix_poly_coeffs<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let combo_count = 100;
         let steps = 1 << 12;
@@ -516,7 +517,7 @@ mod testutil {
     pub(crate) fn hash_fold<H: Hal>(hal_gpu: H) {
         const INPUTS: usize = 16;
         const OUTPUTS: usize = INPUTS / 2;
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
         let mut rng = thread_rng();
         let gpu_io = hal_gpu.alloc_digest("io", INPUTS * 2);
         let cpu_io = hal_cpu.alloc_digest("io", INPUTS * 2);
@@ -552,7 +553,7 @@ mod testutil {
 
     pub(crate) fn hash_rows<H: Hal<Elem = BabyBearElem>>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
         let rows = [1, 2, 3, 4, 10];
         let cols = [16, 32, 64, 128];
         for row_count in rows {
@@ -586,7 +587,7 @@ mod testutil {
 
     pub(crate) fn slice<H: Hal<Elem = BabyBearElem>>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
 
         let rows = 4096;
         let cols = 256;
@@ -622,7 +623,7 @@ mod testutil {
 
     pub(crate) fn zk_shift<H: Hal>(hal_gpu: H) {
         let mut rng = thread_rng();
-        let hal_cpu: CpuHal<H::Elem, H::ExtElem> = CpuHal::new();
+        let hal_cpu: CpuHal<H::Field, HashSuiteSha256<H::Field, sha_cpu::Impl>> = CpuHal::new();
         let counts = [(1000, (1 << 8)), (900, (1 << 12))];
         for (poly_count, steps) in counts {
             let count = poly_count * steps;

--- a/risc0/zkp/src/prove/adapter.rs
+++ b/risc0/zkp/src/prove/adapter.rs
@@ -23,7 +23,7 @@ use risc0_core::field::{Elem, Field};
 
 use crate::{
     adapter::{CircuitDef, CircuitStepContext, CircuitStepHandler, REGISTER_GROUP_ACCUM},
-    core::sha::Sha256,
+    core::config::ConfigRng,
     prove::{
         accum::{Accum, Handler},
         executor::Executor,
@@ -67,17 +67,16 @@ where
 
     /// Perform initial 'execution' setting code + data.
     /// Additionally, write any 'results' as needed.
-    pub fn execute<S: Sha256>(&mut self, iop: &mut WriteIOP<S>) {
+    pub fn execute<R: ConfigRng<F>>(&mut self, iop: &mut WriteIOP<F, R>) {
         iop.write_field_elem_slice(&self.exec.io);
         iop.write_u32_slice(&[self.exec.po2 as u32]);
     }
 
     /// Perform 'accumulate' stage, using the iop for any RNG state.
     #[tracing::instrument(skip_all)]
-    pub fn accumulate<S: Sha256>(&mut self, iop: &mut WriteIOP<S>) {
+    pub fn accumulate<R: ConfigRng<F>>(&mut self, iop: &mut WriteIOP<F, R>) {
         // Make the mixing values
-        self.mix
-            .resize_with(C::MIX_SIZE, || F::Elem::random(&mut iop.rng));
+        self.mix.resize_with(C::MIX_SIZE, || iop.random_elem());
         // Make and compute accum data
         let accum_size = self
             .exec

--- a/risc0/zkp/src/prove/merkle.rs
+++ b/risc0/zkp/src/prove/merkle.rs
@@ -130,7 +130,7 @@ mod tests {
     use crate::verify::VerifyHal;
     use crate::{
         adapter::{MixState, PolyExt},
-        core::{sha_cpu, config::HashSuiteSha256},
+        core::{config::HashSuiteSha256, sha_cpu},
         hal::cpu::{BabyBearSha256CpuHal, CpuHal},
         verify::{merkle::MerkleTreeVerifier, read_iop::ReadIOP, CpuVerifyHal, VerificationError},
     };
@@ -148,7 +148,8 @@ mod tests {
         }
     }
 
-    type TestVerifyHal<'a> = CpuVerifyHal<'a, BabyBear, HashSuiteSha256<BabyBear, sha_cpu::Impl>, MockCircuit>;
+    type TestVerifyHal<'a> =
+        CpuVerifyHal<'a, BabyBear, HashSuiteSha256<BabyBear, sha_cpu::Impl>, MockCircuit>;
 
     fn init_prover<H: Hal>(
         hal: &H,

--- a/risc0/zkp/src/prove/merkle.rs
+++ b/risc0/zkp/src/prove/merkle.rs
@@ -56,12 +56,12 @@ impl<H: Hal> MerkleTreeProver<H> {
         // Allocate nodes
         let nodes = hal.alloc_digest("nodes", rows * 2);
         // SHA-256 hash each column
-        hal.sha_rows(&nodes.slice(rows, rows), matrix);
+        hal.hash_rows(&nodes.slice(rows, rows), matrix);
         // For each layer, sha up the layer below
-        tracing::info_span!("sha_fold").in_scope(|| {
+        tracing::info_span!("hash_fold").in_scope(|| {
             for i in (0..params.layers).rev() {
                 let layer_size = 1 << i;
-                hal.sha_fold(&nodes, layer_size * 2, layer_size);
+                hal.hash_fold(&nodes, layer_size * 2, layer_size);
             }
         });
         let mut nodes_host = Vec::with_capacity(nodes.size());

--- a/risc0/zkp/src/prove/write_iop.rs
+++ b/risc0/zkp/src/prove/write_iop.rs
@@ -13,25 +13,25 @@
 // limitations under the License.
 
 use alloc::vec::Vec;
+use core::marker::PhantomData;
 
-use risc0_core::field;
+use risc0_core::field::{Elem, Field};
 
-use crate::core::{
-    sha::{Digest, Sha256},
-    sha_rng::ShaRng,
-};
+use crate::core::{config::ConfigRng, sha::Digest};
 
-pub struct WriteIOP<S: Sha256> {
+pub struct WriteIOP<F: Field, R: ConfigRng<F>> {
     pub proof: Vec<u32>,
-    pub rng: ShaRng<S>,
+    pub rng: R,
+    phantom: PhantomData<F>,
 }
 
-impl<S: Sha256> WriteIOP<S> {
+impl<F: Field, R: ConfigRng<F>> WriteIOP<F, R> {
     /// Create a new empty proof
     pub fn new() -> Self {
         Self {
             proof: Vec::new(),
-            rng: ShaRng::<S>::new(),
+            rng: R::new(),
+            phantom: PhantomData,
         }
     }
 
@@ -44,8 +44,8 @@ impl<S: Sha256> WriteIOP<S> {
     }
 
     /// Write some field elements to this IOP.
-    pub fn write_field_elem_slice<T: field::Elem>(&mut self, slice: &[T]) {
-        self.proof.extend(field::Elem::as_u32_slice(slice))
+    pub fn write_field_elem_slice<T: Elem>(&mut self, slice: &[T]) {
+        self.proof.extend(Elem::as_u32_slice(slice))
     }
 
     /// Write some plain old data to this IOP.
@@ -57,5 +57,20 @@ impl<S: Sha256> WriteIOP<S> {
     /// earlier or a Merkle root).
     pub fn commit(&mut self, message: &Digest) {
         self.rng.mix(message);
+    }
+
+    /// Get a cryptographically uniform u32
+    pub fn random_u32(&mut self) -> u32 {
+        self.rng.random_u32()
+    }
+
+    /// Get a cryptographically uniform field element
+    pub fn random_elem(&mut self) -> F::Elem {
+        self.rng.random_elem()
+    }
+
+    /// Get a cryptographically uniform extension field element
+    pub fn random_ext_elem(&mut self) -> F::ExtElem {
+        self.rng.random_ext_elem()
     }
 }

--- a/risc0/zkp/src/verify/adapter.rs
+++ b/risc0/zkp/src/verify/adapter.rs
@@ -19,7 +19,7 @@ use risc0_core::field::Field;
 use crate::{
     adapter::{CircuitInfo, TapsProvider},
     taps::TapSet,
-    verify::{read_iop::ReadIOP, ConfigRNG},
+    verify::{read_iop::ReadIOP, ConfigRng},
 };
 
 pub struct VerifyAdapter<'a, F: Field, C: CircuitInfo + TapsProvider> {
@@ -45,7 +45,7 @@ impl<'a, F: Field, C: CircuitInfo + TapsProvider> VerifyAdapter<'a, F, C> {
         self.circuit.get_taps()
     }
 
-    pub fn execute<R: ConfigRNG<F>>(&mut self, iop: &mut ReadIOP<'a, F, R>) {
+    pub fn execute<R: ConfigRng<F>>(&mut self, iop: &mut ReadIOP<'a, F, R>) {
         // Read the outputs + size
         self.out = Some(iop.read_field_elem_slice(C::OUTPUT_SIZE));
         self.po2 = match iop.read_u32s(1) {
@@ -55,7 +55,7 @@ impl<'a, F: Field, C: CircuitInfo + TapsProvider> VerifyAdapter<'a, F, C> {
         self.steps = 1 << self.po2;
     }
 
-    pub fn accumulate<R: ConfigRNG<F>>(&mut self, iop: &mut ReadIOP<'a, F, R>) {
+    pub fn accumulate<R: ConfigRng<F>>(&mut self, iop: &mut ReadIOP<'a, F, R>) {
         // Fill in accum mix
         self.mix = (0..C::MIX_SIZE).map(|_| iop.random_elem()).collect();
     }

--- a/risc0/zkp/src/verify/merkle.rs
+++ b/risc0/zkp/src/verify/merkle.rs
@@ -17,10 +17,8 @@ use core::marker::PhantomData;
 
 use super::VerifyHal;
 use crate::{
-    core::sha::{Digest, Sha256},
-    merkle::MerkleTreeParams,
-    verify::read_iop::ReadIOP,
-    verify::VerificationError,
+    core::config::ConfigHash, core::digest::Digest, merkle::MerkleTreeParams,
+    verify::read_iop::ReadIOP, verify::VerificationError,
 };
 
 /// A struct against which we verify merkle branches, consisting of the
@@ -39,7 +37,7 @@ pub struct MerkleTreeVerifier<'a, H: VerifyHal> {
     top: &'a [Digest],
 
     // These are the rest of the tree.  These have the virtual indexes [1, top_size).
-    rest: Vec<<H::Sha256 as Sha256>::DigestPtr>,
+    rest: Vec<<H::Hash as ConfigHash>::DigestPtr>,
 
     // Support for accelerator operations.
     phantom_hal: PhantomData<H>,
@@ -85,7 +83,7 @@ impl<'a, H: VerifyHal> MerkleTreeVerifier<'a, H> {
     /// Constructs a new MerkleTreeVerifier by making the params, and then
     /// computing the root hashes from the top level hashes.
     pub fn new(
-        iop: &mut ReadIOP<'a, H::Sha256>,
+        iop: &mut ReadIOP<'a, H::Field, H::Rng>,
         row_size: usize,
         col_size: usize,
         queries: usize,
@@ -95,7 +93,8 @@ impl<'a, H: VerifyHal> MerkleTreeVerifier<'a, H> {
         // Fill top vector with digests from IOP.
         let top = iop.read_pod_slice(params.top_size);
         // Populate hashes up to the root of the tree.
-        let mut rest = Vec::<<H::Sha256 as Sha256>::DigestPtr>::with_capacity(params.top_size - 1);
+        let mut rest =
+            Vec::<<H::Hash as ConfigHash>::DigestPtr>::with_capacity(params.top_size - 1);
 
         let fill_rest = rest.spare_capacity_mut();
 
@@ -103,14 +102,14 @@ impl<'a, H: VerifyHal> MerkleTreeVerifier<'a, H> {
             for i in (params.top_size / 2..params.top_size).rev() {
                 let top_idx = params.idx_to_top(2 * i);
                 fill_rest[params.idx_to_rest(i)]
-                    .write(H::Sha256::hash_pair(&top[top_idx], &top[top_idx + 1]));
+                    .write(H::Hash::hash_pair(&top[top_idx], &top[top_idx + 1]));
             }
         }
         for i in (1..params.top_size / 2).rev() {
             // SAFETY: We're working from the top down, so we will
             // have already filled elements at upper_rest_idx.
             let upper_rest_idx = params.idx_to_rest(i * 2);
-            fill_rest[params.idx_to_rest(i)].write(H::Sha256::hash_pair(
+            fill_rest[params.idx_to_rest(i)].write(H::Hash::hash_pair(
                 unsafe { fill_rest[upper_rest_idx].assume_init_ref() },
                 unsafe { fill_rest[upper_rest_idx + 1].assume_init_ref() },
             ));
@@ -145,7 +144,7 @@ impl<'a, H: VerifyHal> MerkleTreeVerifier<'a, H> {
     /// Verifies a branch provided by an IOP.
     pub fn verify(
         &self,
-        iop: &mut ReadIOP<'a, H::Sha256>,
+        iop: &mut ReadIOP<'a, H::Field, H::Rng>,
         mut idx: usize,
     ) -> Result<&'a [H::Elem], VerificationError> {
         if idx >= self.params.row_size {
@@ -157,7 +156,7 @@ impl<'a, H: VerifyHal> MerkleTreeVerifier<'a, H> {
         // Initialize a vector to hold field elements.
         let out: &[H::Elem] = iop.read_field_elem_slice(self.params.col_size);
         // Get the hash at the leaf of the tree by hashing these field elements.
-        let mut cur = H::Sha256::hash_raw_pod_slice(out);
+        let mut cur = H::Hash::hash_raw_pod_slice(out);
         // Shift idx to start of the row
         idx += self.params.row_size;
         while idx >= 2 * self.params.top_size {
@@ -172,9 +171,9 @@ impl<'a, H: VerifyHal> MerkleTreeVerifier<'a, H> {
             // Now ascend to the parent index, and compute the hash there.
             idx /= 2;
             if low_bit == 1 {
-                cur = H::Sha256::hash_pair(&other, &cur);
+                cur = H::Hash::hash_pair(&other, &cur);
             } else {
-                cur = H::Sha256::hash_pair(&cur, &other);
+                cur = H::Hash::hash_pair(&cur, &other);
             }
         }
         // Once we reduce to an index for which we have the hash, check that it's

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -34,12 +34,14 @@ pub use host::CpuVerifyHal;
 use risc0_core::field::{Elem, ExtElem, Field, RootsOfUnity};
 
 use self::adapter::VerifyAdapter;
+#[cfg(not(target_os = "zkvm"))]
+pub use crate::core::config::HashSuite;
 use crate::{
     adapter::{
         CircuitInfo, TapsProvider, REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA,
     },
     core::{
-        config::{ConfigHash, ConfigRng, HashSuite},
+        config::{ConfigHash, ConfigRng},
         digest::Digest,
         log2_ceil,
     },

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -39,7 +39,7 @@ use crate::{
         CircuitInfo, TapsProvider, REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA,
     },
     core::{
-        config::{ConfigHash, ConfigRNG},
+        config::{ConfigHash, ConfigRng},
         digest::Digest,
         log2_ceil,
     },
@@ -86,7 +86,7 @@ impl fmt::Display for VerificationError {
 
 pub trait VerifyHal {
     type Hash: ConfigHash;
-    type Rng: ConfigRNG<Self::Field>;
+    type Rng: ConfigRng<Self::Field>;
     type Elem: Elem + RootsOfUnity;
     type ExtElem: ExtElem<SubElem = Self::Elem>;
     type Field: Field<Elem = Self::Elem, ExtElem = Self::ExtElem>;
@@ -143,13 +143,13 @@ mod host {
         check_mix_pows: Vec<F::ExtElem>,
     }
 
-    pub struct CpuVerifyHal<'a, F: Field, H: ConfigHash, R: ConfigRNG<F>, C: PolyExt<F>> {
+    pub struct CpuVerifyHal<'a, F: Field, H: ConfigHash, R: ConfigRng<F>, C: PolyExt<F>> {
         circuit: &'a C,
         tap_cache: RefCell<Option<TapCache<F>>>,
         phantom: PhantomData<(H, R)>,
     }
 
-    impl<'a, F: Field, H: ConfigHash, R: ConfigRNG<F>, C: PolyExt<F>> CpuVerifyHal<'a, F, H, R, C> {
+    impl<'a, F: Field, H: ConfigHash, R: ConfigRng<F>, C: PolyExt<F>> CpuVerifyHal<'a, F, H, R, C> {
         pub fn new(circuit: &'a C) -> Self {
             Self {
                 circuit,
@@ -159,7 +159,7 @@ mod host {
         }
     }
 
-    impl<'a, F: Field, H: ConfigHash, R: ConfigRNG<F>, C: PolyExt<F>> VerifyHal
+    impl<'a, F: Field, H: ConfigHash, R: ConfigRng<F>, C: PolyExt<F>> VerifyHal
         for CpuVerifyHal<'a, F, H, R, C>
     {
         type Hash = H;

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -39,7 +39,7 @@ use crate::{
         CircuitInfo, TapsProvider, REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA,
     },
     core::{
-        config::{HashSuite, ConfigHash, ConfigRng},
+        config::{ConfigHash, ConfigRng, HashSuite},
         digest::Digest,
         log2_ceil,
     },
@@ -159,9 +159,7 @@ mod host {
         }
     }
 
-    impl<'a, F: Field, HS: HashSuite<F>, C: PolyExt<F>> VerifyHal
-        for CpuVerifyHal<'a, F, HS, C>
-    {
+    impl<'a, F: Field, HS: HashSuite<F>, C: PolyExt<F>> VerifyHal for CpuVerifyHal<'a, F, HS, C> {
         type Hash = HS::Hash;
         type Rng = HS::Rng;
         type Elem = F::Elem;

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -39,7 +39,7 @@ use crate::{
         CircuitInfo, TapsProvider, REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA,
     },
     core::{
-        config::{ConfigHash, ConfigRng},
+        config::{HashSuite, ConfigHash, ConfigRng},
         digest::Digest,
         log2_ceil,
     },
@@ -143,13 +143,13 @@ mod host {
         check_mix_pows: Vec<F::ExtElem>,
     }
 
-    pub struct CpuVerifyHal<'a, F: Field, H: ConfigHash, R: ConfigRng<F>, C: PolyExt<F>> {
+    pub struct CpuVerifyHal<'a, F: Field, HS: HashSuite<F>, C: PolyExt<F>> {
         circuit: &'a C,
         tap_cache: RefCell<Option<TapCache<F>>>,
-        phantom: PhantomData<(H, R)>,
+        phantom: PhantomData<HS>,
     }
 
-    impl<'a, F: Field, H: ConfigHash, R: ConfigRng<F>, C: PolyExt<F>> CpuVerifyHal<'a, F, H, R, C> {
+    impl<'a, F: Field, HS: HashSuite<F>, C: PolyExt<F>> CpuVerifyHal<'a, F, HS, C> {
         pub fn new(circuit: &'a C) -> Self {
             Self {
                 circuit,
@@ -159,11 +159,11 @@ mod host {
         }
     }
 
-    impl<'a, F: Field, H: ConfigHash, R: ConfigRng<F>, C: PolyExt<F>> VerifyHal
-        for CpuVerifyHal<'a, F, H, R, C>
+    impl<'a, F: Field, HS: HashSuite<F>, C: PolyExt<F>> VerifyHal
+        for CpuVerifyHal<'a, F, HS, C>
     {
-        type Hash = H;
-        type Rng = R;
+        type Hash = HS::Hash;
+        type Rng = HS::Rng;
         type Elem = F::Elem;
         type ExtElem = F::ExtElem;
         type Field = F;

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -31,7 +31,7 @@ use core::marker::PhantomData;
 
 #[cfg(not(target_os = "zkvm"))]
 pub use host::CpuVerifyHal;
-use risc0_core::field::{Elem, ExtElem, RootsOfUnity};
+use risc0_core::field::{Elem, ExtElem, Field, RootsOfUnity};
 
 use self::adapter::VerifyAdapter;
 use crate::{
@@ -39,8 +39,9 @@ use crate::{
         CircuitInfo, TapsProvider, REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA,
     },
     core::{
+        config::{ConfigHash, ConfigRNG},
+        digest::Digest,
         log2_ceil,
-        sha::{Digest, Sha256},
     },
     taps::TapSet,
     verify::{fri::fri_verify, merkle::MerkleTreeVerifier, read_iop::ReadIOP},
@@ -84,9 +85,11 @@ impl fmt::Display for VerificationError {
 }
 
 pub trait VerifyHal {
-    type Sha256: Sha256;
+    type Hash: ConfigHash;
+    type Rng: ConfigRNG<Self::Field>;
     type Elem: Elem + RootsOfUnity;
     type ExtElem: ExtElem<SubElem = Self::Elem>;
+    type Field: Field<Elem = Self::Elem, ExtElem = Self::ExtElem>;
 
     const CHECK_SIZE: usize = INV_RATE * Self::ExtElem::EXT_SIZE;
 
@@ -140,26 +143,30 @@ mod host {
         check_mix_pows: Vec<F::ExtElem>,
     }
 
-    pub struct CpuVerifyHal<'a, S: Sha256, F: Field, C: PolyExt<F>> {
+    pub struct CpuVerifyHal<'a, F: Field, H: ConfigHash, R: ConfigRNG<F>, C: PolyExt<F>> {
         circuit: &'a C,
         tap_cache: RefCell<Option<TapCache<F>>>,
-        phantom_sha: PhantomData<S>,
+        phantom: PhantomData<(H, R)>,
     }
 
-    impl<'a, S: Sha256, F: Field, C: PolyExt<F>> CpuVerifyHal<'a, S, F, C> {
+    impl<'a, F: Field, H: ConfigHash, R: ConfigRNG<F>, C: PolyExt<F>> CpuVerifyHal<'a, F, H, R, C> {
         pub fn new(circuit: &'a C) -> Self {
             Self {
                 circuit,
                 tap_cache: RefCell::new(None),
-                phantom_sha: PhantomData,
+                phantom: PhantomData,
             }
         }
     }
 
-    impl<'a, S: Sha256, F: Field, C: PolyExt<F>> VerifyHal for CpuVerifyHal<'a, S, F, C> {
-        type Sha256 = S;
+    impl<'a, F: Field, H: ConfigHash, R: ConfigRNG<F>, C: PolyExt<F>> VerifyHal
+        for CpuVerifyHal<'a, F, H, R, C>
+    {
+        type Hash = H;
+        type Rng = R;
         type Elem = F::Elem;
         type ExtElem = F::ExtElem;
+        type Field = F;
 
         fn debug(&self, msg: &str) {
             log::debug!("{}", msg);
@@ -280,7 +287,7 @@ where
     H: VerifyHal,
     C: CircuitInfo + TapsProvider,
     CheckCode: Fn(u32, &Digest) -> Result<(), VerificationError>,
-    CheckGlobals: Fn(&[u32]) -> Result<(), VerificationError>,
+    CheckGlobals: Fn(&[H::Elem]) -> Result<(), VerificationError>,
 {
     if seal.len() == 0 {
         return Err(VerificationError::ReceiptFormatError);
@@ -290,13 +297,12 @@ where
     let taps = adapter.taps();
 
     // Make IOP
-    let mut iop = ReadIOP::<H::Sha256>::new(seal);
+    let mut iop = ReadIOP::<H::Field, H::Rng>::new(seal);
 
     // Read any execution state
     adapter.execute(&mut iop);
 
     let io = adapter.out.ok_or(VerificationError::ReceiptFormatError)?;
-    let io: Vec<u32> = io.iter().map(|x| x.into()).collect();
     check_globals(&io)?;
 
     // Get the size
@@ -345,7 +351,7 @@ where
 
     // Get a pseudorandom value with which to mix the constraint polynomials.
     // See DEEP-ALI protocol from DEEP-FRI paper for details on constraint mixing.
-    let poly_mix = H::ExtElem::random(&mut iop);
+    let poly_mix = iop.random_ext_elem();
 
     hal.debug("check_merkle");
     let check_merkle = MerkleTreeVerifier::<H>::new(&mut iop, domain, H::CHECK_SIZE, QUERIES);
@@ -353,14 +359,14 @@ where
 
     // Get a pseudorandom DEEP query point
     // See DEEP-ALI protocol from DEEP-FRI paper for details on DEEP query.
-    let z = H::ExtElem::random(&mut iop);
+    let z = iop.random_ext_elem();
     // debug!("Z = {z:?}");
     let back_one = <H::Elem as RootsOfUnity>::ROU_REV[po2 as usize];
 
     // Read the U coeffs (the interpolations of the taps) + commit their hash.
     let num_taps = taps.tap_size();
     let coeff_u = iop.read_field_elem_slice(num_taps + H::CHECK_SIZE);
-    let hash_u = *H::Sha256::hash_raw_pod_slice(coeff_u);
+    let hash_u = *H::Hash::hash_raw_pod_slice(coeff_u);
     iop.commit(&hash_u);
 
     // Now, convert U polynomials from coefficient form to evaluation form
@@ -421,7 +427,7 @@ where
     }
 
     // Set the mix mix value, pseudorandom value used for FRI batching
-    let mix = H::ExtElem::random(&mut iop);
+    let mix = iop.random_ext_elem();
     // debug!("mix = {mix:?}");
 
     // Make the mixed U polynomials.
@@ -469,7 +475,7 @@ where
         hal,
         &mut iop,
         size,
-        |iop: &mut ReadIOP<_>, idx: usize| -> Result<H::ExtElem, VerificationError> {
+        |iop: &mut ReadIOP<H::Field, _>, idx: usize| -> Result<H::ExtElem, VerificationError> {
             hal.debug("fri_verify");
             let x = gen.pow(idx);
             let rows = [

--- a/risc0/zkp/src/verify/read_iop.rs
+++ b/risc0/zkp/src/verify/read_iop.rs
@@ -12,25 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand_core::{Error, RngCore};
-use risc0_core::field;
+use core::marker::PhantomData;
 
-use crate::core::{
-    sha::{Digest, Sha256},
-    sha_rng::ShaRng,
-};
+use risc0_core::field::{Elem, Field};
+
+use crate::core::{config::ConfigRNG, sha::Digest};
 
 #[derive(Debug)]
-pub struct ReadIOP<'a, S: Sha256> {
+pub struct ReadIOP<'a, F: Field, R: ConfigRNG<F>> {
     proof: &'a [u32],
-    rng: ShaRng<S>,
+    rng: R,
+    phantom: PhantomData<F>,
 }
 
-impl<'a, S: Sha256> ReadIOP<'a, S> {
+impl<'a, F: Field, R: ConfigRNG<F>> ReadIOP<'a, F, R> {
     pub fn new(proof: &'a [u32]) -> Self {
         ReadIOP {
             proof,
-            rng: ShaRng::<S>::new(),
+            rng: R::new(),
+            phantom: PhantomData,
         }
     }
 
@@ -42,7 +42,7 @@ impl<'a, S: Sha256> ReadIOP<'a, S> {
 
     /// Read some field elements from this IOP, and check to make sure
     /// they're not INVALID.
-    pub fn read_field_elem_slice<T: field::Elem>(&mut self, n: usize) -> &'a [T] {
+    pub fn read_field_elem_slice<T: Elem>(&mut self, n: usize) -> &'a [T] {
         let u32s = self.read_u32s(n * T::WORDS);
         T::from_u32_slice(u32s)
     }
@@ -66,22 +66,19 @@ impl<'a, S: Sha256> ReadIOP<'a, S> {
     pub fn verify_complete(&self) {
         assert_eq!(self.proof.len(), 0);
     }
-}
 
-impl<'a, S: Sha256> RngCore for ReadIOP<'a, S> {
-    fn next_u32(&mut self) -> u32 {
+    /// Get a cryptographically uniform u32
+    pub fn random_u32(&mut self) -> u32 {
         self.rng.next_u32()
     }
 
-    fn next_u64(&mut self) -> u64 {
-        self.rng.next_u64()
+    /// Get a cryptographically uniform field element
+    pub fn random_elem(&mut self) -> F::Elem {
+        self.rng.next_elem()
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.rng.fill_bytes(dest)
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.rng.try_fill_bytes(dest)
+    /// Get a cryptographically uniform extension field element
+    pub fn random_ext_elem(&mut self) -> F::ExtElem {
+        self.rng.next_ext_elem()
     }
 }

--- a/risc0/zkp/src/verify/read_iop.rs
+++ b/risc0/zkp/src/verify/read_iop.rs
@@ -16,16 +16,16 @@ use core::marker::PhantomData;
 
 use risc0_core::field::{Elem, Field};
 
-use crate::core::{config::ConfigRNG, sha::Digest};
+use crate::core::{config::ConfigRng, sha::Digest};
 
 #[derive(Debug)]
-pub struct ReadIOP<'a, F: Field, R: ConfigRNG<F>> {
+pub struct ReadIOP<'a, F: Field, R: ConfigRng<F>> {
     proof: &'a [u32],
     rng: R,
     phantom: PhantomData<F>,
 }
 
-impl<'a, F: Field, R: ConfigRNG<F>> ReadIOP<'a, F, R> {
+impl<'a, F: Field, R: ConfigRng<F>> ReadIOP<'a, F, R> {
     pub fn new(proof: &'a [u32]) -> Self {
         ReadIOP {
             proof,
@@ -69,16 +69,16 @@ impl<'a, F: Field, R: ConfigRNG<F>> ReadIOP<'a, F, R> {
 
     /// Get a cryptographically uniform u32
     pub fn random_u32(&mut self) -> u32 {
-        self.rng.next_u32()
+        self.rng.random_u32()
     }
 
     /// Get a cryptographically uniform field element
     pub fn random_elem(&mut self) -> F::Elem {
-        self.rng.next_elem()
+        self.rng.random_elem()
     }
 
     /// Get a cryptographically uniform extension field element
     pub fn random_ext_elem(&mut self) -> F::ExtElem {
-        self.rng.next_ext_elem()
+        self.rng.random_ext_elem()
     }
 }

--- a/risc0/zkvm/examples/fib.rs
+++ b/risc0/zkvm/examples/fib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use clap::Parser;
-use risc0_core::field::baby_bear::{BabyBearElem, BabyBearExtElem};
+use risc0_core::field::baby_bear::{BabyBear, BabyBearElem, BabyBearExtElem};
 use risc0_zkp::hal::{EvalCheck, Hal};
 use risc0_zkvm::{prove::default_hal, Prover, Receipt};
 use risc0_zkvm_methods::{FIB_ELF, FIB_ID};
@@ -50,7 +50,7 @@ fn main() {
 #[tracing::instrument(skip_all)]
 fn top<H, E>(hal: &H, eval: &E, iterations: u32) -> Receipt
 where
-    H: Hal<Elem = BabyBearElem, ExtElem = BabyBearExtElem>,
+    H: Hal<Field = BabyBear, Elem = BabyBearElem, ExtElem = BabyBearExtElem>,
     E: EvalCheck<H>,
 {
     let mut prover = Prover::new(FIB_ELF, FIB_ID).unwrap();

--- a/risc0/zkvm/src/prove/loader.rs
+++ b/risc0/zkvm/src/prove/loader.rs
@@ -25,7 +25,7 @@ use risc0_core::field::{baby_bear::BabyBearElem, Elem};
 use risc0_zkp::{
     adapter::TapsProvider,
     core::sha::SHA256_INIT,
-    hal::{cpu::BabyBearCpuHal, Hal},
+    hal::{cpu::BabyBearSha256CpuHal, Hal},
     prove::poly_group::PolyGroup,
     MAX_CYCLES_PO2, MIN_CYCLES_PO2, ZK_CYCLES,
 };
@@ -363,7 +363,7 @@ impl Loader {
 
     pub fn compute_control_id(&self) -> ControlId {
         let code_size = CIRCUIT.code_size();
-        let hal = BabyBearCpuHal::new();
+        let hal = BabyBearSha256CpuHal::new();
 
         // Start with an empty table
         let mut table = Vec::new();


### PR DESCRIPTION
Modify the abstractions for Hal and VerifyHal so that they depend on 1) The field 2) The 'Hash Suite'.  The hash suite in turn determines which hash function is used as well as how RNG in Fiat-Shamir is computed.  This is done via two new traits 'ConfigHash' and 'ConfigRng' which provide the smallest possible API surface.  These API's are implemented using the existing Sha256 based protocol when the HashSuiteSha256 is selected (and given a device appropriate Sha256 trait).  In general, since there are currently no other HashSuite implementation, this entire PR is just a NFC code reorg.