### PR TITLE
Added templ_subdir flag to cargo risczero new

### DIFF
--- a/risc0/cargo-risczero/src/commands/new.rs
+++ b/risc0/cargo-risczero/src/commands/new.rs
@@ -34,7 +34,7 @@ pub struct NewCommand {
     #[clap(value_parser, long, short, default_value = RISC0_GH_REPO)]
     pub template: String,
 
-    /// location of the template
+    /// Location of the template
     ///
     /// The subdirectory location of the template used for generating the new
     /// project. This path is relative to the base repository specified by

--- a/risc0/cargo-risczero/src/commands/new.rs
+++ b/risc0/cargo-risczero/src/commands/new.rs
@@ -34,6 +34,14 @@ pub struct NewCommand {
     #[clap(value_parser, long, short, default_value = RISC0_GH_REPO)]
     pub template: String,
 
+    /// location of the template
+    ///
+    /// The subdirectory location of the template used for generating the new
+    /// project. This path is relative to the base repository specified by
+    /// --template
+    #[clap(value_parser, long, default_value = RISC0_TEMPLATE_DIR)]
+    pub templ_subdir: String,
+
     /// template git tag.
     #[clap(value_parser, long, default_value = RISC0_RELEASE_TAG)]
     pub tag: String,
@@ -76,12 +84,6 @@ pub struct NewCommand {
 impl NewCommand {
     /// Execute this command
     pub fn run(&self) {
-        let subfolder = if self.template == RISC0_GH_REPO {
-            Some(RISC0_TEMPLATE_DIR.to_string())
-        } else {
-            None
-        };
-
         let dest_dir = if let Some(dest_dir) = self.dest.clone() {
             dest_dir
         } else {
@@ -90,7 +92,7 @@ impl NewCommand {
 
         let mut template_path = TemplatePath {
             auto_path: Some(self.template.clone()),
-            subfolder,
+            subfolder: Some(self.templ_subdir.clone()),
             git: None,
             branch: None,
             path: None,

--- a/risc0/cargo-risczero/src/commands/new.rs
+++ b/risc0/cargo-risczero/src/commands/new.rs
@@ -209,6 +209,8 @@ mod tests {
             &template_path
                 .join("templates/rust-starter")
                 .to_string_lossy(),
+            "--templ-subdir",
+            "",
             "--dest",
             &tmpdir.path().to_string_lossy(),
             proj_name,
@@ -241,6 +243,8 @@ mod tests {
             &template_path
                 .join("templates/rust-starter")
                 .to_string_lossy(),
+            "--templ-subdir",
+            "",
             "--dest",
             &tmpdir.path().to_string_lossy(),
             "--no-git",
@@ -271,6 +275,8 @@ mod tests {
             &template_path
                 .join("templates/rust-starter")
                 .to_string_lossy(),
+            "--templ-subdir",
+            "",
             "--dest",
             &tmpdir.path().to_string_lossy(),
             "--std",


### PR DESCRIPTION
Provides the optional ability to select from multiple template locations within a folder|repo at `--template`