### PR TITLE
Fixes risc0-build deadlocks on large outputs

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -409,10 +409,9 @@ fn build_guest_package<P>(
         }
     }
 
-    let status = cmd.status().unwrap();
-
-    if !status.success() {
-        std::process::exit(status.code().unwrap());
+    let res = child.wait().expect("Guest 'cargo build' failed");
+    if !res.success() {
+        std::process::exit(res.code().unwrap());
     }
 }
 


### PR DESCRIPTION
Previously if we had a large volume of `cargo build` errors it would hit the piped limit of the child process terminate. By calling cmd.status() we would invoke a second version of the subprocess. Using the spawn() return value and .wait() means we correctly pull from the right piped IO.

This might have also fixed double-invoking the `cargo build` child process but I am not 100% sure on that.