### PR TITLE
workspace: patch cc crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ xtask = "run --release --package xtask --"
 
 [build]
 rustflags = ["-Dclippy::all", "-Dwarnings"]
+
+[patch.crates-io]
+cc = { git = "https://github.com/rust-lang/cc-rs", rev = "e5bbdfa" }

--- a/templates/rust-starter/.cargo/config.toml
+++ b/templates/rust-starter/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Temporary workaround. See https://github.com/risc0/risc0/issues/754 for more details.
+
+[patch.crates-io]
+cc = { git = "https://github.com/rust-lang/cc-rs", rev = "e5bbdfa" }


### PR DESCRIPTION
The `cc` crate 1.0.80 breaks our build due to our use of our `-Z build-std` flag. This is a temporary fix to pin `cc` to a known working version to get guests to build and CI to run.