### PR TITLE
cargo risczero: update README with reference to remote proving

### DIFF
--- a/risc0/cargo-risczero/README.md
+++ b/risc0/cargo-risczero/README.md
@@ -1,6 +1,6 @@
 # Cargo-risczero
 
-Cargo extension to help create, manage, and test [RISC Zero](https://github.com/risc0/risc0) projects.
+Cargo extension to help create, manage, and test [RISC Zero](https://github.com/risc0/risc0) projects. The default template generated from the `cargo risczero new` command supports both local and remote proving. Refer to the README in [the rust-starter template](https://github.com/risc0/risc0/tree/main/templates/rust-starter) for more information.
 
 ## Install
 


### PR DESCRIPTION
The bonsai quick start guide refers to this documentation as one of 4 options for using Bonsai. This README does not contain any mention of remote proving and could be confusing for users who wish to use cargo risczero to generate a template for remote proving. Add a simple reference to remote proving to provide additional clarity.