### PR TITLE
Fix spurious build warning about "duplicate package `wordle`".

### DIFF
--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -358,17 +358,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wordle"
-version = "0.1.0"
-dependencies = [
- "risc0-zkvm",
- "wordle-core",
-]
-
-[[package]]
 name = "wordle-core"
 version = "1.0.0"
 dependencies = [
  "risc0-zkvm",
  "serde",
+]
+
+[[package]]
+name = "wordle-guest"
+version = "0.1.0"
+dependencies = [
+ "risc0-zkvm",
+ "wordle-core",
 ]

--- a/examples/wordle/methods/guest/Cargo.toml
+++ b/examples/wordle/methods/guest/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wordle"
+name = "wordle-guest"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/wordle/src/main.rs
+++ b/examples/wordle/src/main.rs
@@ -22,7 +22,7 @@ use risc0_zkvm::{
     Executor, ExecutorEnv, SessionReceipt,
 };
 use wordle_core::{GameState, WordFeedback, WORD_LENGTH};
-use wordle_methods::{WORDLE_ELF, WORDLE_ID};
+use wordle_methods::{WORDLE_GUEST_ELF, WORDLE_GUEST_ID};
 
 // The "server" is an agent in the Wordle game that checks the player's guesses.
 struct Server<'a> {
@@ -47,7 +47,7 @@ impl<'a> Server<'a> {
             .add_input(&to_vec(self.secret_word).unwrap())
             .add_input(&to_vec(&guess_word).unwrap())
             .build();
-        let mut exec = Executor::from_elf(env, WORDLE_ELF).unwrap();
+        let mut exec = Executor::from_elf(env, WORDLE_GUEST_ELF).unwrap();
         let session = exec.run().unwrap();
         session.prove().unwrap()
     }
@@ -65,7 +65,7 @@ struct Player {
 impl Player {
     pub fn check_receipt(&self, receipt: SessionReceipt) -> WordFeedback {
         receipt
-            .verify(WORDLE_ID)
+            .verify(WORDLE_GUEST_ID)
             .expect("receipt verification failed");
 
         let game_state: GameState = from_slice(&receipt.journal).unwrap();


### PR DESCRIPTION
It appears having two packages with the same name can cause this error even when they are (I think) not built for the same target. Fix by renaming the guest code in the wordle example. Tests for wordle pass.