### PR TITLE
Collapse CircuitCoreDef and CircuitProveDef into CircuitDef

### DIFF
--- a/risc0/circuit/recursion/src/cpp.rs
+++ b/risc0/circuit/recursion/src/cpp.rs
@@ -22,7 +22,7 @@ use risc0_circuit_recursion_sys::ffi::{
     risc0_circuit_recursion_string_free, risc0_circuit_recursion_string_ptr, Callback, RawError,
 };
 use risc0_zkp::{
-    adapter::{CircuitProveDef, CircuitStep, CircuitStepContext, CircuitStepHandler, PolyFp},
+    adapter::{CircuitDef, CircuitStep, CircuitStepContext, CircuitStepHandler, PolyFp},
     field::baby_bear::{BabyBear, BabyBearElem, BabyBearExtElem},
     hal::cpu::SyncSlice,
 };
@@ -142,7 +142,7 @@ impl PolyFp<BabyBear> for CircuitImpl {
     }
 }
 
-impl CircuitProveDef<BabyBear> for CircuitImpl {}
+impl CircuitDef<BabyBear> for CircuitImpl {}
 
 pub(crate) fn call_step<S, F>(
     ctx: &CircuitStepContext,

--- a/risc0/circuit/recursion/src/lib.rs
+++ b/risc0/circuit/recursion/src/lib.rs
@@ -31,11 +31,7 @@ mod taps;
 pub mod zkr;
 
 use risc0_core::field::baby_bear::{BabyBearElem, BabyBearExtElem};
-use risc0_zkp::{
-    adapter::{CircuitCoreDef, TapsProvider},
-    field::baby_bear::BabyBear,
-    taps::TapSet,
-};
+use risc0_zkp::{adapter::TapsProvider, taps::TapSet};
 
 pub const REGISTER_GROUP_ACCUM: usize = 0;
 pub const REGISTER_GROUP_CODE: usize = 1;
@@ -59,8 +55,6 @@ impl TapsProvider for CircuitImpl {
         self::taps::TAPSET
     }
 }
-
-impl CircuitCoreDef<BabyBear> for CircuitImpl {}
 
 // Values for micro inst "opcode"
 pub mod micro_op {

--- a/risc0/circuit/rv32im/src/cpp.rs
+++ b/risc0/circuit/rv32im/src/cpp.rs
@@ -23,7 +23,7 @@ use risc0_circuit_rv32im_sys::ffi::{
 };
 use risc0_core::field::baby_bear::{BabyBear, BabyBearElem, BabyBearExtElem};
 use risc0_zkp::{
-    adapter::{CircuitProveDef, CircuitStep, CircuitStepContext, CircuitStepHandler, PolyFp},
+    adapter::{CircuitDef, CircuitStep, CircuitStepContext, CircuitStepHandler, PolyFp},
     hal::cpu::SyncSlice,
 };
 
@@ -134,7 +134,7 @@ impl PolyFp<BabyBear> for CircuitImpl {
     }
 }
 
-impl CircuitProveDef<BabyBear> for CircuitImpl {}
+impl CircuitDef<BabyBear> for CircuitImpl {}
 
 pub(crate) fn call_step<S, F>(
     ctx: &CircuitStepContext,

--- a/risc0/circuit/rv32im/src/lib.rs
+++ b/risc0/circuit/rv32im/src/lib.rs
@@ -28,11 +28,7 @@ pub mod metal;
 pub mod poly_ext;
 mod taps;
 
-use risc0_zkp::{
-    adapter::{CircuitCoreDef, TapsProvider},
-    field::baby_bear::BabyBear,
-    taps::TapSet,
-};
+use risc0_zkp::{adapter::TapsProvider, taps::TapSet};
 
 pub struct CircuitImpl;
 
@@ -54,8 +50,6 @@ impl TapsProvider for CircuitImpl {
         taps::TAPSET
     }
 }
-
-impl CircuitCoreDef<BabyBear> for CircuitImpl {}
 
 #[cfg(test)]
 mod tests {

--- a/risc0/zkp/src/adapter.rs
+++ b/risc0/zkp/src/adapter.rs
@@ -120,12 +120,9 @@ pub trait CircuitInfo {
     const MIX_SIZE: usize;
 }
 
-/// traits implemented by generated rust code used in both prover and verifier
-pub trait CircuitCoreDef<F: Field>: CircuitInfo + PolyExt<F> + TapsProvider {}
-
-/// traits implemented by generated rust code used in only the prover
-pub trait CircuitProveDef<F: Field>:
-    CircuitStep<F::Elem> + PolyFp<F> + CircuitCoreDef<F> + Sync
+/// traits implemented by generated rust code used in both the prover and verifier
+pub trait CircuitDef<F: Field>:
+    CircuitStep<F::Elem> + PolyFp<F> + CircuitInfo + PolyExt<F> + TapsProvider + Sync
 {
 }
 

--- a/risc0/zkp/src/prove/adapter.rs
+++ b/risc0/zkp/src/prove/adapter.rs
@@ -19,7 +19,7 @@ use rayon::prelude::*;
 use risc0_core::field::{Elem, Field};
 
 use crate::{
-    adapter::{CircuitProveDef, CircuitStepContext, CircuitStepHandler, REGISTER_GROUP_ACCUM},
+    adapter::{CircuitDef, CircuitStepContext, CircuitStepHandler, REGISTER_GROUP_ACCUM},
     hal::cpu::CpuBuffer,
     prove::{
         accum::{Accum, Handler},
@@ -33,7 +33,7 @@ use crate::{
 pub struct ProveAdapter<'a, F, C, S>
 where
     F: Field,
-    C: 'static + CircuitProveDef<F>,
+    C: 'static + CircuitDef<F>,
     S: CircuitStepHandler<F::Elem>,
 {
     exec: &'a mut Executor<F, C, S>,
@@ -45,7 +45,7 @@ where
 impl<'a, F, C, CS> ProveAdapter<'a, F, C, CS>
 where
     F: Field,
-    C: 'static + CircuitProveDef<F>,
+    C: 'static + CircuitDef<F>,
     CS: CircuitStepHandler<F::Elem>,
 {
     pub fn new(exec: &'a mut Executor<F, C, CS>) -> Self {

--- a/risc0/zkp/src/prove/executor.rs
+++ b/risc0/zkp/src/prove/executor.rs
@@ -22,7 +22,7 @@ use risc0_core::field::{Elem, Field};
 
 use crate::{
     adapter::{
-        CircuitProveDef, CircuitStepContext, CircuitStepHandler, REGISTER_GROUP_CODE,
+        CircuitDef, CircuitStepContext, CircuitStepHandler, REGISTER_GROUP_CODE,
         REGISTER_GROUP_DATA,
     },
     hal::{
@@ -35,7 +35,7 @@ use crate::{
 pub struct Executor<F, C, S>
 where
     F: Field,
-    C: 'static + CircuitProveDef<F>,
+    C: 'static + CircuitDef<F>,
     S: CircuitStepHandler<F::Elem>,
 {
     pub circuit: &'static C,
@@ -66,7 +66,7 @@ where
 impl<F, C, S> Executor<F, C, S>
 where
     F: Field,
-    C: 'static + CircuitProveDef<F>,
+    C: 'static + CircuitDef<F>,
     S: CircuitStepHandler<F::Elem>,
 {
     pub fn new(

--- a/risc0/zkp/src/verify/fri.rs
+++ b/risc0/zkp/src/verify/fri.rs
@@ -18,7 +18,7 @@ use risc0_core::field::{Elem, ExtElem, Field, RootsOfUnity};
 
 use super::Verifier;
 use crate::{
-    adapter::CircuitCoreDef,
+    adapter::CircuitDef,
     core::{
         hash::HashFn,
         log2_ceil,
@@ -57,7 +57,7 @@ impl<'a, F: Field> VerifyRoundInfo<'a, F> {
 impl<'a, F, C> Verifier<'a, F, C>
 where
     F: Field,
-    C: CircuitCoreDef<F>,
+    C: CircuitDef<F>,
 {
     fn verify_query(
         &self,

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -26,7 +26,7 @@ pub use read_iop::ReadIOP;
 use risc0_core::field::{Elem, ExtElem, Field, RootsOfUnity};
 
 use crate::{
-    adapter::{CircuitCoreDef, REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA},
+    adapter::{CircuitDef, REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA},
     core::{digest::Digest, hash::HashSuite, log2_ceil},
     taps::TapSet,
     INV_RATE, MAX_CYCLES_PO2, QUERIES,
@@ -110,7 +110,7 @@ impl<'a, F: Field, C> VerifyParams<F> for Verifier<'a, F, C> {}
 impl<'a, F, C> Verifier<'a, F, C>
 where
     F: Field,
-    C: CircuitCoreDef<F>,
+    C: CircuitDef<F>,
 {
     fn new(circuit: &'a C, suite: &'a HashSuite<F>) -> Self {
         Self {
@@ -441,7 +441,7 @@ pub fn verify<F, C, CheckCode>(
 ) -> Result<(), VerificationError>
 where
     F: Field,
-    C: CircuitCoreDef<F>,
+    C: CircuitDef<F>,
     CheckCode: Fn(u32, &Digest) -> Result<(), VerificationError>,
 {
     Verifier::<F, C>::new(circuit, suite).verify(seal, check_code)


### PR DESCRIPTION
When I published the recursion verifier, I split the CircuitDef trait into two separate traits. Now that the recursion prover and verifier are in the same repo, we can merge the two traits back into one again!