### PR TITLE
Expose `host::api::Connector` to users

### DIFF
--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -104,7 +104,9 @@ impl ConnectionWrapper {
     }
 }
 
+/// Connects a zkVM client and server
 pub trait Connector {
+    /// Create a client-server connection
     fn connect(&self) -> Result<ConnectionWrapper>;
 }
 

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -47,6 +47,7 @@ pub use self::host::server::exec::profiler::Profiler;
 #[cfg(feature = "client")]
 pub use self::host::{
     api::client::Client as ApiClient,
+    api::Connector,
     client::{
         env::{ExecutorEnv, ExecutorEnvBuilder},
         exec::TraceEvent,


### PR DESCRIPTION
Since `ApiClient` has a method that requires a `Connector`, we need to make sure `Connector` is also public. This PR does that, and adds rudimentary docs for `Connector` (they're pretty minimal as I don't know any details about it).