### PR TITLE
Removed Snakecase from risczero new proj name

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["risc0", "risczero", "tool", "cli", "generate"]
 cargo-generate = "0.18"
 clap = { version = "4.0", features = ["derive"] }
 const_format = "0.2"
-convert_case = "0.6"
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/risc0/cargo-risczero/src/commands/new.rs
+++ b/risc0/cargo-risczero/src/commands/new.rs
@@ -17,7 +17,6 @@ use std::path::PathBuf;
 use cargo_generate::{GenerateArgs, TemplatePath, Vcs};
 use clap::Parser;
 use const_format::concatcp;
-use convert_case::{Case, Casing};
 
 const RISC0_GH_REPO: &str = "https://github.com/risc0/risc0";
 const RISC0_TEMPLATE_DIR: &str = "templates/rust-starter";
@@ -127,14 +126,14 @@ impl NewCommand {
         }
 
         if self.std {
-            template_variables.push(format!("risc0_std=true"));
-            template_variables.push(format!("risc0_feature_std=, features = ['std']"));
+            template_variables.push("risc0_std=true".to_string());
+            template_variables.push("risc0_feature_std=, features = ['std']".to_string());
         }
 
         cargo_generate::generate(GenerateArgs {
             template_path,
             list_favorites: false,
-            name: Some(self.name.to_case(Case::Snake)),
+            name: Some(self.name.clone()),
             force: true,
             verbose: true,
             template_values_file: None,


### PR DESCRIPTION
@brianretford pointed out that a input name like `r0ml` gets converted to `r_0_ml` in `risczero new`.  This addresses that as well as some clippy warnings.