### PR TITLE
Added python install step to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,9 @@ jobs:
         working-directory: templates/bonsai
       - run: npm run ci
         working-directory: templates/bonsai
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - run: python license-check.py
 
   test:


### PR DESCRIPTION
Currently we assume python exists on the CI host, this makes the workflows a little more portable.