### PR TITLE
Fix typos in IBonsaiRelay

### DIFF
--- a/bonsai/ethereum/contracts/IBonsaiRelay.sol
+++ b/bonsai/ethereum/contracts/IBonsaiRelay.sol
@@ -42,7 +42,7 @@ struct Callback {
 
 /// @notice The interface for the Bonsai relay contract
 interface IBonsaiRelay {
-    /// @notice Event emitted upon rceiving a callback request through requestCallback.
+    /// @notice Event emitted upon receiving a callback request through requestCallback.
     event CallbackRequest(
         address account,
         bytes32 imageId,
@@ -63,8 +63,8 @@ interface IBonsaiRelay {
         uint64 gasLimit
     ) external;
 
-    /// @notice Determines if the given athorization is valid for the image ID and journal.
-    /// @dev A (imageId, jounral) pair should be valid, and the respective callback authorized, if
+    /// @notice Determines if the given authorization is valid for the image ID and journal.
+    /// @dev A (imageId, journal) pair should be valid, and the respective callback authorized, if
     ///     and only if the journal is the result of the correct execution of the zkVM guest.
     function callbackIsAuthorized(bytes32 imageId, bytes calldata journal, CallbackAuthorization calldata auth)
         external


### PR DESCRIPTION
Addressing typos pointed out in https://github.com/risc0/risc0/pull/712#discussion_r1287783675, this PR fixes spelling comments of `IBonsaiRelay.sol`