### PR TITLE
updating references to 0.18

### DIFF
--- a/bonsai/examples/governance/methods/guest/Cargo.lock
+++ b/bonsai/examples/governance/methods/guest/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "elf",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "log",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "rustix"

--- a/risc0/build/README.md
+++ b/risc0/build/README.md
@@ -31,7 +31,7 @@ guest code. For example, if your guest code is in the `guest` directory,
 then `Cargo.toml` might include
 ```toml
 [build-dependencies]
-risc0-build = "0.17"
+risc0-build = "0.18"
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/risc0/cargo-risczero/src/commands/build_guest.rs
+++ b/risc0/cargo-risczero/src/commands/build_guest.rs
@@ -98,7 +98,7 @@ impl BuildGuest {
         let rustflags_env = &[("RUSTFLAGS", rustflags.as_str())];
 
         let build = DockerFile::new()
-            .from_alias("build", "risczero/risc0-guest-builder:v0.17")
+            .from_alias("build", "risczero/risc0-guest-builder:v0.18")
             .workdir("/src")
             .copy(".", ".")
             .env(manifest_env)


### PR DESCRIPTION
Ran a quick ctrl-f on the risc0 repo to see if there are remaining 0.17 references to update. Caught and updated a few. 

Wasn't sure about these ones, but it sounds like they have been discussed and are OK as is.

![image](https://github.com/risc0/risc0/assets/15272444/14acf10c-5bef-4e0d-9853-2b5ecc8938f7)
![image](https://github.com/risc0/risc0/assets/15272444/5fd9fbc2-037c-47f3-af8e-ec31171ca382)
