### PR TITLE
Delete github-action-benchmark repo directory

### DIFF
--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo bench -F $FEATURE --bench fib -- --output-format=bencher | tee output.txt
+      # Delete existing benchmark repo if it exists, hardcoded path:
+      # https://github.com/risc0/github-action-benchmark/blob/7eeba8924d4ed651010d72d7319b064fc0c10355/src/write.ts#L392
+      - run: rm -rf ./benchmark-data-repository || true
+        shell: bash
       - name: Store benchmark result
         uses: risc0/github-action-benchmark@v1
         with:


### PR DESCRIPTION
Hopefully fixes issues with the benchmark-data-repository directory existing between workflow runs:
https://github.com/risc0/risc0/actions/runs/4692258699/jobs/8317753772
