### PR TITLE
Always provide risc0_zkvm::guest module for easier analyzing, even when not on target=zkvm

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -382,7 +382,18 @@ fn build_guest_package<P>(
 
     let mut cmd = Command::new(cargo);
     let mut child = cmd
-        .env("CARGO_ENCODED_RUSTFLAGS", "-C\x1fpasses=loweratomic")
+        .env(
+            "CARGO_ENCODED_RUSTFLAGS",
+            [
+                // Replace atomic ops with nonatomic versions since the guest is single threaded.
+                "-C",
+                "passes=loweratomic",
+                // Remap absolute pathnames in compiled ELFs for builds that are more reproducible.
+                "-Z",
+                "remap-cwd-prefix=.",
+            ]
+            .join("\x1f"),
+        )
         .env("__CARGO_TESTS_ONLY_SRC_ROOT", risc0_standard_lib)
         .args(args)
         .stderr(Stdio::piped())

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -63,6 +63,7 @@ pub mod sha;
 
 use core::{arch::asm, mem, ptr};
 
+#[cfg(target_os = "zkvm")]
 use getrandom::{register_custom_getrandom, Error};
 use risc0_zkvm_platform::{
     syscall::{nr::SYS_PANIC, sys_panic, sys_rand},
@@ -73,6 +74,7 @@ pub use crate::entry;
 
 /// This is a getrandom handler for the zkvm. It's intended to hook into a
 /// getrandom crate or a depdent of the getrandom crate used by the guest code.
+#[cfg(target_os = "zkvm")]
 pub fn zkvm_getrandom(dest: &mut [u8]) -> Result<(), Error> {
     if dest.is_empty() {
         return Ok(());
@@ -87,6 +89,7 @@ pub fn zkvm_getrandom(dest: &mut [u8]) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(target_os = "zkvm")]
 register_custom_getrandom!(zkvm_getrandom);
 
 #[cfg(target_os = "zkvm")]
@@ -194,5 +197,10 @@ _start:
 /// barrier.
 pub fn memory_barrier<T>(ptr: *const T) {
     // SAFETY: This passes a pointer in, but does nothing with it.
-    unsafe { asm!("/* {0} */", in(reg) (ptr)) }
+    #[cfg(target_os = "zkvm")]
+    unsafe {
+        asm!("/* {0} */", in(reg) (ptr))
+    }
+    #[cfg(not(target_os = "zkvm"))]
+    core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst)
 }

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -25,7 +25,6 @@ pub mod binfmt;
 mod control_id;
 #[cfg(feature = "prove")]
 mod exec;
-#[cfg(any(target_os = "zkvm", doc))]
 pub mod guest;
 #[cfg(feature = "prove")]
 mod opcode;

--- a/templates/rust-starter/.vscode/settings.json
+++ b/templates/rust-starter/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./methods/guest/Cargo.toml"
+    ]
+}


### PR DESCRIPTION
* This allows rust-analyzer to analyze guest code without having to configure it to cross compile for the zkvm target.
* Fixed flaky integration test by remapping absolute pathnames to relative pathnames when compiling the guest