### PR TITLE
Added pull-req perms for comment creation

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -58,6 +58,9 @@ jobs:
   create-comment:
     runs-on: ubuntu-22.04
     needs: [ bench ]
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: actions/download-artifact@v3
       - name: Merge output files


### PR DESCRIPTION
Hopefully fixes issue of 3rd party PR's not correctly having perms to create benchmark report comments:
https://github.com/risc0/risc0/actions/runs/4424882295/jobs/7768618386