### PR TITLE
add reserve to vector extend to avoid multiple reallocations

### DIFF
--- a/risc0/zkvm/src/serde/serializer.rs
+++ b/risc0/zkvm/src/serde/serializer.rs
@@ -469,6 +469,8 @@ impl StreamWriter for AllocVec {
 
     fn try_extend(&mut self, data: &[u8]) -> Result<()> {
         let mut chunks = data.chunks_exact(WORD_SIZE);
+        self.0
+            .reserve(chunks.len() + (!chunks.remainder().is_empty() as usize));
         for chunk in &mut chunks {
             let word = chunk[0] as u32
                 | (chunk[1] as u32) << 8


### PR DESCRIPTION
I was trying to resolve the inconsistency between the slice and vector extend with serializtion. I couldn't find a clean way using safe/stable code, but I figured I'd at least PR in this. This line just makes sure there are not multiple re-allocations during this extend. I don't believe the compiler optimizes this away.

This would potentially be cleaner with `Vec::extend` and iterators or resizing and copying from slice, but I opted to just keep the changes simple.

If you'd prefer switching this to match the slice impl more closely and optimize, I can make the change to resize the `Vec` and copy from the bytes, and if you are open to having unsafe code I could do it with a `reserve`, copy, then `set_len` to avoid the zeroing of the words on extend.

Feel free to close this PR if you don't care to micro-optimize this right now