### PR TITLE
Update Cronjob Time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Tasks
 
 on:
   schedule:
-    - cron: '7 0 * * *' # Nightly (ish) Pacific
+    - cron: '0 7 * * *' # Nightly (ish) Pacific
   workflow_dispatch:
     inputs:
       crate_count:


### PR DESCRIPTION
The nightly cronjobs are triggering around 12:07:00 AM UTC which is around 5:07pm PST, but we actually need to run these around 07:00:00 AM UTC which is our midnight PST.