### PR TITLE
Support CI in cargo-risczero build-toolchain

### DIFF
--- a/risc0/cargo-risczero/src/commands/build_toolchain.rs
+++ b/risc0/cargo-risczero/src/commands/build_toolchain.rs
@@ -52,7 +52,11 @@ impl BuildToolchain {
         };
         let rust_dir = root_dir.join("rust");
 
-        self.prepare_git_repo(RUST_REPO, RUST_BRANCH, &rust_dir)?;
+        let is_ci = std::env::var("CI").is_ok();
+        if !is_ci {
+            self.prepare_git_repo(RUST_REPO, RUST_BRANCH, &rust_dir)?;
+        }
+
         let out = self.build_toolchain(&rust_dir)?;
 
         RustupToolchain::link(RUSTUP_TOOLCHAIN_NAME, &out.toolchain_dir)?;


### PR DESCRIPTION
This is needed to support the rust fork being able to build the toolchain in CI.

See: https://github.com/risc0/rust/pull/13