### PR TITLE
Ethereum-Relay: fix empty journal on dev-mode

### DIFF
--- a/.github/workflows/bonsai.yml
+++ b/.github/workflows/bonsai.yml
@@ -49,6 +49,10 @@ jobs:
       - name: run cargo tests in bonsai
         run: cargo test --manifest-path bonsai/Cargo.toml
 
+      - name: run local e2e test in bonsai/ethereum-relay
+        run: cargo test --package bonsai-ethereum-relay --test e2e_test -- tests::e2e_test_counter --exact --nocapture --ignored
+        working-directory: bonsai/ethereum
+
       - name: run cargo tests in bonsai/examples/governance
         run: cargo test --manifest-path bonsai/examples/governance/Cargo.toml
 

--- a/.github/workflows/bonsai.yml
+++ b/.github/workflows/bonsai.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Test
       - name: run cargo tests in bonsai
-        run: cargo test --manifest-path bonsai/Cargo.toml -- --include-ignored --nocapture
+        run: cargo test --manifest-path bonsai/Cargo.toml --tests -- --include-ignored --nocapture
 
       - name: run cargo tests in bonsai/examples/governance
         run: cargo test --manifest-path bonsai/examples/governance/Cargo.toml

--- a/.github/workflows/bonsai.yml
+++ b/.github/workflows/bonsai.yml
@@ -47,11 +47,7 @@ jobs:
 
       # Test
       - name: run cargo tests in bonsai
-        run: cargo test --manifest-path bonsai/Cargo.toml
-
-      - name: run local e2e test in bonsai/ethereum-relay
-        run: cargo test --package bonsai-ethereum-relay --test e2e_test -- tests::e2e_test_counter --exact --nocapture --ignored
-        working-directory: bonsai/ethereum
+        run: cargo test --manifest-path bonsai/Cargo.toml -- --include-ignored --nocapture
 
       - name: run cargo tests in bonsai/examples/governance
         run: cargo test --manifest-path bonsai/examples/governance/Cargo.toml

--- a/bonsai/rest-api-mock/src/routes.rs
+++ b/bonsai/rest-api-mock/src/routes.rs
@@ -23,6 +23,7 @@ use bonsai_sdk::alpha::responses::{
     CreateSessRes, Groth16Seal, ImgUploadRes, ProofReq, SessionStatusRes, SnarkReceipt, SnarkReq,
     SnarkStatusRes, UploadRes,
 };
+use risc0_zkvm::Receipt;
 use tracing::info;
 
 use crate::{
@@ -118,30 +119,46 @@ pub(crate) async fn session_status(
 }
 
 pub(crate) async fn create_snark(
-    Json(_request): Json<SnarkReq>,
+    Json(request): Json<SnarkReq>,
 ) -> Result<Json<CreateSessRes>, Error> {
     Ok(Json(CreateSessRes {
-        uuid: uuid::Uuid::new_v4().to_string(),
+        uuid: request.session_id,
     }))
 }
 
 pub(crate) async fn snark_status(
-    Path(_snark_id): Path<String>,
+    State(s): State<AppState>,
+    Path(snark_id): Path<String>,
 ) -> Result<Json<SnarkStatusRes>, Error> {
-    Ok(Json(SnarkStatusRes {
-        status: "SUCCEEDED".to_string(),
-        output: Some(SnarkReceipt {
-            snark: Groth16Seal {
-                a: vec![],
-                b: vec![],
-                c: vec![],
-                public: vec![],
-            },
-            post_state_digest: vec![],
-            journal: vec![],
-        }),
-        error_msg: None,
-    }))
+    let storage = s.read()?;
+    storage
+        .get_session(&snark_id)
+        .ok_or_else(|| anyhow::anyhow!("Snark status not found for snark id: {:?}", &snark_id))?;
+    let receipt = storage.get_receipt(&snark_id);
+    match receipt {
+        Some(bytes) => {
+            let receipt: Receipt = bincode::deserialize(&bytes)?;
+            Ok(Json(SnarkStatusRes {
+                status: "SUCCEEDED".to_string(),
+                output: Some(SnarkReceipt {
+                    snark: Groth16Seal {
+                        a: vec![],
+                        b: vec![],
+                        c: vec![],
+                        public: vec![],
+                    },
+                    post_state_digest: vec![],
+                    journal: receipt.journal,
+                }),
+                error_msg: None,
+            }))
+        }
+        None => Ok(Json(SnarkStatusRes {
+            status: "RUNNING".to_string(),
+            output: None,
+            error_msg: None,
+        })),
+    }
 }
 
 pub(crate) async fn get_receipt(


### PR DESCRIPTION
- Return the journal within a snark receipt when using the `bonsai-mock-rest-api`
- Add local e2e test of the relay on CI