### PR TITLE
Require docs for `risc0-core`

### DIFF
--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 //! Baby bear field.
-//! Support for the base finite field modulo `15 * 2^27 + 1`.
+//!
+//! Support for the finite field of order `15 * 2^27 + 1`, and its degree 4
+//! extension field. This field choice allows for 32-bit addition without
+//! overflow.
 
 use alloc::{fmt, vec::Vec};
 use core::{
@@ -61,6 +64,7 @@ const R2: u32 = 1172168163;
 #[repr(transparent)]
 pub struct Elem(u32);
 
+/// Alias for the Baby Bear [Elem]
 pub type BabyBearElem = Elem;
 
 impl Default for Elem {
@@ -185,10 +189,14 @@ impl Elem {
         Self(encode(x % P))
     }
 
+    /// Create a new [BabyBear] from a Montgomery form representation
+    ///
+    /// Requires that `x` comes pre-encoded in Montegomery form.
     pub const fn new_raw(x: u32) -> Self {
         Self(x)
     }
 
+    /// Cast a [BabyBear] to an integer
     pub const fn as_u32(&self) -> u32 {
         decode(self.0)
     }
@@ -360,6 +368,7 @@ const EXT_SIZE: usize = 4;
 #[repr(transparent)]
 pub struct ExtElem([Elem; EXT_SIZE]);
 
+/// Alias for the Baby Bear [ExtElem]
 pub type BabyBearExtElem = ExtElem;
 
 impl Default for ExtElem {

--- a/risc0/core/src/field/goldilocks.rs
+++ b/risc0/core/src/field/goldilocks.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 //! Goldilocks field.
-//! Support for the base finite field modulo `2^64 - 2^32 + 1`.
+//!
+//! Support for the finite field of order `2^64 - 2^32 + 1`, and its degree 2
+//! extension field. This field choice allows for fast reduction.
 
 use alloc::vec::Vec;
 use core::ops;
@@ -40,6 +42,7 @@ use crate::field::{self, Elem as FieldElem};
 #[repr(transparent)]
 pub struct Elem(u64);
 
+/// Alias for the Goldilocks [Elem]
 pub type GoldilocksElem = Elem;
 
 impl Default for Elem {
@@ -329,6 +332,7 @@ const EXT_SIZE: usize = 2;
 #[repr(transparent)]
 pub struct ExtElem([Elem; EXT_SIZE]);
 
+/// Alias for the Goldilocks [ExtElem]
 pub type GoldilocksExtElem = ExtElem;
 
 impl Default for ExtElem {

--- a/risc0/core/src/field/mod.rs
+++ b/risc0/core/src/field/mod.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Document better
-
-//! Defines field extension (and base fields) used for finite field-based
+//! Finite field types and operations
+//!
+//! Defines base fields and extension fields used for finite field-based
 //! operations across the RISC Zero zkVM architecture
 
 use alloc::vec::Vec;

--- a/risc0/core/src/field/mod.rs
+++ b/risc0/core/src/field/mod.rs
@@ -30,7 +30,9 @@ pub mod goldilocks;
 
 /// A pair of fields, one of which is an extension field of the other.
 pub trait Field {
+    /// An element of the base field
     type Elem: Elem + RootsOfUnity;
+    /// An element of the extension field
     type ExtElem: ExtElem<SubElem = Self::Elem>;
 }
 
@@ -162,6 +164,10 @@ pub trait Elem:
 }
 
 /// A field extension which can be constructed from a subfield element [Elem]
+///
+/// Represents an element of an extension field. This extension field is
+/// associated with a base field (sometimes called "subfield") whose element
+/// type is given by the generic type parameter.
 pub trait ExtElem:
     Elem
     + ops::Add<Output = Self>
@@ -176,15 +182,36 @@ pub trait ExtElem:
     + cmp::PartialEq
     + cmp::Eq
 {
+    /// An element of the base field
+    ///
+    /// This type represents an element of the base field (sometimes called
+    /// "subfield") of this extension field.
     type SubElem: Elem;
 
+    /// The degree of the field extension
+    ///
+    /// This the degree of the extension field when interpreted as a vector
+    /// space over the base field. Thus, an [ExtElem] can be represented as
+    /// `EXT_SIZE` [SubElem](ExtElem::SubElem)s.
     const EXT_SIZE: usize;
 
-    /// Construct a field element
+    /// Interpret a base field element as an extension field element
+    ///
+    /// Every [SubElem](ExtElem::SubElem) is (mathematically) an [ExtElem]. This
+    /// constructs the [ExtElem] equal to the given [SubElem](ExtElem::SubElem).
     fn from_subfield(elem: &Self::SubElem) -> Self;
 
+    /// Construct an extension field element
+    ///
+    /// Construct an extension field element from a (mathematical) vector of
+    /// [SubElem](ExtElem::SubElem)s. This vector is length
+    /// [EXT_SIZE](ExtElem::EXT_SIZE).
     fn from_subelems(elems: impl IntoIterator<Item = Self::SubElem>) -> Self;
 
+    /// Express an extension field element in terms of base field elements
+    ///
+    /// Returns the (mathematical) vector of [SubElem](ExtElem::SubElem)s equal
+    /// to the [ExtElem]. This vector is length [EXT_SIZE](ExtElem::EXT_SIZE).
     fn subelems(&self) -> &[Self::SubElem];
 }
 

--- a/risc0/core/src/field/mod.rs
+++ b/risc0/core/src/field/mod.rs
@@ -20,12 +20,7 @@
 use alloc::vec::Vec;
 use core::{cmp, fmt::Debug, ops};
 
-/// The field extension whose subfield is order `15*2^27 + 1`;
-/// this field choice allows 32-bit addition without overflow.
 pub mod baby_bear;
-
-/// The field extension whose subfield is order `2^64 - 2^32 + 1`;
-/// this field choice allows for fast reduction.
 pub mod goldilocks;
 
 /// A pair of fields, one of which is an extension field of the other.

--- a/risc0/core/src/lib.rs
+++ b/risc0/core/src/lib.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Core RISC Zero functionality shared across multiple crates
+//!
+//! This crate contains fundamental code that multiple RISC Zero crates rely on,
+//! most notably representing finite field elements and enabling finite field
+//! arithmetic.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/risc0/core/src/lib.rs
+++ b/risc0/core/src/lib.rs
@@ -19,6 +19,7 @@
 //! arithmetic.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Also adds the currently-missing docs.