### PR TITLE
Convert dev mode unit tests to integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       - run: cargo xtask gen-receipt
       - run: cargo test -F $FEATURE -F profiler
       - run: cargo test -F $FEATURE --tests -- --ignored --test-threads 1
-      - run: cargo test -F disable-dev-mode -p risc0-zkvm -- tests::dev_mode_panic
+      - run: cargo test -F $FEATURE -F disable-dev-mode -p risc0-r0vm
       - run: cargo test --manifest-path bonsai/examples/governance/Cargo.toml
         if: matrix.device == 'cpu'
       - run: cargo check -F $FEATURE --benches

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
         if: matrix.device == 'cpu'
 
   doc:
-    runs-on: ubuntu-22.04-64c
+    runs-on: ubuntu-latest-8-cores
     steps:
       # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
@@ -195,7 +195,7 @@ jobs:
       - run: ${{ runner.temp }}/template-test/target/release/host
 
   web:
-    runs-on: ubuntu-22.04-64c
+    runs-on: ubuntu-latest-8-cores
     env:
       RUSTC_WRAPPER: sccache
     steps:

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -20,10 +20,12 @@ assert_cmd = "2.0"
 assert_fs = "1.0"
 risc0-zkvm-methods = { path = "../zkvm/methods" }
 risc0-zkvm-platform = { workspace = true }
+temp-env = "0.3"
 
 [features]
 cuda = ["risc0-zkvm/cuda"]
 default = []
+disable-dev-mode = ["risc0-zkvm/disable-dev-mode"]
 dual = ["risc0-zkvm/dual"]
 metal = ["risc0-zkvm/metal"]
 profiler = ["risc0-zkvm/profiler"]

--- a/risc0/r0vm/tests/dev_mode.rs
+++ b/risc0/r0vm/tests/dev_mode.rs
@@ -1,0 +1,70 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use assert_cmd::Command;
+use assert_fs::{fixture::PathChild, TempDir};
+use risc0_zkvm::{
+    serde::{from_slice, to_vec},
+    Receipt,
+};
+use risc0_zkvm_methods::{multi_test::MultiTestSpec, MULTI_TEST_PATH};
+
+fn run_dev_mode() -> Receipt {
+    let temp = TempDir::new().unwrap();
+    let receipt_file = temp.child("receipt.dat");
+    let input = to_vec(&MultiTestSpec::DoNothing).unwrap();
+
+    let mut cmd = Command::cargo_bin("r0vm").unwrap();
+    cmd.arg("--elf")
+        .env("RISC0_DEV_MODE", "1")
+        .arg(MULTI_TEST_PATH)
+        .arg("--receipt")
+        .arg(&*receipt_file)
+        .write_stdin(bytemuck::cast_slice(&input));
+
+    cmd.assert().success();
+
+    let data = std::fs::read(receipt_file).unwrap();
+    from_slice(&data).unwrap()
+}
+
+#[test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode() {
+    let receipt = run_dev_mode();
+    temp_env::with_var("RISC0_DEV_MODE", Some("1"), || {
+        receipt.verify(risc0_zkvm_methods::MULTI_TEST_ID).unwrap();
+        assert_eq!(receipt.inner, risc0_zkvm::receipt::InnerReceipt::Fake);
+    });
+}
+
+#[test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode_verify_fail() {
+    let receipt = run_dev_mode();
+    temp_env::with_var("RISC0_DEV_MODE", None::<&str>, || {
+        receipt
+            .verify(risc0_zkvm_methods::MULTI_TEST_ID)
+            .expect_err("Expecting error");
+    });
+}
+
+#[test]
+#[should_panic(
+    expected = "zkVM: Inconsistent settings -- please resolve. The RISC0_DEV_MODE environment variable is set but dev mode has been disabled by feature flag."
+)]
+#[cfg(feature = "disable-dev-mode")]
+fn dev_mode_panic() {
+    run_dev_mode();
+}

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -70,7 +70,6 @@ typetag = { version = "0.2", optional = true }
 clap = { version = "4.0", features = ["derive"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 human-repr = "1.0"
-temp-env = "0.3"
 tracing-forest = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/risc0/zkvm/src/prove/dev_mode.rs
+++ b/risc0/zkvm/src/prove/dev_mode.rs
@@ -27,7 +27,7 @@ use crate::{
 /// Instead, the guest code is executed and a fake receipt is returned with
 /// accurate journal contents but no cryptographic information.
 /// Because the receipt is fake, a verifier can only "verify" this receipt
-/// if DevMode is turned on; verification will otherwise fail.
+/// if dev mode is turned on; verification will otherwise fail.
 ///
 /// CONVENIENT, BUT NOT MEANT FOR PRODUCTION
 /// Dev mode supports rapid development by allowing the developer to quickly
@@ -66,16 +66,15 @@ impl Prover for DevModeProver {
     fn prove_session(&self, _ctx: &VerifierContext, session: &Session) -> Result<Receipt> {
         log::info!("prove_session: {}", self.name);
         eprintln!(
-            "WARNING: Proving in DevMode does not generate a valid receipt. \
+            "WARNING: Proving in dev mode does not generate a valid receipt. \
             Receipts generated from this process are invalid and should never be used in production."
         );
 
         if cfg!(feature = "disable-dev-mode") && std::env::var("RISC0_DEV_MODE").is_ok() {
-            panic!("zkVM: dev mode is disabled. unset RISC0_DEV_MODE environment variable to produce valid proofs")
+            panic!("zkVM: dev mode is disabled. Unset RISC0_DEV_MODE environment variable to produce valid proofs")
         }
 
-        let receipt = Receipt::new(InnerReceipt::Fake, session.journal.clone());
-        Ok(receipt)
+        Ok(Receipt::new(InnerReceipt::Fake, session.journal.clone()))
     }
 
     fn prove_segment(&self, _ctx: &VerifierContext, _segment: &Segment) -> Result<SegmentReceipt> {

--- a/risc0/zkvm/src/prove/mod.rs
+++ b/risc0/zkvm/src/prove/mod.rs
@@ -56,8 +56,6 @@ use risc0_zkp::{
 };
 use risc0_zkvm_platform::{memory::MEM_SIZE, PAGE_SIZE, WORD_SIZE};
 
-#[cfg(not(feature = "disable-dev-mode"))]
-use self::dev_mode::DevModeProver;
 use self::{local::LocalProver, remote::RemoteProver};
 use crate::{
     receipt::{Receipt, VerifierContext},
@@ -238,7 +236,7 @@ fn provers() -> HashMap<String, Rc<dyn Prover>> {
     }
     #[cfg(not(feature = "disable-dev-mode"))]
     {
-        let prover = Rc::new(DevModeProver::new("devmode"));
+        let prover = Rc::new(dev_mode::DevModeProver::new("devmode"));
         table.insert("$devmode".to_string(), prover);
     }
     #[cfg(feature = "cuda")]

--- a/risc0/zkvm/src/prove/tests.rs
+++ b/risc0/zkvm/src/prove/tests.rs
@@ -270,30 +270,6 @@ fn continuation() {
     }
 }
 
-fn run_dev_mode() {
-    temp_env::with_var("RISC0_DEV_MODE", Some("1"), || {
-        let receipt = prove_nothing("$devmode").unwrap();
-        assert_eq!(receipt.inner, crate::receipt::InnerReceipt::Fake);
-        receipt.verify(MULTI_TEST_ID).unwrap();
-    });
-}
-
-#[test]
-#[ignore]
-#[should_panic(
-    expected = "zkVM: Inconsistent settings -- please resolve. The RISC0_DEV_MODE environment variable is set but dev mode has been disabled by feature flag."
-)]
-#[cfg(feature = "disable-dev-mode")]
-fn dev_mode_panic() {
-    run_dev_mode()
-}
-
-#[test]
-#[cfg(not(feature = "disable-dev-mode"))]
-fn dev_mode() {
-    run_dev_mode()
-}
-
 // These tests come from:
 // https://github.com/riscv-software-src/riscv-tests
 // They were built using the toolchain from:


### PR DESCRIPTION
This avoids env var concurrency issues in unit tests