### PR TITLE
load_elf: change maximum memory address to SYSTEM.start()

### DIFF
--- a/risc0/binfmt/src/elf.rs
+++ b/risc0/binfmt/src/elf.rs
@@ -81,6 +81,9 @@ impl Program {
                 .map_err(|err| anyhow!("offset is larger than 32 bits. {err}"))?;
             for i in (0..mem_size).step_by(4) {
                 let addr = vaddr.checked_add(i).context("Invalid segment vaddr")?;
+                if addr >= GUEST_MAX_MEM {
+                    bail!("Address [0x{addr:08x}] exceeds maximum address for guest programs [0x{GUEST_MAX_MEM:08x}]");
+                }
                 if i >= file_size {
                     // Past the file size, all zeros.
                     image.insert(addr, 0);

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -77,7 +77,7 @@ impl Risc0Method {
         }
 
         let elf = fs::read(&self.elf_path).unwrap();
-        let program = Program::load_elf(&elf, memory::MEM_SIZE as u32).unwrap();
+        let program = Program::load_elf(&elf).unwrap();
         let image = MemoryImage::new(&program, PAGE_SIZE as u32).unwrap();
         image.compute_id()
     }

--- a/risc0/zkvm/platform/src/memory.rs
+++ b/risc0/zkvm/platform/src/memory.rs
@@ -16,6 +16,7 @@ use super::WORD_SIZE;
 
 pub const MEM_BITS: usize = 28;
 pub const MEM_SIZE: usize = 1 << MEM_BITS;
+pub const GUEST_MAX_MEM: u32 = SYSTEM.start as u32;
 
 pub struct Region {
     start: usize,

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -21,7 +21,7 @@ use std::{
 use anyhow::{anyhow, bail, Result};
 use bytes::Bytes;
 use risc0_binfmt::{MemoryImage, Program};
-use risc0_zkvm_platform::{memory::MEM_SIZE, PAGE_SIZE};
+use risc0_zkvm_platform::PAGE_SIZE;
 use serde::{Deserialize, Serialize};
 
 use super::{malformed_err, path_to_string, pb, ConnectionWrapper, Connector, TcpConnector};
@@ -52,7 +52,7 @@ impl pb::Binary {
             pb::binary::Kind::Unspecified => bail!(malformed_err()),
             pb::binary::Kind::Image => bincode::deserialize(&bytes)?,
             pb::binary::Kind::Elf => {
-                let program = Program::load_elf(&bytes, MEM_SIZE as u32)?;
+                let program = Program::load_elf(&bytes)?;
                 MemoryImage::new(&program, PAGE_SIZE as u32)?
             }
         };

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -21,7 +21,7 @@ use std::{path::PathBuf, rc::Rc};
 
 use anyhow::Result;
 use risc0_binfmt::{MemoryImage, Program};
-use risc0_zkvm_platform::{memory::MEM_SIZE, PAGE_SIZE};
+use risc0_zkvm_platform::PAGE_SIZE;
 use serde::{Deserialize, Serialize};
 
 use self::{bonsai::BonsaiProver, external::ExternalProver};
@@ -40,7 +40,6 @@ use crate::{is_dev_mode, ExecutorEnv, Receipt, VerifierContext};
 /// use risc0_zkvm::{
 ///     default_prover,
 ///     ExecutorEnv,
-///     MEM_SIZE,
 ///     MemoryImage,
 ///     PAGE_SIZE,
 ///     Program,
@@ -65,7 +64,7 @@ use crate::{is_dev_mode, ExecutorEnv, Receipt, VerifierContext};
 /// // Or you can prove from a `MemoryImage`
 /// // (generating a `MemoryImage` from an ELF file in this way is equivalent
 /// // to the above code.)
-/// let program = Program::load_elf(FIB_ELF, MEM_SIZE as u32).unwrap();
+/// let program = Program::load_elf(FIB_ELF).unwrap();
 /// let image = MemoryImage::new(&program, PAGE_SIZE as u32).unwrap();
 /// let env = ExecutorEnv::builder().add_input(&[20]).build().unwrap();
 /// let ctx = VerifierContext::default();
@@ -104,7 +103,7 @@ pub trait Prover {
         elf: &[u8],
         opts: &ProverOpts,
     ) -> Result<Receipt> {
-        let program = Program::load_elf(elf, MEM_SIZE as u32)?;
+        let program = Program::load_elf(elf)?;
         let image = MemoryImage::new(&program, PAGE_SIZE as u32)?;
         self.prove(env, ctx, opts, image)
     }

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -34,7 +34,6 @@ use risc0_zkp::{
 };
 use risc0_zkvm_platform::{
     fileno,
-    memory::MEM_SIZE,
     syscall::{
         bigint, ecall, halt,
         reg_abi::{REG_A0, REG_A1, REG_A2, REG_A3, REG_A4, REG_T0},
@@ -196,7 +195,7 @@ impl<'a> Executor<'a> {
     /// let mut exec = Executor::from_elf(env, BENCH_ELF).unwrap();
     /// ```
     pub fn from_elf(env: ExecutorEnv<'a>, elf: &[u8]) -> Result<Self> {
-        let program = Program::load_elf(elf, MEM_SIZE as u32)?;
+        let program = Program::load_elf(elf)?;
         let image = MemoryImage::new(&program, PAGE_SIZE as u32)?;
         let obj_ctx = if log::log_enabled!(log::Level::Trace) {
             let file = addr2line::object::read::File::parse(elf)?;

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -37,7 +37,7 @@ use risc0_zkp::{
     core::digest::DIGEST_WORDS,
     hal::{CircuitHal, Hal},
 };
-use risc0_zkvm_platform::{memory::MEM_SIZE, PAGE_SIZE, WORD_SIZE};
+use risc0_zkvm_platform::{PAGE_SIZE, WORD_SIZE};
 
 use self::{dev_mode::DevModeProver, prover_impl::ProverImpl};
 use crate::{
@@ -72,7 +72,7 @@ pub trait ProverServer {
         ctx: &VerifierContext,
         elf: &[u8],
     ) -> Result<Receipt> {
-        let program = Program::load_elf(elf, MEM_SIZE as u32)?;
+        let program = Program::load_elf(elf)?;
         let image = MemoryImage::new(&program, PAGE_SIZE as u32)?;
         self.prove(env, ctx, image)
     }

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -304,7 +304,7 @@ mod riscv {
         use std::io::Read;
 
         use flate2::read::GzDecoder;
-        use risc0_zkvm_platform::{memory::MEM_SIZE, PAGE_SIZE};
+        use risc0_zkvm_platform::PAGE_SIZE;
         use tar::Archive;
 
         let bytes = include_bytes!("../testdata/riscv-tests.tgz");
@@ -323,7 +323,7 @@ mod riscv {
             let mut elf = Vec::new();
             entry.read_to_end(&mut elf).unwrap();
 
-            let program = Program::load_elf(elf.as_slice(), MEM_SIZE as u32).unwrap();
+            let program = Program::load_elf(elf.as_slice()).unwrap();
             let image = MemoryImage::new(&program, PAGE_SIZE as u32).unwrap();
 
             let env = ExecutorEnv::default();


### PR DESCRIPTION
load_elf takes a max_mem parameter before this change, MEM_SIZE was used as the
parameter. Any memory region about `SYSTEM.start()` is intended for use by the
zkVM and is not to be used by the ELF. Rather than have maximum memory as a
parameter, use a hard-coded constant, GUEST_MAX_MEM as the upper bound for
memory during elf load. This PR also restricts the loader to no load above GUEST_MAX_MEM