### PR TITLE
Reword & re-link zkvm README

### DIFF
--- a/risc0/build/README.md
+++ b/risc0/build/README.md
@@ -2,7 +2,7 @@
 Build RISC Zero zkVM guest code and provide handles to the host side.
 
 In order for the host to execute guest code in the [RISC Zero
-zkVM](risc0_zkvm), the host must be provided a compiled RISC-V ELF file and
+zkVM](https://docs.rs/risc0-zkvm), the host must be provided a compiled RISC-V ELF file and
 the corresponding ImageID. This crate
 contains the functions needed to take zkVM guest code, build a corresponding
 ELF file and ImageID, and make the ImageID and a path to the ELF file
@@ -15,8 +15,8 @@ in our [RISC Zero Rust Starter repository](https://github.com/risc0/risc0-rust-s
 In that repository, `risc0-build` is used in the
 [`methods` directory](https://github.com/risc0/risc0-rust-starter/tree/main/methods).
 
-Guest methods are embedded for the host to use by calling [embed_methods]
-(or [embed_methods_with_options]) in a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html).
+Guest methods are embedded for the host to use by calling [embed_methods](crate::embed_methods)
+(or [embed_methods_with_options](crate::embed_methods_with_options)) in a [build script](https://doc.rust-lang.org/cargo/reference/build-scripts.html).
 An example `build.rs` file would look like
 ```no_run
 fn main() {

--- a/risc0/zkp/README.md
+++ b/risc0/zkp/README.md
@@ -7,4 +7,4 @@ utilities that are more commonly used directly from this crate: Developers
 looking to construct (or verify) a zero-knowledge proof with RISC Zero are
 advised to use the [risc0_zkvm] crate instead.
 
-[risc0_zkvm]: https://docs.rs/risc0-zkvm
+[risc0_zkvm]: https://crates.io/crates/risc0-zkvm

--- a/risc0/zkvm/README.md
+++ b/risc0/zkvm/README.md
@@ -1,12 +1,12 @@
 The RISC Zero zkVM is a RISC-V virtual machine that produces
 [zero-knowledge proofs](https://en.wikipedia.org/wiki/Zero-knowledge_proof)
 of code it executes. By using the zkVM, a cryptographic
-[Receipt](Receipt) is produced which anyone can [verify](Receipt::verify)
+[receipt](receipt::Receipt) is produced which anyone can [verify](Receipt::verify)
 was produced by the zkVM's guest code. No additional information about the
 code execution (such as, for example, the inputs provided) is revealed by
-publishing the [Receipt](Receipt).
+publishing the [receipt](receipt::Receipt).
 
-This is the reference documentation for the RISC Zero zkVM. We have
+In addition to [our reference documentation on docs.rs](https://docs.rs/risc0-zkvm), we have
 additional (non-reference) resources for using our zkVM that you may also
 find helpful, especially if you're new to the RISC Zero zkVM. These include:
 


### PR DESCRIPTION
Since the crate-level readmes appear on both crates.io and docs.rs, reword and adjust the links to be appropriate for both. (Example of the status quo, showing the broken links and misleading language on crates.io: https://crates.io/crates/risc0-zkvm/0.12.0)