### PR TITLE
Divide workflow for bench_pr to allow forked repo PR's.

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -55,30 +55,6 @@ jobs:
           path: ${{ matrix.os }}-${{ matrix.feature }}-output.md
           if-no-files-found: error
 
-  create-comment:
-    runs-on: ubuntu-22.04
-    needs: [ bench ]
-    permissions:
-      issues: write
-      pull-requests: write
-
-    steps:
-      - uses: actions/download-artifact@v3
-      - name: Merge output files
-        shell: bash
-        run: sed h ./md-output/*-output.md > merged.md
-        id: download
-
-      - uses: actions/github-script@v3
-        name: Create PR comment
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            var fs = require('fs');
-            var body = fs.readFileSync("./merged.md", 'utf8')
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            })
+      # Note: we just push the comment data into artifacts, here
+      # the bench_pr_comment.yml picks up after this workflow to make the comment
+      # needed because: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

--- a/.github/workflows/bench_pr_comment.yml
+++ b/.github/workflows/bench_pr_comment.yml
@@ -1,0 +1,54 @@
+
+name: Create Benchmark PR comment
+
+on:
+  workflow_run:
+    workflows: ["Benchmark Check"]
+    types:
+      - completed
+
+jobs:
+  create-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "md-output"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/md-output.zip', Buffer.from(download.data));
+
+      - run: unzip md-output.zip
+
+      - name: Merge output files
+        shell: bash
+        run: sed h ./md-output/*-output.md > merged.md
+        id: download
+
+      - uses: actions/github-script@v3
+        name: Create PR comment
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var fs = require('fs');
+            var body = fs.readFileSync("./merged.md", 'utf8')
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })


### PR DESCRIPTION
Allows for forked repo PRs to run bench_pr workflow while not exposing the GITHUB_TOKEN to malicious workflows.
Reference and sample code used from: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/