### PR TITLE
feat: basic wasm_bindgen bindings for receipt verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,3 +191,9 @@ jobs:
           npm install
           npm test -- --firefox
         working-directory: examples/browser-verify
+      # Run tests for wasm bindings
+      - run: |
+          wasm-pack test --headless --firefox
+          wasm-pack build --target nodejs
+          node --test js_tests
+        working-directory: risc0/js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "risc0/zkvm/methods",
   "risc0/zkvm/platform",
   "risc0/zkvm/receipts",
+  "risc0/js",
   "xtask",
 ]
 exclude = ["tools/crates-validator"]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -538,8 +538,7 @@ dependencies = [
 [[package]]
 name = "cc"
 version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+source = "git+https://github.com/rust-lang/cc-rs?rev=e5bbdfa#e5bbdfa1fa468c028cb38fee6c35a3cf2e5a2736"
 dependencies = [
  "jobserver",
 ]

--- a/examples/browser-verify/package-lock.json
+++ b/examples/browser-verify/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rust-webpack-template",
+  "name": "browser-verify",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rust-webpack-template",
+      "name": "browser-verify",
       "version": "0.1.0",
       "devDependencies": {
         "@wasm-tool/wasm-pack-plugin": "^1.1.0",

--- a/risc0/js/.gitignore
+++ b/risc0/js/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/risc0/js/Cargo.toml
+++ b/risc0/js/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "risc0-js"
+description = "Risc0 wasm on javascript bindings"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+bincode = "1.3"
+risc0-zkvm = { workspace = true, default-features = false }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+risc0-zkvm-receipts = { path = "../../risc0/zkvm/receipts" }

--- a/risc0/js/js_tests/test.js
+++ b/risc0/js/js_tests/test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert').strict;
+const fs = require('fs').promises;
+const { Receipt } = require("../pkg");
+
+async function fetchBinaryFiles() {
+  const receiptPromise = fs.readFile(__dirname + '/../../zkvm/receipts/src/fib_receipt.bin');
+  const methodIdPromise = fs.readFile(__dirname + '/../../zkvm/receipts/src/fib_id.bin');
+
+  return Promise.all([receiptPromise, methodIdPromise]);
+}
+
+test('example valid proof verification', async () => {
+  const [receipt, method_id] = await fetchBinaryFiles();
+  Receipt.bincode_deserialize(receipt).validate(method_id);
+});
+
+test('invalid proof verification should fail with invalid method id', async () => {
+  const [serializedReceipt] = await fetchBinaryFiles();
+  const invalidMethodId = Buffer.alloc(32, 1);
+  const receipt = Receipt.bincode_deserialize(serializedReceipt);
+  assert.throws(() => {
+    receipt.validate(invalidMethodId);
+  }, new Error('Failed to validate proof: image_id mismatch'));
+});
+
+test('invalid proof verification should fail with invalid journal', async () => {
+  const [serializedReceipt, methodId] = await fetchBinaryFiles();
+  // Write a new value as the journal (last bytes of the serialized receipt are the journal)
+  serializedReceipt.writeUInt32LE(123456, serializedReceipt.length - 4);
+  const receipt = Receipt.bincode_deserialize(serializedReceipt);
+  assert.throws(() => {
+    receipt.validate(methodId);
+  }, new Error('Failed to validate proof: Journal digest mismatch detected'));
+});
+
+test('invalid bytes should throw bincode deserialize error', async () => {
+  assert.throws(() => {
+    Receipt.bincode_deserialize(Buffer.alloc(32, 1));
+  });
+});

--- a/risc0/js/src/lib.rs
+++ b/risc0/js/src/lib.rs
@@ -1,0 +1,47 @@
+use risc0_zkvm::receipt;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct Receipt(receipt::Receipt);
+
+#[wasm_bindgen]
+impl Receipt {
+    pub fn bincode_deserialize(buffer: &[u8]) -> Result<Receipt, JsError> {
+        let receipt = bincode::deserialize(buffer)
+            .map_err(|e| JsError::new(&format!("Failed to deserialize receipt: {e}")))?;
+        Ok(Receipt(receipt))
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn journal(&self) -> Vec<u8> {
+        self.0.journal.clone()
+    }
+
+    pub fn validate(&self, image_id: &[u8]) -> Result<(), JsError> {
+        let image_id: [u8; 32] = image_id.try_into()?;
+        self.0
+            .verify(image_id)
+            .map_err(|e| JsError::new(&format!("Failed to validate proof: {e}")))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use risc0_zkvm_receipts::{FIB_ID, FIB_RECEIPT};
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    use wasm_bindgen_test::*;
+
+    use super::Receipt;
+
+    #[wasm_bindgen_test]
+    fn verify_receipt() {
+        let receipt = Receipt::bincode_deserialize(FIB_RECEIPT)
+            .unwrap_or_else(|_| panic!("invalid deserialization"));
+        receipt
+            .validate(&FIB_ID)
+            .unwrap_or_else(|_| panic!("invalid validation"));
+    }
+}

--- a/risc0/zkvm/receipts/.gitignore
+++ b/risc0/zkvm/receipts/.gitignore
@@ -1,1 +1,2 @@
 /src/receipts.rs
+/src/*.bin

--- a/risc0/zkvm/receipts/build.rs
+++ b/risc0/zkvm/receipts/build.rs
@@ -21,13 +21,22 @@ fn main() {
     let path = Path::new(&out_dir).join("lib.rs");
 
     if File::open(RECEIPTS).is_ok() {
+        // Copy fib ID and receipt binary files to the out directory to be used also.
+        for &file in ["src/fib_id.bin", "src/fib_receipt.bin"].iter() {
+            if let Ok(_) = File::open(file) {
+                let in_file_path = Path::new(file);
+                let out_file_path = Path::new(&out_dir).join(in_file_path.file_name().unwrap());
+                std::fs::copy(in_file_path, out_file_path).unwrap();
+            }
+        }
+
         let content = std::fs::read(RECEIPTS).unwrap();
         std::fs::write(path, content).unwrap();
     } else {
         std::fs::write(
             path,
             r##"
-pub const FIB_ID: [u32; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
+pub const FIB_ID: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 pub const FIB_RECEIPT: &[u8] = &[];
                 "##,
         )

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,7 @@ semver = "1.0"
 svm-rs = { version = "0.2", features = ["blocking"] }
 which = "4.4"
 xshell = "0.2"
+bytemuck = "1.12"
 
 [package.metadata.release]
 release = false

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -53,10 +53,17 @@ impl Commands {
         let receipt = default_prover().prove_elf(env, FIB_ELF).unwrap();
         let receipt_bytes = bincode::serialize(&receipt).unwrap();
 
+        std::fs::write("risc0/zkvm/receipts/src/fib_receipt.bin", &receipt_bytes).unwrap();
+        std::fs::write(
+            "risc0/zkvm/receipts/src/fib_id.bin",
+            &bytemuck::cast::<[u32; 8], [u8; 32]>(FIB_ID),
+        )
+        .unwrap();
+
         let rust_code = format!(
             r##"
-pub const FIB_ID: [u32; 8] = {FIB_ID:?};
-pub const FIB_RECEIPT: &[u8] = &{receipt_bytes:?};
+pub const FIB_ID: [u8; 32] = *include_bytes!("fib_id.bin");
+pub const FIB_RECEIPT: &[u8] = include_bytes!("fib_receipt.bin");
 "##
         );
 


### PR DESCRIPTION
This PR just serves as the basis for creating the wasm bindings for js/web verification of receipts. I tried to make changes as undisruptive to the previous receipt usage setup, but happy to change this in any direction suggested.

This is porting code from https://github.com/austinabell/risc0-js

Possible TODOs for this PR or later (can open any issues for ones not done here):
- Extend binding interface (to include verify with context and other serialization/deserialization methods)
  - Intentionally tried to keep API small for now to avoid breaking changes
- Update browser example to use these wasm bindings
  - Browser example seems like just the test is working, and would be enough changes that I'd rather have it separate PR to build a frontend example
- Release js bindings for different targets
  - Assume wouldn't want me doing this

I didn't really create any docs around this, but will do if thumbs up is given that you are open to these changes coming in

cc @flaub as you suggested in Discord that you'd like these bindings in the repo 