### PR TITLE
Quick fix for continuation test

### DIFF
--- a/risc0/zkvm/src/prove/tests.rs
+++ b/risc0/zkvm/src/prove/tests.rs
@@ -206,8 +206,8 @@ fn continuation() {
     const COUNT: usize = 7; // Number of total chunks to aim for.
     let segment_limit_po2 = 15; // 32k cycles
 
-    // -1000: Hack to work around non-det in rust compiles.
-    let mut cycles = (1 << segment_limit_po2) - 1000;
+    // -5000: Hack to work around non-det in rust compiles.
+    let cycles = (1 << segment_limit_po2) - 5000;
     let spec = &to_vec(&MultiTestSpec::BusyLoop { cycles }).unwrap();
     let env = ExecutorEnv::builder()
         .add_input(&spec)

--- a/risc0/zkvm/src/prove/tests.rs
+++ b/risc0/zkvm/src/prove/tests.rs
@@ -205,8 +205,9 @@ fn pause_continue() {
 fn continuation() {
     const COUNT: usize = 7; // Number of total chunks to aim for.
     let segment_limit_po2 = 15; // 32k cycles
-    let cycles = 1 << segment_limit_po2;
 
+    // -1000: Hack to work around non-det in rust compiles.
+    let mut cycles = (1 << segment_limit_po2) - 1000;
     let spec = &to_vec(&MultiTestSpec::BusyLoop { cycles }).unwrap();
     let env = ExecutorEnv::builder()
         .add_input(&spec)


### PR DESCRIPTION
Hopefully -1000 cycles is enough to provide a little headroom for the unit test to pass in CI.