### PR TITLE
Fix typos in governance demo

### DIFF
--- a/bonsai/examples/governance/contracts/BonsaiGovernorCounting.sol
+++ b/bonsai/examples/governance/contracts/BonsaiGovernorCounting.sol
@@ -172,7 +172,7 @@ abstract contract BonsaiGovernorCounting is Governor {
             address account = address(uint160(uint192(ballot)));
 
             // Look up the voting weight for the account associated with the ballot.
-            // NOTE: If a singature was invalid, it will likely result in a lookup for a random
+            // NOTE: If a signature was invalid, it will likely result in a lookup for a random
             // account, which will almost certainly has zero voting weight.
             uint256 weight = _getVotes(account, snapshot, params);
             if (support == uint8(VoteType.Against)) {

--- a/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
+++ b/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
@@ -147,7 +147,7 @@ fn main() {
     // Commit the proposal ID, ballot box hash, and 24-byte encoded ballots to the
     // journal.
     // NOTE: Padding bytes are inserted to maintain u32 word alignment. It is not
-    // well-established that this actually results in a more effecient program,
+    // well-established that this actually results in a more efficient program,
     // so this needs to be tested.
     env::commit_slice(&proposal_id[..]);
     env::commit_slice(&ballot_box_accum[..]);

--- a/bonsai/examples/governance/tests/Governor.t.sol
+++ b/bonsai/examples/governance/tests/Governor.t.sol
@@ -93,7 +93,7 @@ contract Voter is Test {
         bytes32 digest = gov.voteHash(proposalId, support);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(delegateKey(), digest);
 
-        // Does not check that the VoteCast event is emitted becasue BonsaiGovernor does not emit this event.
+        // Does not check that the VoteCast event is emitted because BonsaiGovernor does not emit this event.
         gov.castVoteBySig(proposalId, support, v, r, s);
     }
 }
@@ -295,7 +295,7 @@ abstract contract BonsaiGovernorTest is GovernorTest, BonsaiTest {
     }
 
     /// @notice mapping of proposals to ballot boxes.
-    /// @dev ballots are persisted to storage because evnts can only ever be obtained once from vm.getRecordedLogs().
+    /// @dev ballots are persisted to storage because events can only ever be obtained once from vm.getRecordedLogs().
     mapping(uint256 => BallotBox) internal ballotBoxes;
 
     function setUp() public withRelay {
@@ -349,7 +349,7 @@ abstract contract BonsaiGovernorTest is GovernorTest, BonsaiTest {
         return (box.guestInput);
     }
 
-    /// @notice implments the vote finalization logic matching the zkVM guest.
+    /// @notice implements the vote finalization logic matching the zkVM guest.
     ///   Can be used to test the Governor contract with running the zkVM.
     function finalizeVotesSolidityImpl(bytes memory guestInput) internal returns (bytes memory) {
         // This function normally executes off-chain in the guest.


### PR DESCRIPTION
Corrected some typos is `.rs` and `.sol` files.