### PR TITLE
Combine HAL kernels

### DIFF
--- a/risc0/zkp/src/hal/cuda.rs
+++ b/risc0/zkp/src/hal/cuda.rs
@@ -865,12 +865,6 @@ mod tests {
 
     #[test]
     #[serial]
-    fn batch_expand() {
-        testutil::batch_expand(CudaHalSha256::new());
-    }
-
-    #[test]
-    #[serial]
     fn batch_expand_into_evaluate_ntt() {
         testutil::batch_expand_into_evaluate_ntt(CudaHalSha256::new());
     }

--- a/risc0/zkp/src/hal/cuda.rs
+++ b/risc0/zkp/src/hal/cuda.rs
@@ -439,61 +439,65 @@ impl<CH: CudaHash> Hal for CudaHal<CH> {
     }
 
     #[tracing::instrument(skip_all)]
-    fn batch_expand(
+    fn batch_expand_into_evaluate_ntt(
         &self,
         output: &Self::Buffer<Self::Elem>,
         input: &Self::Buffer<Self::Elem>,
-        poly_count: usize,
+        count: usize,
+        expand_bits: usize,
     ) {
-        let out_size = output.size() / poly_count;
-        let in_size = input.size() / poly_count;
-        let expand_bits = log2_ceil(out_size / in_size);
-        assert_eq!(output.size(), out_size * poly_count);
-        assert_eq!(input.size(), in_size * poly_count);
-        assert_eq!(out_size, in_size * (1 << expand_bits));
+        // batch_expand
+        {
+            let out_size = output.size() / count;
+            let in_size = input.size() / count;
+            let expand_bits = log2_ceil(out_size / in_size);
+            assert_eq!(output.size(), out_size * count);
+            assert_eq!(input.size(), in_size * count);
+            assert_eq!(out_size, in_size * (1 << expand_bits));
 
-        let stream = Stream::new(StreamFlags::DEFAULT, None).unwrap();
-        let kernel = self.module.get_function("batch_expand").unwrap();
-        let params = self.compute_simple_params(out_size.try_into().unwrap());
-        unsafe {
-            launch!(kernel<<<params.0, params.1, 0, stream>>>(
-                output.as_device_ptr(),
-                input.as_device_ptr(),
-                poly_count as u32,
-                out_size as u32,
-                in_size as u32,
-                expand_bits as u32
-            ))
-            .unwrap();
-        }
-        stream.synchronize().unwrap();
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn batch_evaluate_ntt(&self, io: &Self::Buffer<Self::Elem>, count: usize, expand_bits: usize) {
-        let row_size = io.size() / count;
-        assert_eq!(row_size * count, io.size());
-        let n_bits = log2_ceil(row_size);
-        assert_eq!(row_size, 1 << n_bits);
-        assert!(n_bits >= expand_bits);
-        assert!(n_bits < Self::Elem::MAX_ROU_PO2);
-        let rou = self.copy_from_elem("rou", Self::Elem::ROU_FWD);
-
-        let stream = Stream::new(StreamFlags::DEFAULT, None).unwrap();
-        let kernel = self.module.get_function("multi_ntt_fwd_step").unwrap();
-        for s_bits in 1 + expand_bits..=n_bits {
-            let params = self.compute_launch_params(n_bits as u32, s_bits as u32, count as u32);
+            let stream = Stream::new(StreamFlags::DEFAULT, None).unwrap();
+            let kernel = self.module.get_function("batch_expand").unwrap();
+            let params = self.compute_simple_params(out_size.try_into().unwrap());
             unsafe {
                 launch!(kernel<<<params.0, params.1, 0, stream>>>(
-                    io.as_device_ptr(),
-                    rou.as_device_ptr(),
-                    n_bits as u32,
-                    s_bits as u32,
-                    count as u32
+                    output.as_device_ptr(),
+                    input.as_device_ptr(),
+                    count as u32,
+                    out_size as u32,
+                    in_size as u32,
+                    expand_bits as u32
                 ))
                 .unwrap();
             }
             stream.synchronize().unwrap();
+        }
+
+        // batch_evaluate_ntt
+        {
+            let row_size = output.size() / count;
+            assert_eq!(row_size * count, output.size());
+            let n_bits = log2_ceil(row_size);
+            assert_eq!(row_size, 1 << n_bits);
+            assert!(n_bits >= expand_bits);
+            assert!(n_bits < Self::Elem::MAX_ROU_PO2);
+            let rou = self.copy_from_elem("rou", Self::Elem::ROU_FWD);
+
+            let stream = Stream::new(StreamFlags::DEFAULT, None).unwrap();
+            let kernel = self.module.get_function("multi_ntt_fwd_step").unwrap();
+            for s_bits in 1 + expand_bits..=n_bits {
+                let params = self.compute_launch_params(n_bits as u32, s_bits as u32, count as u32);
+                unsafe {
+                    launch!(kernel<<<params.0, params.1, 0, stream>>>(
+                        output.as_device_ptr(),
+                        rou.as_device_ptr(),
+                        n_bits as u32,
+                        s_bits as u32,
+                        count as u32
+                    ))
+                    .unwrap();
+                }
+                stream.synchronize().unwrap();
+            }
         }
     }
 
@@ -867,8 +871,8 @@ mod tests {
 
     #[test]
     #[serial]
-    fn batch_evaluate_ntt() {
-        testutil::batch_evaluate_ntt(CudaHalSha256::new());
+    fn batch_expand_into_evaluate_ntt() {
+        testutil::batch_expand_into_evaluate_ntt(CudaHalSha256::new());
     }
 
     #[test]

--- a/risc0/zkp/src/hal/dual.rs
+++ b/risc0/zkp/src/hal/dual.rs
@@ -172,21 +172,19 @@ where
         BufferImpl::new(lhs, rhs)
     }
 
-    fn batch_expand(
+    #[tracing::instrument(skip_all)]
+    fn batch_expand_into_evaluate_ntt(
         &self,
         output: &Self::Buffer<Self::Elem>,
         input: &Self::Buffer<Self::Elem>,
         count: usize,
+        expand_bits: usize,
     ) {
-        self.lhs.batch_expand(&output.lhs, &input.lhs, count);
-        self.rhs.batch_expand(&output.rhs, &input.rhs, count);
+        self.lhs
+            .batch_expand_into_evaluate_ntt(&output.lhs, &input.lhs, count, expand_bits);
+        self.rhs
+            .batch_expand_into_evaluate_ntt(&output.rhs, &input.rhs, count, expand_bits);
         output.assert_eq();
-    }
-
-    fn batch_evaluate_ntt(&self, io: &Self::Buffer<Self::Elem>, count: usize, expand_bits: usize) {
-        self.lhs.batch_evaluate_ntt(&io.lhs, count, expand_bits);
-        self.rhs.batch_evaluate_ntt(&io.rhs, count, expand_bits);
-        io.assert_eq();
     }
 
     fn batch_interpolate_ntt(&self, io: &Self::Buffer<Self::Elem>, count: usize) {

--- a/risc0/zkp/src/prove/fri.rs
+++ b/risc0/zkp/src/prove/fri.rs
@@ -47,10 +47,9 @@ impl<H: Hal> ProveRoundInfo<H> {
         let evaluated = hal.alloc_elem("evaluated", domain * ext_size);
         // Put in the coefficients, padding out with zeros so that we are left with the
         // same polynomial represented by a larger coefficient list
-        hal.batch_expand(&evaluated, coeffs, ext_size);
         // Evaluate the NTT in-place, filling the buffer with the evaluations of the
         // polynomial.
-        hal.batch_evaluate_ntt(&evaluated, ext_size, log2_ceil(INV_RATE));
+        hal.batch_expand_into_evaluate_ntt(&evaluated, coeffs, ext_size, log2_ceil(INV_RATE));
         // Compute a Merkle tree committing to the polynomial evaluations.
         let merkle = MerkleTreeProver::new(
             hal,

--- a/risc0/zkp/src/prove/poly_group.rs
+++ b/risc0/zkp/src/prove/poly_group.rs
@@ -68,8 +68,7 @@ impl<H: Hal> PolyGroup<H> {
         assert_eq!(coeffs.size(), count * size);
         let domain = size * INV_RATE;
         let evaluated = hal.alloc_elem("evaluated", count * domain);
-        hal.batch_expand(&evaluated, &coeffs, count);
-        hal.batch_evaluate_ntt(&evaluated, count, log2_ceil(INV_RATE));
+        hal.batch_expand_into_evaluate_ntt(&evaluated, &coeffs, count, log2_ceil(INV_RATE));
         hal.batch_bit_reverse(&coeffs, count);
         let merkle = MerkleTreeProver::new(hal, &evaluated, domain, count, QUERIES);
         PolyGroup {


### PR DESCRIPTION
This combines the `batch_expand` and `batch_evaluate_ntt` kernels into a single HAL function. This is because they are always called together and allows for better GPU optimization by treating them as a single unit.