### PR TITLE
Print VerificationError message instead of variant

### DIFF
--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -46,7 +46,7 @@ pub enum VerificationError {
 
 impl fmt::Debug for VerificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self, f)
+        fmt::Display::fmt(&self, f)
     }
 }
 

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -19,7 +19,7 @@ mod merkle;
 mod read_iop;
 
 use alloc::{vec, vec::Vec};
-use core::{cell::RefCell, fmt, iter::zip};
+use core::{cell::RefCell, fmt::{self, Display}, iter::zip};
 
 pub(crate) use merkle::MerkleTreeVerifier;
 pub use read_iop::ReadIOP;

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     INV_RATE, MAX_CYCLES_PO2, QUERIES,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub enum VerificationError {
     ReceiptFormatError,
     ControlVerificationError,
@@ -42,6 +42,12 @@ pub enum VerificationError {
     JournalDigestMismatch,
     UnexpectedExitCode,
     InvalidHashSuite,
+}
+
+impl fmt::Debug for VerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self, f)
+    }
 }
 
 impl fmt::Display for VerificationError {

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -19,7 +19,11 @@ mod merkle;
 mod read_iop;
 
 use alloc::{vec, vec::Vec};
-use core::{cell::RefCell, fmt::{self, Display}, iter::zip};
+use core::{
+    cell::RefCell,
+    fmt::{self, Display},
+    iter::zip,
+};
 
 pub(crate) use merkle::MerkleTreeVerifier;
 pub use read_iop::ReadIOP;

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -19,11 +19,7 @@ mod merkle;
 mod read_iop;
 
 use alloc::{vec, vec::Vec};
-use core::{
-    cell::RefCell,
-    fmt::{self, Display},
-    iter::zip,
-};
+use core::{cell::RefCell, fmt, iter::zip};
 
 pub(crate) use merkle::MerkleTreeVerifier;
 pub use read_iop::ReadIOP;


### PR DESCRIPTION
This PR changes how Debug behaves on the VerificationError struct. Instead of printing the variant of the struct, it uses the Display format to print the custom message.