### PR TITLE
Fixed evm block off-by-one, added block_numb arg

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -700,6 +700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
+dependencies = [
+ "quote 1.0.26",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "cust"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1011,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1470,6 +1489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.26",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "gif"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,6 +1839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
+dependencies = [
+ "ctor",
+ "ghost",
 ]
 
 [[package]]
@@ -2194,6 +2234,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -3043,6 +3084,7 @@ dependencies = [
  "hex",
  "lazy-regex",
  "log",
+ "num-bigint 0.4.3",
  "num-derive",
  "num-traits",
  "rand",
@@ -3055,6 +3097,7 @@ dependencies = [
  "serde",
  "sha2",
  "tracing",
+ "typetag",
 ]
 
 [[package]]
@@ -3899,6 +3942,30 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "typetag"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6898cc6f6a32698cc3e14d5632a14d2b23ed9f7b11e6b8e05ce685990acc22"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3e1c30cedd24fc597f7d37a721efdbdc2b1acae012c1ef1218f4c7c2c0f3e7"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.26",
+ "syn 2.0.13",
+]
 
 [[package]]
 name = "uint"

--- a/examples/evm/src/main.rs
+++ b/examples/evm/src/main.rs
@@ -33,8 +33,12 @@ use risc0_zkvm::{
 struct Args {
     #[clap(short, long)]
     tx_hash: String,
+
     #[clap(short, long)]
     rpc_url: String,
+
+    #[clap(short, long)]
+    block_numb: Option<u64>,
 }
 
 #[tokio::main]
@@ -47,13 +51,18 @@ async fn main() {
     let client = Arc::new(client);
 
     let tx = client.get_transaction(tx_hash).await.unwrap().unwrap();
-    let block_numb = tx.block_number.unwrap();
+    let block_numb = if let Some(numb) = args.block_numb {
+        numb
+    } else {
+        let numb = tx.block_number.unwrap();
+        numb.as_u64() - 1
+    };
     info!("Running TX: 0x{:x} at block {}", tx_hash, block_numb);
 
     let mut env = Env::default();
-    env.block.number = U256::from(block_numb.as_u64()).into();
+    env.block.number = U256::from(block_numb).into();
     env.tx = evm_core::ether_trace::txenv_from_tx(tx);
-    let trace_db = evm_core::ether_trace::TraceTx::new(client, Some(block_numb.as_u64())).unwrap();
+    let trace_db = evm_core::ether_trace::TraceTx::new(client, Some(block_numb)).unwrap();
 
     let mut evm = EVM::new();
     evm.database(trace_db);


### PR DESCRIPTION
Small fix to the evm example to ensure the EVM state is correct for a transaction, additionally added a block_numb param to swap to new blocks if the user wants. 