### PR TITLE
Align implementations of image ID and system state struct hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Discord chat][discord-badge]][discord-url]
 [![Twitter][twitter-badge]][twitter-url]
 
-[crates-badge]: https://img.shields.io/badge/crates.io-v0.15-orange
+[crates-badge]: https://img.shields.io/badge/crates.io-v0.16-orange
 [crates-url]: https://crates.io/crates/risc0-zkvm
 [licence-badge]: https://img.shields.io/github/license/risc0/risc0?color=blue
 [licence-url]: https://github.com/risc0/risc0/blob/main/LICENSE
@@ -126,23 +126,24 @@ structured, and other resources useful to developers new to RISC Zero, see our
 
 | crate          | [crates.io]                                                                                          |
 | -------------- | ---------------------------------------------------------------------------------------------------- |
-| cargo-risczero | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/cargo-risczero) |
-| risc0-r0vm     | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-r0vm)     |
-| risc0-tools    | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-tools)    |
+| cargo-risczero | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/cargo-risczero) |
+| risc0-r0vm     | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-r0vm)     |
+| risc0-tools    | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-tools)    |
 
 ## Rust Libraries
 
 | crate                    | [crates.io]                                                                                                    | [docs.rs](https://docs.rs)                                                                              |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| risc0-build              | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-build)              | [![](https://img.shields.io/docsrs/risc0-build)](https://docs.rs/risc0-build)                           |
-| risc0-build-kernel       | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-build-kernel)       | [![](https://img.shields.io/docsrs/risc0-build-kernel)](https://docs.rs/risc0-build-kernel)             |
-| risc0-circuit-rv32im     | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-circuit-rv32im)     | [![](https://img.shields.io/docsrs/risc0-circuit-rv32im)](https://docs.rs/risc0-circuit-rv32im)         |
-| risc0-circuit-rv32im-sys | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-circuit-rv32im-sys) | [![](https://img.shields.io/docsrs/risc0-circuit-rv32im-sys)](https://docs.rs/risc0-circuit-rv32im-sys) |
-| risc0-core               | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-core)               | [![](https://img.shields.io/docsrs/risc0-core)](https://docs.rs/risc0-core)                             |
-| risc0-sys                | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-sys)                | [![](https://img.shields.io/docsrs/risc0-sys)](https://docs.rs/risc0-sys)                               |
-| risc0-zkp                | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-zkp)                | [![](https://img.shields.io/docsrs/risc0-zkp)](https://docs.rs/risc0-zkp)                               |
-| risc0-zkvm               | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-zkvm)               | [![](https://img.shields.io/docsrs/risc0-zkvm)](https://docs.rs/risc0-zkvm)                             |
-| risc0-zkvm-platform      | [![x](https://img.shields.io/badge/crates.io-v0.15-orange)](https://crates.io/crates/risc0-zkvm-platform)      | [![](https://img.shields.io/docsrs/risc0-zkvm-platform)](https://docs.rs/risc0-zkvm-platform)           |
+| bonsai-sdk               | [![x](https://img.shields.io/badge/crates.io-v0.2-orange)](https://crates.io/crates/bonsai-sdk)                | [![](https://img.shields.io/docsrs/bonsai-sdk)](https://docs.rs/bonsai-sdk)                             |
+| risc0-build              | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-build)              | [![](https://img.shields.io/docsrs/risc0-build)](https://docs.rs/risc0-build)                           |
+| risc0-build-kernel       | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-build-kernel)       | [![](https://img.shields.io/docsrs/risc0-build-kernel)](https://docs.rs/risc0-build-kernel)             |
+| risc0-circuit-rv32im     | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-circuit-rv32im)     | [![](https://img.shields.io/docsrs/risc0-circuit-rv32im)](https://docs.rs/risc0-circuit-rv32im)         |
+| risc0-circuit-rv32im-sys | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-circuit-rv32im-sys) | [![](https://img.shields.io/docsrs/risc0-circuit-rv32im-sys)](https://docs.rs/risc0-circuit-rv32im-sys) |
+| risc0-core               | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-core)               | [![](https://img.shields.io/docsrs/risc0-core)](https://docs.rs/risc0-core)                             |
+| risc0-sys                | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-sys)                | [![](https://img.shields.io/docsrs/risc0-sys)](https://docs.rs/risc0-sys)                               |
+| risc0-zkp                | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-zkp)                | [![](https://img.shields.io/docsrs/risc0-zkp)](https://docs.rs/risc0-zkp)                               |
+| risc0-zkvm               | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-zkvm)               | [![](https://img.shields.io/docsrs/risc0-zkvm)](https://docs.rs/risc0-zkvm)                             |
+| risc0-zkvm-platform      | [![x](https://img.shields.io/badge/crates.io-v0.16-orange)](https://crates.io/crates/risc0-zkvm-platform)      | [![](https://img.shields.io/docsrs/risc0-zkvm-platform)](https://docs.rs/risc0-zkvm-platform)           |
 
 ## Feature flags
 

--- a/risc0/zkvm/src/recursion/receipt.rs
+++ b/risc0/zkvm/src/recursion/receipt.rs
@@ -106,13 +106,14 @@ impl SystemState {
         write_sha_halfs(flat, &self.merkle_root);
     }
 
-    pub(crate) fn digest(&self) -> Digest {
+    /// Hash the [crate::SystemState] to get a digest of the struct.
+    pub fn digest(&self) -> Digest {
         tagged_struct("risc0.SystemState", &[self.merkle_root], &[self.pc])
     }
 }
 
 impl ReceiptMetadata {
-    /// decode a [crate::ReceiptMetadata] from a list of [u32]'s
+    /// Decode a [crate::ReceiptMetadata] from a list of [u32]'s
     pub fn decode(flat: &mut VecDeque<u32>) -> Result<Self, VerificationError> {
         let input = read_sha_halfs(flat);
         let pre = SystemState::decode(flat);
@@ -131,7 +132,7 @@ impl ReceiptMetadata {
         })
     }
 
-    /// encode a [crate::ReceiptMetadata] to a list of [u32]'s
+    /// Encode a [crate::ReceiptMetadata] to a list of [u32]'s
     pub fn encode(&self, flat: &mut Vec<u32>) -> Result<(), VerificationError> {
         write_sha_halfs(flat, &self.input);
         self.pre.encode(flat);
@@ -143,7 +144,8 @@ impl ReceiptMetadata {
         Ok(())
     }
 
-    pub(crate) fn digest(&self) -> Result<Digest, VerificationError> {
+    /// Hash the [crate::ReceiptMetadata] to get a digest of the struct.
+    pub fn digest(&self) -> Result<Digest, VerificationError> {
         let (sys_exit, user_exit) = self.get_exit_code_pairs()?.clone();
         Ok(tagged_struct(
             "risc0.ReceiptMeta",

--- a/risc0/zkvm/src/recursion/receipt.rs
+++ b/risc0/zkvm/src/recursion/receipt.rs
@@ -45,15 +45,16 @@ pub fn valid_control_ids() -> Vec<Digest> {
     all_ids
 }
 
-fn tagged_struct(tag: &str, down: &[Digest], data: &[u32]) -> Digest {
+/// Implementation of the struct hash described in the recursion predicates RFC.
+pub(crate) fn tagged_struct(tag: &str, down: &[Digest], data: &[u32]) -> Digest {
     let tag_digest: Digest = *sha::Impl::hash_bytes(tag.as_bytes());
     let mut all = Vec::<u8>::new();
     all.extend_from_slice(tag_digest.as_bytes());
     for digest in down {
-        all.extend_from_slice((*digest).as_bytes());
+        all.extend_from_slice(digest.as_ref());
     }
-    for word in data {
-        all.extend_from_slice(&(*word).to_le_bytes());
+    for word in data.iter().copied() {
+        all.extend_from_slice(&word.to_le_bytes());
     }
     let down_count: u16 = down.len().try_into().unwrap();
     all.extend_from_slice(&down_count.to_le_bytes());
@@ -105,7 +106,7 @@ impl SystemState {
         write_sha_halfs(flat, &self.merkle_root);
     }
 
-    fn digest(&self) -> Digest {
+    pub(crate) fn digest(&self) -> Digest {
         tagged_struct("risc0.SystemState", &[self.merkle_root], &[self.pc])
     }
 }
@@ -142,7 +143,7 @@ impl ReceiptMetadata {
         Ok(())
     }
 
-    fn digest(&self) -> Result<Digest, VerificationError> {
+    pub(crate) fn digest(&self) -> Result<Digest, VerificationError> {
         let (sys_exit, user_exit) = self.get_exit_code_pairs()?.clone();
         Ok(tagged_struct(
             "risc0.ReceiptMeta",


### PR DESCRIPTION
Currently the hash of the memory image root and program counter (PC) used as the "image ID" is distinct from the struct hash used within the recursion predicates for hashing the `ReaceiptMetadata` and the `SystemState` within it. In particular, `compute_image_id(...)` currently uses a non-standard SHA-256 padding when combining the Merkle root and PC, which raises difficulties in Solidity where we do not have an implementation of the SHA-256 compress function.

This PR changes `compute_image_id(...)` to use the `SystemState::digest(...)` function, making the memory commitments used in these two contexts equal.