### PR TITLE
Rebuild on CUDA related env vars

### DIFF
--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -143,9 +143,13 @@ impl KernelBuild {
             "fatbin",
             CUDA_INCS,
             |_out_dir, out_path, sys_inc_dir| {
+                println!("cargo:rerun-if-env-changed=RISC0_CUDA_OPT");
+                println!("cargo:rerun-if-env-changed=NVCC_PREPEND_FLAGS");
+                println!("cargo:rerun-if-env-changed=NVCC_APPEND_FLAGS");
+
                 let mut cmd = Command::new("nvcc");
                 cmd.arg("--fatbin");
-                cmd.arg("-o").arg(&out_path);
+                cmd.arg("-o").arg(out_path);
                 cmd.args(self.files.iter());
                 cmd.arg("-I").arg(sys_inc_dir);
 


### PR DESCRIPTION
Triggers rebuilds for couple more env vars if they change between invokes of the kernel build:

Previously missing:
RISC0_CUDA_OPT

New:
NVCC_PREPEND_FLAGS
NVCC_APPEND_FLAGS

This allows someone outside the build system to tweak the nvcc flags to build for a specific GPU while correctly triggering a rebuild if those flags change.