### PR TITLE
Include tools in build-toolchain

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [alias]
+risc0 = "run --package cargo-risczero -- risczero"
 xfast = "run --package xtask --"
-xtask = "run --release --package xtask --"
+xtask = "run --package xtask --release --"
 
 [build]
 rustflags = ["-Dclippy::all", "-Dwarnings"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       - run: cargo xtask install
       - run: cargo xtask gen-receipt
       - run: cargo test -F $FEATURE -F profiler
-      - run: cargo test --workspace --exclude cargo-risczero -F $FEATURE --tests -- --ignored --test-threads 1
+      - run: cargo test --workspace -F $FEATURE --tests -- --ignored --test-threads 1
       - run: cargo test -F $FEATURE -F disable-dev-mode -p risc0-r0vm
       - run: cargo test --manifest-path bonsai/examples/governance/Cargo.toml
         if: matrix.device == 'cpu'
@@ -227,4 +227,4 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: cargo test --package cargo-risczero --tests -- --ignored
+      - run: cargo test -p cargo-risczero -F docker

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -9,6 +9,10 @@ description = "RISC Zero CLI tools"
 readme = "README.md"
 keywords = ["risc0", "risczero", "tool", "cli", "generate"]
 
+[[bin]]
+path = "src/bin/main.rs"
+name = "cargo-risczero"
+
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
 cargo-generate = "0.18"
@@ -29,15 +33,9 @@ risc0-binfmt = { workspace = true }
 risc0-zkvm-platform = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 tar = "0.4"
+tempfile = "3"
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-[dev-dependencies]
-# Note, due to tempfile = ~3.5 in cargo-generate
-# we have to downgrade all uses of tempfile to 3.5 in our workspace due to:
-# https://github.com/rust-lang/cargo/issues/7880
-tempfile = "3.5"
-
-[[bin]]
-path = "src/bin/main.rs"
-name = "cargo-risczero"
+[features]
+docker = []

--- a/risc0/cargo-risczero/src/commands/build_guest.rs
+++ b/risc0/cargo-risczero/src/commands/build_guest.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use std::{
-    fs::{self, File},
-    io::Write,
-    path::PathBuf,
+    fs,
+    path::{Path, PathBuf},
     process::Command,
 };
 
@@ -24,7 +23,11 @@ use cargo_metadata::MetadataCommand;
 use clap::Parser;
 use docker_generate::DockerFile;
 use risc0_binfmt::{MemoryImage, Program};
-use risc0_zkvm_platform::{memory, memory::MEM_SIZE, PAGE_SIZE};
+use risc0_zkvm_platform::{
+    memory::{MEM_SIZE, TEXT_START},
+    PAGE_SIZE,
+};
+use tempfile::tempdir;
 
 use crate::utils::{ensure_binary, CommandExt};
 
@@ -34,42 +37,51 @@ const DOCKER_IGNORE: &str = r#"
 **/.git
 "#;
 
+const TARGET_DIR: &str = "target/riscv-guest/riscv32im-risc0-zkvm-elf/docker";
+
 /// `cargo risczero build`
 #[derive(Parser)]
 pub struct BuildGuest {
-    /// Location of the Cargo.toml of the guest code
+    /// Location of the Cargo.toml for the guest code.
     ///
-    /// This path is relative to the current directory
-    #[clap(value_parser, long)]
-    pub manifest_path: String,
+    /// This path is relative to the current directory.
+    #[arg(long)]
+    pub manifest_path: PathBuf,
 }
 
 impl BuildGuest {
     pub fn run(&self) -> Result<()> {
         let meta = MetadataCommand::new()
-            .manifest_path(self.manifest_path.as_str())
+            .manifest_path(&self.manifest_path)
             .exec()?;
-        let pkg_name = &meta
-            .root_package()
-            .context("failed to parse Cargo.toml")?
-            .name;
-        eprintln!("Building the riscv32im-risc0-zkvm-elf binary for {pkg_name}...");
+        let root_pkg = meta.root_package().context("failed to parse Cargo.toml")?;
+        let pkg_name = &root_pkg.name;
+
+        eprintln!("Building ELF binaries in {pkg_name} for riscv32im-risc0-zkvm-elf target...");
+
         ensure_binary("docker", &["--version"])?;
+
         if let Err(err) = self.check_cargo_lock() {
             eprintln!("{err}");
         }
-        let package_name = pkg_name.replace('-', "_");
-        self.create_dockerfile(package_name.as_str())?;
-        self.build()?;
-        self.clean()?;
 
-        let paths = fs::read_dir(&format!(
-            "./target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/{package_name}/"
-        ))?;
+        let pkg_name = pkg_name.replace('-', "_");
+        {
+            let temp_dir = tempdir()?;
+            let temp_path = temp_dir.path();
+            self.create_dockerfile(temp_path, pkg_name.as_str())?;
+            self.build(temp_path)?;
+        }
+
+        let target_dir = PathBuf::from(TARGET_DIR);
         println!("ELFs ready at:");
-        for path in paths {
-            let entry = path.unwrap().path();
-            println!("{} - ImageID: {}", entry.display(), self.image_id(&entry)?);
+
+        for target in root_pkg.targets.iter() {
+            if target.is_bin() {
+                let elf_path = target_dir.join(&pkg_name).join(&target.name);
+                let image_id = self.compute_image_id(&elf_path)?;
+                println!("ImageID: {} - {:?}", image_id, elf_path);
+            }
         }
 
         Ok(())
@@ -78,44 +90,49 @@ impl BuildGuest {
     /// Create the dockerfile.
     ///
     /// Overwrites if a dockerfile already exists.
-    fn create_dockerfile(&self, pkg_name: &str) -> Result<()> {
-        let manifest_env = &[("CARGO_MANIFEST_PATH", self.manifest_path.as_str())];
-        let pkg_env = &[("PKG_NAME", pkg_name)];
-        let c_flags = format!(
-            "-C passes=loweratomic -C link-arg=-Ttext=0x{:08X} -C link-arg=--fatal-warnings",
-            memory::TEXT_START
+    fn create_dockerfile(&self, temp_dir: &Path, pkg_name: &str) -> Result<()> {
+        let manifest_env = &[("CARGO_MANIFEST_PATH", self.manifest_path.to_str().unwrap())];
+        let rustflags = format!(
+            "-C passes=loweratomic -C link-arg=-Ttext=0x{TEXT_START:08X} -C link-arg=--fatal-warnings",
         );
-        let c_flags_env = &[("RUSTFLAGS", c_flags.as_str())];
+        let rustflags_env = &[("RUSTFLAGS", rustflags.as_str())];
 
         let build = DockerFile::new()
             .from_alias("build", "risczero/risc0-guest-builder:v0.17")
             .workdir("/src")
             .copy(".", ".")
             .env(manifest_env)
-            .env(c_flags_env)
+            .env(rustflags_env)
+            .env(&[("CARGO_TARGET_DIR", "target")])
+            // Fetching separately allows docker to cache the downloads, assuming the Cargo.lock
+            // doesn't change.
             .run(
-                "cargo +risc0 fetch --target riscv32im-risc0-zkvm-elf --manifest-path $CARGO_MANIFEST_PATH --locked",
+                "cargo +risc0 fetch \
+                    --locked \
+                    --target riscv32im-risc0-zkvm-elf \
+                    --manifest-path $CARGO_MANIFEST_PATH",
             )
             .run(
-                "CARGO_TARGET_DIR=target \\\n\
-                \tcargo +risc0 build \\\n\
-                \t--locked \\\n\
-                \t--release \\\n\
-                \t--target riscv32im-risc0-zkvm-elf \\\n\
-                \t--manifest-path $CARGO_MANIFEST_PATH")
-            .run(r"find target/riscv32im-risc0-zkvm-elf/release -maxdepth 1 -type f -exec test -x {} \; -exec cp {} /tmp/ \;");
+                "cargo +risc0 build \
+                    --locked \
+                    --release \
+                    --target riscv32im-risc0-zkvm-elf \
+                    --manifest-path $CARGO_MANIFEST_PATH",
+            );
 
-        let binary: DockerFile<'_> = DockerFile::new()
-            .comment("binary stage")
-            .from_alias("binary", "scratch")
-            .env(pkg_env)
-            .copy_from("build", "/tmp", "/$PKG_NAME");
+        let out_dir = format!("/{pkg_name}");
+        let binary = DockerFile::new()
+            .comment("export stage")
+            .from_alias("export", "scratch")
+            .copy_from(
+                "build",
+                "/src/target/riscv32im-risc0-zkvm-elf/release",
+                out_dir.as_str(),
+            );
 
         let file = DockerFile::new().dockerfile(build).dockerfile(binary);
-        let mut dockerfile = File::create("Dockerfile")?;
-        dockerfile.write_all(file.to_string().as_bytes())?;
-        let mut dockerignore = File::create(".dockerignore")?;
-        dockerignore.write_all(DOCKER_IGNORE.as_bytes())?;
+        fs::write(temp_dir.join("Dockerfile"), file.to_string())?;
+        fs::write(temp_dir.join("Dockerfile.dockerignore"), DOCKER_IGNORE)?;
 
         Ok(())
     }
@@ -123,28 +140,19 @@ impl BuildGuest {
     /// Build the dockerfile and ouputs the ELF.
     ///
     /// Overwrites if an ELF with the same name already exists.
-    fn build(&self) -> Result<()> {
+    fn build(&self, temp_dir: &Path) -> Result<()> {
         Command::new("docker")
-            .args([
-                "build",
-                "--output=target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/",
-                "--target=binary",
-                ".",
-            ])
-            .run_verbose()?;
-
-        Ok(())
-    }
-
-    /// Remove Dockerfile and .dockerignore files.
-    fn clean(&self) -> Result<()> {
-        Command::new("rm")
-            .args(["Dockerfile", ".dockerignore"])
+            .arg("build")
+            .arg(format!("--output={TARGET_DIR}"))
+            .arg("-f")
+            .arg(temp_dir.join("Dockerfile"))
+            .arg(".")
             .run_verbose()
     }
 
     fn check_cargo_lock(&self) -> Result<()> {
-        let lock_file = PathBuf::from(&self.manifest_path)
+        let lock_file = self
+            .manifest_path
             .parent()
             .context("invalid manifest path")?
             .join("Cargo.lock");
@@ -156,7 +164,7 @@ impl BuildGuest {
     }
 
     /// Compute the image ID for a given ELF.
-    fn image_id(&self, elf_path: &PathBuf) -> Result<String> {
+    fn compute_image_id(&self, elf_path: &Path) -> Result<String> {
         let elf = fs::read(elf_path)?;
         let program = Program::load_elf(&elf, MEM_SIZE as u32).context("unable to load elf")?;
         let image = MemoryImage::new(&program, PAGE_SIZE as u32)
@@ -165,65 +173,55 @@ impl BuildGuest {
     }
 }
 
+// requires Docker to be installed
+#[cfg(feature = "docker")]
 #[cfg(test)]
 mod test {
-    use std::{env, path::PathBuf};
+    use std::path::PathBuf;
 
-    use super::BuildGuest;
-
-    struct Elf {
-        path: String,
-        image_id: String,
-    }
+    use super::{BuildGuest, TARGET_DIR};
 
     struct Tester {
-        manifest_path: String,
-        elfs: Vec<Elf>,
+        builder: BuildGuest,
     }
 
     impl Tester {
-        fn run(&self) {
-            env::set_current_dir("../../").unwrap();
+        fn new(manifest_path: &str) -> Self {
+            std::env::set_current_dir("../../").unwrap();
             let builder = BuildGuest {
-                manifest_path: self.manifest_path.clone(),
+                manifest_path: PathBuf::from(manifest_path),
             };
             builder.run().unwrap();
-            for elf in self.elfs.iter() {
-                assert_eq!(
-                    builder.image_id(&PathBuf::from(&elf.path)).unwrap(),
-                    elf.image_id
-                );
-            }
+            Self { builder }
+        }
+
+        fn compare_image_id(&self, bin_path: &str, expected: &str) {
+            let target_dir = PathBuf::from(TARGET_DIR);
+            let elf_path = target_dir.join(bin_path);
+            let actual = self.builder.compute_image_id(&elf_path).unwrap();
+            assert_eq!(expected, actual);
         }
     }
+
+    // Test build reproducibility for risc0_zkvm_methods_guest.
+    // If the code of the package or any of its dependencies change,
+    // it may be required to recompute the expected image_ids.
+    // For that, run:
+    // `cargo risczero build --manifest-path risc0/zkvm/methods/guest/Cargo.toml`
     #[test]
-    #[ignore] // requires Docker to be installed
-              // Test build reproducibility for risc0_zkvm_methods_guest.
-              // If the code of the package or any of its dependencies change,
-              // it may be required to recompute the expected image_ids.
-              // For that, run:
-              // `cargo risczero build --manifest-path risc0/zkvm/methods/guest/Cargo.toml`
     fn test_reproducible_methods_guest() {
-        let zkvm_methods_guest = Tester {
-            manifest_path: "risc0/zkvm/methods/guest/Cargo.toml".to_string(),
-            elfs: vec![
-                Elf {
-                    path: "target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/risc0_zkvm_methods_guest/hello_commit"
-                    .to_string(),
-                    image_id: "eb12f9b97d8759327f651afeb09ae9a5713e7dbc428284d453b8cf56e8dadd5a".to_string()
-                },
-                Elf {
-                    path: "target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/risc0_zkvm_methods_guest/multi_test"
-                    .to_string(),
-                    image_id: "761900e766a4ae1d8edcb2b49dc9aee54b94e42c9b0d6421cfb112314c4e3efc".to_string(),
-                },
-                Elf {
-                    path: "target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/risc0_zkvm_methods_guest/slice_io"
-                    .to_string(),
-                    image_id: "3f2ad1a2d500ab4ab927eebe241d872d3f598065b8987b182410cf01f350f74c".to_string()
-                }
-            ],
-        };
-        zkvm_methods_guest.run()
+        let tester = Tester::new("risc0/zkvm/methods/guest/Cargo.toml");
+        tester.compare_image_id(
+            "risc0_zkvm_methods_guest/hello_commit",
+            "eb12f9b97d8759327f651afeb09ae9a5713e7dbc428284d453b8cf56e8dadd5a",
+        );
+        tester.compare_image_id(
+            "risc0_zkvm_methods_guest/multi_test",
+            "44750696d3d67caaaf9b1ca9441d1ffe5d5b9370d6945ce56b1972c10e42da59",
+        );
+        tester.compare_image_id(
+            "risc0_zkvm_methods_guest/slice_io",
+            "3f2ad1a2d500ab4ab927eebe241d872d3f598065b8987b182410cf01f350f74c",
+        );
     }
 }

--- a/risc0/cargo-risczero/src/commands/build_toolchain.rs
+++ b/risc0/cargo-risczero/src/commands/build_toolchain.rs
@@ -58,6 +58,15 @@ impl BuildToolchain {
         }
 
         let out = self.build_toolchain(&rust_dir)?;
+        let tools_bin_dir = out.toolchain_dir.parent().unwrap().join("stage2-tools-bin");
+        let target_bin_dir = out.toolchain_dir.join("bin");
+
+        for tool in tools_bin_dir.read_dir()? {
+            let tool = tool?;
+            let tool_name = tool.file_name();
+            eprintln!("copy tool: {tool_name:?}");
+            std::fs::copy(&tool.path(), target_bin_dir.join(tool_name))?;
+        }
 
         RustupToolchain::link(RUSTUP_TOOLCHAIN_NAME, &out.toolchain_dir)?;
 

--- a/risc0/cargo-risczero/src/commands/config.toml
+++ b/risc0/cargo-risczero/src/commands/config.toml
@@ -3,7 +3,7 @@ changelog-seen = 2
 [build]
 target = ["riscv32im-risc0-zkvm-elf"]
 extended = true
-tools = ["clippy", "rustfmt"]
+tools = ["cargo", "cargo-clippy", "clippy", "rustfmt"]
 configure-args = []
 
 [rust]

--- a/risc0/cargo-risczero/src/lib.rs
+++ b/risc0/cargo-risczero/src/lib.rs
@@ -44,7 +44,7 @@ pub struct Risczero {
 #[derive(Subcommand)]
 /// Primary commands  of `cargo risczero`.
 pub enum RisczeroCmd {
-    /// Build a guest code in a reproducible way.
+    /// Build guest code.
     Build(BuildGuest),
     /// Build the riscv32im-risc0-zkvm-elf toolchain.
     BuildToolchain(BuildToolchain),

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "autocfg"
@@ -37,9 +37,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "blake2"
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f1226cd9da55587234753d1245dd5b132343ea240f26b6a9003d68706141ba"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "libc",
 ]
@@ -311,9 +311,9 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pkcs1"
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -648,11 +648,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -676,18 +676,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -756,9 +756,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -789,18 +789,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -902,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -917,45 +917,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
 
 [[package]]
 name = "zeroize"


### PR DESCRIPTION
* Since Cargo.lock changed, update docker test image_ids
* Use tempdir for Dockerfile
* Use `docker` feature for tests
* Export all files from docker build