### PR TITLE
aligning quick start

### DIFF
--- a/examples/browser-verify/README.md
+++ b/examples/browser-verify/README.md
@@ -3,15 +3,17 @@
 Verify a RISC Zero program in your browser using WASM!
 
 ## Quickstart
-
-### Dependencies
-
-In addition to [Rust] and [Node.js], you will need
+In addition to [Rust] [Node.js] , you will need
 ```
 cargo xtask install
 cargo xtask gen-receipt
 ```
 
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
 ### Running a test of in-browser verification
 
 From this directory, run
@@ -24,5 +26,6 @@ where `$BROWSER` is one of
 - `firefox`
 - `safari`
 
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 [Rust]: https://www.rust-lang.org/tools/install
 [Node.js]: https://nodejs.dev/en/learn/how-to-install-nodejs/

--- a/examples/browser-verify/README.md
+++ b/examples/browser-verify/README.md
@@ -26,6 +26,5 @@ where `$BROWSER` is one of
 - `firefox`
 - `safari`
 
-[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
-[Rust]: https://www.rust-lang.org/tools/install
+[Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 [Node.js]: https://nodejs.dev/en/learn/how-to-install-nodejs/

--- a/examples/browser-verify/README.md
+++ b/examples/browser-verify/README.md
@@ -3,7 +3,7 @@
 Verify a RISC Zero program in your browser using WASM!
 
 ## Quickstart
-In addition to [Rust] [Node.js] , you will need
+In addition to [Rust] and [Node.js], you will need
 ```
 cargo xtask install
 cargo xtask gen-receipt

--- a/examples/digital-signature/README.md
+++ b/examples/digital-signature/README.md
@@ -2,6 +2,23 @@
 
 A simple digital signature scheme built on the RISC Zero platform.
 
+## Quick Start
+
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+Then, run the example with:
+```bash
+cargo run --release -- "This is a signed message" --passphrase="passw0rd"
+```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 ## Summary
 
 From [Wikipedia](https://en.wikipedia.org/wiki/Digital_signature):
@@ -27,9 +44,3 @@ receipt proves that the identity was computed by taking the SHA-256d of
 the signer's passphrase (i.e. not just copied). Thus the signer must possess the
 passphrase. Sending those along with the message covers the full scope of a
 typical digital signature scheme.
-
-## Run the example
-
-```bash
-cargo run --release -- "This is a signed message" --passphrase="passw0rd"
-```

--- a/examples/ecdsa/README.md
+++ b/examples/ecdsa/README.md
@@ -2,6 +2,23 @@
 
 This example demonstrates how to verify an ECDSA signature inside the zkVM.
 
+## Quick Start
+
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+Then, run the example with:
+```bash
+cargo run --release
+```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 ## Use Cases
 
 Verifying digital signatures is a primary method of authentication for many protocols, and ECDSA is

--- a/examples/factors/README.md
+++ b/examples/factors/README.md
@@ -2,7 +2,8 @@
 
 The _factors_ example is a minimalistic RISC Zero zkVM proof. The prover demonstrates that they know two nontrivial factors (i.e. both greater than 1) of a number, without revealing what those factors are. Thus, the prover demonstrates that a number is composite — and that they know the factors — without revealing any further information about the number.
 
-First, [install Rust] if you don't already have it. 
+## Quick Start
+First, [install Rust] if you don't already have it.
 
 Next, install the `cargo-risczero` tool and install the toolchain with:
 

--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -2,6 +2,23 @@
 
 This code demonstrates how to prove that a JSON file contains a specific field and value using the RISC Zero zkVM. The JSON file is identified by SHA-256 hash, allowing users to commit to a specific JSON file and then prove some of its contents without revealing the full file.
 
+## Quick Start
+
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+Then, run the example with:
+```bash
+cargo run --release
+```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 ## Video Tutorial
 
 For a walk-through of this example, check out this [excerpt from our workshop at ZK HACK III](https://www.youtube.com/watch?v=6vIgBHx61vc&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=7).

--- a/examples/password-checker/README.md
+++ b/examples/password-checker/README.md
@@ -4,6 +4,23 @@ This simple password checker is implemented in Rust. The program is implemented 
 
 The policy checker accepts a password string and a salt from the host driver and checks the validity of the password. A password validity-checking function then examines the password and panics if criteria are not met. If the password meets validity criteria, execution proceeds and the zkVM appends a hash of the salted password to the journal. The journal is a readable record of all values committed by code in the zkVM; it is attached to the receipt (a record of correct execution).
 
+## Quick Start
+
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+Then, run the example with:
+```bash
+cargo run --release
+```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 # Why use zkVM to run this?
 
 Our goal is to run our own password check locally without having to share our password directly with a recipient, preferring instead to share only a SHA-256 password hash. Because the validity-checking and hashing functionality runs on the zkVM, it generates a receipt that identifies which binary was executed (via the method ID), associates shared results with this particular execution (via the journal), and confirms its own integrity (via the cryptographic seal).
@@ -13,14 +30,6 @@ Our goal is to run our own password check locally without having to share our pa
 The main program that calls a method in the guest ZKVM is in [src/main.rs](src/main.rs). The code that runs inside the ZKVM is in [methods/guest/src/bin/pw_checker.rs](methods/guest/src/bin/pw_checker.rs). The rest of the project is build support.
 
 For the main RISC Zero project, see [here](https://github.com/risc0/risc0).
-
-# Run this example
-
-To build and run this example, use:
-
-```
-cargo run --release
-```
 
 # And now, some fine print
 

--- a/examples/prorata/README.md
+++ b/examples/prorata/README.md
@@ -4,6 +4,23 @@ This example demonstrates how to use the zkVM to calculate pro rata distribution
 
 Walking through this example on Linux requires a minimum of around 12GB of RAM and under 20 minutes including compile time on a reasonably modern CPU such as the 8-core Ryzen 5800X.
 
+## Quick Start
+
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+Then, run the example with:
+```bash
+cargo run --release
+```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 ## Building
 
 To run tests and then build a copy of the pro rata command line utility:

--- a/examples/sha/README.md
+++ b/examples/sha/README.md
@@ -2,6 +2,23 @@
 
 This code demonstrates how to provably compute the SHA-256 hash of a string using RISC Zero.
 
+## Quick Start
+
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+Then, run the example with:
+```bash
+cargo run --release
+```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 Notable details:
 * We show two ways of calling the hash function:
   * Using `risc0_zkvm::sha`, which is the SHA-256 interface included in the `risc0_zkvm` crate.

--- a/examples/waldo/README.md
+++ b/examples/waldo/README.md
@@ -18,6 +18,37 @@ This example implements a RISC0 zero-knowledge program which allows a prover to
 convince a verifier they know Waldo's location in a public Where's Waldo puzzle,
 without revealing Waldo's coordinates.
 
+## Quick Start
+### External Dependencies
+First, [install Rust] if you don't already have it.
+
+### RISC Zero Dependencies
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+### Run the Prover to construct a Receipt
+Now, you're ready to construct a [receipt] that proves you know where Waldo is located. From the `waldo` folder, run:
+```bash
+# Prove that you know where Waldo is in waldo.webp
+cargo run --release --bin prove -- -i waldo.webp -x 1150 -y 291 --width 58 --height 70 -m waldo_mask.png
+```
+
+Congratulations! You just proved that you know where Waldo is!
+
+### Run the Verifier
+You can send the `receipt` to a third party, who can `verify` it by running:
+```bash
+# Verify that the prover actually found Waldo.
+cargo run --release --bin verify -- -i waldo.webp -r receipt.bin
+```
+
+Running the verifier proves that the contents of [receipt.journal] were indeed constructed by the binary file associated with the expected [ImageID].
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 ## Approach
 
 The approach for this example is similar to the analogy. It takes the full image

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -2,8 +2,19 @@
 
 Example of running WASM code within the ZKVM using the [wasmi](https://crates.io/crates/wasmi) crate. In this example we define a fibonacci function in WAT format, compile it to WASM bytecode then run it within the ZKVM guest code. Returning the result of the fib() function back to the host. This sample can be extended to run arbitrary WAT/WASM modules or run a specific WASM bytecode if you compile the WASM code into the guest image.
 
-## Running
+## Quick Start
 
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+Then, run the example with:
 ```bash
 cargo run --release
 ```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html

--- a/examples/wordle/README.md
+++ b/examples/wordle/README.md
@@ -2,15 +2,22 @@
 
 ## Quick Start
 
-First, make sure [rustup](https://rustup.rs) is installed. This project uses a [nightly](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html) version of [Rust](https://doc.rust-lang.org/book/ch01-01-installation.html). The [`rust-toolchain.toml`](../../rust-toolchain.toml) file will be used by `cargo` to automatically install the correct version.
+First, [install Rust] if you don't already have it.
 
-To build all methods and play Wordle within the zkVM, run the following command:
-
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
 ```
-cargo run
+
+Then, run the example with:
+```bash
+cargo run --release
 ```
 
-Then, start guessing 5 letter words!
+Welcome to Wordle! Start guessing 5 letter words!
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 
 ## About the game
 

--- a/examples/zkevm-demo/README.md
+++ b/examples/zkevm-demo/README.md
@@ -11,6 +11,18 @@ Currently, this demo accepts an Ethereum transaction hash and replays the transa
 * It currently defaults to the revm default forkid which is BERLIN. Older transactions might vary in results.
 * This demo only runs pre-existing transactions by tx_hash.
 
+## Dependencies
+
+First, [install Rust] if you don't already have it.
+
+Next, install the `cargo-risczero` tool and install the toolchain with:
+```bash
+cargo install cargo-risczero
+cargo risczero install
+```
+
+[install Rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
+
 ## Building
 
 ```bash


### PR DESCRIPTION
Several examples are currently missing essential information that's necessary to run the examples. 
This PR resolves that issue by adding those instructions to the Quick Start sections. 

Edit: Frank points out that to reduce maintenance, it's probably better to have a single `installation` page and have all the READMEs point there. probably worth landing this as a stop-gap