### PR TITLE
fix(ci-nightly): Fix path for crates validator config file

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Generate the profile
         run: |
           target/release/gen-profiles \
-          -P ${{ github.workspace }}/profiles/config.yaml \
+          -P ${{ github.workspace }}/tools/crates-validator/profiles/config.yaml \
           -o ${{ runner.temp }}/crate-validation/profiles.yaml \
           -c $TOP_N_CRATES
         working-directory: tools/crates-validator/


### PR DESCRIPTION
Should fix the CI error we got earlier due to non-existent file.