### PR TITLE
fix: include debug error message for unspecified error

### DIFF
--- a/bonsai/rest-api-mock/src/prover.rs
+++ b/bonsai/rest-api-mock/src/prover.rs
@@ -133,7 +133,7 @@ impl Prover {
                             .write()?
                             .put_session(task.session_id.clone(), "FAILED".to_string()),
                     };
-                    tracing::error!("Task {} failed! - {}", msg, err)
+                    tracing::error!("Task {} failed! - {:?}", msg, err)
                 }
             }
         }


### PR DESCRIPTION
Alternatively, https://github.com/risc0/risc0/blob/be8e7bb6d35bad0ef357a213219e918a886a5fa3/bonsai/rest-api-mock/src/error.rs#L39 could be transparent to just inherit the base type's display impl. Right now it just logs the static string, which is unhelpful.