### PR TITLE
[proof system] Reducing use of the term `plonk` 

### DIFF
--- a/risc0/zkp/src/prove/accum.rs
+++ b/risc0/zkp/src/prove/accum.rs
@@ -101,7 +101,7 @@ impl<'a, F: Field> CircuitStepHandler<F::Elem> for Handler<'a, F> {
     ) -> Result<()> {
         assert!(cycle < self.cycles);
         match name {
-            "plonkWriteAccum" => {
+            "WriteAccumulator" => {
                 assert_eq!(args.len(), F::ExtElem::EXT_SIZE);
                 let elem = F::ExtElem::from_subelems(args.iter().copied());
                 let ptr = self.get_ptr(extra);
@@ -109,7 +109,7 @@ impl<'a, F: Field> CircuitStepHandler<F::Elem> for Handler<'a, F> {
                 // buffer.
                 unsafe { ptr.add(cycle).write(elem) };
             }
-            "plonkReadAccum" => {
+            "ReadAccumulator" => {
                 assert_eq!(outs.len(), F::ExtElem::EXT_SIZE);
                 let ptr = self.get_ptr(extra);
                 // Already checked that our cycle number is in range, so this offset is in the

--- a/risc0/zkp/src/prove/accum.rs
+++ b/risc0/zkp/src/prove/accum.rs
@@ -19,12 +19,12 @@ use risc0_core::field::{Elem, ExtElem, Field};
 
 use crate::adapter::CircuitStepHandler;
 
-/// Tracks grand product accumulations for PLONK-style permutation arguments.
+/// Tracks grand product accumulations for permutation and lookup arguments
 pub struct Accum<E: Elem> {
     /// Total number of cycles in this run.
     cycles: usize,
 
-    // We use two PLONK-style grand product accumulation checks;
+    // We use two grand product accumulation checks;
     // one for the memory permutation and a second for a lookup table.
     // We have two `kinds`: memory and bytes.
     kinds: BTreeMap<String, Vec<E>>,

--- a/risc0/zkvm/src/host/server/prove/exec.rs
+++ b/risc0/zkvm/src/host/server/prove/exec.rs
@@ -62,7 +62,7 @@ pub struct MemoryState {
 
     // Tables for sorting using non-deterministic advice from the host.
     // The correctness of the sorting is checked using a permutation argument.
-    pub ram_table: plonk::MemoryTable,
+    pub ram_table: plonk::RamTable,
     pub bytes_table: plonk::BytesTable,
 
     // Grand product accumulations for compute_accum and verify_accum phases
@@ -73,7 +73,7 @@ impl MemoryState {
     pub(crate) fn new(image: MemoryImage) -> Self {
         Self {
             ram: image,
-            ram_table: plonk::MemoryTable::new(),
+            ram_table: plonk::RamTable::new(),
             bytes_table: plonk::BytesTable::new(),
             grand_product_accum: BTreeMap::new(),
         }

--- a/risc0/zkvm/src/host/server/prove/exec.rs
+++ b/risc0/zkvm/src/host/server/prove/exec.rs
@@ -217,11 +217,11 @@ impl CircuitStepHandler<Elem> for MachineContext {
                 self.table_read(extra, outs);
                 Ok(())
             }
-            "WriteAccum" => {
+            "WriteAccumulator" => {
                 self.table_write_accum(extra, args);
                 Ok(())
             }
-            "ReadAccum" => {
+            "ReadAccumulator" => {
                 self.table_read_accum(extra, outs);
                 Ok(())
             }

--- a/risc0/zkvm/src/host/server/prove/exec.rs
+++ b/risc0/zkvm/src/host/server/prove/exec.rs
@@ -62,7 +62,7 @@ pub struct MemoryState {
 
     // Tables for sorting using non-deterministic advice from the host.
     // The correctness of the sorting is checked using a permutation argument.
-    pub memory_table: plonk::MemoryTable,
+    pub ram_table: plonk::MemoryTable,
     pub bytes_table: plonk::BytesTable,
 
     // Grand product accumulations for compute_accum and verify_accum phases
@@ -73,7 +73,7 @@ impl MemoryState {
     pub(crate) fn new(image: MemoryImage) -> Self {
         Self {
             ram: image,
-            memory_table: plonk::MemoryTable::new(),
+            ram_table: plonk::MemoryTable::new(),
             bytes_table: plonk::BytesTable::new(),
             grand_product_accum: BTreeMap::new(),
         }
@@ -246,7 +246,7 @@ impl CircuitStepHandler<Elem> for MachineContext {
 
     #[tracing::instrument(skip(self))]
     fn sort(&mut self, _: &str) {
-        self.memory.memory_table.sort();
+        self.memory.ram_table.sort();
         self.memory.bytes_table.sort();
     }
 }
@@ -630,7 +630,7 @@ impl MachineContext {
 
     fn table_read(&mut self, name: &str, outs: &mut [Elem]) {
         match name {
-            "ram" => self.memory.memory_table.read(outs.try_into().unwrap()),
+            "ram" => self.memory.ram_table.read(outs.try_into().unwrap()),
             "bytes" => self.memory.bytes_table.read(outs.try_into().unwrap()),
             _ => panic!("Unknown table type {name}"),
         }
@@ -638,7 +638,7 @@ impl MachineContext {
 
     fn table_write(&mut self, name: &str, args: &[Elem]) {
         match name {
-            "ram" => self.memory.memory_table.write(args.try_into().unwrap()),
+            "ram" => self.memory.ram_table.write(args.try_into().unwrap()),
             "bytes" => self.memory.bytes_table.write(args.try_into().unwrap()),
             _ => panic!("Unknown table type {name}"),
         }

--- a/risc0/zkvm/src/host/server/prove/plonk.rs
+++ b/risc0/zkvm/src/host/server/prove/plonk.rs
@@ -27,16 +27,16 @@ struct MemoryOperationRow {
     val: u32,
 }
 
-pub struct MemoryPermutation {
+pub struct MemoryOperationTable {
     main_ram: Vec<MemoryOperationRow>,
 }
 
-impl MemoryPermutation {
+impl MemoryOperationTable {
     pub fn new() -> Self {
         // Make sure cycle_and_write_flag won't overflow
         assert!(MAX_CYCLES < ((u32::MAX as usize) << 2));
 
-        MemoryPermutation {
+        MemoryOperationTable {
             main_ram: Vec::new(),
         }
     }

--- a/risc0/zkvm/src/host/server/prove/plonk.rs
+++ b/risc0/zkvm/src/host/server/prove/plonk.rs
@@ -17,26 +17,26 @@ use std::collections::VecDeque;
 use risc0_core::field::{Elem, ExtElem, Field};
 use risc0_zkp::MAX_CYCLES;
 
-// A MemoryOperationRow consists of 7 elements:
+// A RamOperationRow consists of 7 elements:
 // addr, cycle, isWrite, byte0, byte1, byte2, byte3
 #[derive(Ord, PartialOrd, Eq, PartialEq)]
-struct MemoryOperationRow {
+struct RamOperationRow {
     addr: u32,
     // (cycle << 2) | mem_op
     cycle_and_write_flag: u32,
     val: u32,
 }
 
-pub struct MemoryOperationTable {
-    main_ram: Vec<MemoryOperationRow>,
+pub struct RamOperationTable {
+    main_ram: Vec<RamOperationRow>,
 }
 
-impl MemoryOperationTable {
+impl RamOperationTable {
     pub fn new() -> Self {
         // Make sure cycle_and_write_flag won't overflow
         assert!(MAX_CYCLES < ((u32::MAX as usize) << 2));
 
-        MemoryOperationTable {
+        RamOperationTable {
             main_ram: Vec::new(),
         }
     }
@@ -54,7 +54,7 @@ impl MemoryOperationTable {
         for elem in &elems[3..] {
             debug_assert!(u32::from(*elem) < 256);
         }
-        self.main_ram.push(MemoryOperationRow {
+        self.main_ram.push(RamOperationRow {
             addr,
             cycle_and_write_flag,
             val: u32::from(elems[3])

--- a/risc0/zkvm/src/host/server/prove/plonk.rs
+++ b/risc0/zkvm/src/host/server/prove/plonk.rs
@@ -27,16 +27,16 @@ struct MemoryOperationRow {
     val: u32,
 }
 
-pub struct MemoryOperationTable {
+pub struct MemoryPermutation {
     main_ram: Vec<MemoryOperationRow>,
 }
 
-impl MemoryOperationTable {
+impl MemoryPermutation {
     pub fn new() -> Self {
         // Make sure cycle_and_write_flag won't overflow
         assert!(MAX_CYCLES < ((u32::MAX as usize) << 2));
 
-        MemoryOperationTable {
+        MemoryPermutation {
             main_ram: Vec::new(),
         }
     }


### PR DESCRIPTION
The term `plonk` is overloaded and confusing in our codebase; this PR reduces use of that term to disambiguate meaning. 

Please review based on whether the suggested names make sense; we can worry about the implications in terms of breaking changes once we're in alignment about whether the names are good names. 

Resolves #922 