### PR TITLE
Add with_stdin_obj and with_stdout_obj to ProverOpts

### DIFF
--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -28,10 +28,7 @@ use risc0_zkvm::{
     sha::{Digest, Sha256},
 };
 use risc0_zkvm_methods::multi_test::{MultiTestSpec, SYS_MULTI_TEST};
-use risc0_zkvm_platform::{
-    fileno,
-    syscall::{sys_read, sys_write},
-};
+use risc0_zkvm_platform::syscall::sys_read;
 
 risc0_zkvm::entry!(main);
 
@@ -146,17 +143,8 @@ pub fn main() {
             env::pause();
             env::log("after");
         }
-        MultiTestSpec::CopyToStdout { fd } => {
-            // Unaligned buffer size to exercise things a little bit.
-            const BUF_SIZE: usize = 9;
-            let mut buf = [0u8; BUF_SIZE];
-            loop {
-                let nread = unsafe { sys_read(fd, buf.as_mut_ptr(), buf.len()) };
-                if nread == 0 {
-                    break;
-                }
-                unsafe { sys_write(fileno::STDOUT, buf.as_mut_ptr(), nread) }
-            }
+        MultiTestSpec::CopyToStdout => {
+            env::write(&impl_select);
         }
         MultiTestSpec::BusyLoop { cycles } => {
             let mut last_cycles = env::get_cycle_count();

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -18,7 +18,7 @@
 #![no_std]
 
 extern crate alloc;
-use alloc::vec;
+use alloc::{string::String, vec};
 use core::arch::asm;
 
 use getrandom::getrandom;
@@ -143,8 +143,10 @@ pub fn main() {
             env::pause();
             env::log("after");
         }
-        MultiTestSpec::CopyToStdout => {
+        MultiTestSpec::ObjectIo => {
             env::write(&impl_select);
+            let msg: String = env::read();
+            env::write(&msg);
         }
         MultiTestSpec::BusyLoop { cycles } => {
             let mut last_cycles = env::get_cycle_count();

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 use risc0_zkvm::declare_syscall;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum MultiTestSpec {
     DoNothing,
     ShaConforms,
@@ -31,9 +31,7 @@ pub enum MultiTestSpec {
     EventTrace,
     Profiler,
     Fail,
-    CopyToStdout {
-        fd: u32,
-    },
+    CopyToStdout,
     ReadWriteMem {
         /// Tuples of (address, value). Zero means read the value and
         /// output it; nonzero means write that value.

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -31,7 +31,7 @@ pub enum MultiTestSpec {
     EventTrace,
     Profiler,
     Fail,
-    CopyToStdout,
+    ObjectIo,
     ReadWriteMem {
         /// Tuples of (address, value). Zero means read the value and
         /// output it; nonzero means write that value.

--- a/risc0/zkvm/src/tests.rs
+++ b/risc0/zkvm/src/tests.rs
@@ -302,20 +302,17 @@ fn sha_cycle_count() {
 
 #[test]
 fn stdio() {
-    const MSG: &str = "Hello world!  This is a test of standard input and output.";
-    const FD: u32 = 123;
-    let mut stdout: Vec<u8> = Vec::new();
+    let spec = MultiTestSpec::CopyToStdout;
+    let mut out_spec = MultiTestSpec::DoNothing;
     {
-        let spec = &to_vec(&MultiTestSpec::CopyToStdout { fd: FD }).unwrap();
         let opts = ProverOpts::default()
             .with_skip_seal(true)
-            .with_read_fd(FD, MSG.as_bytes())
-            .with_stdin(bytemuck::cast_slice(&spec))
-            .with_stdout(&mut stdout);
+            .with_stdin_obj(&spec)
+            .with_stdout_obj(&mut out_spec);
         let mut prover = Prover::new_with_opts(MULTI_TEST_ELF, opts).unwrap();
         prover.run().unwrap();
     }
-    assert_eq!(MSG, core::str::from_utf8(&stdout).unwrap());
+    assert_eq!(&spec, &out_spec);
 }
 
 #[test]


### PR DESCRIPTION
These make serialization/deserialization of standard input and output cleaner for user use.