### PR TITLE
Fix full segment bug

### DIFF
--- a/risc0/cargo-risczero/src/commands/build_guest.rs
+++ b/risc0/cargo-risczero/src/commands/build_guest.rs
@@ -213,7 +213,7 @@ mod test {
         let tester = Tester::new("risc0/zkvm/methods/guest/Cargo.toml");
         tester.compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "2a1f586685d5d7ff121cacdeab79432ae6e872bc2b8ff99335cfebe7ea3987c4",
+            "e292842cb47a065057c3b7dae52c93dd849307e2e2746eec22c58517a3474f92",
         );
         tester.compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",

--- a/risc0/zkp/src/prove/executor.rs
+++ b/risc0/zkp/src/prove/executor.rs
@@ -132,7 +132,8 @@ where
 
     pub fn expand(&mut self) -> Result<()> {
         debug!("expand");
-        if self.steps > (1 << self.max_po2) {
+        assert!(false, "expand must not be called.");
+        if self.steps >= (1 << self.max_po2) {
             bail!("Cannot expand, max po2 of {} reached.", self.max_po2);
         }
         let new_code = self.expand_buf(&self.code, F::Elem::ZERO, self.code_size);

--- a/risc0/zkp/src/prove/executor.rs
+++ b/risc0/zkp/src/prove/executor.rs
@@ -132,7 +132,7 @@ where
 
     pub fn expand(&mut self) -> Result<()> {
         debug!("expand");
-        if self.steps >= (1 << self.max_po2) {
+        if self.steps > (1 << self.max_po2) {
             bail!("Cannot expand, max po2 of {} reached.", self.max_po2);
         }
         let new_code = self.expand_buf(&self.code, F::Elem::ZERO, self.code_size);

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -111,6 +111,13 @@ pub fn main() {
             let digest = sha::Impl::hash_bytes(&data);
             env::commit(&digest);
         }
+        MultiTestSpec::ShaDigestIter { data, num_iter } => {
+            let mut hash = &data[..];
+            for _ in 0..num_iter {
+                hash = sha::Impl::hash_bytes(hash).as_bytes();
+            }
+            env::commit(&Digest::try_from(hash).unwrap())
+        }
         MultiTestSpec::Syscall { count } => {
             let mut input: &[u8] = &[];
             let mut input_len: usize = 0;

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -29,6 +29,10 @@ pub enum MultiTestSpec {
     ShaDigest {
         data: Vec<u8>,
     },
+    ShaDigestIter {
+        data: Vec<u8>,
+        num_iter: u32,
+    },
     EventTrace,
     Profiler,
     Fail,

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -374,7 +374,7 @@ impl<'a> Executor<'a> {
         // * return ExitCode::SystemSplit
         // otherwise, commit memory and hart
         let total_pending_cycles = self.total_cycles() + opcode.cycles + op_result.extra_cycles;
-        // log::info!(
+        // log::debug!(
         //     "cycle: {}, segment: {}, total: {}",
         //     self.segment_cycle,
         //     total_pending_cycles,

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -56,7 +56,7 @@ use crate::{
 };
 
 /// The number of cycles required to compress a SHA-256 block.
-const SHA_CYCLES: usize = 72;
+const SHA_CYCLES: usize = 73;
 
 /// Number of cycles required to complete a BigInt operation.
 const BIGINT_CYCLES: usize = 9;
@@ -373,15 +373,8 @@ impl<'a> Executor<'a> {
         // * don't record any activity
         // * return ExitCode::SystemSplit
         // otherwise, commit memory and hart
-        let extra_cycles = if self.monitor.pending_cycles() == 0 {
-            1280
-        } else {
-            0
-        };
-
-        let total_pending_cycles =
-            self.total_cycles() + opcode.cycles + op_result.extra_cycles + extra_cycles;
-        // log::debug!(
+        let total_pending_cycles = self.total_cycles() + opcode.cycles + op_result.extra_cycles;
+        // log::info!(
         //     "cycle: {}, segment: {}, total: {}",
         //     self.segment_cycle,
         //     total_pending_cycles,

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -373,8 +373,14 @@ impl<'a> Executor<'a> {
         // * don't record any activity
         // * return ExitCode::SystemSplit
         // otherwise, commit memory and hart
+        let extra_cycles = if self.monitor.pending_cycles() == 0 {
+            1280
+        } else {
+            0
+        };
 
-        let total_pending_cycles = self.total_cycles() + opcode.cycles + op_result.extra_cycles;
+        let total_pending_cycles =
+            self.total_cycles() + opcode.cycles + op_result.extra_cycles + extra_cycles;
         // log::debug!(
         //     "cycle: {}, segment: {}, total: {}",
         //     self.segment_cycle,

--- a/risc0/zkvm/src/host/server/exec/monitor.rs
+++ b/risc0/zkvm/src/host/server/exec/monitor.rs
@@ -364,6 +364,22 @@ impl MemoryMonitor {
         Ok(())
     }
 
+    pub fn pending_cycles(&mut self) -> usize {
+        let mut pending_cycles: usize = 0;
+        for action in self.pending_actions.iter().rev() {
+            match action {
+                Action::PageRead(_page_idx, cycles) => {
+                    pending_cycles += cycles;
+                }
+                Action::PageWrite(_page_idx, cycles) => {
+                    pending_cycles += cycles;
+                }
+                _ => {}
+            }
+        }
+        pending_cycles
+    }
+
     // commit all pending activity
     pub fn commit(&mut self, cycle: usize) {
         self.pending_actions.clear();

--- a/risc0/zkvm/src/host/server/exec/monitor.rs
+++ b/risc0/zkvm/src/host/server/exec/monitor.rs
@@ -364,22 +364,6 @@ impl MemoryMonitor {
         Ok(())
     }
 
-    pub fn pending_cycles(&mut self) -> usize {
-        let mut pending_cycles: usize = 0;
-        for action in self.pending_actions.iter().rev() {
-            match action {
-                Action::PageRead(_page_idx, cycles) => {
-                    pending_cycles += cycles;
-                }
-                Action::PageWrite(_page_idx, cycles) => {
-                    pending_cycles += cycles;
-                }
-                _ => {}
-            }
-        }
-        pending_cycles
-    }
-
     // commit all pending activity
     pub fn commit(&mut self, cycle: usize) {
         self.pending_actions.clear();

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -117,6 +117,25 @@ fn sha_basics() {
 }
 
 #[test]
+#[serial]
+fn sha_iter() {
+    let input = to_vec(&MultiTestSpec::ShaDigestIter {
+        data: Vec::from([0u8; 32]),
+        num_iter: 1453,
+    })
+    .unwrap();
+    let env = ExecutorEnv::builder().add_input(&input).build().unwrap();
+    let mut exec = Executor::from_elf(env, MULTI_TEST_ELF).unwrap();
+    let session = exec.run().unwrap();
+    let receipt = session.prove().unwrap();
+    let digest = Digest::try_from(receipt.journal).unwrap();
+    assert_eq!(
+        hex::encode(digest),
+        "64f0f3d366aba3c216392318bcf94931d92f77a4275511a44efffe0f8c6d9c23"
+    )
+}
+
+#[test]
 fn bigint_accel() {
     let cases = testutils::generate_bigint_test_cases(&mut rand::thread_rng(), 10);
     for case in cases {

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -121,7 +121,7 @@ fn sha_basics() {
 fn sha_iter() {
     let input = to_vec(&MultiTestSpec::ShaDigestIter {
         data: Vec::from([0u8; 32]),
-        num_iter: 1453,
+        num_iter: 1500,
     })
     .unwrap();
     let env = ExecutorEnv::builder().add_input(&input).build().unwrap();
@@ -131,7 +131,7 @@ fn sha_iter() {
     let digest = Digest::try_from(receipt.journal).unwrap();
     assert_eq!(
         hex::encode(digest),
-        "64f0f3d366aba3c216392318bcf94931d92f77a4275511a44efffe0f8c6d9c23"
+        "9d4d1940b5c0c6d09c10add9631806f9df9467884d3e9ce4a147113e27f5c02a"
     )
 }
 


### PR DESCRIPTION
This PR fixes a bug occurring when calling iteratively sha2, ending up calling the `expand` function. The fix increases the const `SHA_CYCLES` from 72 to 73. 
It also adds a unit test for that case.

Fixes #820  