### PR TITLE
[Bonsai Template] Update guest serialization to latest Bonsai commit

### DIFF
--- a/templates/bonsai/contracts/contracts/BonsaiApp.sol
+++ b/templates/bonsai/contracts/contracts/BonsaiApp.sol
@@ -50,7 +50,7 @@ abstract contract BonsaiApp is IBonsaiApp {
   function callback(bytes32 _image_id, bytes calldata journal) external {
     // Require that caller is the trusted proxy contract and guest program.
     require(msg.sender == address(bonsai_proxy), "calls must come from Bonsai");
-    require(_image_id == image_id, "journal must be expected guest");
+    require(_image_id == image_id, "call must be from expected guest");
 
     // Now pass the jounral to the user-defined bonsai_callback function.
     bonsai_callback(journal);

--- a/templates/bonsai/contracts/tests/contract_tests/utils.rs
+++ b/templates/bonsai/contracts/tests/contract_tests/utils.rs
@@ -96,9 +96,7 @@ impl BonsaiMock {
                         ProverOpts::default().with_skip_seal(true),
                     )
                     .expect("failed to create prover");
-                    let input: &[u8] = submit_request_log.input.deref();
-                    prover.add_input_u32_slice(&[input.len() as u32]);
-                    prover.add_input_u8_slice(input);
+                    prover.add_input_u8_slice(submit_request_log.input.deref());
                     prover.run().expect("failed to run guest")
                 };
 

--- a/templates/bonsai/methods/guest/Cargo.toml
+++ b/templates/bonsai/methods/guest/Cargo.toml
@@ -5,10 +5,6 @@ edition = "2021"
 
 [workspace]
 
-[build-dependencies]
-# Must match RISC Zero version specified in the project root.
-risc0-build = { version = "0.13" }
-
 [dependencies]
 # NOTE: ethabi is used here instead of ethers because ethers requires getrandom support.
 ethabi = { version = "18.0", default-features = false }

--- a/templates/bonsai/methods/guest/src/bin/fibonacci.rs
+++ b/templates/bonsai/methods/guest/src/bin/fibonacci.rs
@@ -29,10 +29,12 @@ fn fibonacci(n: U256) -> U256 {
     return curr;
 }
 
+const INPUT_LEN: usize = core::mem::size_of::<U256>();
+
 pub fn main() {
     // NOTE: env::read_slice requires a length argument. Reads must be of known
     // length. https://github.com/risc0/risc0/issues/402
-    let input = ethabi::decode_whole(&[ParamType::Uint(256)], env::read_slice(32)).unwrap();
+    let input = ethabi::decode_whole(&[ParamType::Uint(256)], env::read_slice(INPUT_LEN)).unwrap();
     let n: U256 = input[0].clone().into_uint().unwrap();
 
     // Run the computation.

--- a/templates/bonsai/methods/guest/src/bin/fibonacci.rs
+++ b/templates/bonsai/methods/guest/src/bin/fibonacci.rs
@@ -30,10 +30,9 @@ fn fibonacci(n: U256) -> U256 {
 }
 
 pub fn main() {
-    // NOTE: Currently env::read_slice requires a length argument. Bonsai passes the length at the
-    // start of the input. https://github.com/risc0/risc0/issues/402
-    let input_len = env::read_slice::<u32>(1)[0] as usize;
-    let input = ethabi::decode_whole(&[ParamType::Uint(256)], env::read_slice(input_len)).unwrap();
+    // NOTE: env::read_slice requires a length argument. Reads must be of known
+    // length. https://github.com/risc0/risc0/issues/402
+    let input = ethabi::decode_whole(&[ParamType::Uint(256)], env::read_slice(32)).unwrap();
     let n: U256 = input[0].clone().into_uint().unwrap();
 
     // Run the computation.

--- a/templates/bonsai/methods/src/lib.rs
+++ b/templates/bonsai/methods/src/lib.rs
@@ -35,9 +35,7 @@ mod tests {
             ProverOpts::default().with_skip_seal(true),
         )?;
 
-        let input = ethabi::encode(&[Token::Uint(U256::from(10))]);
-        prover.add_input_u32_slice(&[input.len() as u32]);
-        prover.add_input_u8_slice(&input);
+        prover.add_input_u8_slice(&ethabi::encode(&[Token::Uint(U256::from(10))]));
 
         let receipt = prover.run()?;
 


### PR DESCRIPTION
Bonsai's proxy contract and bridge dropped the addition of the input length from the guest input in
a change on Februrary 28th. This PR updates the starter template to reflect this change.

Note that this new version of the service is what is deployed for use by Eth Denver hackathon
participants. Participants will need to use the template as updated by this PR, or make the same
changes to their own code.
