### PR TITLE
Check for unused crate dependencies in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
       FEATURE: ${{ matrix.feature }}
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache
+      RUSTFLAGS: "-Dunused-crate-dependencies"
     steps:
       # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
@@ -129,6 +130,7 @@ jobs:
       FEATURE: ${{ matrix.feature }}
       RUST_BACKTRACE: full
       RUSTC_WRAPPER: sccache
+      RUSTFLAGS: "-Dunused-crate-dependencies"
     steps:
       # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"


### PR DESCRIPTION
This draft PR adds a Rust flag to check for, and deny, unused crate dependencies declared in Cargo.toml. This is useful, because if a dependency is declared, it is always built even if it is not used.

This PR is a draft and not the suggested implemenation.
