### PR TITLE
[proof system] code to control

### DIFF
--- a/risc0/zkp/src/hal/mod.rs
+++ b/risc0/zkp/src/hal/mod.rs
@@ -156,7 +156,7 @@ pub trait CircuitHal<H: Hal> {
     fn eval_check(
         &self,
         check: &H::Buffer<H::Elem>,
-        // Register groups, e.g. accum, code, data.  These should have one row for each cycle.
+        // Register groups, e.g. accum, control, data.  These should have one row for each cycle.
         groups: &[&H::Buffer<H::Elem>],
         // Globals.  These should have one row total.
         globals: &[&H::Buffer<H::Elem>],

--- a/risc0/zkp/src/prove/adapter.rs
+++ b/risc0/zkp/src/prove/adapter.rs
@@ -62,7 +62,7 @@ where
         self.exec.circuit.get_taps()
     }
 
-    /// Perform initial 'execution' setting code + data.
+    /// Perform initial 'execution' setting control + data.
     /// Additionally, write any 'results' as needed.
     pub fn execute(&mut self, iop: &mut WriteIOP<F>) {
         iop.write_field_elem_slice(&self.exec.io.as_slice());
@@ -71,7 +71,7 @@ where
 
     fn compute_accum(&mut self) {
         let args = &[
-            self.exec.code.as_slice_sync(),
+            self.exec.control.as_slice_sync(),
             self.exec.io.as_slice_sync(),
             self.exec.data.as_slice_sync(),
             self.mix.as_slice_sync(),
@@ -152,8 +152,8 @@ where
         self.exec.po2 as u32
     }
 
-    pub fn get_code(&self) -> &CpuBuffer<F::Elem> {
-        &self.exec.code
+    pub fn get_control(&self) -> &CpuBuffer<F::Elem> {
+        &self.exec.control
     }
 
     pub fn get_data(&self) -> &CpuBuffer<F::Elem> {

--- a/risc0/zkp/src/prove/prover.rs
+++ b/risc0/zkp/src/prove/prover.rs
@@ -181,7 +181,7 @@ impl<'a, H: Hal> Prover<'a, H> {
         let mut all_xs = Vec::new();
 
         // Now, we evaluate each group at the approriate points (relative to Z).
-        // From here on out, we always process groups in accum, code, data order,
+        // From here on out, we always process groups in accum, control, data order,
         // since this is the order used by the codegen system (alphabetical).
         // Sometimes it's a requirement for matching generated code, but even when
         // it's not we keep the order for consistency.

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -15,7 +15,7 @@
 use anyhow::Result;
 use risc0_circuit_rv32im::{
     layout::{OutBuffer, LAYOUT},
-    REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA,
+    REGISTER_GROUP_ACCUM, REGISTER_GROUP_CONTROL, REGISTER_GROUP_DATA,
 };
 use risc0_core::field::baby_bear::{BabyBear, Elem, ExtElem};
 #[cfg(feature = "fault-proof")]
@@ -117,8 +117,8 @@ where
         prover.set_po2(adapter.po2() as usize);
 
         prover.commit_group(
-            REGISTER_GROUP_CODE,
-            hal.copy_from_elem("code", &adapter.get_code().as_slice()),
+            REGISTER_GROUP_CONTROL,
+            hal.copy_from_elem("control", &adapter.get_control().as_slice()),
         );
         prover.commit_group(
             REGISTER_GROUP_DATA,


### PR DESCRIPTION
I think we're in agreement on changing the term `code` to `control` in the context of polyGoups. 

This PR starts implementing this change, although it seems like this change is going to have pretty wide-reaching impact and ctrl-f for `code` returns a lot of irrelevant results... 

(Getting this started but would definitely be happy to pass this off!)