### PR TITLE
Hash all pages to fix issues with executor

### DIFF
--- a/risc0/zkvm/src/prove/exec.rs
+++ b/risc0/zkvm/src/prove/exec.rs
@@ -351,6 +351,7 @@ impl MachineContext {
 
     fn page_info(&mut self, cycle: usize) -> (Elem, Elem, Elem) {
         if let Some(page_idx) = self.faults.reads.pop_last() {
+            log::debug!("[{cycle}] page_read: 0x{page_idx:08x}");
             return (Elem::ONE, page_idx.into(), Elem::ZERO);
         }
 


### PR DESCRIPTION
This is a hotfix until a real solution can be found to allow for only dirty pages to be hashed and thereby increase executor performance.