### PR TITLE
Automatize cycles count for datasheet

### DIFF
--- a/.github/workflows/bench_datasheet.yml
+++ b/.github/workflows/bench_datasheet.yml
@@ -64,6 +64,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo run --release -F $FEATURE --example loop -- --json | tee ${{ matrix.os }}-${{ matrix.device }}.json
         working-directory: risc0/zkvm
+      - run: cargo run --release -- --out ../../risc0/zkvm/cycle_count.csv
+        working-directory: benchmarks/cycle_count
+        if: matrix.feature == 'metal'
       - name: Save commit hash to a file
         run: echo "${{ github.sha }}" > COMMIT_HASH.txt
         working-directory: risc0/zkvm
@@ -74,6 +77,7 @@ jobs:
           path: |
             risc0/zkvm/${{ matrix.os }}-${{ matrix.device }}.json
             risc0/zkvm/COMMIT_HASH.txt
+            risc0/zkvm/cycle_count.csv
 
   push_to_ghpages:
     needs: bench
@@ -100,6 +104,7 @@ jobs:
           git add dev/datasheet/Linux-nvidia_rtx_a5000.json
           git add dev/datasheet/Linux-cpu.json
           git add dev/datasheet/COMMIT_HASH.txt
+          git add dev/datasheet/cycle_count.csv
           if git diff --cached --exit-code; then
             echo "No changes to commit"
           else

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -45,6 +45,17 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -100,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0391754c09fab4eae3404d19d0d297aa1c670c1775ab51d8a5312afeca23157"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -226,7 +237,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -236,7 +247,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -248,7 +259,7 @@ checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -261,7 +272,7 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -325,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -348,7 +359,7 @@ checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -407,6 +418,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bevy-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +447,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -502,6 +526,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+dependencies = [
+ "borsh-derive",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +581,28 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -529,7 +620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -597,6 +688,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chess-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "chess-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,7 +744,7 @@ checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -648,6 +753,12 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -844,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -881,7 +992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3bc95fe629aed92b2423de6ccff9e40174b21d19cb6ee6281a4d04ac72f66"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -913,7 +1024,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "strsim",
  "syn 2.0.37",
 ]
@@ -925,7 +1036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -961,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -973,7 +1084,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -1000,6 +1111,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "digital-signature-core"
+version = "0.1.0"
+dependencies = [
+ "risc0-zkvm",
+ "serde",
+]
+
+[[package]]
+name = "digital-signature-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
+
+[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1145,12 @@ dependencies = [
  "redox_users",
  "windows-sys",
 ]
+
+[[package]]
+name = "divrem"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
 
 [[package]]
 name = "docker-generate"
@@ -1045,6 +1177,13 @@ dependencies = [
  "serdect",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ecdsa-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
 ]
 
 [[package]]
@@ -1101,6 +1240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "elsa"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714f766f3556b44e7e4776ad133fcc3445a489517c25c704ace411bb14790194"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,7 +1282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -1259,7 +1407,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tiny-keccak",
- "unicode-xid",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -1301,6 +1449,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
+dependencies = [
+ "bit_field",
+ "flume",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1485,15 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+dependencies = [
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1348,7 +1521,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1396,6 +1569,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -1513,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -1591,6 +1777,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,10 +1860,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1675,7 +1883,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "serde",
 ]
 
@@ -1699,6 +1907,13 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hello-world-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1870,6 +2085,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "jpeg-decoder",
+ "num-rational",
+ "num-traits",
+ "png",
+ "qoi",
+ "tiff",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,7 +2137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1995,12 +2229,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
 ]
 
 [[package]]
@@ -2059,7 +2309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8edfc11b8f56ce85e207e62ea21557cfa09bb24a8f6b04ae181b086ff8611c22"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "regex",
  "syn 1.0.109",
 ]
@@ -2070,8 +2320,20 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -2151,6 +2413,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkle_light"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b879f617ec392ad9c11a50356ca373009c52363c0953b34c2e1b2234037a26a9"
+
+[[package]]
+name = "merkle_light_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f214fe0b551d8162d746f1a74b7016659b771231bafae36b4f4264991a34c4fd"
+dependencies = [
+ "merkle_light",
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
+
+[[package]]
 name = "metal"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2202,6 +2482,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "native-tls"
@@ -2287,7 +2576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -2359,9 +2648,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -2431,7 +2720,7 @@ checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
 dependencies = [
  "bytes",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2457,7 +2746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -2505,9 +2794,9 @@ version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2532,6 +2821,20 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "password-checker-core"
+version = "0.12.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "password-checker-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
 ]
 
 [[package]]
@@ -2602,7 +2905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -2641,6 +2944,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
+name = "png"
+version = "0.17.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,6 +2988,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
@@ -2688,7 +3013,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -2700,7 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "version_check",
 ]
 
@@ -2731,6 +3056,25 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prorata-core"
+version = "0.1.0"
+dependencies = [
+ "csv",
+ "hex",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "prorata-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
 ]
 
 [[package]]
@@ -2774,7 +3118,7 @@ dependencies = [
  "anyhow",
  "itertools 0.11.0",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -2797,10 +3141,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -2947,6 +3326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "rend"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,7 +3459,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -3247,6 +3635,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-examples-cycle-counter"
+version = "0.18.0"
+dependencies = [
+ "bevy-methods",
+ "chess-core",
+ "chess-methods",
+ "clap",
+ "csv",
+ "digital-signature-core",
+ "digital-signature-methods",
+ "ecdsa-methods",
+ "env_logger",
+ "hello-world-methods",
+ "image",
+ "json-methods",
+ "k256",
+ "log",
+ "password-checker-core",
+ "password-checker-methods",
+ "prorata-core",
+ "prorata-methods",
+ "rand",
+ "rand_core",
+ "risc0-zkvm",
+ "rmp-serde",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha-methods",
+ "sha2",
+ "smartcore",
+ "smartcore-ml-methods",
+ "waldo-core",
+ "waldo-methods",
+ "wasm-methods",
+ "wat",
+ "wordle-methods",
+]
+
+[[package]]
 name = "risc0-sys"
 version = "0.18.0"
 dependencies = [
@@ -3370,6 +3798,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8524b46783b58b00e9b2a4712e837093c975b23cf25bfaf99e1cf69e9011bf6b"
 
 [[package]]
+name = "rkyv"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,8 +3843,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -3429,6 +3907,32 @@ name = "ruint-macro"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+
+[[package]]
+name = "rust_decimal"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rust_decimal_macros"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86444b802de0b10ac5e563b5ddb43b541b9705de4e01a50e82194d2b183c1835"
+dependencies = [
+ "quote 1.0.33",
+ "rust_decimal",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -3557,9 +4061,9 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3587,6 +4091,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -3681,7 +4191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -3734,7 +4244,7 @@ checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -3746,6 +4256,13 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sha-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
 ]
 
 [[package]]
@@ -3800,6 +4317,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,6 +4354,28 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
+name = "smartcore"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42ca1fcd851ada8834d3dfcd088850dc8c703bde50c2baccd89181b74dc3ade"
+dependencies = [
+ "approx",
+ "cfg-if",
+ "num",
+ "num-traits",
+ "rand",
+ "serde",
+ "typetag",
+]
+
+[[package]]
+name = "smartcore-ml-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
 
 [[package]]
 name = "smol_str"
@@ -3860,6 +4411,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -3958,7 +4518,7 @@ checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "rustversion",
  "syn 2.0.37",
 ]
@@ -3984,12 +4544,23 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -4000,8 +4571,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "unicode-ident",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -4048,8 +4628,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -4130,7 +4721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -4184,6 +4775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4225,7 +4825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -4310,7 +4910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfc13d450dc4a695200da3074dacf43d449b968baee95e341920e47f61a3b40f"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -4360,6 +4960,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4393,6 +5005,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "valuable"
@@ -4434,6 +5052,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "waldo-core"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "divrem",
+ "elsa",
+ "image",
+ "merkle_light",
+ "merkle_light_derive",
+ "risc0-zkvm",
+ "serde",
+]
+
+[[package]]
+name = "waldo-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,7 +5107,7 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
@@ -4491,7 +5130,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4502,7 +5141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -4513,6 +5152,43 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34180c89672b3e4825c3a8db4b61a674f1447afd5fe2445b2d22c3d8b6ea086c"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
+
+[[package]]
+name = "wast"
+version = "66.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da7529bb848d58ab8bf32230fc065b363baee2bd338d5e58c589a1e7d83ad07"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4780374047c65b6b6e86019093fe80c18b66825eb684df778a4e068282a780e7"
+dependencies = [
+ "wast",
+]
 
 [[package]]
 name = "web-sys"
@@ -4529,6 +5205,12 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "which"
@@ -4668,6 +5350,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wordle-methods"
+version = "0.1.0"
+dependencies = [
+ "risc0-build 0.18.0",
+]
+
+[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,7 +5400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 2.0.37",
 ]
 
@@ -4765,4 +5454,13 @@ dependencies = [
  "sha2",
  "sha3",
  "thiserror",
+]
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
 ]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2021"
 [workspace]
 members = [
     "methods",
-    "shared"
+    "shared",
+    "cycle_count"
 ]
 
 [workspace.dependencies]
+risc0-examples-cycle_count = { path = "cycle_count" }
 risc0-benchmark-methods = { path = "methods" }
 risc0-benchmark-lib = { path = "shared" }
 risc0-build = { path = "../risc0/build" }

--- a/benchmarks/cycle_count/Cargo.toml
+++ b/benchmarks/cycle_count/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "risc0-examples-cycle-counter"
+version = "0.18.0"
+edition = "2021"
+
+[dependencies]
+bevy-methods = { path = "../../examples/bevy/methods" }
+chess-core = { path = "../../examples/chess/core" }
+chess-methods = { path = "../../examples/chess/methods" }
+clap = { version = "4.0", features = ["derive"] }
+csv = "1.1"
+digital-signature-core = { path = "../../examples/digital-signature/core" }
+digital-signature-methods = { path = "../../examples/digital-signature/methods" }
+ecdsa-methods = { path = "../../examples/ecdsa/methods" }
+env_logger = "0.10"
+hello-world-methods = { path = "../../examples/hello-world/methods" }
+image = "0.24"
+json-methods = { path = "../../examples/json/methods" }
+k256 = { version = "0.13", features = ["serde"] }
+log = "0.4"
+password-checker-core = { path = "../../examples/password-checker/core" }
+password-checker-methods = { path = "../../examples/password-checker/methods" }
+prorata-core = { path = "../../examples/prorata/core" }
+prorata-methods = { path = "../../examples/prorata/methods" }
+rand = "0.8"
+rand_core = "0.6.4"
+risc0-zkvm = { path = "../../risc0/zkvm", default-features = false, features = ["prove"] }
+rmp-serde = "1.1"
+rust_decimal = { version = "1.29", features = ["serde-str"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha-methods = { path = "../../examples/sha/methods" }
+sha2 = "0.10"
+smartcore = { version = "0.3", features = ['serde'] }
+smartcore-ml-methods = { path = "../../examples/smartcore-ml/methods" }
+waldo-core = { path = "../../examples/waldo/core" }
+waldo-methods = { path = "../../examples/waldo/methods" }
+wasm-methods = { path = "../../examples/wasm/methods" }
+wat = "1.0"
+wordle-methods = { path = "../../examples/wordle/methods" }
+
+[features]
+cuda = []
+metal = []

--- a/benchmarks/cycle_count/src/examples/bevy.rs
+++ b/benchmarks/cycle_count/src/examples/bevy.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = bevy_methods::BEVY_GUEST_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "bevy";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let input: u32 = 3;
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&input).unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/chess.rs
+++ b/benchmarks/cycle_count/src/examples/chess.rs
@@ -1,0 +1,45 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = chess_methods::CHECKMATE_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "chess";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let mv = "Qxf7".to_string();
+        let board =
+            "r1bqkb1r/pppp1ppp/2n2n2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 4 4".to_string();
+        let input = chess_core::Inputs { board, mv };
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&input).unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/digital_signature.rs
+++ b/benchmarks/cycle_count/src/examples/digital_signature.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use digital_signature_core::{Message, Passphrase, SigningRequest};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+use sha2::{Digest, Sha256};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = digital_signature_methods::SIGN_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "digital-signature";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let params = SigningRequest {
+            passphrase: Passphrase {
+                pass: Sha256::digest("passphrase").try_into().unwrap(),
+            },
+            msg: Message {
+                msg: Sha256::digest("message").try_into().unwrap(),
+            },
+        };
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&params).unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/ecdsa.rs
+++ b/benchmarks/cycle_count/src/examples/ecdsa.rs
@@ -1,0 +1,55 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use k256::ecdsa::{signature::Signer, Signature, SigningKey};
+use rand_core::OsRng;
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = ecdsa_methods::ECDSA_VERIFY_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "ecdsa";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        // Generate a random secp256k1 keypair and sign the message.
+        let signing_key = SigningKey::random(&mut OsRng); // Serialize with `::to_bytes()`
+        let message = b"This is a message that will be signed, and verified within the zkVM";
+        let signature: Signature = signing_key.sign(message);
+        let verifying_key = signing_key.verifying_key();
+        let env = ExecutorEnv::builder()
+            .add_input(
+                &to_vec(&(
+                    verifying_key.to_encoded_point(true),
+                    message.as_slice(),
+                    &signature,
+                ))
+                .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/hello_world.rs
+++ b/benchmarks/cycle_count/src/examples/hello_world.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = hello_world_methods::MULTIPLY_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "hello-world";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let a: u64 = 17;
+        let b: u64 = 23;
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&a).unwrap())
+            .add_input(&to_vec(&b).unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/json.rs
+++ b/benchmarks/cycle_count/src/examples/json.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = json_methods::SEARCH_JSON_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "json";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let data = include_str!("../../../../examples/json/res/example.json");
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&data).unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/mod.rs
+++ b/benchmarks/cycle_count/src/examples/mod.rs
@@ -1,0 +1,27 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod bevy;
+pub mod chess;
+pub mod digital_signature;
+pub mod ecdsa;
+pub mod hello_world;
+pub mod json;
+pub mod password_checker;
+pub mod prorata;
+pub mod sha;
+pub mod smartcore_ml;
+pub mod waldo;
+pub mod wasm;
+pub mod wordle;

--- a/benchmarks/cycle_count/src/examples/password_checker.rs
+++ b/benchmarks/cycle_count/src/examples/password_checker.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use password_checker_core::PasswordRequest;
+use rand::prelude::*;
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = password_checker_methods::PW_CHECKER_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "password-checker";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let mut rng = StdRng::from_entropy();
+        let mut salt = [0u8; 32];
+        rng.fill_bytes(&mut salt);
+        let request = PasswordRequest {
+            password: "S00perSecr1t!!!".into(),
+            salt,
+        };
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&request).unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/prorata.rs
+++ b/benchmarks/cycle_count/src/examples/prorata.rs
@@ -1,0 +1,54 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use prorata_core::AllocationQuery;
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+use rust_decimal::Decimal;
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = prorata_methods::PRORATA_GUEST_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "prorata";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let recipients_csv = std::fs::read("../../examples/prorata/sample/ingen.csv")
+            .expect("Failed to read input file");
+        let target = "John Hammond".to_string();
+        let amount = Decimal::from_str_radix("1000000000", 10).unwrap();
+        let env = ExecutorEnv::builder()
+            .add_input(
+                &to_vec(&AllocationQuery {
+                    amount,
+                    recipients_csv,
+                    target,
+                })
+                .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/sha.rs
+++ b/benchmarks/cycle_count/src/examples/sha.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = sha_methods::HASH_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "sha";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec("").unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/smartcore_ml.rs
+++ b/benchmarks/cycle_count/src/examples/smartcore_ml.rs
@@ -1,0 +1,61 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+use smartcore::{
+    linalg::basic::matrix::DenseMatrix, tree::decision_tree_classifier::DecisionTreeClassifier,
+};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = smartcore_ml_methods::ML_TEMPLATE_PATH;
+
+const JSON_MODEL: &str =
+    include_str!("../../../../examples/smartcore-ml/res/ml-model/tree_model_bytes.json");
+const JSON_DATA: &str =
+    include_str!("../../../../examples/smartcore-ml/res/input-data/tree_model_data_bytes.json");
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "smartcore-ml";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        // Convert the model and input data from JSON into byte arrays.
+        let model_bytes: Vec<u8> = serde_json::from_str(JSON_MODEL).unwrap();
+        let data_bytes: Vec<u8> = serde_json::from_str(JSON_DATA).unwrap();
+
+        // Deserialize the data from rmp into native rust types.
+        type Model = DecisionTreeClassifier<f64, u32, DenseMatrix<f64>, Vec<u32>>;
+        let model: Model =
+            rmp_serde::from_slice(&model_bytes).expect("model failed to deserialize byte array");
+        let data: DenseMatrix<f64> =
+            rmp_serde::from_slice(&data_bytes).expect("data filed to deserialize byte array");
+
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&model).expect("model failed to serialize"))
+            .add_input(&to_vec(&data).expect("data failed to serialize"))
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/examples/waldo.rs
+++ b/benchmarks/cycle_count/src/examples/waldo.rs
@@ -1,0 +1,76 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use image::{io::Reader as ImageReader, GenericImageView};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv};
+use waldo_core::{
+    image::{ImageMask, ImageMerkleTree, IMAGE_CHUNK_SIZE},
+    merkle::SYS_VECTOR_ORACLE,
+    PrivateInput,
+};
+
+pub struct Job {
+    pub cycles: u32,
+}
+
+const METHOD_PATH: &'static str = waldo_methods::IMAGE_CROP_PATH;
+
+impl CycleCounter for Job {
+    const NAME: &'static str = "waldo";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+
+        // Read the image from disk.
+        let img = ImageReader::open("../../examples/waldo/waldo.webp")
+            .unwrap()
+            .decode()
+            .unwrap();
+        let crop_location: (u32, u32) = (1150, 291);
+        let crop_dimensions: (u32, u32) = (58, 70);
+
+        // Read the image mask from disk.
+        let mask: ImageMask = ImageReader::open("../../examples/waldo/waldo_mask.png")
+            .unwrap()
+            .decode()
+            .unwrap()
+            .into();
+
+        // Construct a Merkle tree from the full Where's Waldo image.
+        let img_merkle_tree = ImageMerkleTree::<{ IMAGE_CHUNK_SIZE }>::new(&img);
+
+        // Give the private input to the guest, including Waldo's location.
+        let input = PrivateInput {
+            root: img_merkle_tree.root(),
+            image_dimensions: img.dimensions(),
+            mask: Some(mask.into_raw()),
+            crop_location,
+            crop_dimensions,
+        };
+
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&input).unwrap())
+            .io_callback(SYS_VECTOR_ORACLE, img_merkle_tree.vector_oracle_callback())
+            .build()
+            .unwrap();
+
+        let cycles = exec_compute(image, env);
+        Job { cycles }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        self.cycles
+    }
+}

--- a/benchmarks/cycle_count/src/examples/wasm.rs
+++ b/benchmarks/cycle_count/src/examples/wasm.rs
@@ -1,0 +1,102 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = wasm_methods::WASM_INTERP_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "wasm";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let wasm = wat2wasm().expect("Failed to parse_str");
+        let iters: i32 = 100;
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec(&wasm).unwrap())
+            .add_input(&to_vec(&iters).unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}
+
+fn wat2wasm() -> Result<Vec<u8>, wat::Error> {
+    let wat = r#"
+    (module
+        (export "fib" (func $fib))
+        (func $fib (; 0 ;) (param $0 i32) (result i32)
+        (local $1 i32)
+        (local $2 i32)
+        (local $3 i32)
+        (local $4 i32)
+        (local.set $4
+         (i32.const 1)
+        )
+        (block $label$0
+         (br_if $label$0
+          (i32.lt_s
+           (local.get $0)
+           (i32.const 1)
+          )
+         )
+         (local.set $3
+          (i32.const 0)
+         )
+         (loop $label$1
+          (local.set $1
+           (i32.add
+            (local.get $3)
+            (local.get $4)
+           )
+          )
+          (local.set $2
+           (local.get $4)
+          )
+          (local.set $3
+           (local.get $4)
+          )
+          (local.set $4
+           (local.get $1)
+          )
+          (br_if $label$1
+           (local.tee $0
+            (i32.add
+             (local.get $0)
+             (i32.const -1)
+            )
+           )
+          )
+         )
+         (return
+          (local.get $2)
+         )
+        )
+        (i32.const 0)
+       )
+    )
+    "#;
+    wat::parse_str(wat)
+}

--- a/benchmarks/cycle_count/src/examples/wordle.rs
+++ b/benchmarks/cycle_count/src/examples/wordle.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{exec_compute, get_image, CycleCounter};
+use risc0_zkvm::{serde::to_vec, ExecutorEnv, MemoryImage};
+
+pub struct Job<'a> {
+    pub env: ExecutorEnv<'a>,
+    pub image: MemoryImage,
+}
+
+const METHOD_PATH: &'static str = wordle_methods::WORDLE_GUEST_PATH;
+
+impl CycleCounter for Job<'_> {
+    const NAME: &'static str = "wordle";
+
+    fn new() -> Self {
+        let image = get_image(METHOD_PATH);
+        let env = ExecutorEnv::builder()
+            .add_input(&to_vec("fuzzy").unwrap())
+            .add_input(&to_vec("fuzzy").unwrap())
+            .build()
+            .unwrap();
+
+        Job { env, image }
+    }
+
+    fn exec_compute(&mut self) -> u32 {
+        exec_compute(self.image.clone(), self.env.clone())
+    }
+}

--- a/benchmarks/cycle_count/src/lib.rs
+++ b/benchmarks/cycle_count/src/lib.rs
@@ -1,0 +1,111 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+
+use log::info;
+use risc0_zkvm::{ExecutorEnv, ExecutorImpl, MemoryImage, Program, GUEST_MAX_MEM, PAGE_SIZE};
+use serde::Serialize;
+
+pub mod examples;
+
+pub struct Metrics {
+    pub name: String,
+    pub cycles: u32,
+}
+
+impl Metrics {
+    pub fn new(name: String) -> Self {
+        Metrics { name, cycles: 0 }
+    }
+
+    pub fn println(&self, prefix: &str) {
+        info!("{}name:           {:?}", prefix, &self.name);
+        info!("{}cycles:         {:?}", prefix, &self.cycles);
+    }
+}
+
+pub trait CycleCounter {
+    const NAME: &'static str;
+
+    fn new() -> Self;
+    fn exec_compute(&mut self) -> u32;
+    fn run(&mut self) -> Metrics {
+        let mut metrics = Metrics::new(String::from(Self::NAME));
+        metrics.cycles = self.exec_compute();
+        metrics
+    }
+}
+
+pub fn get_image(path: &str) -> MemoryImage {
+    let elf = std::fs::read(path).expect("elf");
+    let program = Program::load_elf(&elf, GUEST_MAX_MEM as u32).unwrap();
+    MemoryImage::new(&program, PAGE_SIZE as u32).unwrap()
+}
+
+pub fn exec_compute<'a>(image: MemoryImage, env: ExecutorEnv<'a>) -> u32 {
+    let mut exec = ExecutorImpl::new(env.clone(), image.clone()).unwrap();
+    let session = exec.run().unwrap();
+    let segments = session.resolve().unwrap();
+    let cycles = segments
+        .iter()
+        .fold(0, |cycles, segment| (cycles + (1 << segment.po2)));
+    cycles as u32
+}
+
+pub fn init_logging() {
+    env_logger::init();
+}
+
+#[derive(Serialize)]
+struct CsvRow<'a> {
+    name: &'a str,
+    cycles: u32,
+}
+
+pub fn run_jobs<C: CycleCounter>(out_path: &PathBuf) -> Metrics {
+    info!("");
+    info!("Running job; saving output to {}", out_path.display());
+
+    let mut out = {
+        let out_file_exists = Path::new(out_path).exists();
+        let out_file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .create(true)
+            .open(out_path)
+            .unwrap();
+        csv::WriterBuilder::new()
+            .has_headers(!out_file_exists)
+            .from_writer(out_file)
+    };
+
+    let mut job = C::new();
+    info!("");
+    info!("+ begin: {}", C::NAME);
+
+    let job_metrics = job.run();
+    job_metrics.println("+ ");
+    out.serialize(CsvRow {
+        name: &job_metrics.name,
+        cycles: job_metrics.cycles,
+    })
+    .expect("Could not serialize");
+
+    out.flush().expect("Could not flush");
+    info!("Finished");
+
+    job_metrics
+}

--- a/benchmarks/cycle_count/src/main.rs
+++ b/benchmarks/cycle_count/src/main.rs
@@ -1,0 +1,106 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::{Parser, Subcommand};
+use risc0_examples_cycle_counter::{init_logging, run_jobs};
+use std::path::PathBuf;
+
+use risc0_examples_cycle_counter::examples::*;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    // CSV output file
+    #[arg(long, value_name = "FILE")]
+    out: PathBuf,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Eq, PartialEq, Subcommand)]
+enum Command {
+    All,
+    Bevy,
+    Chess,
+    DigitalSignature,
+    Ecdsa,
+    HelloWorld,
+    Json,
+    PasswordChecker,
+    Prorata,
+    Sha,
+    SmartcoreMl,
+    Waldo,
+    Wasm,
+    Wordle,
+}
+
+fn main() {
+    init_logging();
+
+    let cli = Cli::parse();
+
+    if cli.command == Command::All || cli.command == Command::Bevy {
+        run_jobs::<bevy::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Chess {
+        run_jobs::<chess::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::DigitalSignature {
+        run_jobs::<digital_signature::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Ecdsa {
+        run_jobs::<ecdsa::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::HelloWorld {
+        run_jobs::<hello_world::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Json {
+        run_jobs::<json::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::PasswordChecker {
+        run_jobs::<password_checker::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Prorata {
+        run_jobs::<prorata::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Sha {
+        run_jobs::<sha::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::SmartcoreMl {
+        run_jobs::<smartcore_ml::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Waldo {
+        run_jobs::<waldo::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Wasm {
+        run_jobs::<wasm::Job>(&cli.out);
+    }
+
+    if cli.command == Command::All || cli.command == Command::Wordle {
+        run_jobs::<wordle::Job>(&cli.out);
+    }
+}

--- a/ghpages/dev/datasheet/index.html
+++ b/ghpages/dev/datasheet/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>
   <style>
     .head-wrapper {
       position: relative;
@@ -132,6 +133,7 @@
 
       .box {
         padding: 10px;
+        margin-top: -5px;
       }
 
       table {
@@ -241,59 +243,12 @@
       Initializing a zkVM guest requires over 16 k cycles. Combined with this power of two rounding, this means that no
       program can be executed in fewer than 32 k cycles.
       <br></br>
-      To give context for these numbers we have included a table indicating the size of each of our example programs in
+      To give context for these numbers we have included a table indicating the size of some of our example programs in
       cycles. Note that some programs vary in cycle count depending on input data. The cycle counts given here use the
       default input data, or, for examples with no defaults, the input data suggested in the associated README file.
       <br></br>
     </div>
-    <div class="box">
-      <table>
-        <thead>
-          <tr>
-            <th>Example</th>
-            <th>Cycles</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Factors</td>
-            <td>32 k</td>
-          </tr>
-          <tr>
-            <td>Chess</td>
-            <td>256 k</td>
-          </tr>
-          <tr>
-            <td>Digital Signature</td>
-            <td>64 k</td>
-          </tr>
-          <tr>
-            <td>EVM</td>
-            <td>2048 k</td>
-          </tr>
-          <tr>
-            <td>JSON</td>
-            <td>64 k</td>
-          </tr>
-          <tr>
-            <td>Password Checker</td>
-            <td>64 k</td>
-          </tr>
-          <tr>
-            <td>SHA</td>
-            <td>64 k</td>
-          </tr>
-          <tr>
-            <td>Waldo</td>
-            <td>8192 k</td>
-          </tr>
-          <tr>
-            <td>Wordle</td>
-            <td>64 k</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <div class="box" id="table_cycle_count"></div>
   </div>
   <div class="qrcode-container">
     <div class="qrcode-box">
@@ -356,6 +311,68 @@
       } catch (error) {
         console.error('Error fetching commit hash:', error);
       }
+    }
+
+    // Array of examples to include in the table
+    const includeExamples = [
+      "bevy",
+      "chess",
+      "digital-signature",
+      "ecdsa",
+      "hello-world",
+      "json",
+      "password-checker",
+      "prorata",
+      "sha",
+      "smartcore-ml",
+      "waldo",
+      "wasm",
+      "wordle"
+    ];
+
+    function cycleCountTable() {
+      // Parse the CSV file
+      Papa.parse('cycle_count.csv', {
+        download: true,
+        header: true,
+        complete: function (results) {
+          const data = results.data;
+
+          // Filter the data based on the includeExamples array
+          const filteredData = data.filter(item => includeExamples.includes(item.name));
+
+          // Get the correct container for this table
+          const tableContainer = document.getElementById(`table_cycle_count`);
+
+          // Create a table element
+          const table = document.createElement('table');
+
+          // Create and append the table header
+          const headerRow = document.createElement('tr');
+          const nameHeader = document.createElement('th');
+          nameHeader.textContent = 'Example';
+          const cyclesHeader = document.createElement('th');
+          cyclesHeader.textContent = 'Cycles';
+          headerRow.appendChild(nameHeader);
+          headerRow.appendChild(cyclesHeader);
+          table.appendChild(headerRow);
+
+          // Create and append the table rows
+          filteredData.forEach(item => {
+            const row = document.createElement('tr');
+            const nameCell = document.createElement('td');
+            nameCell.textContent = item.name;
+            const cyclesCell = document.createElement('td');
+            cyclesCell.textContent = `${item.cycles / 1024}k`;
+            row.appendChild(nameCell);
+            row.appendChild(cyclesCell);
+            table.appendChild(row);
+          });
+
+          // Append the table to the document body
+          tableContainer.appendChild(table);
+        }
+      });
     }
 
     async function fetchData() {
@@ -449,6 +466,8 @@
     document.addEventListener("DOMContentLoaded", fetchCommitHash);
     // Invoke fetchData when the document is ready
     document.addEventListener("DOMContentLoaded", fetchData);
+    // Invoke cycleCountTable when the document is ready
+    document.addEventListener("DOMContentLoaded", cycleCountTable);
   </script>
 
 </body>

--- a/ghpages/dev/datasheet/index.html
+++ b/ghpages/dev/datasheet/index.html
@@ -225,7 +225,7 @@
   </div>
 
   <div class="footnote">
-    <p>*this uses continuations, reducing the memory usage but producing more receipts (if not rolled up with Bonsai).
+    <p>*This uses continuations, reducing the memory usage but producing more receipts (if not rolled up with Bonsai).
     </p>
   </div>
 
@@ -235,13 +235,14 @@
       therefore give
       performance data for different guest execution lengths, as indicated in the "Cycles" column. For cryptographic
       reasons, the
-      cycle count is always rounded up in length to the next highest power of two; thus, a program that requires 33000
+      cycle count for each segment is always rounded up in length to the next highest power of two; thus, a program that
+      requires 33000
       cycles
       will have the same performance as a program that requires 63000 cycles, as both will round up to 65536 (64 k)
       cycles.
       <br></br>
       Initializing a zkVM guest requires over 16 k cycles. Combined with this power of two rounding, this means that no
-      program can be executed in fewer than 32 k cycles.
+      program can be executed in fewer than 64 k cycles.
       <br></br>
       To give context for these numbers we have included a table indicating the size of some of our example programs in
       cycles. Note that some programs vary in cycle count depending on input data. The cycle counts given here use the


### PR DESCRIPTION
This PR adds a new step in the `bench_datasheet` workflow to count the cycles of our examples.
Currently, `zkevm-demo` has been excluded as it requires a connection to some Ethereum node.

The new table in the ghpages will look something like this:
<img width="406" alt="Screenshot 2023-10-05 at 10 19 50" src="https://github.com/risc0/risc0/assets/33255129/9ef389d4-e897-4b84-a403-ceb4d9e7ff6e">

The displayed examples can also be filtered by modifying:
https://github.com/risc0/risc0/blob/731a9793fa7f8e4350b06fd2df9e1e8465b7d32a/ghpages/dev/datasheet/index.html#L316-L331

Closes #940 