### PR TITLE
CI: add no_std build test and fix risc0-zkvm build issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,8 @@ jobs:
       - run: cargo check -F $FEATURE -p risc0-sys
       - run: cargo check -F $FEATURE -p risc0-zkp
       - run: cargo check -F $FEATURE -p risc0-zkvm
+      # build risc0-zkvm verifier for a no-std environment
+      - run: cargo check --target x86_64-unknown-none -p risc0-zkvm --no-default-features
       - uses: risc0/clippy-action@main
         with:
           reporter: 'github-pr-check'

--- a/bonsai/examples/governance/Cargo.lock
+++ b/bonsai/examples/governance/Cargo.lock
@@ -3650,7 +3650,6 @@ dependencies = [
  "rrs-lib",
  "serde",
  "sha2 0.10.7",
- "tempfile",
  "thiserror",
  "tracing",
  "typetag",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3401,7 +3401,6 @@ dependencies = [
  "rrs-lib",
  "serde",
  "sha2",
- "tempfile",
  "thiserror",
  "tracing",
  "typetag",

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -69,7 +69,6 @@ rand = { version = "0.8", optional = true }
 rayon = { version = "1.5", optional = true }
 rrs-lib = { version = "0.1", optional = true }
 sha2 = { version = "0.10", optional = true }
-tempfile = "3"
 thiserror = { version = "1.0", optional = true }
 tracing = { version = "0.1", default-features = false, features = [
   "attributes",
@@ -89,6 +88,7 @@ flate2 = "1.0"
 risc0-zkvm-methods = { path = "methods" }
 serial_test = "2.0"
 tar = "0.4"
+tempfile = "3"
 test-log = { version = "0.2", features = ["trace"] }
 
 [features]

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -31,12 +31,6 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
@@ -219,12 +213,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "generic-array"
@@ -473,15 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,7 +570,6 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "serde",
- "tempfile",
  "tracing",
 ]
 
@@ -652,7 +630,7 @@ version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -763,19 +741,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "stable"
 components = ["clippy", "rustfmt", "rust-src"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "x86_64-unknown-none"]
 profile = "minimal"


### PR DESCRIPTION
I looked into various solutions and building using this command seems to be the easiest
way to build `risc0-zkvm` with `no_std`. I used `x86_64-unknown-none` explicitly
because it seemed like a widely available target (as opposed to smaller arm targets). I
didn't chose `aarch64-apple-darwin` because seems to allows building the zkvm
with the tempfile dependency which might be caused by inclusion of some item
from std from this target.

This PR also moves zkvm's tempfile as a dev-dependency (this was causing the newly
added CI command to fail).