### PR TITLE
Full documentation for `risc0_zkvm`

### DIFF
--- a/risc0/zkvm/src/binfmt/mod.rs
+++ b/risc0/zkvm/src/binfmt/mod.rs
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Manages formatted binaries used by the RISC Zero zkVM
+
 pub(crate) mod elf;
 pub(crate) mod image;

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -16,7 +16,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 extern crate alloc;
 

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![warn(missing_docs)]
 
 extern crate alloc;
 

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -51,12 +51,16 @@ pub use crate::receipt::Receipt;
 
 const CIRCUIT: risc0_circuit_rv32im::CircuitImpl = risc0_circuit_rv32im::CircuitImpl::new();
 
+/// A collection of hashes attesting to the circuit architecture
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ControlId {
+    /// The hashes comprising the [ControlId]
     pub table: alloc::vec::Vec<Digest>,
 }
 
+/// A trait for objects with an associated [ControlId]
 pub trait ControlIdLocator {
+    /// Get the [ControlId] associated with this object
     fn get_control_id() -> ControlId;
 }
 

--- a/risc0/zkvm/src/prove/io.rs
+++ b/risc0/zkvm/src/prove/io.rs
@@ -41,6 +41,11 @@ pub trait SliceIoHandler {
     type FromGuest: Pod;
     /// Type for data sent to guest
     type ToGuest: Pod;
+    /// Host side IO handling
+    ///
+    /// Whatever data the guest sent is received by this function in
+    /// `from_guest`, and this function is to return the data the host is
+    /// sending to the guest.
     fn handle_io(&self, from_guest: &[Self::FromGuest]) -> Vec<Self::ToGuest>;
 }
 
@@ -50,6 +55,11 @@ pub trait SliceIoHandler {
 ///
 /// Users may find SliceIoHandler more friendly to use.
 pub trait RawIoHandler {
+    /// Host side IO handling
+    ///
+    /// Whatever data the guest sent is received by this function in
+    /// `from_guest`, and the data the host is sending is written in `to_guest`.
+    /// This returns the words in the guest's `a0` and `a1` registers.
     fn handle_raw_io(&self, from_guest: &[u8], to_guest: &mut [u32]) -> (u32, u32);
 }
 

--- a/risc0/zkvm/src/prove/io.rs
+++ b/risc0/zkvm/src/prove/io.rs
@@ -41,7 +41,7 @@ pub trait SliceIoHandler {
     type FromGuest: Pod;
     /// Type for data sent to guest
     type ToGuest: Pod;
-    /// Host side IO handling
+    /// Host side I/O handling
     ///
     /// Whatever data the guest sent is received by this function in
     /// `from_guest`, and this function is to return the data the host is
@@ -55,7 +55,7 @@ pub trait SliceIoHandler {
 ///
 /// Users may find SliceIoHandler more friendly to use.
 pub trait RawIoHandler {
-    /// Host side IO handling
+    /// Host side I/O handling
     ///
     /// Whatever data the guest sent is received by this function in
     /// `from_guest`, and the data the host is sending is written in `to_guest`.

--- a/risc0/zkvm/src/prove/io.rs
+++ b/risc0/zkvm/src/prove/io.rs
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Handlers for two-way private I/O between host and guest
+//!
+//! These handlers can be enabled for a zkVM by setting them when a
+//! [crate::prove::Prover] is created using [crate::prove::ProverOpts].
+//! Specifically, the [ProverOpts](crate::prove::ProverOpts) functions
+//! [with_sendrecv_callback](crate::prove::ProverOpts::with_sendrecv_callback),
+//! [with_slice_io_handler](crate::prove::ProverOpts::with_slice_io_handler),
+//! and [with_raw_io_handler](crate::prove::ProverOpts::with_raw_io_handler) can
+//! be used to enable the handlers provided in this module.
+
 use core::{cell::RefCell, marker::PhantomData, mem::take};
 use std::ops::DerefMut;
 
@@ -27,7 +37,9 @@ use risc0_zkvm_platform::WORD_SIZE;
 /// elements are to be sent back to the guest, and the second call
 /// actually returns the elements after the guest allocates space.
 pub trait SliceIoHandler {
+    /// Type for data received from guest
     type FromGuest: Pod;
+    /// Type for data sent to guest
     type ToGuest: Pod;
     fn handle_io(&self, from_guest: &[Self::FromGuest]) -> Vec<Self::ToGuest>;
 }

--- a/risc0/zkvm/src/prove/loader.rs
+++ b/risc0/zkvm/src/prove/loader.rs
@@ -321,6 +321,10 @@ impl<'a> Iterator for TripleWordIter<'a> {
     }
 }
 
+/// Loads data into the zkVM image
+///
+/// Handles both loading the initial zkVM data and also loading updated data for
+/// each time step.
 pub struct Loader {
     system: Vec<TripleWord>,
 }
@@ -328,6 +332,9 @@ pub struct Loader {
 impl Loader {
     const SETUP_CYCLES: usize = setup_count(SETUP_STEP_REGS);
 
+    /// Construct a Loader
+    ///
+    /// Loads the common setup data used by all zkVMs
     pub fn new() -> Self {
         let mut image: BTreeMap<u32, u32> = BTreeMap::new();
 
@@ -346,6 +353,11 @@ impl Loader {
         }
     }
 
+    /// Load data specific to this zkVM instance
+    ///
+    /// Starting from the initialized image created by [Loader::new], use the
+    /// function `step` to repeatedly update the image, thereby creating an
+    /// execution trace.
     #[tracing::instrument(skip_all)]
     pub fn load<F>(&self, step: F) -> Result<usize>
     where
@@ -363,6 +375,7 @@ impl Loader {
         Ok(loader.cycle)
     }
 
+    /// Compute the [ControlId] associated with the given HAL
     pub fn compute_control_id<H: Hal<Elem = BabyBearElem>>(&self, hal: &H) -> ControlId {
         let code_size = CIRCUIT.code_size();
 

--- a/risc0/zkvm/src/prove/mod.rs
+++ b/risc0/zkvm/src/prove/mod.rs
@@ -193,6 +193,9 @@ cfg_if::cfg_if! {
         use risc0_circuit_rv32im::cuda::CudaEvalCheck;
         use risc0_zkp::hal::cuda::CudaHal;
 
+        /// Returns the default SHA-256 HAL for the RISC Zero circuit
+        ///
+        /// See the non-cuda version of this documentation for details
         pub fn default_hal() -> (Rc<CudaHal>, CudaEvalCheck) {
             let hal = Rc::new(CudaHal::new());
             let eval = CudaEvalCheck::new(hal.clone());
@@ -204,12 +207,18 @@ cfg_if::cfg_if! {
         use risc0_circuit_rv32im::metal::{MetalEvalCheck, MetalEvalCheckSha256};
         use risc0_zkp::hal::metal::{MetalHalSha256, MetalHalPoseidon, MetalHashPoseidon};
 
+        /// Returns the default SHA-256 HAL for the RISC Zero circuit
+        ///
+        /// See the non-metal version of this documentation for details
         pub fn default_hal() -> (Rc<MetalHalSha256>, MetalEvalCheckSha256) {
             let hal = Rc::new(MetalHalSha256::new());
             let eval = MetalEvalCheckSha256::new(hal.clone());
             (hal, eval)
         }
 
+        /// Returns the default Poseidon HAL for the RISC Zero circuit
+        ///
+        /// See the non-metal version of this documentation for details
         pub fn default_poseidon_hal() -> (Rc<MetalHalPoseidon>, MetalEvalCheck<MetalHashPoseidon>) {
             let hal = Rc::new(MetalHalPoseidon::new());
             let eval = MetalEvalCheck::<MetalHashPoseidon>::new(hal.clone());

--- a/risc0/zkvm/src/prove/mod.rs
+++ b/risc0/zkvm/src/prove/mod.rs
@@ -219,7 +219,7 @@ cfg_if::cfg_if! {
         use risc0_circuit_rv32im::{CircuitImpl, cpu::CpuEvalCheck};
         use risc0_zkp::hal::cpu::{BabyBearSha256CpuHal, BabyBearPoseidonCpuHal};
 
-        /// Returns the default HAL for the RISC Zero circuit
+        /// Returns the default SHA-256 HAL for the RISC Zero circuit
         ///
         /// RISC Zero uses a
         /// [HAL](https://docs.rs/risc0-zkp/latest/risc0_zkp/hal/index.html)
@@ -239,6 +239,10 @@ cfg_if::cfg_if! {
             (hal, eval)
         }
 
+        /// Returns the default Poseidon HAL for the RISC Zero circuit
+        ///
+        /// The same as [default_hal] except it gives the default HAL for
+        /// securing the circuit using Poseidon (instead of SHA-256).
         pub fn default_poseidon_hal() -> (Rc<BabyBearPoseidonCpuHal>, CpuEvalCheck<'static, CircuitImpl>) {
             let hal = Rc::new(BabyBearPoseidonCpuHal::new());
             let eval = CpuEvalCheck::new(&CIRCUIT);

--- a/risc0/zkvm/src/prove/mod.rs
+++ b/risc0/zkvm/src/prove/mod.rs
@@ -194,8 +194,6 @@ cfg_if::cfg_if! {
         use risc0_zkp::hal::cuda::CudaHal;
 
         /// Returns the default SHA-256 HAL for the RISC Zero circuit
-        ///
-        /// See the non-cuda version of this documentation for details
         pub fn default_hal() -> (Rc<CudaHal>, CudaEvalCheck) {
             let hal = Rc::new(CudaHal::new());
             let eval = CudaEvalCheck::new(hal.clone());
@@ -208,8 +206,6 @@ cfg_if::cfg_if! {
         use risc0_zkp::hal::metal::{MetalHalSha256, MetalHalPoseidon, MetalHashPoseidon};
 
         /// Returns the default SHA-256 HAL for the RISC Zero circuit
-        ///
-        /// See the non-metal version of this documentation for details
         pub fn default_hal() -> (Rc<MetalHalSha256>, MetalEvalCheckSha256) {
             let hal = Rc::new(MetalHalSha256::new());
             let eval = MetalEvalCheckSha256::new(hal.clone());
@@ -217,8 +213,6 @@ cfg_if::cfg_if! {
         }
 
         /// Returns the default Poseidon HAL for the RISC Zero circuit
-        ///
-        /// See the non-metal version of this documentation for details
         pub fn default_poseidon_hal() -> (Rc<MetalHalPoseidon>, MetalEvalCheck<MetalHashPoseidon>) {
             let hal = Rc::new(MetalHalPoseidon::new());
             let eval = MetalEvalCheck::<MetalHashPoseidon>::new(hal.clone());

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -122,6 +122,24 @@ pub fn insecure_skip_seal() -> bool {
         && std::env::var("RISC0_INSECURE_SKIP_SEAL").unwrap_or_default() == "1"
 }
 
+/// Reports whether the zkVM is in the insecure seal skipping mode
+///
+/// Returns `true` when in the insecure seal skipping mode. Returns `false` when
+/// in normal secure mode.
+///
+/// When `insecure_skip_seal` is `false`, [crate::prove::Prover::run] will
+/// generate a seal when run that proves faithful execution, and
+/// [Receipt::verify] will check the seal and return an `Err` if the seal is
+/// missing or invalid.
+///
+/// When `insecure_skip_seal` is `true`, [crate::prove::Prover::run] will not
+/// generate a seal and the Receipt does not contain a proof of execution, and
+/// [Receipt::verify] will not check the seal and will return an `Ok` even if
+/// the seal is missing or invalid.
+///
+/// In particular, if [Receipt::verify] is run with `insecure_skip_seal` being
+/// `false`, it will always return an `Err` for any [Receipt] generated while
+/// `insecure_skip_seal` was `true`.
 #[cfg(target_os = "zkvm")]
 pub fn insecure_skip_seal() -> bool {
     cfg!(feature = "insecure_skip_seal")

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -124,22 +124,7 @@ pub fn insecure_skip_seal() -> bool {
 
 /// Reports whether the zkVM is in the insecure seal skipping mode
 ///
-/// Returns `true` when in the insecure seal skipping mode. Returns `false` when
-/// in normal secure mode.
-///
-/// When `insecure_skip_seal` is `false`, [crate::prove::Prover::run] will
-/// generate a seal when run that proves faithful execution, and
-/// [Receipt::verify] will check the seal and return an `Err` if the seal is
-/// missing or invalid.
-///
-/// When `insecure_skip_seal` is `true`, [crate::prove::Prover::run] will not
-/// generate a seal and the Receipt does not contain a proof of execution, and
-/// [Receipt::verify] will not check the seal and will return an `Ok` even if
-/// the seal is missing or invalid.
-///
-/// In particular, if [Receipt::verify] is run with `insecure_skip_seal` being
-/// `false`, it will always return an `Err` for any [Receipt] generated while
-/// `insecure_skip_seal` was `true`.
+/// See the non-zkvm version of this documentation for details.
 #[cfg(target_os = "zkvm")]
 pub fn insecure_skip_seal() -> bool {
     cfg!(feature = "insecure_skip_seal")

--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -21,11 +21,17 @@ use super::{
     err::{Error, Result},
 };
 
+/// Deserialize a slice into the specified type.
+///
+/// Deserialize `slice` into type `T`. Returns an `Err` if deserialization isn't
+/// possible, such as if `slice` is not the serialized form of an object of type
+/// `T`.
 pub fn from_slice<'a, T: Deserialize<'a>, P: Pod>(slice: &'a [P]) -> Result<T> {
     let mut deserializer = Deserializer::new(bytemuck::cast_slice(slice));
     T::deserialize(&mut deserializer)
 }
 
+/// Interface for deserializing from bytes
 pub struct Deserializer<'de> {
     slice: &'de [u8],
 }
@@ -123,6 +129,9 @@ impl<'a, 'de: 'a> serde::de::MapAccess<'de> for MapAccess<'a, 'de> {
 }
 
 impl<'de> Deserializer<'de> {
+    /// Construct a Deserializer
+    ///
+    /// Creates a deserializer for deserializing the contents of `slice`
     pub fn new(slice: &'de [u8]) -> Self {
         Deserializer { slice }
     }
@@ -153,6 +162,11 @@ impl<'de> Deserializer<'de> {
         Ok(&bytes[..len])
     }
 
+    /// Read bytes, removing them from the Deserializer and returning them
+    ///
+    /// Returns the first `len` bytes and remove them from the Deserializer.
+    /// If there are fewer than `len` bytes in the Deserializer, return an
+    /// `Err`.
     pub fn read_bytes(&mut self, len: usize) -> Result<&'de [u8]> {
         if self.slice.len() >= len {
             let (head, tail) = self.slice.split_at(len);

--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -31,7 +31,7 @@ pub fn from_slice<'a, T: Deserialize<'a>, P: Pod>(slice: &'a [P]) -> Result<T> {
     T::deserialize(&mut deserializer)
 }
 
-/// Interface for deserializing from bytes
+/// Interface for deserializing
 pub struct Deserializer<'de> {
     slice: &'de [u8],
 }

--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -31,7 +31,7 @@ pub fn from_slice<'a, T: Deserialize<'a>, P: Pod>(slice: &'a [P]) -> Result<T> {
     T::deserialize(&mut deserializer)
 }
 
-/// Interface for deserializing
+/// Enables deserializing from a slice
 pub struct Deserializer<'de> {
     slice: &'de [u8],
 }

--- a/risc0/zkvm/src/serde/err.rs
+++ b/risc0/zkvm/src/serde/err.rs
@@ -28,6 +28,7 @@ pub enum Error {
     SerializeBufferFull,
 }
 
+/// A Result type for `risc0_zkvm::serde` operations that can fail
 pub type Result<T> = core::result::Result<T, Error>;
 
 impl Display for Error {

--- a/risc0/zkvm/src/serde/serializer.rs
+++ b/risc0/zkvm/src/serde/serializer.rs
@@ -82,7 +82,7 @@ pub trait StreamWriter {
     fn release(&mut self) -> Result<Self::Output>;
 }
 
-/// Interface for serializing
+/// Enables serializing to a stream
 pub struct Serializer<W: StreamWriter> {
     stream: W,
 }

--- a/risc0/zkvm/src/serde/serializer.rs
+++ b/risc0/zkvm/src/serde/serializer.rs
@@ -24,6 +24,7 @@ use super::{
     err::{Error, Result},
 };
 
+/// Serialize to a vector of u32 words
 pub fn to_vec<'a, T>(value: &'a T) -> Result<Vec<u32>>
 where
     T: Serialize + ?Sized,
@@ -36,6 +37,10 @@ where
     serializer.stream.release()
 }
 
+/// Serialize to a vector of u32 words with size hinting
+///
+/// Includes a caller-provided hint `cap` giving the capacity of u32 words
+/// necessary to serialize `value`.
 pub fn to_vec_with_capacity<'a, T>(value: &'a T, cap: usize) -> Result<Vec<u32>>
 where
     T: Serialize + ?Sized,
@@ -46,30 +51,51 @@ where
     serializer.stream.release()
 }
 
+/// `StreamWriter`s can have data written to them in a streamed manner
+///
+/// The various `write` functions can be called repeatedly to add data to the
+/// `StreamWriter`. Then [StreamWriter::release] can be called to return a
+/// [StreamWriter::Output] containing the written data.
 pub trait StreamWriter {
+    /// The type to be written into
+    ///
+    /// This is the type that will be returned when [StreamWriter::release]
+    /// is called.
     type Output;
 
+    /// Write a u32 word
     fn write_u32(&mut self, data: u32) -> Result<()>;
 
+    /// Write a u64
+    ///
+    /// Equivalent to writing first the least significant 32 bits and then the
+    /// most significant 32 bits with [StreamWriter::write_u32].
     fn write_u64(&mut self, data: u64) -> Result<()> {
         self.write_u32((data & 0xffffffff) as u32)?;
         self.write_u32((data >> 32) as u32)
     }
 
+    /// Write a slice
     fn write_slice<T: Pod>(&mut self, slice: &[T]) -> Result<()>;
 
+    /// Return the written data as a [StreamWriter::Output]
     fn release(&mut self) -> Result<Self::Output>;
 }
 
+/// Interface for serializing
 pub struct Serializer<W: StreamWriter> {
     stream: W,
 }
 
 impl<W: StreamWriter> Serializer<W> {
+    /// Construct a Serializer
+    ///
+    /// Creates a serializer that writes to `stream`.
     pub fn new(stream: W) -> Self {
         Serializer { stream }
     }
 
+    /// Returns the contents of the Serializer stream.
     pub fn release(&mut self) -> Result<W::Output> {
         self.stream.release()
     }
@@ -402,13 +428,18 @@ impl<'a, W: StreamWriter> serde::ser::SerializeStructVariant for &'a mut Seriali
     }
 }
 
+/// A vector of bytes that can be written to with a stream interface
 pub struct AllocVec(pub Vec<u8>);
 
 impl AllocVec {
+    /// Construct an empty AllocVec
     pub fn new() -> Self {
         AllocVec(Vec::new())
     }
 
+    /// Construct an empty AllocVec with preallocated capacity
+    ///
+    /// The `capacity` parameter gives how many bytes are preallocated.
     pub fn with_capacity(capacity: usize) -> Self {
         AllocVec(Vec::with_capacity(capacity))
     }

--- a/risc0/zkvm/src/serde/serializer.rs
+++ b/risc0/zkvm/src/serde/serializer.rs
@@ -429,6 +429,8 @@ impl<'a, W: StreamWriter> serde::ser::SerializeStructVariant for &'a mut Seriali
 }
 
 /// A vector of bytes that can be written to with a stream interface
+///
+/// This is designed for host-side use and is not intended for use in the guest.
 pub struct AllocVec(pub Vec<u8>);
 
 impl AllocVec {


### PR DESCRIPTION
Complete at least brief documentation for all of the `risc0_zkvm` crate and turn on `warn(missing_docs)` for this crate.

Major topics with added documentation include:
* Serde
* MemoryImage
* ControlID
* Loader
* I/O
* Poseidon HAL

I learned about some of these as I documented, so there's definitely a possibility of errors -- I would appreciate review for accuracy not just style, and have tagged reviewers I think would know about these topics. If you see something that you think needs review by someone I haven't tagged please add them.