### PR TITLE
cc-1.0.79 patch

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ xtask = "run --release --package xtask --"
 
 [build]
 rustflags = ["-Dclippy::all", "-Dwarnings"]
+
+[patch.crates-io]
+cc = { git = "https://github.com/rust-lang/cc-rs", tag = "1.0.79" }


### PR DESCRIPTION
A workaround to `cc` version `1.0.80` breaking guest builds.