### PR TITLE
crate validator: harden cargo risczero install

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,9 @@ jobs:
 
       - run: cargo install --force --path risc0/cargo-risczero
 
-      - run: cargo risczero install
+      - run: cargo run --bin cargo-risczero -- risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: cargo build --release
         working-directory: tools/crates-validator/


### PR DESCRIPTION
This is a suggestion by Frank. This chagne make this run command more resilient against github's IP throttling.