### PR TITLE
chore: remove unused Once type

### DIFF
--- a/risc0/zkvm/src/guest/env.rs
+++ b/risc0/zkvm/src/guest/env.rs
@@ -35,34 +35,6 @@ use crate::{
     sha::rust_crypto::{Digest as _, Output, Sha256},
 };
 
-struct Once<T> {
-    data: UnsafeCell<MaybeUninit<T>>,
-}
-
-unsafe impl<T: Send + Sync> Sync for Once<T> {}
-
-impl<T: Default> Once<T> {
-    const fn new() -> Self {
-        Once {
-            data: UnsafeCell::new(MaybeUninit::uninit()),
-        }
-    }
-
-    fn init(&self, value: T) {
-        unsafe { &mut *(self.data.get()) }.write(value);
-    }
-
-    fn get(&self) -> &mut T {
-        unsafe {
-            self.data
-                .get()
-                .as_mut()
-                .unwrap_unchecked()
-                .assume_init_mut()
-        }
-    }
-}
-
 static mut HASHER: Option<Sha256> = None;
 
 pub(crate) fn init() {


### PR DESCRIPTION
was reading code and noticed this. API looked strange and seemed unused, opening PR to see if necessary or if CI runs a test I missed in verifying

Edit: there seems to be a lot of strange things ignored by the fact the guest crate uses `#![allow(unused)]`. Would you like me to take a stab to fix these issues and clean it up?