### PR TITLE
Added GITHUB_TOKEN explicitly to risczero install

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: risc0/criterion-compare-action@risc0
         id: criterion-cmp
         with:

--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo bench -F $FEATURE --bench fib -- --output-format=bencher | tee output.txt
       - name: Store benchmark result
         uses: risc0/github-action-benchmark@risc0

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -29,6 +29,8 @@ jobs:
         uses: ./.github/actions/rustup
 
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Foundry
         uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,8 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo xtask install
       - run: cargo xtask gen-receipt
       - run: cargo test -F $FEATURE -F profiler
@@ -136,6 +138,8 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo test -F $FEATURE
         working-directory: examples
       - run: cargo test -F $FEATURE
@@ -156,6 +160,8 @@ jobs:
         with:
           key: Linux
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo xtask gen-receipt
       - run: cargo doc --no-deps --exclude=risc0-zkvm-methods --workspace
       - name: Install mdbook
@@ -179,6 +185,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/rustup
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           cargo run -p cargo-risczero risczero new --template templates/rust-starter --templ-subdir="" --path $(pwd) --dest ${{ runner.temp }} template-test
         shell: bash
@@ -201,6 +209,8 @@ jobs:
           node-version: 18
       - uses: ./.github/actions/sccache
       - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo xtask install
       - run: cargo xtask gen-receipt
       - run: |


### PR DESCRIPTION
Attempt to fix 403 errors in the CI by manually setting the GITHUB_TOKEN during the `risczero install` command:

Reference error in CI: https://github.com/risc0/risc0/actions/runs/5826106139/job/15799276430?pr=759#step:6:951