### PR TITLE
recursion: fix compiler warning in guest

### DIFF
--- a/risc0/zkvm/src/recursion/circuit_impl.rs
+++ b/risc0/zkvm/src/recursion/circuit_impl.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::recursion::TAPSET;
-use risc0_zkp::taps::TapSet;
-use crate::recursion::TapsProvider;
-use crate::recursion::CircuitCoreDef;
-use risc0_zkp::field::baby_bear::BabyBear;
-use crate::recursion::CircuitImpl;
+use risc0_zkp::{field::baby_bear::BabyBear, taps::TapSet};
+
+use crate::recursion::{CircuitCoreDef, CircuitImpl, TapsProvider, TAPSET};
 
 impl CircuitImpl {
     const fn new() -> Self {

--- a/risc0/zkvm/src/recursion/circuit_impl.rs
+++ b/risc0/zkvm/src/recursion/circuit_impl.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::recursion::TAPSET;
+use risc0_zkp::taps::TapSet;
+use crate::recursion::TapsProvider;
+use crate::recursion::CircuitCoreDef;
+use risc0_zkp::field::baby_bear::BabyBear;
+use crate::recursion::CircuitImpl;
+
+impl CircuitImpl {
+    const fn new() -> Self {
+        CircuitImpl
+    }
+}
+
+impl TapsProvider for CircuitImpl {
+    fn get_taps(&self) -> &'static TapSet<'static> {
+        TAPSET
+    }
+}
+
+impl CircuitCoreDef<BabyBear> for CircuitImpl {}
+
+pub(crate) const CIRCUIT_CORE: CircuitImpl = CircuitImpl::new();

--- a/risc0/zkvm/src/recursion/mod.rs
+++ b/risc0/zkvm/src/recursion/mod.rs
@@ -16,16 +16,17 @@
 //!
 //! This module implements receipts that are generated from the recursion
 //! circuit as well as verification functions for each type of receipt.
+#[cfg(not(target_os = "zkvm"))]
 use risc0_zkp::{
     adapter::{CircuitCoreDef, TapsProvider},
-    field::baby_bear::BabyBear,
-    taps::TapSet,
 };
 mod control_id;
 mod info;
 mod poly_ext;
 mod receipt;
 mod taps;
+#[cfg(not(target_os = "zkvm"))]
+mod circuit_impl;
 
 pub use poly_ext::DEF;
 pub use receipt::{valid_control_ids, ReceiptMeta, SegmentRecursionReceipt, SessionRollupReceipt};
@@ -35,19 +36,3 @@ pub use taps::TAPSET;
 /// circuit definition. The only reason this is private is to facilitate getting
 /// the values from the `info` module from the recursion prover.
 pub struct CircuitImpl;
-
-impl CircuitImpl {
-    const fn new() -> Self {
-        CircuitImpl
-    }
-}
-
-impl TapsProvider for CircuitImpl {
-    fn get_taps(&self) -> &'static TapSet<'static> {
-        taps::TAPSET
-    }
-}
-
-impl CircuitCoreDef<BabyBear> for CircuitImpl {}
-
-pub(crate) const CIRCUIT_CORE: CircuitImpl = CircuitImpl::new();

--- a/risc0/zkvm/src/recursion/mod.rs
+++ b/risc0/zkvm/src/recursion/mod.rs
@@ -17,16 +17,14 @@
 //! This module implements receipts that are generated from the recursion
 //! circuit as well as verification functions for each type of receipt.
 #[cfg(not(target_os = "zkvm"))]
-use risc0_zkp::{
-    adapter::{CircuitCoreDef, TapsProvider},
-};
+use risc0_zkp::adapter::{CircuitCoreDef, TapsProvider};
+#[cfg(not(target_os = "zkvm"))]
+mod circuit_impl;
 mod control_id;
 mod info;
 mod poly_ext;
 mod receipt;
 mod taps;
-#[cfg(not(target_os = "zkvm"))]
-mod circuit_impl;
 
 pub use poly_ext::DEF;
 pub use receipt::{valid_control_ids, ReceiptMeta, SegmentRecursionReceipt, SessionRollupReceipt};

--- a/risc0/zkvm/src/recursion/receipt.rs
+++ b/risc0/zkvm/src/recursion/receipt.rs
@@ -14,7 +14,7 @@
 
 use alloc::{collections::VecDeque, vec::Vec};
 
-use risc0_zkp::core::{digest::Digest, hash::sha::Sha256};
+use risc0_zkp::core::digest::Digest;
 #[cfg(not(target_os = "zkvm"))]
 use risc0_zkp::{adapter::CircuitInfo, verify::VerificationError};
 use serde::{Deserialize, Serialize};
@@ -22,11 +22,12 @@ use serde::{Deserialize, Serialize};
 #[cfg(not(target_os = "zkvm"))]
 use crate::receipt::compute_image_id;
 #[cfg(not(target_os = "zkvm"))]
-use crate::recursion::CIRCUIT_CORE;
-use crate::{
-    sha::{self},
-    ControlId,
-};
+use crate::recursion::circuit_impl::CIRCUIT_CORE;
+use crate::ControlId;
+#[cfg(not(target_os = "zkvm"))]
+use crate::sha::{self};
+#[cfg(not(target_os = "zkvm"))]
+use risc0_zkp::core::hash::sha::Sha256;
 
 /// This function gets valid control ID's from the posidon and recursion
 /// circuits
@@ -43,6 +44,7 @@ pub fn valid_control_ids() -> Vec<Digest> {
     all_ids
 }
 
+#[cfg(not(target_os = "zkvm"))]
 fn tagged_struct(tag: &str, down: &[Digest], data: &[u32]) -> Digest {
     let tag_digest: Digest = *sha::Impl::hash_bytes(tag.as_bytes());
     let mut all = Vec::<u8>::new();
@@ -136,6 +138,7 @@ impl SystemState {
         write_sha_halfs(flat, &self.image_id);
     }
 
+    #[cfg(not(target_os = "zkvm"))]
     fn digest(&self) -> Digest {
         tagged_struct("risc0.SystemState", &[self.image_id], &[self.pc])
     }
@@ -163,6 +166,7 @@ impl ReceiptMeta {
         write_sha_halfs(flat, &self.output);
     }
 
+    #[cfg(not(target_os = "zkvm"))]
     fn digest(&self) -> Digest {
         tagged_struct(
             "risc0.ReceiptMeta",

--- a/risc0/zkvm/src/recursion/receipt.rs
+++ b/risc0/zkvm/src/recursion/receipt.rs
@@ -16,6 +16,8 @@ use alloc::{collections::VecDeque, vec::Vec};
 
 use risc0_zkp::core::digest::Digest;
 #[cfg(not(target_os = "zkvm"))]
+use risc0_zkp::core::hash::sha::Sha256;
+#[cfg(not(target_os = "zkvm"))]
 use risc0_zkp::{adapter::CircuitInfo, verify::VerificationError};
 use serde::{Deserialize, Serialize};
 
@@ -23,11 +25,9 @@ use serde::{Deserialize, Serialize};
 use crate::receipt::compute_image_id;
 #[cfg(not(target_os = "zkvm"))]
 use crate::recursion::circuit_impl::CIRCUIT_CORE;
-use crate::ControlId;
 #[cfg(not(target_os = "zkvm"))]
 use crate::sha::{self};
-#[cfg(not(target_os = "zkvm"))]
-use risc0_zkp::core::hash::sha::Sha256;
+use crate::ControlId;
 
 /// This function gets valid control ID's from the posidon and recursion
 /// circuits


### PR DESCRIPTION
add `#[cfg(not(target_os = "zkvm"))]` to items that are not needed for guest compilation