### PR TITLE
Added libm externs to zkvm guest

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -700,6 +700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
+dependencies = [
+ "quote 1.0.26",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "cust"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1011,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1470,6 +1489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.26",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "gif"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,6 +1839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
+dependencies = [
+ "ctor",
+ "ghost",
 ]
 
 [[package]]
@@ -2194,6 +2234,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -3042,7 +3083,9 @@ dependencies = [
  "getrandom",
  "hex",
  "lazy-regex",
+ "libm",
  "log",
+ "num-bigint 0.4.3",
  "num-derive",
  "num-traits",
  "rand",
@@ -3055,6 +3098,7 @@ dependencies = [
  "serde",
  "sha2",
  "tracing",
+ "typetag",
 ]
 
 [[package]]
@@ -3899,6 +3943,30 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "typetag"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6898cc6f6a32698cc3e14d5632a14d2b23ed9f7b11e6b8e05ce685990acc22"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3e1c30cedd24fc597f7d37a721efdbdc2b1acae012c1ef1218f4c7c2c0f3e7"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.26",
+ "syn 2.0.13",
+]
 
 [[package]]
 name = "uint"

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -159,6 +159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +277,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -130,6 +130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +248,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/evm/methods/guest/Cargo.lock
+++ b/examples/evm/methods/guest/Cargo.lock
@@ -263,14 +263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "externc-libm"
-version = "0.1.0"
-source = "git+https://github.com/HaruxOS/externc-libm#873e2ee216f59f20521599adf7669ccc9014b60d"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,7 +464,6 @@ name = "methods-guest"
 version = "0.1.0"
 dependencies = [
  "evm-core",
- "externc-libm",
  "risc0-zkvm",
 ]
 
@@ -842,6 +833,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/evm/methods/guest/Cargo.toml
+++ b/examples/evm/methods/guest/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 
 [dependencies]
 evm-core = { path = "../../core", default-features = false }
-externc-libm = { git = "https://github.com/HaruxOS/externc-libm" }
 risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = [ "std" ] }

--- a/examples/evm/methods/guest/src/bin/evm.rs
+++ b/examples/evm/methods/guest/src/bin/evm.rs
@@ -16,7 +16,6 @@
 #![allow(unused_imports)]
 
 use evm_core::{Env, EvmResult, ExecutionResult, ZkDb, EVM};
-use externc_libm::math::fmod;
 use risc0_zkvm::guest::env;
 
 risc0_zkvm::guest::entry!(main);

--- a/examples/factors/methods/guest/Cargo.lock
+++ b/examples/factors/methods/guest/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +247,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -136,6 +136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +254,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +255,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -129,6 +129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +247,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -180,6 +180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +342,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -95,14 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "externc-libm"
-version = "0.1.0"
-source = "git+https://github.com/HaruxOS/externc-libm#873e2ee216f59f20521599adf7669ccc9014b60d"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +252,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",
@@ -392,7 +385,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 name = "wasm-interp"
 version = "0.1.0"
 dependencies = [
- "externc-libm",
  "risc0-zkvm",
  "wasmi",
 ]

--- a/examples/wasm/methods/guest/Cargo.toml
+++ b/examples/wasm/methods/guest/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2021"
 [dependencies]
 risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = ["std"] }
 wasmi = "0.29"
-externc-libm = { git = "https://github.com/HaruxOS/externc-libm" }

--- a/examples/wasm/methods/guest/src/main.rs
+++ b/examples/wasm/methods/guest/src/main.rs
@@ -17,7 +17,6 @@
 
 risc0_zkvm::guest::entry!(main);
 
-use externc_libm::math::fmod;
 use risc0_zkvm::guest::env;
 use wasmi::{Caller, Engine, Func, Linker, Module, Store};
 

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +240,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
+ "libm",
  "log",
  "num-derive",
  "num-traits",

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -31,6 +31,7 @@ risc0-zkp = { workspace = true }
 risc0-zkvm-platform = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
+libm = "0.2"
 
 # TODO(nils): Change these `target_os` checks to `target_vendor` checks when we
 # have a real target triple.

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -25,13 +25,13 @@ bytemuck = "1.12"
 cfg-if = "1.0"
 getrandom = { version = "0.2", features = ["custom"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+libm = "0.2"
 risc0-circuit-rv32im = { workspace = true }
 risc0-core = { workspace = true }
 risc0-zkp = { workspace = true }
 risc0-zkvm-platform = { workspace = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
-libm = "0.2"
 
 # TODO(nils): Change these `target_os` checks to `target_vendor` checks when we
 # have a real target triple.

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -186,5 +186,10 @@ pub fn main() {
             }
             env::commit_slice(&result);
         }
+        MultiTestSpec::LibM => {
+            use core::hint::black_box;
+            let f = black_box(1.0_f32);
+            black_box(f.min(1.0));
+        }
     }
 }

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -61,6 +61,7 @@ pub enum MultiTestSpec {
         /// Busy loop until the guest has run for at least this number of cycles
         cycles: u32,
     },
+    LibM,
 }
 
 declare_syscall!(pub SYS_MULTI_TEST);

--- a/risc0/zkvm/src/exec/tests.rs
+++ b/risc0/zkvm/src/exec/tests.rs
@@ -91,8 +91,6 @@ fn system_split() {
 }
 
 #[test]
-#[cfg_attr(feature = "insecure_skip_seal", ignore)]
-#[cfg_attr(feature = "cuda", serial)]
 fn libm_build() {
     let env = ExecutorEnv::builder()
         .add_input(&to_vec(&MultiTestSpec::LibM).unwrap())

--- a/risc0/zkvm/src/exec/tests.rs
+++ b/risc0/zkvm/src/exec/tests.rs
@@ -91,6 +91,18 @@ fn system_split() {
 }
 
 #[test]
+#[cfg_attr(feature = "insecure_skip_seal", ignore)]
+#[cfg_attr(feature = "cuda", serial)]
+fn libm_build() {
+    let env = ExecutorEnv::builder()
+        .add_input(&to_vec(&MultiTestSpec::LibM).unwrap())
+        .build();
+
+    let mut exec = Executor::from_elf(env, MULTI_TEST_ELF).unwrap();
+    exec.run().expect("Could not get receipt");
+}
+
+#[test]
 fn host_syscall() {
     let expected: Vec<Vec<u8>> = vec![
         "".into(),

--- a/risc0/zkvm/src/guest/libm_extern.rs
+++ b/risc0/zkvm/src/guest/libm_extern.rs
@@ -1,0 +1,548 @@
+#[no_mangle]
+pub extern "C" fn acosf(x: f32) -> f32 {
+    libm::acosf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn acoshf(x: f32) -> f32 {
+    libm::acoshf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn acosh(x: f64) -> f64 {
+    libm::acosh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn acos(x: f64) -> f64 {
+    libm::acos(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asinf(x: f32) -> f32 {
+    libm::asinf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asinhf(x: f32) -> f32 {
+    libm::asinhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asinh(x: f64) -> f64 {
+    libm::asinh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asin(x: f64) -> f64 {
+    libm::asin(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atan2f(y: f32, x: f32) -> f32 {
+    libm::atan2f(y, x)
+}
+
+#[no_mangle]
+pub extern "C" fn atan2(y: f64, x: f64) -> f64 {
+    libm::atan2(y, x)
+}
+
+#[no_mangle]
+pub extern "C" fn atanf(x: f32) -> f32 {
+    libm::atanf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atanhf(x: f32) -> f32 {
+    libm::atanhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atanh(x: f64) -> f64 {
+    libm::atanh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn atan(x: f64) -> f64 {
+    libm::atan(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cbrtf(x: f32) -> f32 {
+    libm::cbrtf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cbrt(x: f64) -> f64 {
+    libm::cbrt(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ceilf(x: f32) -> f32 {
+    libm::ceilf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ceil(x: f64) -> f64 {
+    libm::ceil(x)
+}
+
+#[no_mangle]
+pub extern "C" fn copysignf(x: f32, y: f32) -> f32 {
+    libm::copysignf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn copysign(x: f64, y: f64) -> f64 {
+    libm::copysign(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn cosf(x: f32) -> f32 {
+    libm::cosf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn coshf(x: f32) -> f32 {
+    libm::coshf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cosh(x: f64) -> f64 {
+    libm::cosh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cos(x: f64) -> f64 {
+    libm::cos(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erfcf(x: f32) -> f32 {
+    libm::erfcf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erfc(x: f64) -> f64 {
+    libm::erfc(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erff(x: f32) -> f32 {
+    libm::erff(x)
+}
+
+#[no_mangle]
+pub extern "C" fn erf(x: f64) -> f64 {
+    libm::erf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp10f(x: f32) -> f32 {
+    libm::exp10f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp10(x: f64) -> f64 {
+    libm::exp10(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp2f(x: f32) -> f32 {
+    libm::exp2f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp2(x: f64) -> f64 {
+    libm::exp2(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expf(x: f32) -> f32 {
+    libm::expf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expm1f(x: f32) -> f32 {
+    libm::expm1f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expm1(x: f64) -> f64 {
+    libm::expm1(x)
+}
+
+#[no_mangle]
+pub extern "C" fn exp(x: f64) -> f64 {
+    libm::exp(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fabsf(x: f32) -> f32 {
+    libm::fabsf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fabs(x: f64) -> f64 {
+    libm::fabs(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fdimf(x: f32, y: f32) -> f32 {
+    libm::fdimf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fdim(x: f64, y: f64) -> f64 {
+    libm::fdim(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn floorf(x: f32) -> f32 {
+    libm::floorf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn floor(x: f64) -> f64 {
+    libm::floor(x)
+}
+
+#[no_mangle]
+pub extern "C" fn fmaf(x: f32, y: f32, z: f32) -> f32 {
+    libm::fmaf(x, y, z)
+}
+
+#[no_mangle]
+pub extern "C" fn fma(x: f64, y: f64, z: f64) -> f64 {
+    libm::fma(x, y, z)
+}
+
+#[no_mangle]
+pub extern "C" fn fmaxf(x: f32, y: f32) -> f32 {
+    libm::fmaxf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmax(x: f64, y: f64) -> f64 {
+    libm::fmax(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fminf(x: f32, y: f32) -> f32 {
+    libm::fminf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmin(x: f64, y: f64) -> f64 {
+    libm::fmin(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmodf(x: f32, y: f32) -> f32 {
+    libm::fmodf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn fmod(x: f64, y: f64) -> f64 {
+    libm::fmod(x, y)
+}
+
+pub fn frexpf(x: f32) -> (f32, i32) {
+    libm::frexpf(x)
+}
+
+pub fn frexp(x: f64) -> (f64, i32) {
+    libm::frexp(x)
+}
+
+#[no_mangle]
+pub extern "C" fn hypotf(x: f32, y: f32) -> f32 {
+    libm::hypotf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn hypot(x: f64, y: f64) -> f64 {
+    libm::hypot(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn ilogbf(x: f32) -> i32 {
+    libm::ilogbf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ilogb(x: f64) -> i32 {
+    libm::ilogb(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j0f(x: f32) -> f32 {
+    libm::j0f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j0(x: f64) -> f64 {
+    libm::j0(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j1f(x: f32) -> f32 {
+    libm::j1f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn j1(x: f64) -> f64 {
+    libm::j1(x)
+}
+
+#[no_mangle]
+pub extern "C" fn jnf(n: i32, x: f32) -> f32 {
+    libm::jnf(n, x)
+}
+
+#[no_mangle]
+pub extern "C" fn jn(n: i32, x: f64) -> f64 {
+    libm::jn(n, x)
+}
+
+#[no_mangle]
+pub extern "C" fn ldexpf(x: f32, n: i32) -> f32 {
+    libm::ldexpf(x, n)
+}
+
+#[no_mangle]
+pub extern "C" fn ldexp(x: f64, n: i32) -> f64 {
+    libm::ldexp(x, n)
+}
+
+pub fn lgammaf_r(x: f32) -> (f32, i32) {
+    libm::lgammaf_r(x)
+}
+
+pub fn lgammf(x: f32) -> f32 {
+    libm::lgammaf(x)
+}
+
+pub fn lgamma_r(x: f64) -> (f64, i32) {
+    libm::lgamma_r(x)
+}
+
+#[no_mangle]
+pub extern "C" fn lgamma(x: f64) -> f64 {
+    libm::lgamma(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log10f(x: f32) -> f32 {
+    libm::log10f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log10(x: f64) -> f64 {
+    libm::log10(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log1pf(x: f32) -> f32 {
+    libm::log1pf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log1p(x: f64) -> f64 {
+    libm::log1p(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log2f(x: f32) -> f32 {
+    libm::log2f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log2(x: f64) -> f64 {
+    libm::log2(x)
+}
+
+#[no_mangle]
+pub extern "C" fn logf(x: f32) -> f32 {
+    libm::logf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log(x: f64) -> f64 {
+    libm::log(x)
+}
+
+pub fn modff(x: f32) -> (f32, f32) {
+    libm::modff(x)
+}
+
+pub fn modf(x: f64) -> (f64, f64) {
+    libm::modf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn nextafterf(x: f32, y: f32) -> f32 {
+    libm::nextafterf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn nextafter(x: f64, y: f64) -> f64 {
+    libm::nextafter(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn powf(x: f32, y: f32) -> f32 {
+    libm::powf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn pow(x: f64, y: f64) -> f64 {
+    libm::pow(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn remainderf(x: f32, y: f32) -> f32 {
+    libm::remainderf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn remainder(x: f64, y: f64) -> f64 {
+    libm::remainder(x, y)
+}
+
+pub fn remquof(x: f32, y: f32) -> (f32, i32) {
+    libm::remquof(x, y)
+}
+
+pub fn remquo(x: f64, y: f64) -> (f64, i32) {
+    libm::remquo(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn roundf(x: f32) -> f32 {
+    libm::roundf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn round(x: f64) -> f64 {
+    libm::round(x)
+}
+
+#[no_mangle]
+pub extern "C" fn scalbnf(x: f32, n: i32) -> f32 {
+    libm::scalbnf(x, n)
+}
+
+#[no_mangle]
+pub extern "C" fn scalbn(x: f64, n: i32) -> f64 {
+    libm::scalbn(x, n)
+}
+
+pub fn sincosf(x: f32) -> (f32, f32) {
+    libm::sincosf(x)
+}
+
+pub fn sincos(x: f64) -> (f64, f64) {
+    libm::sincos(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sinf(x: f32) -> f32 {
+    libm::sinf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sinhf(x: f32) -> f32 {
+    libm::sinhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sinh(x: f64) -> f64 {
+    libm::sinh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sin(x: f64) -> f64 {
+    libm::sin(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sqrtf(x: f32) -> f32 {
+    libm::sqrtf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sqrt(x: f64) -> f64 {
+    libm::sqrt(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tanf(x: f32) -> f32 {
+    libm::tanf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tanhf(x: f32) -> f32 {
+    libm::tanhf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tanh(x: f64) -> f64 {
+    libm::tanh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tan(x: f64) -> f64 {
+    libm::tan(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tgammaf(x: f32) -> f32 {
+    libm::tgammaf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn tgamma(x: f64) -> f64 {
+    libm::tgamma(x)
+}
+
+#[no_mangle]
+pub extern "C" fn truncf(x: f32) -> f32 {
+    libm::truncf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn trunc(x: f64) -> f64 {
+    libm::trunc(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y0f(x: f32) -> f32 {
+    libm::y0f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y0(x: f64) -> f64 {
+    libm::y0(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y1f(x: f32) -> f32 {
+    libm::y1f(x)
+}
+
+#[no_mangle]
+pub extern "C" fn y1(x: f64) -> f64 {
+    libm::y1(x)
+}
+
+#[no_mangle]
+pub extern "C" fn ynf(n: i32, x: f32) -> f32 {
+    libm::ynf(n, x)
+}
+
+#[no_mangle]
+pub extern "C" fn yn(n: i32, x: f64) -> f64 {
+    libm::yn(n, x)
+}

--- a/risc0/zkvm/src/guest/libm_extern.rs
+++ b/risc0/zkvm/src/guest/libm_extern.rs
@@ -1,3 +1,19 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Functions for interacting with the host environment.
+
 #[no_mangle]
 pub extern "C" fn acosf(x: f32) -> f32 {
     libm::acosf(x)

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -94,6 +94,9 @@ core::arch::global_asm!(include_str!("memset.s"));
 #[cfg(target_os = "zkvm")]
 core::arch::global_asm!(include_str!("memcpy.s"));
 
+#[cfg(target_os = "zkvm")]
+mod libm_extern;
+
 fn _fault() -> ! {
     #[cfg(target_os = "zkvm")]
     unsafe {


### PR DESCRIPTION
Fixes #465 without the git based dep.

Added a module into the zkvm::guest module that exports the extern versions of the libm functions. Additional added unit tests to ensure it works correctly and removed the externc-libm from evm / wasm examples.
