### PR TITLE
Add concurrency to CI

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -10,6 +10,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bench:
     runs-on: [self-hosted, bench, "${{ matrix.os }}", "${{ matrix.device }}"]

--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -12,6 +12,10 @@ on:
   # pull_request:
   #   branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bench:
     runs-on: [self-hosted, bench, "${{ matrix.os }}", "${{ matrix.device }}"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds concurrency to the Github workflows to automatically cancel current in-progress workflow runs when new commits are added.

The definition `${{ github.workflow }}` makes it so that only this workflow is cancelled instead of a widespread cancelling of workflows.

The definition group: `${{ github.event.pull_request.number || github.ref }}` targets workflows within the same PR, branch, or tag.