### PR TITLE
Bonsai Guest SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "bonsai/guest-sdk",
   "bonsai/sdk",
   "risc0/bootstrap",
   "risc0/bootstrap/poseidon",
@@ -30,6 +31,7 @@ homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
+bonsai-guest-sdk     = { version = "0.1.0", default-features = false, path = "bonsai/guest-sdk" }
 bonsai-sdk           = { version = "0.1.0", default-features = false, path = "bonsai/sdk" }
 risc0-build          = { version = "0.15.0", default-features = false, path = "risc0/build" }
 risc0-build-kernel   = { version = "0.15.0", default-features = false, path = "risc0/build_kernel" }

--- a/bonsai/guest-sdk/Cargo.toml
+++ b/bonsai/guest-sdk/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "bonsai-guest-sdk"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ethabi = { version = "18.0", default-features = false }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "release-0.15", default-features = false }
+
+[dev-dependencies]
+hex = "0.4"

--- a/bonsai/guest-sdk/Cargo.toml
+++ b/bonsai/guest-sdk/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 ethabi = { version = "18.0", default-features = false }
-risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "release-0.15", default-features = false }
+risc0-zkvm = { workspace = true, default-features = false }
 
 [dev-dependencies]
 hex = "0.4"

--- a/bonsai/guest-sdk/src/lib.rs
+++ b/bonsai/guest-sdk/src/lib.rs
@@ -1,0 +1,195 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{boxed::Box, vec, vec::Vec};
+
+use ethabi::{ethereum_types::U256, ParamType, Token};
+use risc0_zkvm::guest::env;
+
+pub trait InputStream {
+    fn read_slice(&mut self, slice: &mut [u8]);
+}
+
+impl InputStream for () {
+    fn read_slice(&mut self, slice: &mut [u8]) {
+        env::read_slice(slice);
+    }
+}
+
+impl InputStream for Vec<u8> {
+    fn read_slice(&mut self, slice: &mut [u8]) {
+        let n = slice.len();
+        slice.copy_from_slice(&self[..n]);
+        self.drain(..n);
+    }
+}
+
+pub struct EthABIReader {
+    reader: Box<dyn InputStream>,
+}
+
+impl Default for EthABIReader {
+    fn default() -> Self {
+        EthABIReader {
+            reader: Box::new(()),
+        }
+    }
+}
+
+impl EthABIReader {
+    pub fn new(reader: Box<dyn InputStream>) -> Self {
+        EthABIReader { reader }
+    }
+    pub fn read_abi_encoded_input(
+        &mut self,
+        types: &[ParamType],
+        buffer: &mut Vec<u8>,
+        mut relative_offset: usize,
+        base_offset: usize,
+    ) -> usize {
+        for abi_type in types {
+            relative_offset = self.read_abi_type(abi_type, buffer, relative_offset, base_offset);
+        }
+        relative_offset
+    }
+
+    fn read_abi_type(
+        &mut self,
+        abi_type: &ParamType,
+        buffer: &mut Vec<u8>,
+        relative_offset: usize,
+        base_offset: usize,
+    ) -> usize {
+        match abi_type {
+            ParamType::Bytes | ParamType::String => {
+                // Read the offset bytes
+                let relative_item_tail_offset =
+                    self.read_usize(buffer, relative_offset, base_offset);
+                // Read the item bytes
+                let byte_length =
+                    32 + self.read_usize(buffer, relative_item_tail_offset, base_offset);
+                self.buffer_until(
+                    buffer,
+                    base_offset + relative_item_tail_offset + byte_length,
+                );
+            }
+            ParamType::Array(t) => {
+                // Read the offset bytes
+                let relative_item_tail_offset =
+                    self.read_usize(buffer, relative_offset, base_offset);
+                // Read the item count
+                let item_count = self.read_usize(buffer, relative_item_tail_offset, base_offset);
+                let array_base_offset = base_offset + relative_item_tail_offset + 32;
+                let mut item_offset = 0;
+                for _ in 0..item_count {
+                    item_offset = self.read_abi_type(t, buffer, item_offset, array_base_offset);
+                }
+            }
+            ParamType::FixedArray(t, item_count) => {
+                let is_dynamic_type = t.is_dynamic();
+
+                let (array_base_offset, mut item_offset) = if is_dynamic_type {
+                    // Read the offset bytes
+                    (
+                        base_offset + self.read_usize(buffer, relative_offset, base_offset),
+                        0,
+                    )
+                } else {
+                    // Use current offset
+                    (base_offset, relative_offset)
+                };
+                for _ in 0..*item_count {
+                    item_offset = self.read_abi_type(t, buffer, item_offset, array_base_offset);
+                }
+
+                if !is_dynamic_type {
+                    return item_offset;
+                }
+            }
+            ParamType::Tuple(vt) => {
+                let is_dynamic_type = abi_type.is_dynamic();
+
+                let (array_base_offset, mut item_offset) = if is_dynamic_type {
+                    // Read the offset bytes
+                    (
+                        base_offset + self.read_usize(buffer, relative_offset, base_offset),
+                        0,
+                    )
+                } else {
+                    // Use current offset
+                    (base_offset, relative_offset)
+                };
+
+                for abi_type in vt {
+                    item_offset =
+                        self.read_abi_type(abi_type, buffer, item_offset, array_base_offset);
+                }
+
+                if !is_dynamic_type {
+                    return item_offset;
+                }
+            }
+            _ => {
+                // Read uint256 worth of bytes into the buffer
+                self.buffer_until(buffer, base_offset + relative_offset + 32);
+            }
+        };
+        // Return the next offset to process
+        relative_offset + 32
+    }
+
+    fn buffer_until(&mut self, buffer: &mut Vec<u8>, length: usize) {
+        if length > buffer.len() {
+            let slice_size = length - buffer.len();
+            let mut extra_input = vec![0u8; slice_size];
+            self.reader.read_slice(&mut extra_input);
+            // env::read_slice(&mut extra_input);
+            buffer.append(&mut extra_input);
+        }
+    }
+
+    fn read_usize(
+        &mut self,
+        buffer: &mut Vec<u8>,
+        relative_offset: usize,
+        base_offset: usize,
+    ) -> usize {
+        // Derive u256 aligned indices
+        let usize_start = base_offset + relative_offset;
+        let usize_end = usize_start + 32;
+        // Ensure the offset bytes are loaded into the buffer
+        self.buffer_until(buffer, usize_end);
+        // Read the offset value
+        U256::from(&buffer[usize_start..usize_end]).as_usize()
+    }
+}
+
+pub fn decode_eth_abi_input(types: &[ParamType]) -> Result<Vec<Token>, ethabi::Error> {
+    ethabi::decode(types, &read_eth_abi_input(types))
+}
+
+pub fn decode_whole_eth_abi_input(types: &[ParamType]) -> Result<Vec<Token>, ethabi::Error> {
+    ethabi::decode_whole(types, &read_eth_abi_input(types))
+}
+
+fn read_eth_abi_input(types: &[ParamType]) -> Vec<u8> {
+    let mut reader = EthABIReader::default();
+    let mut input = Vec::new();
+    reader.read_abi_encoded_input(types, &mut input, 0, 0);
+    input
+}

--- a/bonsai/guest-sdk/tests/abi_input.rs
+++ b/bonsai/guest-sdk/tests/abi_input.rs
@@ -1,0 +1,199 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bonsai_guest_sdk::EthABIReader;
+use ethabi::{ethereum_types::U256, ParamType, Token};
+
+#[test]
+pub fn test_abi_input_construction() {
+    let vec_input = Box::new(vec![0u8; 32]);
+    EthABIReader::new(vec_input);
+
+    let env_input = Box::new(());
+    EthABIReader::new(env_input);
+}
+
+#[test]
+pub fn test_abi_input_simple() {
+    let tokens = [
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::Uint(U256::from(1u128 << 120)),
+    ];
+
+    let types = [ParamType::Uint(256), ParamType::Uint(256)];
+    // assert success
+    assert!(check_read_length(&tokens, &types));
+}
+
+#[test]
+pub fn test_abi_input_fixed_array() {
+    let tokens = [Token::FixedArray(vec![
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::Uint(U256::from(1u128 << 120)),
+    ])];
+
+    let types = [ParamType::FixedArray(Box::from(ParamType::Uint(256)), 2)];
+    // assert failure
+    assert!(!check_read_length(&tokens, &types));
+    let types = [ParamType::FixedArray(Box::from(ParamType::Uint(256)), 3)];
+    // assert success
+    assert!(check_read_length(&tokens, &types));
+}
+
+#[test]
+pub fn test_abi_input_dynamic_array() {
+    let tokens = [Token::Array(vec![
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::Uint(U256::from(1u128 << 120)),
+    ])];
+
+    let types = [ParamType::Array(Box::from(ParamType::Uint(256)))];
+    // assert success
+    assert!(check_read_length(&tokens, &types));
+}
+
+#[test]
+pub fn test_abi_input_tuple_dynamic() {
+    let tokens = [Token::Tuple(vec![
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::Array(vec![
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+        ]),
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::FixedArray(vec![
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+        ]),
+    ])];
+
+    let types = [ParamType::Tuple(vec![
+        ParamType::Uint(256),
+        ParamType::Array(Box::from(ParamType::Uint(256))),
+        ParamType::Uint(256),
+        ParamType::FixedArray(Box::new(ParamType::Uint(256)), 3),
+    ])];
+    // assert success
+    assert!(check_read_length(&tokens, &types));
+}
+
+#[test]
+pub fn test_abi_input_tuple_fixed() {
+    let bytes = "abracadarba".as_bytes().to_vec();
+    let byte_len = bytes.len();
+    let tokens = [Token::Tuple(vec![
+        Token::FixedArray(vec![Token::Uint(U256::from(1u128 << 120))]),
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::FixedArray(vec![
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+        ]),
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::FixedArray(vec![
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+        ]),
+        Token::FixedBytes(bytes),
+    ])];
+
+    let types = [ParamType::Tuple(vec![
+        ParamType::FixedArray(Box::new(ParamType::Uint(256)), 1),
+        ParamType::Uint(256),
+        ParamType::FixedArray(Box::new(ParamType::Uint(256)), 3),
+        ParamType::Uint(256),
+        ParamType::FixedArray(Box::new(ParamType::Uint(256)), 5),
+        ParamType::FixedBytes(byte_len),
+    ])];
+    // assert success
+    assert!(check_read_length(&tokens, &types));
+}
+#[test]
+pub fn test_abi_input_tuple_nested() {
+    let bytes = "abracadarba".as_bytes().to_vec();
+    let byte_len = bytes.len();
+    let tokens = [Token::Tuple(vec![
+        Token::FixedArray(vec![Token::Uint(U256::from(1u128 << 120))]),
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::FixedArray(vec![
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+        ]),
+        Token::Uint(U256::from(1u128 << 120)),
+        Token::Tuple(vec![
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Array(vec![
+                Token::Uint(U256::from(1u128 << 120)),
+                Token::Uint(U256::from(1u128 << 120)),
+                Token::Uint(U256::from(1u128 << 120)),
+                Token::Uint(U256::from(1u128 << 120)),
+                Token::Uint(U256::from(1u128 << 120)),
+            ]),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::FixedArray(vec![
+                Token::Uint(U256::from(1u128 << 120)),
+                Token::Uint(U256::from(1u128 << 120)),
+                Token::Uint(U256::from(1u128 << 120)),
+            ]),
+        ]),
+        Token::FixedArray(vec![
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+            Token::Uint(U256::from(1u128 << 120)),
+        ]),
+        Token::FixedBytes(bytes),
+    ])];
+
+    let types = [ParamType::Tuple(vec![
+        ParamType::FixedArray(Box::new(ParamType::Uint(256)), 1),
+        ParamType::Uint(256),
+        ParamType::FixedArray(Box::new(ParamType::Uint(256)), 3),
+        ParamType::Uint(256),
+        ParamType::Tuple(vec![
+            ParamType::Uint(256),
+            ParamType::Array(Box::from(ParamType::Uint(256))),
+            ParamType::Uint(256),
+            ParamType::FixedArray(Box::new(ParamType::Uint(256)), 3),
+        ]),
+        ParamType::FixedArray(Box::new(ParamType::Uint(256)), 5),
+        ParamType::FixedBytes(byte_len),
+    ])];
+    // assert success
+    assert!(check_read_length(&tokens, &types));
+}
+
+fn check_read_length(tokens: &[Token], types: &[ParamType]) -> bool {
+    let vec_input = ethabi::encode(tokens);
+    dbg!(hex::encode(&vec_input));
+    let byte_length = vec_input.len();
+    let mut reader = EthABIReader::new(Box::new(vec_input));
+    let mut buffer = Vec::new();
+    reader.read_abi_encoded_input(types, &mut buffer, 0, 0);
+    let buffered_length = buffer.len();
+    dbg!(&byte_length);
+    dbg!(&buffered_length);
+    byte_length == buffered_length
+}

--- a/bonsai/guest-sdk/tests/abi_input.rs
+++ b/bonsai/guest-sdk/tests/abi_input.rs
@@ -195,5 +195,10 @@ fn check_read_length(tokens: &[Token], types: &[ParamType]) -> bool {
     let buffered_length = buffer.len();
     dbg!(&byte_length);
     dbg!(&buffered_length);
-    byte_length == buffered_length
+    let result = byte_length == buffered_length;
+    if result {
+        // validate success scenarios
+        assert_eq!(ethabi::decode(types, &buffer).unwrap().as_slice(), tokens);
+    }
+    result
 }


### PR DESCRIPTION
# bonsai-guest-sdk

This PR introduces a new crate designed to reduce boilerplate for Bonsai guest code.

The first feature set includes two convenience methods for reading ethereum abi-encoded guest input and decoding it using `ethabi`:
1. `fn decode_eth_abi_input(types: &[ParamType]) -> Result<Vec<Token>, ethabi::Error>`, which uses `ethabi::decode`.
2. `fn decode_whole_eth_abi_input(types: &[ParamType]) -> Result<Vec<Token>, ethabi::Error>`, which uses uses `ethabi::decode_whole`.
Both methods use the input abi-encoding `types` to keep reading the necessary number of bytes for the `ethabi` decoding call to succeed, then return its output.