### PR TITLE
Fix warning about using features in patch for smartcore

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
  "serde_json",
  "sha-methods",
  "sha2",
- "smartcore",
+ "smartcore 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smartcore-ml-methods",
  "waldo-core",
  "waldo-methods",
@@ -4342,6 +4342,21 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 [[package]]
 name = "smartcore"
 version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42ca1fcd851ada8834d3dfcd088850dc8c703bde50c2baccd89181b74dc3ade"
+dependencies = [
+ "approx",
+ "cfg-if",
+ "num",
+ "num-traits",
+ "rand",
+ "serde",
+ "typetag",
+]
+
+[[package]]
+name = "smartcore"
+version = "0.3.2"
 source = "git+https://github.com/risc0/smartcore.git#4bd3cadd50ed988c45c239f5264c3e2c2af0a690"
 dependencies = [
  "approx",
@@ -4360,7 +4375,7 @@ dependencies = [
  "risc0-zkvm",
  "rmp-serde",
  "serde_json",
- "smartcore",
+ "smartcore 0.3.2 (git+https://github.com/risc0/smartcore.git)",
  "smartcore-ml-methods",
 ]
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4374,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "smartcore"
 version = "0.3.2"
-source = "git+https://github.com/risc0/smartcore.git#4bd3cadd50ed988c45c239f5264c3e2c2af0a690"
+source = "git+https://github.com/risc0/smartcore.git?rev=4bd3cadd50ed988c45c239f5264c3e2c2af0a690#4bd3cadd50ed988c45c239f5264c3e2c2af0a690"
 dependencies = [
  "approx",
  "cfg-if",
@@ -4392,7 +4392,7 @@ dependencies = [
  "risc0-zkvm",
  "rmp-serde",
  "serde_json",
- "smartcore 0.3.2 (git+https://github.com/risc0/smartcore.git)",
+ "smartcore 0.3.2 (git+https://github.com/risc0/smartcore.git?rev=4bd3cadd50ed988c45c239f5264c3e2c2af0a690)",
  "smartcore-ml-methods",
 ]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -43,6 +43,3 @@ lto = true
 
 [profile.release.build-override]
 opt-level = 3
-
-[patch.crates-io]
-smartcore = { git = "https://github.com/risc0/smartcore.git", features = ["serde"] }

--- a/examples/smartcore-ml/Cargo.toml
+++ b/examples/smartcore-ml/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 risc0-zkvm = { path = "../../risc0/zkvm" }
 rmp-serde = "1.1"
 serde_json = "1.0"
-smartcore = { git = "https://github.com/risc0/smartcore.git", features = ["serde"] }
+smartcore = { git = "https://github.com/risc0/smartcore.git", rev = "4bd3cadd50ed988c45c239f5264c3e2c2af0a690", features = ["serde"] }
 smartcore-ml-methods = { path = "methods" }
 
 [features]

--- a/examples/smartcore-ml/Cargo.toml
+++ b/examples/smartcore-ml/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 risc0-zkvm = { path = "../../risc0/zkvm" }
 rmp-serde = "1.1"
 serde_json = "1.0"
-smartcore = { git = "https://github.com/risc0/smartcore.git", features = ["serde"]}
+smartcore = { git = "https://github.com/risc0/smartcore.git", features = ["serde"] }
 smartcore-ml-methods = { path = "methods" }
 
 [features]

--- a/examples/smartcore-ml/Cargo.toml
+++ b/examples/smartcore-ml/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 risc0-zkvm = { path = "../../risc0/zkvm" }
 rmp-serde = "1.1"
 serde_json = "1.0"
-smartcore = { version = "0.3", features = ["serde"] }
+smartcore = { git = "https://github.com/risc0/smartcore.git", features = ["serde"]}
 smartcore-ml-methods = { path = "methods" }
 
 [features]

--- a/examples/smartcore-ml/Cargo.toml
+++ b/examples/smartcore-ml/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 risc0-zkvm = { path = "../../risc0/zkvm" }
 rmp-serde = "1.1"
 serde_json = "1.0"
+# Using git dependency as a workaround for https://github.com/smartcorelib/smartcore/issues/267
 smartcore = { git = "https://github.com/risc0/smartcore.git", rev = "4bd3cadd50ed988c45c239f5264c3e2c2af0a690", features = ["serde"] }
 smartcore-ml-methods = { path = "methods" }
 

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "smartcore"
 version = "0.3.2"
-source = "git+https://github.com/risc0/smartcore.git#4bd3cadd50ed988c45c239f5264c3e2c2af0a690"
+source = "git+https://github.com/risc0/smartcore.git?rev=4bd3cadd50ed988c45c239f5264c3e2c2af0a690#4bd3cadd50ed988c45c239f5264c3e2c2af0a690"
 dependencies = [
  "approx",
  "cfg-if",

--- a/examples/smartcore-ml/methods/guest/Cargo.toml
+++ b/examples/smartcore-ml/methods/guest/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = [
   "std",
 ] }
+# Using git dependency as a workaround for https://github.com/smartcorelib/smartcore/issues/267
 smartcore = { git = "https://github.com/risc0/smartcore.git", rev = "4bd3cadd50ed988c45c239f5264c3e2c2af0a690", features = ["serde"]}

--- a/examples/smartcore-ml/methods/guest/Cargo.toml
+++ b/examples/smartcore-ml/methods/guest/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = [
   "std",
 ] }
-smartcore = { git = "https://github.com/risc0/smartcore.git", features = ["serde"]}
+smartcore = { git = "https://github.com/risc0/smartcore.git", rev = "4bd3cadd50ed988c45c239f5264c3e2c2af0a690", features = ["serde"]}

--- a/examples/smartcore-ml/methods/guest/Cargo.toml
+++ b/examples/smartcore-ml/methods/guest/Cargo.toml
@@ -9,7 +9,4 @@ edition = "2021"
 risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = [
   "std",
 ] }
-smartcore = { version = "0.3", features = ["serde"]}
-
-[patch.crates-io]
-smartcore = { git = "https://github.com/risc0/smartcore.git", features = ['serde'] }
+smartcore = { git = "https://github.com/risc0/smartcore.git", features = ["serde"]}


### PR DESCRIPTION
Currently on `main` building the examples triggers a warning about the non-effect of setting features on the `smartcore` crate, in the `smartcore-ml` example. I looked into this and realized that additionally this example is using the patch mechanism when it could just be referencing the git dependency directly. I've modified the example to dependency directly, silencing the warning and avoiding unnecessary use of the patch mechanism.
