### PR TITLE
CI: disable building dependency docs and zkvm guests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,4 +94,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/rustup
-      - run: cargo doc
+      - run: RISC0_SKIP_BUILD=1 cargo doc --no-deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,4 +94,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/rustup
-      - run: RISC0_SKIP_BUILD=1 cargo doc --no-deps
+      - run: RISC0_SKIP_BUILD=1 cargo doc --no-deps --exclude=risc0-zkvm-methods --workspace


### PR DESCRIPTION
Should reduce the CI build time for the `doc` job a good bit.