### PR TITLE
Disable Governance test with zkVM in CI

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -47,15 +47,15 @@ jobs:
         run: forge test -vvv
         working-directory: bonsai/ethereum
 
-      - name: run forge tests in bonsai/examples/governance
+      - name: run forge tests in bonsai/examples/governance without zkVM
         env:
           TEST_USE_ZKVM: false
         run: forge test -vvv
         working-directory: bonsai/examples/governance
 
-      - name: run forge tests in bonsai/examples/governance
-        env:
-          TEST_USE_ZKVM: true
-          BONSAI_PROVING: local
-        run: forge test -vvv
-        working-directory: bonsai/examples/governance
+        # TODO(#783): Test currently takes ~1 hour to run, and so it is currently disabled.
+        #- name: run forge tests in bonsai/examples/governance with zkVM
+        #env:
+        #  TEST_USE_ZKVM: true
+        #run: forge test -vvv
+        #working-directory: bonsai/examples/governance


### PR DESCRIPTION
Related to https://github.com/risc0/risc0/issues/783, the governance example tests with zkVM execution take too long to run. This PR disables those tests for now.

Note that a basic build and functionality test for the zkVM guest is included in `cargo test`. Tests for the Solidity code is included in `forge test` with `TEST_USE_ZKVM=false`. So both these components are individually covered by tests in CI. With this PR their integration will not be covered until https://github.com/risc0/risc0/issues/783 is fixed.