### PR TITLE
executor: add address checks for ecalls

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,7 +233,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "ad6dfae83cfc5b8be6f9fd3695b89f6d369d176e4201c0e57c2d2074948b741b",
+            "7208ba9a49d9264a085d6fcede1ef87cb8283193a21d9efd72e83974ff757d0f",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -245,7 +245,7 @@ pub fn main() {
             asm!( "mv x6, {}", "sw x5, (x6)" , in(reg) addr, out("x5") _, out("x6") _);
         },
         MultiTestSpec::TooManySha => unsafe {
-            asm!("ecall", in("x5") 3, in("x10") 0, in("x11") 0, in("x12") 0, in("x13") 0, in("x14") 10000,);
+            asm!("ecall", in("x5") 3, in("x10") 0x400, in("x11") 0x400, in("x12") 0x400, in("x13") 0x400, in("x14") 10000,);
         },
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -244,6 +244,9 @@ pub fn main() {
             // fault
             asm!( "mv x6, {}", "sw x5, (x6)" , in(reg) addr, out("x5") _, out("x6") _);
         },
+        MultiTestSpec::OutOfBoundsEcall => unsafe {
+            asm!("ecall", in("x5") 3, in("x10") 0x0, in("x11") 0x0, in("x12") 0x0, in("x13") 0x0, in("x14") 10000,);
+        },
         MultiTestSpec::TooManySha => unsafe {
             asm!("ecall", in("x5") 3, in("x10") 0x400, in("x11") 0x400, in("x12") 0x400, in("x13") 0x400, in("x14") 10000,);
         },

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -73,6 +73,7 @@ pub enum MultiTestSpec {
     LibM,
     Oom,
     OutOfBounds,
+    OutOfBoundsEcall,
     RsaCompat,
     TooManySha,
 }

--- a/risc0/zkvm/platform/src/memory.rs
+++ b/risc0/zkvm/platform/src/memory.rs
@@ -17,6 +17,11 @@ use super::WORD_SIZE;
 pub const MEM_BITS: usize = 28;
 pub const MEM_SIZE: usize = 1 << MEM_BITS;
 pub const GUEST_MAX_MEM: usize = SYSTEM.start;
+pub const GUEST_MIN_MEM: usize = 0x0000_0400;
+
+pub fn is_guest_memory(addr: u32) -> bool {
+    GUEST_MIN_MEM <= (addr as usize) && (addr as usize) < GUEST_MAX_MEM
+}
 
 pub struct Region {
     start: usize,

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -626,7 +626,7 @@ impl<'a> ExecutorImpl<'a> {
         }
 
         self.monitor
-            .store_region(out_state_ptr, bytemuck::cast_slice(&state))?;
+            .store_region_to_guest_memory(out_state_ptr, bytemuck::cast_slice(&state))?;
 
         Ok(OpCodeResult::new(
             self.pc + WORD_SIZE as u32,
@@ -681,7 +681,7 @@ impl<'a> ExecutorImpl<'a> {
             .enumerate()
         {
             self.monitor
-                .store_u32(z_ptr + (i * WORD_SIZE) as u32, word.to_le())?;
+                .store_u32_to_guest_memory(z_ptr + (i * WORD_SIZE) as u32, word.to_le())?;
         }
 
         Ok(OpCodeResult::new(

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -553,7 +553,7 @@ impl<'a> ExecutorImpl<'a> {
 
     fn ecall_halt(&mut self) -> Result<OpCodeResult> {
         let tot_reg = self.monitor.load_register(REG_A0);
-        let output_ptr = self.monitor.load_register(REG_A1);
+        let output_ptr = self.monitor.load_guest_addr_from_register(REG_A1)?; // TODO Fails basic() test
         let halt_type = tot_reg & 0xff;
         let user_exit = (tot_reg >> 8) & 0xff;
         self.monitor
@@ -576,17 +576,17 @@ impl<'a> ExecutorImpl<'a> {
 
     fn ecall_input(&mut self) -> Result<OpCodeResult> {
         log::debug!("ecall(input)");
-        let in_addr = self.monitor.load_register(REG_A0);
+        let in_addr = self.monitor.load_guest_addr_from_register(REG_A0)?;
         self.monitor
             .load_array::<{ DIGEST_WORDS * WORD_SIZE }>(in_addr)?;
         Ok(OpCodeResult::new(self.pc + WORD_SIZE as u32, None, 0))
     }
 
     fn ecall_sha(&mut self) -> Result<OpCodeResult> {
-        let out_state_ptr = self.monitor.load_register(REG_A0);
-        let in_state_ptr = self.monitor.load_register(REG_A1);
-        let mut block1_ptr = self.monitor.load_register(REG_A2);
-        let mut block2_ptr = self.monitor.load_register(REG_A3);
+        let out_state_ptr = self.monitor.load_guest_addr_from_register(REG_A0)?;
+        let in_state_ptr = self.monitor.load_guest_addr_from_register(REG_A1)?;
+        let mut block1_ptr = self.monitor.load_guest_addr_from_register(REG_A2)?;
+        let mut block2_ptr = self.monitor.load_guest_addr_from_register(REG_A3)?;
         let count = self.monitor.load_register(REG_A4);
 
         let in_state: [u8; DIGEST_BYTES] = self.monitor.load_array(in_state_ptr)?;
@@ -636,11 +636,11 @@ impl<'a> ExecutorImpl<'a> {
     // Take reads inputs x, y, and N and writes output z = x * y mod N.
     // Note that op is currently ignored but must be set to 0.
     fn ecall_bigint(&mut self) -> Result<OpCodeResult> {
-        let z_ptr = self.monitor.load_register(REG_A0);
+        let z_ptr = self.monitor.load_guest_addr_from_register(REG_A0)?;
         let op = self.monitor.load_register(REG_A1);
-        let x_ptr = self.monitor.load_register(REG_A2);
-        let y_ptr = self.monitor.load_register(REG_A3);
-        let n_ptr = self.monitor.load_register(REG_A4);
+        let x_ptr = self.monitor.load_guest_addr_from_register(REG_A2)?;
+        let y_ptr = self.monitor.load_guest_addr_from_register(REG_A3)?;
+        let n_ptr = self.monitor.load_guest_addr_from_register(REG_A4)?;
 
         let mut load_bigint_le_bytes = |ptr: u32| -> Result<[u8; bigint::WIDTH_BYTES]> {
             let mut arr = [0u32; bigint::WIDTH_WORDS];

--- a/risc0/zkvm/src/host/server/exec/monitor.rs
+++ b/risc0/zkvm/src/host/server/exec/monitor.rs
@@ -322,6 +322,14 @@ impl MemoryMonitor {
         Ok(())
     }
 
+    pub fn store_u32_to_guest_memory(&mut self, addr: u32, data: u32) -> Result<()> {
+        let end_addr: u32 = addr + 4;
+        if !is_guest_memory(addr) || !is_guest_memory(end_addr) {
+            bail!("address range 0x{addr:08x} - 0x{end_addr:08x} is outside of guest memory");
+        }
+        self.store_u32(addr, data)
+    }
+
     pub fn store_region(&mut self, addr: u32, slice: &[u8]) -> Result<()> {
         // log::trace!("store_region: 0x{addr:08x}");
         slice
@@ -329,6 +337,14 @@ impl MemoryMonitor {
             .enumerate()
             .try_for_each(|(i, x)| self.raw_store_u8(addr + i as u32, *x))?;
         Ok(())
+    }
+
+    pub fn store_region_to_guest_memory(&mut self, addr: u32, slice: &[u8]) -> Result<()> {
+        let end_addr: u32 = addr + u32::try_from(slice.len())?;
+        if !is_guest_memory(addr) || !is_guest_memory(end_addr) {
+            bail!("address range 0x{addr:08x} - 0x{end_addr:08x} is outside of guest memory");
+        }
+        self.store_region(addr, slice)
     }
 
     pub fn store_register(&mut self, idx: usize, data: u32) {

--- a/risc0/zkvm/src/host/server/exec/monitor.rs
+++ b/risc0/zkvm/src/host/server/exec/monitor.rs
@@ -278,6 +278,20 @@ impl MemoryMonitor {
         String::from_utf8(s).map_err(anyhow::Error::msg)
     }
 
+    pub fn load_string_from_guest_memory(&mut self, mut addr: u32) -> Result<String> {
+        let start_addr = addr;
+        let mut len = 0;
+        loop {
+            if self.load_u8(addr)? == 0 {
+                break;
+            }
+            addr += 1;
+            len += 1;
+        }
+        Self::check_guest_addr_range(start_addr, start_addr + len)?;
+        self.load_string(start_addr)
+    }
+
     fn raw_store_u8(&mut self, addr: u32, data: u8) -> Result<()> {
         // log::trace!("raw_store_u8: 0x{addr:08x}");
         let old = self.load_u8(addr)?;

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -688,12 +688,13 @@ fn post_state_digest_randomization() {
 #[test]
 #[should_panic(expected = "cycle count too large")]
 fn too_many_sha() {
-    let spec = to_vec(&MultiTestSpec::TooManySha).unwrap();
-    let env = ExecutorEnv::builder().add_input(&spec).build().unwrap();
-    ExecutorImpl::from_elf(env, MULTI_TEST_ELF)
-        .unwrap()
-        .run()
-        .unwrap();
+    run_test(MultiTestSpec::TooManySha);
+}
+
+#[test]
+#[should_panic(expected = "is an invalid guest address")]
+fn out_of_bounds_ecall() {
+    run_test(MultiTestSpec::OutOfBoundsEcall);
 }
 
 #[cfg(feature = "docker")]

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -59,7 +59,8 @@ fn basic() {
         (0x4000, 0x1234b137), // lui x2, 0x1234b000
         (0x4004, 0xf387e1b7), // lui x3, 0xf387e000
         (0x4008, 0x003100b3), // add x1, x2, x3
-        (0x400c, 0x00000073), // ecall(halt)
+        (0x400c, 0x000055b7), // lui x11, 0x5
+        (0x4010, 0x00000073), // ecall(halt)
     ]);
     let program = Program {
         entry: 0x4000,


### PR DESCRIPTION
This PR adds checks to addresses that are used in all ecalls. This is done to ensure that register values that represent pointers and address ranges being read and written to within the ecall handers are within valid guest address ranges.