### PR TITLE
Move gh-repository location in bench-trend workflow

### DIFF
--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -49,12 +49,13 @@ jobs:
       - run: rm -rf ./benchmark-data-repository || true
         shell: bash
       - name: Store benchmark result
-        uses: risc0/github-action-benchmark@v1
+        uses: risc0/github-action-benchmark@risc0
         with:
           name: "${{ matrix.os }}-${{ matrix.device }}"
           tool: 'cargo'
           github-token: ${{ secrets.BENCHMARK_TOKEN }}
           gh-repository: 'github.com/risc0/benchmarks'
+          gh-repository-dir: '${{ runner.temp }}/benchmark-data-repository'
           gh-pages-branch: main
           output-file-path: output.txt
           comment-always: false

--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -44,10 +44,6 @@ jobs:
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo bench -F $FEATURE --bench fib -- --output-format=bencher | tee output.txt
-      # Delete existing benchmark repo if it exists, hardcoded path:
-      # https://github.com/risc0/github-action-benchmark/blob/7eeba8924d4ed651010d72d7319b064fc0c10355/src/write.ts#L392
-      - run: rm -rf ./benchmark-data-repository || true
-        shell: bash
       - name: Store benchmark result
         uses: risc0/github-action-benchmark@risc0
         with:


### PR DESCRIPTION
Moves the gh-repo clone location to runner.temp to prevent. Depends on the following PR to be merged to `risc0` branch:
https://github.com/risc0/github-action-benchmark/pull/2