### PR TITLE
Using Blake2b as a hash function

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -107,6 +107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +1985,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "fil-rustacuda",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -57,6 +57,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1076,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1052,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/examples/factors/methods/guest/Cargo.lock
+++ b/examples/factors/methods/guest/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1052,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1058,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1060,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1052,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1141,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -51,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1044,7 @@ name = "risc0-zkp"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "bytemuck",
  "digest",
  "hex",

--- a/risc0/bootstrap/src/control_id.rs
+++ b/risc0/bootstrap/src/control_id.rs
@@ -44,3 +44,18 @@ pub const POSEIDON_CONTROL_ID: [&'static str; risc0_zkp::MAX_CYCLES_PO2 - risc0_
     "{}", //
 ];
 
+pub const BLAKE2B_CONTROL_ID: [&'static str; risc0_zkp::MAX_CYCLES_PO2 - risc0_zkp::MIN_CYCLES_PO2] = [
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+    "{}", //
+];

--- a/risc0/bootstrap/src/main.rs
+++ b/risc0/bootstrap/src/main.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_zkp::hal::cpu::{BabyBearPoseidonCpuHal, BabyBearSha256CpuHal};
+use risc0_zkp::hal::cpu::{BabyBearBlake2bCpuHal, BabyBearPoseidonCpuHal, BabyBearSha256CpuHal};
 use risc0_zkvm::Loader;
 
 fn main() {
     let loader = Loader::new();
     let control_id = loader.compute_control_id(&BabyBearSha256CpuHal::new());
     let control_id_poseidon = loader.compute_control_id(&BabyBearPoseidonCpuHal::new());
+    let control_id_blake2b = loader.compute_control_id(&BabyBearBlake2bCpuHal::new());
     let contents = format!(
         include_str!("control_id.rs"),
         control_id.table[0],
@@ -47,6 +48,19 @@ fn main() {
         control_id_poseidon.table[10],
         control_id_poseidon.table[11],
         control_id_poseidon.table[12],
+        control_id_blake2b.table[0],
+        control_id_blake2b.table[1],
+        control_id_blake2b.table[2],
+        control_id_blake2b.table[3],
+        control_id_blake2b.table[4],
+        control_id_blake2b.table[5],
+        control_id_blake2b.table[6],
+        control_id_blake2b.table[7],
+        control_id_blake2b.table[8],
+        control_id_blake2b.table[9],
+        control_id_blake2b.table[10],
+        control_id_blake2b.table[11],
+        control_id_blake2b.table[12],
     );
     println!("{contents}");
     std::fs::write("risc0/zkvm/src/control_id.rs", contents).unwrap();

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -13,6 +13,7 @@ harness = false
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
+blake2 = { version = "0.10.6", default-features = false }
 bytemuck = { version = "1.12", features = ["derive"] }
 digest = "0.10"
 fil-rustacuda = { version = "0.1", optional = true }

--- a/risc0/zkp/src/core/blake2b.rs
+++ b/risc0/zkp/src/core/blake2b.rs
@@ -1,0 +1,155 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A Blake2b HashSuite.
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
+use blake2::{
+    digest::{Update, VariableOutput},
+    Blake2bVar,
+};
+use rand_core::{impls, Error, RngCore};
+use risc0_core::field::baby_bear::{BabyBear, BabyBearElem, BabyBearExtElem};
+use risc0_core::field::Elem;
+use risc0_core::field::ExtElem;
+
+use super::config::HashSuite;
+use super::digest::Digest;
+use crate::core::config::{ConfigHash, ConfigRng};
+
+/// Hash function trait.
+pub trait Blake2b {
+    /// A function producing a hash from a list of u8.
+    fn blake2b<T: AsRef<[u8]>>(data: T) -> [u8; 32];
+}
+
+/// Implementation of blake2b using CPU.
+pub struct Blake2bCpuImpl;
+
+/// Type alias for Blake2b HashSuite using CPU.
+pub type HashSuiteBlake2bCpu = HashSuiteBlake2b<Blake2bCpuImpl>;
+
+impl Blake2b for Blake2bCpuImpl {
+    fn blake2b<T: AsRef<[u8]>>(data: T) -> [u8; 32] {
+        let mut result = [0; 32];
+        let mut hasher = Blake2bVar::new(32).expect("Initializing Blake2bVar failed");
+
+        hasher.update(data.as_ref());
+        hasher
+            .finalize_variable(&mut result)
+            .expect("Finalizing Blake2bVar failed");
+        result
+    }
+}
+
+/// Blake2b HashSuite.
+/// We are using a generic hasher to allow different implementations.
+pub struct HashSuiteBlake2b<T: Blake2b> {
+    hasher: PhantomData<T>,
+}
+
+impl<T: Blake2b> HashSuite<BabyBear> for HashSuiteBlake2b<T> {
+    type Hash = ConfigHashBlake2b<T>;
+    type Rng = Blake2bRng<T>;
+}
+
+/// Blake2b ConfigHash.
+pub struct ConfigHashBlake2b<T: Blake2b> {
+    hasher: PhantomData<T>,
+}
+
+impl<T: Blake2b> ConfigHash<BabyBear> for ConfigHashBlake2b<T> {
+    type DigestPtr = Box<Digest>;
+
+    fn hash_pair(a: &Digest, b: &Digest) -> Self::DigestPtr {
+        let concat = [a.as_bytes().as_ref(), b.as_bytes()].concat();
+        Box::new(Digest::from(T::blake2b(concat)))
+    }
+
+    fn hash_elem_slice(slice: &[BabyBearElem]) -> Self::DigestPtr {
+        let mut data = Vec::<u8>::new();
+        for el in slice {
+            data.extend_from_slice(el.as_u32_montgomery().to_be_bytes().as_slice());
+        }
+        Box::new(Digest::from(T::blake2b(data)))
+    }
+
+    fn hash_ext_elem_slice(slice: &[BabyBearExtElem]) -> Self::DigestPtr {
+        let mut data = Vec::<u8>::new();
+        for ext_el in slice {
+            for el in ext_el.subelems() {
+                data.extend_from_slice(el.as_u32_montgomery().to_be_bytes().as_slice());
+            }
+        }
+        Box::new(Digest::from(T::blake2b(data)))
+    }
+}
+
+/// Blake2b-based random number generator.
+pub struct Blake2bRng<T: Blake2b> {
+    current: [u8; 32],
+    hasher: PhantomData<T>,
+}
+
+impl<T: Blake2b> ConfigRng<BabyBear> for Blake2bRng<T> {
+    fn new() -> Self {
+        Self {
+            current: [0; 32],
+            hasher: Default::default(),
+        }
+    }
+
+    fn mix(&mut self, val: &Digest) {
+        let concat = [self.current.as_ref(), val.as_bytes()].concat();
+        self.current = T::blake2b(concat);
+    }
+
+    fn random_u32(&mut self) -> u32 {
+        let next = T::blake2b(self.current);
+        self.current = next;
+
+        ((next[0] as u32) << 24)
+            + ((next[1] as u32) << 16)
+            + ((next[2] as u32) << 8)
+            + ((next[3] as u32) << 0)
+    }
+
+    fn random_elem(&mut self) -> BabyBearElem {
+        BabyBearElem::random(self)
+    }
+
+    fn random_ext_elem(&mut self) -> BabyBearExtElem {
+        BabyBearExtElem::random(self)
+    }
+}
+
+impl<T: Blake2b> RngCore for Blake2bRng<T> {
+    fn next_u32(&mut self) -> u32 {
+        self.random_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        impls::next_u64_via_u32(self)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_next(self, dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
+}

--- a/risc0/zkp/src/core/mod.rs
+++ b/risc0/zkp/src/core/mod.rs
@@ -24,6 +24,7 @@
 
 extern crate alloc;
 
+pub mod blake2b;
 pub mod config;
 pub mod digest;
 pub mod ntt;

--- a/risc0/zkp/src/hal/cpu.rs
+++ b/risc0/zkp/src/hal/cpu.rs
@@ -29,6 +29,7 @@ use risc0_core::field::{baby_bear::BabyBear, Elem, ExtElem, Field};
 use super::{Buffer, Hal};
 use crate::{
     core::{
+        blake2b::HashSuiteBlake2bCpu,
         config::{ConfigHash, HashSuite, HashSuitePoseidon, HashSuiteSha256},
         digest::Digest,
         log2_ceil,
@@ -44,6 +45,7 @@ pub struct CpuHal<F: Field, HS: HashSuite<F>> {
 
 pub type BabyBearSha256CpuHal = CpuHal<BabyBear, HashSuiteSha256<BabyBear, sha_cpu::Impl>>;
 pub type BabyBearPoseidonCpuHal = CpuHal<BabyBear, HashSuitePoseidon>;
+pub type BabyBearBlake2bCpuHal = CpuHal<BabyBear, HashSuiteBlake2bCpu>;
 
 impl<F: Field, HS: HashSuite<F>> CpuHal<F, HS> {
     pub fn new() -> Self {

--- a/risc0/zkvm/src/control_id.rs
+++ b/risc0/zkvm/src/control_id.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Values of the control ID were calculated using the
+// risc0/bootstrap/src/main.rs script.
 pub const CONTROL_ID: [&'static str; risc0_zkp::MAX_CYCLES_PO2 - risc0_zkp::MIN_CYCLES_PO2] = [
     "26aaf5e87e2df3a5b2ba1c07764a9755b8fa5221b5f0bfd96a129427d016ece1", //
     "f9ec28d3b9cea704a33a130529ef1e75cb5f510ca1de612acc78846f359c6238", //
@@ -43,4 +45,21 @@ pub const POSEIDON_CONTROL_ID: [&'static str;
     "1a9d8a06a5d4ed0dc6bbfa6c3d06e7140ff9a3051d64c37456c0171286281211", //
     "61c9ea4e60f1276b6d28db11ba3438200a41a256358d4d1d86caa90886288475", //
     "d0286431d057fa42df74b572dd1c6870818d2a7094e4ef6d4b7ae44c4b4dd56a", //
+];
+
+pub const BLAKE2B_CONTROL_ID: [&'static str;
+    risc0_zkp::MAX_CYCLES_PO2 - risc0_zkp::MIN_CYCLES_PO2] = [
+    "51265ccd3158b166191ebc9d6851c2bc1719d9dcff42bde84669ec6d1d1033b1", //
+    "c452124fb40f79255cd1b6508d2fa528fe842c5157721eb0f51b236c5479aa4d", //
+    "90b8aa518f2795a68dd98715d22040a883fcc48827231d20a02b60aed5aa9c6c", //
+    "110045267c6de55c5c6ece41fb9643a40e2f50242f7becc434751e6a080eac56", //
+    "6a87fceae16dc30a090dcbf78b416c3cabc0ff473ec374ee4d6dbfa2ad1b2caa", //
+    "07134a794a282ca9181d758193eb06792cff6b9a019a93631805a0d624604536", //
+    "94291ff35262bef14b38af3057748e8c2f5cb1bafc9b761a86a11b8e05dd4972", //
+    "ebaf330b59e48e72c1551c23d4947dbd2ef0a6740fbb0f24ce806d6abdc1d123", //
+    "ee59bbe1ac9902297b684a41df66a15d47da93b6f7b647c25d2f0df2c4c0eefb", //
+    "be13930445d9097cb20841c3afcd0a63c9d9673429acecd58a3cf0e762cc3ab6", //
+    "b2323de771f4d31035aae557346e6aa84023b5bcef77ec9c4e39f01aba11b567", //
+    "db6584f5b284b622f3ad08afaea9ab669fd493f460a11f999d285301214ee595", //
+    "2a9517ab4454868bb07d4d39043512f46f1df2b623722507b3346ee69c7d4cbc", //
 ];

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -36,6 +36,7 @@ pub use anyhow::Result;
 use control_id::CONTROL_ID;
 use control_id::POSEIDON_CONTROL_ID;
 use hex::FromHex;
+use risc0_zkp::core::blake2b::{Blake2b, ConfigHashBlake2b};
 use risc0_zkp::core::config::{ConfigHashPoseidon, ConfigHashSha256};
 use risc0_zkp::core::digest::Digest;
 use risc0_zkp::core::sha::Sha256;
@@ -43,6 +44,7 @@ pub use risc0_zkvm_platform::{memory::MEM_SIZE, PAGE_SIZE};
 
 #[cfg(feature = "binfmt")]
 pub use crate::binfmt::{elf::Program, image::MemoryImage};
+use crate::control_id::BLAKE2B_CONTROL_ID;
 #[cfg(feature = "prove")]
 pub use crate::prove::{loader::Loader, Prover, ProverOpts};
 pub use crate::receipt::Receipt;
@@ -72,6 +74,16 @@ impl ControlIdLocator for ConfigHashPoseidon {
     fn get_control_id() -> ControlId {
         let mut table = alloc::vec::Vec::new();
         for entry in POSEIDON_CONTROL_ID {
+            table.push(Digest::from_hex(entry).unwrap());
+        }
+        ControlId { table }
+    }
+}
+
+impl<T: Blake2b> ControlIdLocator for ConfigHashBlake2b<T> {
+    fn get_control_id() -> ControlId {
+        let mut table = alloc::vec::Vec::new();
+        for entry in BLAKE2B_CONTROL_ID {
             table.push(Digest::from_hex(entry).unwrap());
         }
         ControlId { table }

--- a/risc0/zkvm/src/tests.rs
+++ b/risc0/zkvm/src/tests.rs
@@ -16,6 +16,7 @@ use std::{fmt, sync::Mutex};
 
 use anyhow::Result;
 use risc0_zeroio::to_vec;
+use risc0_zkp::core::blake2b::{Blake2bCpuImpl, HashSuiteBlake2bCpu};
 use risc0_zkp::core::sha::Digest;
 use risc0_zkvm_methods::{
     multi_test::MultiTestSpec, HELLO_COMMIT_ELF, HELLO_COMMIT_ID, MULTI_TEST_ELF, MULTI_TEST_ID,
@@ -307,6 +308,26 @@ fn test_poseidon_proof() {
     let receipt = prover.run_with_hal(&hal, &eval).unwrap();
     receipt
         .verify_with_hash::<HashSuitePoseidon, _>(&MULTI_TEST_ID)
+        .unwrap();
+}
+
+#[test]
+fn test_blake2b_proof() {
+    use risc0_circuit_rv32im::cpu::CpuEvalCheck;
+    use risc0_core::field::baby_bear::BabyBear;
+    use risc0_zkp::core::blake2b::HashSuiteBlake2b;
+    use risc0_zkp::hal::cpu::CpuHal;
+
+    use crate::CIRCUIT;
+
+    let hal = CpuHal::<BabyBear, HashSuiteBlake2bCpu>::new();
+    let eval = CpuEvalCheck::new(&CIRCUIT);
+    let opts = ProverOpts::default().with_skip_verify(true);
+    let mut prover = Prover::new_with_opts(MULTI_TEST_ELF, MULTI_TEST_ID, opts).unwrap();
+    prover.add_input_u32_slice(&to_vec(&MultiTestSpec::DoNothing).unwrap());
+    let receipt = prover.run_with_hal(&hal, &eval).unwrap();
+    receipt
+        .verify_with_hash::<HashSuiteBlake2b<Blake2bCpuImpl>, _>(&MULTI_TEST_ID)
         .unwrap();
 }
 


### PR DESCRIPTION
Implementation of Blake2b hash function. It uses generics to allow supplying different hashers implementations.