### PR TITLE
template: add notes on remote proving

### DIFF
--- a/templates/rust-starter/README.md
+++ b/templates/rust-starter/README.md
@@ -1,7 +1,7 @@
 # RISC Zero Rust Starter Template
 
-Welcome to the RISC Zero Rust Starter Template! This template is intended to give you a starting point for building a project using the RISC Zero zkVM. Throughout the code are comments labelled `TODO` in places where we expect projects will need to modify the code. 
-To better understand the concepts behind this template, check out our [Understanding the Starter Template] explainer. 
+Welcome to the RISC Zero Rust Starter Template! This template is intended to give you a starting point for building a project using the RISC Zero zkVM. Throughout the code are comments labelled `TODO` in places where we expect projects will need to modify the code.
+To better understand the concepts behind this template, check out our [Understanding the Starter Template] explainer.
 
 TODO: Replace this README with a README for your project
 TODO: Verify whether the included `.gitignore`, `LICENSE`, and `rust-toolchain` files are appropriate to your project
@@ -20,6 +20,8 @@ This is an empty template, and so there is no expected output (until you modify 
 
 ### Running proofs remotely on Bonsai
 
+*Note: The Bonsai proving service is still in early Alpha; an API key is required for access. [Click here to request access].*
+
 If you have access to the URL and API key to Bonsai you can run your proofs
 remotely. To prove in Bonsai mode, invoke `cargo run` with two additional
 environment variables:
@@ -28,8 +30,7 @@ environment variables:
 BONSAI_API_KEY="YOUR_API_KEY" BONSAI_API_URL="BONSAI_URL" cargo run
 ```
 
-At the time of writing, access to the URL and API key are limited to special
-events such as hackathons.
+[Click here to request access]: https://docs.google.com/forms/d/e/1FAIpQLSf9mu18V65862GS4PLYd7tFTEKrl90J5GTyzw_d14ASxrruFQ/viewform
 
 ## How to create a project based on this template
 

--- a/templates/rust-starter/README.md
+++ b/templates/rust-starter/README.md
@@ -18,6 +18,19 @@ cargo run
 
 This is an empty template, and so there is no expected output (until you modify the code).
 
+### Running proofs remotely on Bonsai
+
+If you have access to the URL and API key to Bonsai you can run your proofs
+remotely. To prove in Bonsai mode, invoke `cargo run` with two additional
+environment variables:
+
+```
+BONSAI_API_KEY="YOUR_API_KEY" BONSAI_API_URL="BONSAI_URL" cargo run
+```
+
+At the time of writing, access to the URL and API key are limited to special
+events such as hackathons.
+
 ## How to create a project based on this template
 
 Search this template for the string `TODO`, and make the necessary changes to implement the required feature described by the `TODO` comment. Some of these changes will be complex, and so we have a number of instructional resources to assist you in learning how to write your own code for the RISC Zero zkVM:


### PR DESCRIPTION
This PR adds directions on how to run remote proving using the rust starter template.