### PR TITLE
Add additional perms for PR comments

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [ bench ]
     permissions:
+      issues: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Apparently we need issue write as well? Possibly even `content` but this thread has some highly variable results: https://github.com/actions/first-interaction/issues/10#issuecomment-1114048624