### PR TITLE
CI: check that the verifier builds in no_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,9 @@ jobs:
       - run: cargo check -F $FEATURE -p risc0-sys
       - run: cargo check -F $FEATURE -p risc0-zkp
       - run: cargo check -F $FEATURE -p risc0-zkvm
+      - run: cargo install --git https://github.com/SchmErik/cargo-no-std-check
+      # This check ensures that the zkvm without default featuers is no_std.
+      - run: cargo no-std-check -p risc0-zkvm --no-default-features
       - uses: risc0/clippy-action@main
         with:
           reporter: 'github-pr-check'


### PR DESCRIPTION
This uses a fork on the `cargo no-std-check` utility that does not require the use of a nightly compiler.