### PR TITLE
Remove Bonsai SDK ImageIdExists error

### DIFF
--- a/bonsai/ethereum-relay/src/downloader/proxy_callback_proof_processor.rs
+++ b/bonsai/ethereum-relay/src/downloader/proxy_callback_proof_processor.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use bonsai_ethereum_contracts::i_bonsai_relay::CallbackRequestFilter;
 use bonsai_sdk::{
     alpha::Client,
-    alpha_async::{create_session, put_input},
+    alpha_async::{create_session, upload_input},
 };
 use tokio::sync::Notify;
 use tracing::info;
@@ -52,7 +52,8 @@ impl<S: Storage + Sync + Send> EventProcessor for ProxyCallbackProofRequestProce
         &self,
         event: CallbackRequestFilter,
     ) -> Result<(), crate::api::error::Error> {
-        let input_id = put_input(self.bonsai_client.clone(), event.input.clone().to_vec()).await?;
+        let input_id =
+            upload_input(self.bonsai_client.clone(), event.input.clone().to_vec()).await?;
         let bonsai_session_id = create_session(
             self.bonsai_client.clone(),
             hex::encode(event.image_id),

--- a/bonsai/ethereum-relay/tests/e2e_test.rs
+++ b/bonsai/ethereum-relay/tests/e2e_test.rs
@@ -30,8 +30,8 @@ mod tests {
         Relayer,
     };
     use bonsai_sdk::{
-        alpha::{Client as BonsaiClient, SdkErr},
-        alpha_async::{get_client_from_parts, put_image},
+        alpha::Client as BonsaiClient,
+        alpha_async::{get_client_from_parts, upload_img},
     };
     use ethers::types::{Bytes, H256 as ethers_H256, U256};
     use risc0_zkvm::{MemoryImage, Program, MEM_SIZE, PAGE_SIZE};
@@ -166,11 +166,9 @@ mod tests {
                 .expect("unable to create memory image");
             let image_id = hex::encode(image.compute_id());
             let image = bincode::serialize(&image).expect("Failed to serialize memory img");
-            let upload_result = put_image(bonsai_client.clone(), image_id.clone(), image).await;
-            match upload_result {
-                Ok(_) | Err(SdkErr::ImageIdExists) => {}
-                Err(_) => upload_result.expect("unable to upload result"),
-            }
+            upload_img(bonsai_client.clone(), image_id.clone(), image)
+                .await
+                .expect("unable to upload result");
             image_id
         };
         dbg!(&image_key);
@@ -313,11 +311,9 @@ mod tests {
             MemoryImage::new(&program, PAGE_SIZE as u32).expect("unable to create memory image");
         let image_id = hex::encode(image.compute_id());
         let image = bincode::serialize(&image).expect("Failed to serialize memory img");
-        let upload_result = put_image(bonsai_client.clone(), image_id.clone(), image).await;
-        match upload_result {
-            Ok(_) | Err(SdkErr::ImageIdExists) => {}
-            Err(_) => upload_result.expect("unable to upload result"),
-        }
+        upload_img(bonsai_client.clone(), image_id.clone(), image)
+            .await
+            .expect("unable to upload result");
 
         // Since we are using the True Elf, the first 4 bytes need to be the length
         // of the slice (in little endian)

--- a/bonsai/examples/governance/relay/src/lib.rs
+++ b/bonsai/examples/governance/relay/src/lib.rs
@@ -65,11 +65,7 @@ pub fn prove_alpha(elf: &[u8], input: Vec<u8>) -> Result<Output> {
 
     let img_id = get_digest(elf).context("Failed to generate elf memory image")?;
 
-    match client.upload_img(&img_id, elf.to_vec()) {
-        Ok(()) => (),
-        Err(SdkErr::ImageIdExists) => (),
-        Err(err) => return Err(err.into()),
-    }
+    client.upload_img(&img_id, elf.to_vec())?;
 
     let input_id = client
         .upload_input(input)

--- a/bonsai/examples/governance/relay/src/lib.rs
+++ b/bonsai/examples/governance/relay/src/lib.rs
@@ -15,7 +15,7 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
-use bonsai_sdk::alpha::{responses::SnarkProof, Client, SdkErr};
+use bonsai_sdk::alpha::{responses::SnarkProof, Client};
 use risc0_build::GuestListEntry;
 use risc0_zkvm::{
     Executor, ExecutorEnv, MemoryImage, Program, Receipt, ReceiptMetadata, MEM_SIZE, PAGE_SIZE,

--- a/bonsai/examples/governance/relay/src/main.rs
+++ b/bonsai/examples/governance/relay/src/main.rs
@@ -19,7 +19,7 @@ use bonsai_ethereum_relay::{EthersClientConfig, Relayer};
 use bonsai_ethereum_relay_cli::{resolve_guest_entry, resolve_image_output, Output};
 use bonsai_sdk::{
     alpha::{responses::SnarkProof, SdkErr},
-    alpha_async::{get_client_from_parts, put_image},
+    alpha_async::{get_client_from_parts, upload_img},
 };
 use clap::{Args, Parser, Subcommand};
 use ethers::{
@@ -295,16 +295,11 @@ async fn upload_images(
             get_client_from_parts(bonsai_api_url.to_string(), bonsai_api_key.to_string()).await?;
         let img_id = image_id.clone();
 
-        match put_image(
+        upload_img(
             bonsai_client.clone(),
             img_id.clone(),
             guest_entry.elf.to_vec(),
-        )
-        .await
-        {
-            Ok(()) | Err(SdkErr::ImageIdExists) => Ok::<_, anyhow::Error>(()),
-            Err(err) => Err(err.into()),
-        }?;
+        )?;
 
         image_ids.push(guest_entry.image_id.into());
     }

--- a/bonsai/examples/governance/relay/src/main.rs
+++ b/bonsai/examples/governance/relay/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::Context;
 use bonsai_ethereum_relay::{EthersClientConfig, Relayer};
 use bonsai_ethereum_relay_cli::{resolve_guest_entry, resolve_image_output, Output};
 use bonsai_sdk::{
-    alpha::{responses::SnarkProof, SdkErr},
+    alpha::responses::SnarkProof,
     alpha_async::{get_client_from_parts, upload_img},
 };
 use clap::{Args, Parser, Subcommand};
@@ -299,7 +299,8 @@ async fn upload_images(
             bonsai_client.clone(),
             img_id.clone(),
             guest_entry.elf.to_vec(),
-        )?;
+        )
+        .await?;
 
         image_ids.push(guest_entry.image_id.into());
     }

--- a/bonsai/rest-api-mock/src/lib.rs
+++ b/bonsai/rest-api-mock/src/lib.rs
@@ -111,12 +111,12 @@ mod test {
             let image = MemoryImage::new(&program, PAGE_SIZE as u32)?;
             let image_id = hex::encode(image.compute_id());
             let image = bincode::serialize(&image).expect("Failed to serialize memory img");
-            bonsai_sdk::put_image(client.clone(), image_id.clone(), image).await?;
+            bonsai_sdk::upload_img(client.clone(), image_id.clone(), image).await?;
             image_id
         };
 
         // Prepare input data and upload it.
-        let input_id = bonsai_sdk::put_input(client.clone(), vec![]).await?;
+        let input_id = bonsai_sdk::upload_input(client.clone(), vec![]).await?;
 
         // Start a session running the prover
         let session = bonsai_sdk::create_session(client.clone(), img_id, input_id).await?;

--- a/bonsai/sdk/src/alpha_async.rs
+++ b/bonsai/sdk/src/alpha_async.rs
@@ -35,7 +35,7 @@ pub async fn get_client_from_parts(url: String, api_key: String) -> Result<Clien
 }
 
 /// Upload a input buffer to the /inputs/ route
-pub async fn put_input(bonsai_client: Client, buf: Vec<u8>) -> Result<String, SdkErr> {
+pub async fn upload_input(bonsai_client: Client, buf: Vec<u8>) -> Result<String, SdkErr> {
     tokio::task::spawn_blocking(move || bonsai_client.upload_input(buf))
         .await
         .map_err(|err| SdkErr::InternalServerErr(format!("{err}")))?
@@ -43,14 +43,16 @@ pub async fn put_input(bonsai_client: Client, buf: Vec<u8>) -> Result<String, Sd
 
 /// Upload a image buffer to the /images/ route
 ///
+/// The boolean return indicates if the image already exists in bonsai
+///
 /// The image data can be either:
 /// * ELF file bytes
 /// * bincode encoded MemoryImage
-pub async fn put_image(
+pub async fn upload_img(
     bonsai_client: Client,
     image_id: String,
     image: Vec<u8>,
-) -> Result<(), SdkErr> {
+) -> Result<bool, SdkErr> {
     tokio::task::spawn_blocking(move || bonsai_client.upload_img(&image_id, image))
         .await
         .map_err(|err| SdkErr::InternalServerErr(format!("{err}")))?

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -15,7 +15,7 @@
 use core::time::Duration;
 
 use anyhow::{anyhow, bail, Result};
-use bonsai_sdk::alpha::{Client, SdkErr};
+use bonsai_sdk::alpha::Client;
 use risc0_binfmt::MemoryImage;
 
 use super::Prover;
@@ -53,13 +53,8 @@ impl Prover for BonsaiProver {
         let image_id = hex::encode(image.compute_id());
         let image = bincode::serialize(&image)?;
 
-        // ImageIdExists indicates that this image has already been uploaded to bonsai.
-        // If this is the case, simply move on to uploading the input.
-        match client.upload_img(&image_id, image) {
-            Ok(()) => (),
-            Err(SdkErr::ImageIdExists) => (),
-            Err(err) => return Err(err.into()),
-        }
+        // return value 'exists' is ignored here
+        client.upload_img(&image_id, image)?;
 
         // upload input data
         let input_id = client.upload_input(env.input)?;


### PR DESCRIPTION
Now upload_img() returns a boolean for a user to check if the image exists within bonsai instead of a Err variant.