### PR TITLE
Bonsai: Migrate SnarkProof types to match backend

### DIFF
--- a/bonsai/ethereum-relay/src/lib.rs
+++ b/bonsai/ethereum-relay/src/lib.rs
@@ -38,6 +38,7 @@ use ethers::core::types::Address;
 use storage::{in_memory::InMemoryStorage, Storage};
 use tokio::sync::Notify;
 use tracing::info;
+pub use uploader::completed_proofs::snark::tokenize_snark_proof;
 use uploader::{
     completed_proofs::manager::BonsaiCompleteProofManager,
     pending_proofs::manager::BonsaiPendingProofManager,

--- a/bonsai/ethereum-relay/src/lib.rs
+++ b/bonsai/ethereum-relay/src/lib.rs
@@ -38,7 +38,7 @@ use ethers::core::types::Address;
 use storage::{in_memory::InMemoryStorage, Storage};
 use tokio::sync::Notify;
 use tracing::info;
-pub use uploader::completed_proofs::snark::tokenize_snark_proof;
+pub use uploader::completed_proofs::snark::tokenize_snark_receipt;
 use uploader::{
     completed_proofs::manager::BonsaiCompleteProofManager,
     pending_proofs::manager::BonsaiPendingProofManager,

--- a/bonsai/ethereum-relay/src/tests/utils.rs
+++ b/bonsai/ethereum-relay/src/tests/utils.rs
@@ -16,7 +16,7 @@
 pub(crate) mod tests {
     use bonsai_ethereum_contracts::i_bonsai_relay::CallbackRequestFilter;
     use bonsai_sdk::alpha::{
-        responses::{CreateSessRes, Groth16Seal, SessionStatusRes, SnarkProof, SnarkStatusRes},
+        responses::{CreateSessRes, Groth16Seal, SessionStatusRes, SnarkReceipt, SnarkStatusRes},
         SessionId,
     };
     use ethers::types::{Address, Bytes, H256};
@@ -64,7 +64,7 @@ pub(crate) mod tests {
             zeroes.clone(),
             zeroes.clone(),
         ];
-        let dummy_snark = Some(SnarkProof {
+        let dummy_snark = Some(SnarkReceipt {
             snark: Groth16Seal { a, b, c, public },
             post_state_digest: vec![],
             journal: vec![],

--- a/bonsai/ethereum-relay/src/tests/utils.rs
+++ b/bonsai/ethereum-relay/src/tests/utils.rs
@@ -16,7 +16,7 @@
 pub(crate) mod tests {
     use bonsai_ethereum_contracts::i_bonsai_relay::CallbackRequestFilter;
     use bonsai_sdk::alpha::{
-        responses::{CreateSessRes, SessionStatusRes, SnarkProof, SnarkStatusRes},
+        responses::{CreateSessRes, Groth16Seal, SessionStatusRes, SnarkProof, SnarkStatusRes},
         SessionId,
     };
     use ethers::types::{Address, Bytes, H256, U256};
@@ -64,7 +64,11 @@ pub(crate) mod tests {
             zeroes.to_string(),
             zeroes.to_string(),
         ];
-        let dummy_snark = Some(SnarkProof { a, b, c, public });
+        let dummy_snark = Some(SnarkProof {
+            snark: Groth16Seal { a, b, c, public },
+            post_state_digest: vec![],
+            journal: vec![],
+        });
         let snark_status_res = SnarkStatusRes {
             status: "SUCCEEDED".to_string(),
             output: dummy_snark,

--- a/bonsai/ethereum-relay/src/tests/utils.rs
+++ b/bonsai/ethereum-relay/src/tests/utils.rs
@@ -19,7 +19,7 @@ pub(crate) mod tests {
         responses::{CreateSessRes, Groth16Seal, SessionStatusRes, SnarkProof, SnarkStatusRes},
         SessionId,
     };
-    use ethers::types::{Address, Bytes, H256, U256};
+    use ethers::types::{Address, Bytes, H256};
     use risc0_zkvm::{InnerReceipt, Receipt};
     use uuid::Uuid;
     use wiremock::{
@@ -51,18 +51,18 @@ pub(crate) mod tests {
         let create_snark_res = CreateSessRes {
             uuid: receipt_id.to_string(),
         };
-        let zeroes = &U256::zero().to_string();
-        let a = vec![zeroes.to_string(), zeroes.to_string()];
+        let zeroes = vec![0x0];
+        let a = vec![zeroes.clone(), zeroes.clone()];
         let b = vec![
-            vec![zeroes.to_string(), zeroes.to_string()],
-            vec![zeroes.to_string(), zeroes.to_string()],
+            vec![zeroes.clone(), zeroes.clone()],
+            vec![zeroes.clone(), zeroes.clone()],
         ];
-        let c = vec![zeroes.to_string(), zeroes.to_string()];
+        let c = vec![zeroes.clone(), zeroes.clone()];
         let public = vec![
-            zeroes.to_string(),
-            zeroes.to_string(),
-            zeroes.to_string(),
-            zeroes.to_string(),
+            zeroes.clone(),
+            zeroes.clone(),
+            zeroes.clone(),
+            zeroes.clone(),
         ];
         let dummy_snark = Some(SnarkProof {
             snark: Groth16Seal { a, b, c, public },

--- a/bonsai/ethereum-relay/src/uploader/completed_proofs/complete_proof.rs
+++ b/bonsai/ethereum-relay/src/uploader/completed_proofs/complete_proof.rs
@@ -17,10 +17,9 @@ use bonsai_ethereum_contracts::i_bonsai_relay::{
 };
 use bonsai_sdk::{
     alpha::{Client, SessionId},
-    alpha_async::{download, session_status},
+    alpha_async::session_status,
 };
 use ethers::abi;
-use risc0_zkvm::Receipt;
 
 use super::snark::tokenize_snark_proof;
 use crate::{api, uploader::completed_proofs::error::CompleteProofError};
@@ -37,23 +36,7 @@ pub(crate) async fn get_complete_proof(
     bonsai_proof_id: SessionId,
     callback_request: CallbackRequestFilter,
 ) -> Result<CompleteProof, CompleteProofError> {
-    let bonsai_response = session_status(bonsai_client.clone(), bonsai_proof_id.clone())
-        .await
-        .map_err(|err| CompleteProofError::ClientAPI {
-            source: api::error::Error::Bonsai(err),
-            id: bonsai_proof_id.clone(),
-        })?;
-
-    let receipt_url_result = match bonsai_response.receipt_url {
-        Some(url) => Ok(url),
-        None => Err(CompleteProofError::ReceiptNotFound {
-            id: bonsai_proof_id.clone(),
-        }),
-    };
-
-    let receipt_url = receipt_url_result?;
-
-    let receipt_buf = download(bonsai_client.clone(), receipt_url)
+    session_status(bonsai_client.clone(), bonsai_proof_id.clone())
         .await
         .map_err(|err| CompleteProofError::ClientAPI {
             source: api::error::Error::Bonsai(err),
@@ -67,33 +50,25 @@ pub(crate) async fn get_complete_proof(
             .await?;
     let seal = match dev_mode {
         true => vec![],
-        false => abi::encode(&[tokenize_snark_proof(&snark_proof).map_err(|_| {
+        false => abi::encode(&[tokenize_snark_proof(&snark_proof.snark).map_err(|_| {
             CompleteProofError::SnarkFailed {
                 id: bonsai_proof_id.clone(),
             }
         })?]),
     };
 
-    let receipt: Receipt =
-        bincode::deserialize(&receipt_buf).map_err(|_| CompleteProofError::InvalidReceipt {
-            id: bonsai_proof_id.clone(),
-        })?;
     let post_state_digest: [u8; 32] = match dev_mode {
-        false => {
-            let metadata =
-                receipt
-                    .get_metadata()
-                    .map_err(|_| CompleteProofError::InvalidReceipt {
-                        id: bonsai_proof_id.clone(),
-                    })?;
-            metadata.post.digest().into()
-        }
+        false => snark_proof.post_state_digest.try_into().map_err(|_err| {
+            CompleteProofError::SnarkFailed {
+                id: bonsai_proof_id.clone(),
+            }
+        })?,
         true => [0u8; 32],
     };
 
     let payload = [
         callback_request.function_selector.as_slice(),
-        receipt.journal.as_slice(),
+        snark_proof.journal.as_slice(),
         callback_request.image_id.as_slice(),
     ]
     .concat();

--- a/bonsai/ethereum-relay/src/uploader/completed_proofs/error.rs
+++ b/bonsai/ethereum-relay/src/uploader/completed_proofs/error.rs
@@ -66,8 +66,6 @@ impl BonsaiCompleteProofManagerError {
 pub(crate) enum CompleteProofError {
     /// bonsai client error for proof
     ClientAPI { source: Error, id: ProofID },
-    /// bonsai receipt was not found for proof
-    ReceiptNotFound { id: ProofID },
     /// bonsai snark conversion for proof failed
     SnarkFailed { id: ProofID },
     /// bonsai snark timed out
@@ -76,8 +74,6 @@ pub(crate) enum CompleteProofError {
     SnarkAborted { id: ProofID },
     /// bonsai snark is in unknown state
     SnarkUnknown { id: ProofID },
-    /// invalid receipt
-    InvalidReceipt { id: ProofID },
 }
 
 impl CompleteProofError {
@@ -87,8 +83,6 @@ impl CompleteProofError {
             | CompleteProofError::SnarkFailed { id }
             | CompleteProofError::SnarkTimedOut { id }
             | CompleteProofError::SnarkUnknown { id }
-            | CompleteProofError::ReceiptNotFound { id }
-            | CompleteProofError::InvalidReceipt { id }
             | CompleteProofError::ClientAPI { id, .. } => id,
         }
     }

--- a/bonsai/ethereum-relay/src/uploader/completed_proofs/mod.rs
+++ b/bonsai/ethereum-relay/src/uploader/completed_proofs/mod.rs
@@ -15,4 +15,4 @@
 mod complete_proof;
 mod error;
 pub(crate) mod manager;
-mod snark;
+pub(crate) mod snark;

--- a/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
+++ b/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
@@ -15,7 +15,7 @@
 use std::time::Duration;
 
 use bonsai_sdk::{
-    alpha::{responses::SnarkSeal, Client, SessionId, SnarkId},
+    alpha::{responses::Groth16Seal, Client, SessionId, SnarkId},
     alpha_async::{create_snark, snark_status},
 };
 use ethers::{
@@ -69,7 +69,7 @@ pub(crate) async fn get_snark_proof(
     Ok(proof)
 }
 
-pub fn tokenize_snark_proof(proof: &SnarkSeal) -> anyhow::Result<Token> {
+pub fn tokenize_snark_proof(proof: &Groth16Seal) -> anyhow::Result<Token> {
     if proof.b.len() != 2 {
         anyhow::bail!("hex-strings encoded proof is not well formed");
     }

--- a/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
+++ b/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
@@ -40,7 +40,7 @@ pub(crate) async fn get_snark_id(
     Ok(snark_id)
 }
 
-pub(crate) async fn get_snark_proof(
+pub(crate) async fn get_snark_receipt(
     client: Client,
     snark_id: SnarkId,
     session_id: SessionId,
@@ -57,7 +57,7 @@ pub(crate) async fn get_snark_proof(
             })?;
         match (snark.status.as_str(), snark.output) {
             ("RUNNING", _) => tokio::time::sleep(Duration::from_secs(1)).await,
-            ("SUCCEEDED", Some(snark_proof)) => break snark_proof,
+            ("SUCCEEDED", Some(snark_receipt)) => break snark_receipt,
             ("SUCCEEDED", None) => return Err(CompleteProofError::SnarkFailed { id: session_id }),
             ("FAILED", _) => return Err(CompleteProofError::SnarkFailed { id: session_id }),
             ("TIMED_OUT", _) => return Err(CompleteProofError::SnarkTimedOut { id: session_id }),
@@ -69,7 +69,7 @@ pub(crate) async fn get_snark_proof(
     Ok(proof)
 }
 
-pub fn tokenize_snark_proof(proof: &Groth16Seal) -> anyhow::Result<Token> {
+pub fn tokenize_snark_receipt(proof: &Groth16Seal) -> anyhow::Result<Token> {
     if proof.b.len() != 2 {
         anyhow::bail!("hex-strings encoded proof is not well formed");
     }

--- a/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
+++ b/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
@@ -44,7 +44,7 @@ pub(crate) async fn get_snark_proof(
     client: Client,
     snark_id: SnarkId,
     session_id: SessionId,
-) -> Result<bonsai_sdk::alpha::responses::SnarkProof, CompleteProofError> {
+) -> Result<bonsai_sdk::alpha::responses::SnarkReceipt, CompleteProofError> {
     // Hit the Bonsai API until the receipt is ready
     // TODO: This is not the most efficient way to do this. We should convert to
     // a Future implementation later.
@@ -83,20 +83,20 @@ pub fn tokenize_snark_proof(proof: &Groth16Seal) -> anyhow::Result<Token> {
             proof
                 .a
                 .iter()
-                .map(|elm| U256::from_little_endian(elm).into_token())
+                .map(|elm| U256::from_big_endian(elm).into_token())
                 .collect(),
         ),
         Token::FixedArray(vec![
             Token::FixedArray(
                 proof.b[0]
                     .iter()
-                    .map(|elm| U256::from_little_endian(elm).into_token())
+                    .map(|elm| U256::from_big_endian(elm).into_token())
                     .collect(),
             ),
             Token::FixedArray(
                 proof.b[1]
                     .iter()
-                    .map(|elm| U256::from_little_endian(elm).into_token())
+                    .map(|elm| U256::from_big_endian(elm).into_token())
                     .collect(),
             ),
         ]),
@@ -104,7 +104,7 @@ pub fn tokenize_snark_proof(proof: &Groth16Seal) -> anyhow::Result<Token> {
             proof
                 .c
                 .iter()
-                .map(|elm| U256::from_little_endian(elm).into_token())
+                .map(|elm| U256::from_big_endian(elm).into_token())
                 .collect(),
         ),
     ]))

--- a/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
+++ b/bonsai/ethereum-relay/src/uploader/completed_proofs/snark.rs
@@ -83,20 +83,20 @@ pub fn tokenize_snark_proof(proof: &Groth16Seal) -> anyhow::Result<Token> {
             proof
                 .a
                 .iter()
-                .map(|elm| U256::from_little_endian(&elm).into_token())
+                .map(|elm| U256::from_little_endian(elm).into_token())
                 .collect(),
         ),
         Token::FixedArray(vec![
             Token::FixedArray(
                 proof.b[0]
                     .iter()
-                    .map(|elm| U256::from_little_endian(&elm).into_token())
+                    .map(|elm| U256::from_little_endian(elm).into_token())
                     .collect(),
             ),
             Token::FixedArray(
                 proof.b[1]
                     .iter()
-                    .map(|elm| U256::from_little_endian(&elm).into_token())
+                    .map(|elm| U256::from_little_endian(elm).into_token())
                     .collect(),
             ),
         ]),
@@ -104,7 +104,7 @@ pub fn tokenize_snark_proof(proof: &Groth16Seal) -> anyhow::Result<Token> {
             proof
                 .c
                 .iter()
-                .map(|elm| U256::from_little_endian(&elm).into_token())
+                .map(|elm| U256::from_little_endian(elm).into_token())
                 .collect(),
         ),
     ]))

--- a/bonsai/examples/governance/relay/src/lib.rs
+++ b/bonsai/examples/governance/relay/src/lib.rs
@@ -22,7 +22,7 @@ use risc0_zkvm::{Executor, ExecutorEnv, MemoryImage, Program, Receipt, MEM_SIZE,
 /// Result of executing a guest image, possibly containing a proof.
 pub enum Output {
     Execution { journal: Vec<u8> },
-    Bonsai { snark_proof: SnarkReceipt },
+    Bonsai { snark_receipt: SnarkReceipt },
 }
 
 /// Execute and prove the guest locally, on this machine, as opposed to sending
@@ -105,7 +105,7 @@ pub fn prove_alpha(elf: &[u8], input: Vec<u8>) -> Result<Output> {
     })()?;
 
     let snark_session = client.create_snark(session.uuid)?;
-    let snark_proof: SnarkReceipt = (|| loop {
+    let snark_receipt: SnarkReceipt = (|| loop {
         let res = snark_session.status(&client)?;
         match res.status.as_str() {
             "RUNNING" => {
@@ -126,7 +126,7 @@ pub fn prove_alpha(elf: &[u8], input: Vec<u8>) -> Result<Output> {
         }
     })()?;
 
-    Ok(Output::Bonsai { snark_proof })
+    Ok(Output::Bonsai { snark_receipt })
 }
 
 pub fn resolve_guest_entry<'a>(

--- a/bonsai/examples/governance/relay/src/lib.rs
+++ b/bonsai/examples/governance/relay/src/lib.rs
@@ -15,14 +15,14 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
-use bonsai_sdk::alpha::{responses::SnarkProof, Client};
+use bonsai_sdk::alpha::{responses::SnarkReceipt, Client};
 use risc0_build::GuestListEntry;
 use risc0_zkvm::{Executor, ExecutorEnv, MemoryImage, Program, Receipt, MEM_SIZE, PAGE_SIZE};
 
 /// Result of executing a guest image, possibly containing a proof.
 pub enum Output {
     Execution { journal: Vec<u8> },
-    Bonsai { snark_proof: SnarkProof },
+    Bonsai { snark_proof: SnarkReceipt },
 }
 
 /// Execute and prove the guest locally, on this machine, as opposed to sending
@@ -105,7 +105,7 @@ pub fn prove_alpha(elf: &[u8], input: Vec<u8>) -> Result<Output> {
     })()?;
 
     let snark_session = client.create_snark(session.uuid)?;
-    let snark_proof: SnarkProof = (|| loop {
+    let snark_proof: SnarkReceipt = (|| loop {
         let res = snark_session.status(&client)?;
         match res.status.as_str() {
             "RUNNING" => {

--- a/bonsai/examples/governance/relay/src/lib.rs
+++ b/bonsai/examples/governance/relay/src/lib.rs
@@ -17,20 +17,12 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 use bonsai_sdk::alpha::{responses::SnarkProof, Client};
 use risc0_build::GuestListEntry;
-use risc0_zkvm::{
-    Executor, ExecutorEnv, MemoryImage, Program, Receipt, ReceiptMetadata, MEM_SIZE, PAGE_SIZE,
-};
+use risc0_zkvm::{Executor, ExecutorEnv, MemoryImage, Program, Receipt, MEM_SIZE, PAGE_SIZE};
 
 /// Result of executing a guest image, possibly containing a proof.
 pub enum Output {
-    Execution {
-        journal: Vec<u8>,
-    },
-    Bonsai {
-        journal: Vec<u8>,
-        receipt_metadata: ReceiptMetadata,
-        snark_proof: SnarkProof,
-    },
+    Execution { journal: Vec<u8> },
+    Bonsai { snark_proof: SnarkProof },
 }
 
 /// Execute and prove the guest locally, on this machine, as opposed to sending
@@ -76,7 +68,7 @@ pub fn prove_alpha(elf: &[u8], input: Vec<u8>) -> Result<Output> {
         .context("Failed to create remote proving session")?;
 
     // Poll and await the result of the STARK rollup proving session.
-    let receipt: Receipt = (|| {
+    let _receipt: Receipt = (|| {
         loop {
             let res = match session.status(&client) {
                 Ok(res) => res,
@@ -111,7 +103,6 @@ pub fn prove_alpha(elf: &[u8], input: Vec<u8>) -> Result<Output> {
             }
         }
     })()?;
-    let metadata = receipt.get_metadata()?;
 
     let snark_session = client.create_snark(session.uuid)?;
     let snark_proof: SnarkProof = (|| loop {
@@ -135,11 +126,7 @@ pub fn prove_alpha(elf: &[u8], input: Vec<u8>) -> Result<Output> {
         }
     })()?;
 
-    Ok(Output::Bonsai {
-        journal: receipt.journal,
-        receipt_metadata: metadata,
-        snark_proof,
-    })
+    Ok(Output::Bonsai { snark_proof })
 }
 
 pub fn resolve_guest_entry<'a>(

--- a/bonsai/examples/governance/relay/src/main.rs
+++ b/bonsai/examples/governance/relay/src/main.rs
@@ -15,7 +15,7 @@
 use std::io::Write;
 
 use anyhow::Context;
-use bonsai_ethereum_relay::{tokenize_snark_proof, EthersClientConfig, Relayer};
+use bonsai_ethereum_relay::{tokenize_snark_receipt, EthersClientConfig, Relayer};
 use bonsai_ethereum_relay_cli::{resolve_guest_entry, resolve_image_output, Output};
 use bonsai_sdk::alpha_async::{get_client_from_parts, upload_img};
 use clap::{Args, Parser, Subcommand};
@@ -139,12 +139,12 @@ async fn main() -> anyhow::Result<()> {
                         (true, Output::Execution { journal }) => {
                             vec![Token::Bytes(journal)]
                         }
-                        (false, Output::Bonsai { snark_proof }) => {
+                        (false, Output::Bonsai { snark_receipt }) => {
                             vec![
-                                Token::Bytes(snark_proof.journal),
-                                Token::Bytes(snark_proof.post_state_digest),
-                                Token::Bytes(ethers::abi::encode(&[tokenize_snark_proof(
-                                    &snark_proof.snark,
+                                Token::Bytes(snark_receipt.journal),
+                                Token::FixedBytes(snark_receipt.post_state_digest),
+                                Token::Bytes(ethers::abi::encode(&[tokenize_snark_receipt(
+                                    &snark_receipt.snark,
                                 )?])),
                             ]
                         }

--- a/bonsai/rest-api-mock/src/routes.rs
+++ b/bonsai/rest-api-mock/src/routes.rs
@@ -20,7 +20,7 @@ use axum::{
     Extension, Json,
 };
 use bonsai_sdk::alpha::responses::{
-    CreateSessRes, ImgUploadRes, ProofReq, SessionStatusRes, SnarkProof, SnarkReq, SnarkSeal,
+    CreateSessRes, Groth16Seal, ImgUploadRes, ProofReq, SessionStatusRes, SnarkProof, SnarkReq,
     SnarkStatusRes, UploadRes,
 };
 use tracing::info;
@@ -131,7 +131,7 @@ pub(crate) async fn snark_status(
     Ok(Json(SnarkStatusRes {
         status: "SUCCEEDED".to_string(),
         output: Some(SnarkProof {
-            snark: SnarkSeal {
+            snark: Groth16Seal {
                 a: vec![],
                 b: vec![],
                 c: vec![],

--- a/bonsai/rest-api-mock/src/routes.rs
+++ b/bonsai/rest-api-mock/src/routes.rs
@@ -20,8 +20,8 @@ use axum::{
     Extension, Json,
 };
 use bonsai_sdk::alpha::responses::{
-    CreateSessRes, ImgUploadRes, ProofReq, SessionStatusRes, SnarkProof, SnarkReq, SnarkStatusRes,
-    UploadRes,
+    CreateSessRes, ImgUploadRes, ProofReq, SessionStatusRes, SnarkProof, SnarkReq, SnarkSeal,
+    SnarkStatusRes, UploadRes,
 };
 use tracing::info;
 
@@ -131,10 +131,14 @@ pub(crate) async fn snark_status(
     Ok(Json(SnarkStatusRes {
         status: "SUCCEEDED".to_string(),
         output: Some(SnarkProof {
-            a: vec![],
-            b: vec![vec![]],
-            c: vec![],
-            public: vec![],
+            snark: SnarkSeal {
+                a: vec![],
+                b: vec![],
+                c: vec![],
+                public: vec![],
+            },
+            post_state_digest: vec![],
+            journal: vec![],
         }),
         error_msg: None,
     }))

--- a/bonsai/rest-api-mock/src/routes.rs
+++ b/bonsai/rest-api-mock/src/routes.rs
@@ -20,7 +20,7 @@ use axum::{
     Extension, Json,
 };
 use bonsai_sdk::alpha::responses::{
-    CreateSessRes, Groth16Seal, ImgUploadRes, ProofReq, SessionStatusRes, SnarkProof, SnarkReq,
+    CreateSessRes, Groth16Seal, ImgUploadRes, ProofReq, SessionStatusRes, SnarkReceipt, SnarkReq,
     SnarkStatusRes, UploadRes,
 };
 use tracing::info;
@@ -130,7 +130,7 @@ pub(crate) async fn snark_status(
 ) -> Result<Json<SnarkStatusRes>, Error> {
     Ok(Json(SnarkStatusRes {
         status: "SUCCEEDED".to_string(),
-        output: Some(SnarkProof {
+        output: Some(SnarkReceipt {
             snark: Groth16Seal {
                 a: vec![],
                 b: vec![],

--- a/bonsai/sdk/README.md
+++ b/bonsai/sdk/README.md
@@ -87,8 +87,8 @@ fn run_stark2snark(session_id: String) -> Result<()> {
                 continue;
             }
             "SUCCEEDED" => {
-                let snark_proof = res.output;
-                tracing::info!("Snark proof!: {snark_proof:?}");
+                let snark_receipt = res.output;
+                tracing::info!("Snark proof!: {snark_receipt:?}");
                 break;
             }
             _ => {

--- a/bonsai/sdk/src/alpha.rs
+++ b/bonsai/sdk/src/alpha.rs
@@ -126,13 +126,13 @@ pub mod responses {
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub struct SnarkSeal {
         /// Proof 'a' value
-        pub a: Vec<String>,
+        pub a: Vec<Vec<u8>>,
         /// Proof 'b' value
-        pub b: Vec<Vec<String>>,
+        pub b: Vec<Vec<Vec<u8>>>,
         /// Proof 'c' value
-        pub c: Vec<String>,
+        pub c: Vec<Vec<u8>>,
         /// Proof public outputs
-        pub public: Vec<String>,
+        pub public: Vec<Vec<u8>>,
     }
 
     /// Snark Proof object

--- a/bonsai/sdk/src/alpha.rs
+++ b/bonsai/sdk/src/alpha.rs
@@ -135,11 +135,11 @@ pub mod responses {
         pub public: Vec<Vec<u8>>,
     }
 
-    /// Snark Proof object
+    /// Snark Receipt object
     ///
     /// All relevant data to verify both the snark proof an corresponding imageId on chain.
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
-    pub struct SnarkProof {
+    pub struct SnarkReceipt {
         /// Snark seal from snarkjs
         pub snark: Groth16Seal,
         /// Post State Digest
@@ -157,10 +157,10 @@ pub mod responses {
         ///
         /// values: `[ RUNNING | SUCCEEDED | FAILED | TIMED_OUT | ABORTED ]`
         pub status: String,
-        /// SNARK proof output
+        /// SNARK receipt output
         ///
-        /// Generated snark proof,
-        pub output: Option<SnarkProof>,
+        /// Generated snark receipt,
+        pub output: Option<SnarkReceipt>,
         /// Snark Error message
         ///
         /// If the SNARK status is not `RUNNING` or `SUCCEEDED`, this is the error raised from within bonsai.

--- a/bonsai/sdk/src/alpha.rs
+++ b/bonsai/sdk/src/alpha.rs
@@ -124,7 +124,7 @@ pub mod responses {
     /// following the snarkjs calldata format:
     /// <https://github.com/iden3/snarkjs#26-simulate-a-verification-call>
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
-    pub struct SnarkSeal {
+    pub struct Groth16Seal {
         /// Proof 'a' value
         pub a: Vec<Vec<u8>>,
         /// Proof 'b' value
@@ -141,7 +141,7 @@ pub mod responses {
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     pub struct SnarkProof {
         /// Snark seal from snarkjs
-        pub snark: SnarkSeal,
+        pub snark: Groth16Seal,
         /// Post State Digest
         ///
         /// Collected from the STARK proof via `receipt.get_metadata().post.digest()`

--- a/bonsai/sdk/src/alpha.rs
+++ b/bonsai/sdk/src/alpha.rs
@@ -123,8 +123,11 @@ pub mod responses {
     }
 
     /// Snark Proof object
+    ///
+    /// following the snarkjs calldata format:
+    /// <https://github.com/iden3/snarkjs#26-simulate-a-verification-call>
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
-    pub struct SnarkProof {
+    pub struct SnarkSeal {
         /// Proof 'a' value
         pub a: Vec<String>,
         /// Proof 'b' value
@@ -133,6 +136,21 @@ pub mod responses {
         pub c: Vec<String>,
         /// Proof public outputs
         pub public: Vec<String>,
+    }
+
+    /// Snark Proof object
+    ///
+    /// All relevant data to verify both the snark proof an corresponding imageId on chain.
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    pub struct SnarkProof {
+        /// Snark seal from snarkjs
+        pub snark: SnarkSeal,
+        /// Post State Digest
+        ///
+        /// Collected from the STARK proof via `receipt.get_metadata().post.digest()`
+        pub post_state_digest: Vec<u8>,
+        /// Journal data from the risc-zkvm Receipt object
+        pub journal: Vec<u8>,
     }
 
     /// Session Status response
@@ -144,8 +162,7 @@ pub mod responses {
         pub status: String,
         /// SNARK proof output
         ///
-        /// Generated snark proof, following the snarkjs calldata format:
-        /// <https://github.com/iden3/snarkjs#26-simulate-a-verification-call>
+        /// Generated snark proof,
         pub output: Option<SnarkProof>,
         /// Snark Error message
         ///


### PR DESCRIPTION
Migrated to the more complete SnarkProof type from Bonsai to enable easier ETH verify integrations. 

I updated most of the relay codebase to match the the new format, I hope I got everything wired up correctly but if someone who knows how to drive e2e testing with bonsai could help me validate it that would be great!.