### PR TITLE
Release v0.19.0-rc.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      crates-validator: ${{ steps.filter.outputs.crates-validator }}
+    steps:
+      - uses: risc0/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            crates-validator:
+              - tools/crates-validator/**
+
   check:
     runs-on: ubuntu-latest
     steps:
@@ -218,22 +230,6 @@ jobs:
         shell: bash
       - run: cargo build --release --manifest-path ${{ runner.temp }}/template-test/Cargo.toml
       - run: ${{ runner.temp }}/template-test/target/release/host
-
-  changes:
-    runs-on: [self-hosted, prod, cpu, "${{ matrix.os }}"]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [Linux, macOS]
-    outputs:
-      crates-validator: ${{ steps.filter.outputs.crates-validator }}
-    steps:
-      - uses: risc0/paths-filter@master
-        id: filter
-        with:
-          filters: |
-            crates-validator:
-              - tools/crates-validator/**
 
   crates-validator:
     needs: changes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       crates-validator: ${{ steps.filter.outputs.crates-validator }}
     steps:
-      - uses: risc0/paths-filter@v2
+      - uses: risc0/paths-filter@4067d885736b84de7c414f582ac45897079b0a78
         id: filter
         with:
           filters: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -36,21 +36,20 @@ repository = "https://github.com/risc0/risc0/"
 bonsai-ethereum-contracts = { version = "0.1.0", path = "bonsai/ethereum" }
 bonsai-ethereum-relay = { version = "0.1.0", default-features = false, path = "bonsai/ethereum-relay" }
 bonsai-rest-api-mock = { version = "0.1.0", default-features = false, path = "bonsai/rest-api-mock" }
-bonsai-sdk = { version = "0.5.0-alpha.1", default-features = false, path = "bonsai/sdk" }
-risc0-benchmark = { version = "0.19.0-alpha.1", default-features = false, path = "benchmarks" }
-risc0-binfmt = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-recursion = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/core" }
-risc0-r0vm = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/zkp" }
-risc0-zkvm = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "0.19.0-alpha.1", default-features = false, path = "risc0/zkvm/platform" }
+bonsai-sdk = { version = "0.5.0-rc.1", default-features = false, path = "bonsai/sdk" }
+risc0-binfmt = { version = "0.19.0-rc.1", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "0.19.0-rc.1", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "0.19.0-rc.1", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-recursion = { version = "0.19.0-rc.1", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "0.19.0-rc.1", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "0.19.0-rc.1", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "0.19.0-rc.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "0.19.0-rc.1", default-features = false, path = "risc0/core" }
+risc0-r0vm = { version = "0.19.0-rc.1", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "0.19.0-rc.1", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "0.19.0-rc.1", default-features = false, path = "risc0/zkp" }
+risc0-zkvm = { version = "0.19.0-rc.1", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "0.19.0-rc.1", default-features = false, path = "risc0/zkvm/platform" }
 
 [profile.bench]
 lto = true

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1024,6 +1024,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "downloader"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3196,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cust",
+ "downloader",
  "log",
  "metal",
  "rand",
@@ -3189,6 +3204,7 @@ dependencies = [
  "risc0-circuit-recursion-sys",
  "risc0-core 0.19.0-rc.1",
  "risc0-zkp 0.19.0-rc.1",
+ "sha2",
  "tracing",
  "zip",
 ]

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -36,17 +36,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -102,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0391754c09fab4eae3404d19d0d297aa1c670c1775ab51d8a5312afeca23157"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -228,7 +217,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -238,7 +227,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -250,7 +239,7 @@ checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -263,7 +252,7 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -327,7 +316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -350,7 +339,7 @@ checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -409,13 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bevy-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,12 +420,6 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -509,56 +485,11 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-alpha.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "reqwest",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "borsh"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
-dependencies = [
- "borsh-derive",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
-dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote 1.0.33",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -572,28 +503,6 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
-dependencies = [
- "proc-macro2",
- "quote 1.0.33",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "bytemuck"
@@ -611,7 +520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -679,20 +588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chess-core"
-version = "0.1.0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "chess-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,7 +630,7 @@ checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -744,12 +639,6 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -946,7 +835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -983,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3bc95fe629aed92b2423de6ccff9e40174b21d19cb6ee6281a4d04ac72f66"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1015,7 +904,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "strsim",
  "syn 2.0.37",
 ]
@@ -1027,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -1063,7 +952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1075,7 +964,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -1102,21 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digital-signature-core"
-version = "0.1.0"
-dependencies = [
- "risc0-zkvm",
- "serde",
-]
-
-[[package]]
-name = "digital-signature-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
-
-[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,12 +1010,6 @@ dependencies = [
  "redox_users",
  "windows-sys",
 ]
-
-[[package]]
-name = "divrem"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
 
 [[package]]
 name = "docker-generate"
@@ -1168,13 +1036,6 @@ dependencies = [
  "serdect",
  "signature",
  "spki",
-]
-
-[[package]]
-name = "ecdsa-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
 ]
 
 [[package]]
@@ -1231,15 +1092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "elsa"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714f766f3556b44e7e4776ad133fcc3445a489517c25c704ace411bb14790194"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,7 +1125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -1398,7 +1250,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tiny-keccak",
- "unicode-xid 0.2.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1440,22 +1292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
-dependencies = [
- "bit_field",
- "flume",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,15 +1312,6 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
-dependencies = [
- "simd-adler32",
 ]
 
 [[package]]
@@ -1512,7 +1339,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1560,19 +1387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin 0.9.8",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,7 +1418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -1690,7 +1504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -1768,16 +1582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,22 +1649,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1868,7 +1660,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash",
  "serde",
 ]
 
@@ -1892,13 +1684,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hello-world-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -2070,25 +1855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.24.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "exr",
- "gif",
- "jpeg-decoder",
- "num-rational",
- "num-traits",
- "png",
- "qoi",
- "tiff",
-]
-
-[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,7 +1888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2214,28 +1980,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "jpeg-decoder"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
-dependencies = [
- "rayon",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
 ]
 
 [[package]]
@@ -2294,7 +2044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8edfc11b8f56ce85e207e62ea21557cfa09bb24a8f6b04ae181b086ff8611c22"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "regex",
  "syn 1.0.109",
 ]
@@ -2305,20 +2055,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
-
-[[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -2398,23 +2136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merkle_light"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b879f617ec392ad9c11a50356ca373009c52363c0953b34c2e1b2234037a26a9"
-
-[[package]]
-name = "merkle_light_derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f214fe0b551d8162d746f1a74b7016659b771231bafae36b4f4264991a34c4fd"
-dependencies = [
- "merkle_light",
- "quote 0.3.15",
- "syn 0.11.11",
-]
-
-[[package]]
 name = "metal"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,7 +2163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2467,15 +2187,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "native-tls"
@@ -2561,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -2633,9 +2344,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -2696,7 +2407,7 @@ checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
 dependencies = [
  "bytes",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2722,7 +2433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -2770,9 +2481,9 @@ version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2797,20 +2508,6 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
-]
-
-[[package]]
-name = "password-checker-core"
-version = "0.12.0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "password-checker-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
 ]
 
 [[package]]
@@ -2881,7 +2578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -2920,19 +2617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
-name = "png"
-version = "0.17.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,15 +2648,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
@@ -2989,7 +2664,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3001,7 +2676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "version_check",
 ]
 
@@ -3032,25 +2707,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prorata-core"
-version = "0.1.0"
-dependencies = [
- "csv",
- "hex",
- "rust_decimal",
- "rust_decimal_macros",
- "serde",
- "sha2",
-]
-
-[[package]]
-name = "prorata-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
 ]
 
 [[package]]
@@ -3094,7 +2750,7 @@ dependencies = [
  "anyhow",
  "itertools 0.11.0",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -3117,45 +2773,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -3302,15 +2923,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
-name = "rend"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,7 +3047,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted",
  "web-sys",
  "winapi",
@@ -3452,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-benchmark"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 dependencies = [
  "blake2",
  "blake3",
@@ -3468,7 +3080,7 @@ dependencies = [
  "rand_core",
  "risc0-benchmark-lib",
  "risc0-benchmark-methods",
- "risc0-zkp 0.19.0-alpha.1",
+ "risc0-zkp 0.19.0-rc.1",
  "risc0-zkvm",
  "risc0-zkvm-methods",
  "serde",
@@ -3483,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-benchmark-lib"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 dependencies = [
  "risc0-zkvm",
  "serde",
@@ -3492,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-benchmark-methods"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 dependencies = [
- "risc0-build 0.19.0-alpha.1",
+ "risc0-build 0.19.0-rc.1",
 ]
 
 [[package]]
@@ -3513,13 +3125,13 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
  "log",
- "risc0-zkp 0.19.0-alpha.1",
- "risc0-zkvm-platform 0.19.0-alpha.1",
+ "risc0-zkp 0.19.0-rc.1",
+ "risc0-zkvm-platform 0.19.0-rc.1",
  "serde",
 ]
 
@@ -3539,14 +3151,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "docker-generate",
- "risc0-binfmt 0.19.0-alpha.1",
- "risc0-zkp 0.19.0-alpha.1",
- "risc0-zkvm-platform 0.19.0-alpha.1",
+ "risc0-binfmt 0.19.0-rc.1",
+ "risc0-zkp 0.19.0-rc.1",
+ "risc0-zkvm-platform 0.19.0-rc.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -3554,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "cc",
  "directories",
@@ -3565,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3575,24 +3187,24 @@ dependencies = [
  "rand",
  "rayon",
  "risc0-circuit-recursion-sys",
- "risc0-core 0.19.0-alpha.1",
- "risc0-zkp 0.19.0-alpha.1",
+ "risc0-core 0.19.0-rc.1",
+ "risc0-zkp 0.19.0-rc.1",
  "tracing",
  "zip",
 ]
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
- "risc0-core 0.19.0-alpha.1",
+ "risc0-core 0.19.0-rc.1",
 ]
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -3601,19 +3213,19 @@ dependencies = [
  "rand",
  "rayon",
  "risc0-circuit-rv32im-sys",
- "risc0-core 0.19.0-alpha.1",
- "risc0-zkp 0.19.0-alpha.1",
- "risc0-zkvm-platform 0.19.0-alpha.1",
+ "risc0-core 0.19.0-rc.1",
+ "risc0-zkp 0.19.0-rc.1",
+ "risc0-zkvm-platform 0.19.0-rc.1",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
- "risc0-core 0.19.0-alpha.1",
+ "risc0-core 0.19.0-rc.1",
 ]
 
 [[package]]
@@ -3628,55 +3240,15 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
 ]
 
 [[package]]
-name = "risc0-examples-cycle-counter"
-version = "0.19.0-alpha.1"
-dependencies = [
- "bevy-methods",
- "chess-core",
- "chess-methods",
- "clap",
- "csv",
- "digital-signature-core",
- "digital-signature-methods",
- "ecdsa-methods",
- "env_logger",
- "hello-world-methods",
- "image",
- "json-methods",
- "k256",
- "log",
- "password-checker-core",
- "password-checker-methods",
- "prorata-core",
- "prorata-methods",
- "rand",
- "rand_core",
- "risc0-zkvm",
- "rmp-serde",
- "rust_decimal",
- "serde",
- "serde_json",
- "sha-methods",
- "sha2",
- "smartcore",
- "smartcore-ml-methods",
- "waldo-core",
- "waldo-methods",
- "wasm-methods",
- "wat",
- "wordle-methods",
-]
-
-[[package]]
 name = "risc0-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "risc0-build-kernel",
 ]
@@ -3704,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3721,9 +3293,9 @@ dependencies = [
  "rand",
  "rand_core",
  "rayon",
- "risc0-core 0.19.0-alpha.1",
+ "risc0-core 0.19.0-rc.1",
  "risc0-sys",
- "risc0-zkvm-platform 0.19.0-alpha.1",
+ "risc0-zkvm-platform 0.19.0-rc.1",
  "serde",
  "sha2",
  "tracing",
@@ -3731,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3752,12 +3324,12 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "rayon",
- "risc0-binfmt 0.19.0-alpha.1",
+ "risc0-binfmt 0.19.0-rc.1",
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
- "risc0-core 0.19.0-alpha.1",
- "risc0-zkp 0.19.0-alpha.1",
- "risc0-zkvm-platform 0.19.0-alpha.1",
+ "risc0-core 0.19.0-rc.1",
+ "risc0-zkp 0.19.0-rc.1",
+ "risc0-zkvm-platform 0.19.0-rc.1",
  "rrs-lib",
  "semver 1.0.19",
  "serde",
@@ -3768,12 +3340,12 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "env_logger",
- "risc0-build 0.19.0-alpha.1",
+ "risc0-build 0.19.0-rc.1",
  "risc0-zkvm",
- "risc0-zkvm-platform 0.19.0-alpha.1",
+ "risc0-zkvm-platform 0.19.0-rc.1",
  "serde",
 ]
 
@@ -3785,39 +3357,11 @@ checksum = "8524b46783b58b00e9b2a4712e837093c975b23cf25bfaf99e1cf69e9011bf6b"
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",
  "libm",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
-dependencies = [
- "bitvec",
- "bytecheck",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
-dependencies = [
- "proc-macro2",
- "quote 1.0.33",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3838,30 +3382,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "rmp"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
 ]
 
 [[package]]
@@ -3902,32 +3424,6 @@ name = "ruint-macro"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
-
-[[package]]
-name = "rust_decimal"
-version = "1.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand",
- "rkyv",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rust_decimal_macros"
-version = "1.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86444b802de0b10ac5e563b5ddb43b541b9705de4e01a50e82194d2b183c1835"
-dependencies = [
- "quote 1.0.33",
- "rust_decimal",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -4056,9 +3552,9 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4086,12 +3582,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -4186,7 +3676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4239,7 +3729,7 @@ checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4251,13 +3741,6 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
-]
-
-[[package]]
-name = "sha-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
 ]
 
 [[package]]
@@ -4312,18 +3795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,28 +3820,6 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
-
-[[package]]
-name = "smartcore"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42ca1fcd851ada8834d3dfcd088850dc8c703bde50c2baccd89181b74dc3ade"
-dependencies = [
- "approx",
- "cfg-if",
- "num",
- "num-traits",
- "rand",
- "serde",
- "typetag",
-]
-
-[[package]]
-name = "smartcore-ml-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
 
 [[package]]
 name = "smol_str"
@@ -4406,15 +3855,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -4513,7 +3953,7 @@ checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "rustversion",
  "syn 2.0.37",
 ]
@@ -4539,23 +3979,12 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "unicode-ident",
 ]
 
@@ -4566,17 +3995,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -4632,7 +4052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4643,19 +4063,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
-]
-
-[[package]]
-name = "tiff"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
 ]
 
 [[package]]
@@ -4736,7 +4145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4790,15 +4199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4840,7 +4240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4925,7 +4325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfc13d450dc4a695200da3074dacf43d449b968baee95e341920e47f61a3b40f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -4975,18 +4375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5020,12 +4408,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "valuable"
@@ -5067,27 +4449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waldo-core"
-version = "0.1.0"
-dependencies = [
- "bincode",
- "divrem",
- "elsa",
- "image",
- "merkle_light",
- "merkle_light_derive",
- "risc0-zkvm",
- "serde",
-]
-
-[[package]]
-name = "waldo-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,7 +4483,7 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
@@ -5145,7 +4506,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5156,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -5167,43 +4528,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "wasm-encoder"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34180c89672b3e4825c3a8db4b61a674f1447afd5fe2445b2d22c3d8b6ea086c"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
-
-[[package]]
-name = "wast"
-version = "66.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da7529bb848d58ab8bf32230fc065b363baee2bd338d5e58c589a1e7d83ad07"
-dependencies = [
- "leb128",
- "memchr",
- "unicode-width",
- "wasm-encoder",
-]
-
-[[package]]
-name = "wat"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4780374047c65b6b6e86019093fe80c18b66825eb684df778a4e068282a780e7"
-dependencies = [
- "wast",
-]
 
 [[package]]
 name = "web-sys"
@@ -5220,12 +4544,6 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
-
-[[package]]
-name = "weezl"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "which"
@@ -5365,13 +4683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wordle-methods"
-version = "0.1.0"
-dependencies = [
- "risc0-build 0.19.0-alpha.1",
-]
-
-[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5415,7 +4726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.37",
 ]
 
@@ -5510,13 +4821,4 @@ checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
 ]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "risc0-benchmark"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 edition = "2021"
 
 [workspace]
-members = [
-    "methods",
-    "shared"]
+members = ["methods", "shared"]
 
 [workspace.dependencies]
 risc0-benchmark-methods = { path = "methods" }
@@ -14,12 +12,14 @@ risc0-benchmark-lib = { path = "shared" }
 risc0-build = { path = "../risc0/build" }
 
 [dependencies]
-blake2 = { version = "0.10.6", default-features = false }
+blake2 = { version = "0.10", default-features = false }
 blake3 = { version = "1.4", default-features = false }
 byteorder = "1.4"
 clap = { version = "4.0", features = ["derive"] }
 csv = "1.1"
-ed25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["rand_core"] }
+ed25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = [
+  "rand_core",
+] }
 env_logger = "0.10"
 hex = "0.4"
 k256 = { version = "0.13", features = ["serde"] }
@@ -29,7 +29,9 @@ rand_core = "0.6.4"
 risc0-benchmark-lib = { workspace = true }
 risc0-benchmark-methods = { workspace = true }
 risc0-zkp = { path = "../risc0/zkp", default-features = false }
-risc0-zkvm = { path = "../risc0/zkvm", default-features = false, features = ["prove"] }
+risc0-zkvm = { path = "../risc0/zkvm", default-features = false, features = [
+  "prove",
+] }
 risc0-zkvm-methods = { path = "../risc0/zkvm/methods" }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,7 @@
 # Benchmarks
 
 ## How to update the ghpages
+
 On every PR merged to `main`, the benchmark results will be pushed to the https://github.com/risc0/ghpages/tree/dev branch. After reviewing the result, you should create a PR on the ghpages repo to publish on https://risc0.github.io/ghpages/dev/benchmarks/index.html.
 
 All `ghpages` static files reside in the `ghpages` folder of the `risc0` repo. Any modifications to `ghpages` should be made via the `risc0` repo henceforth.
@@ -94,6 +95,7 @@ Verifies a given Sudoku solution.
 Computes the proof for a given Ethereum block containing a given number of transactions.
 
 ## Average benchmark
+
 An average (i.e., a given job runs for several iterations, then the time to prove a single iteration is extracted as its average) version of this benchmark is available by running:
 
 ### CPU
@@ -115,6 +117,7 @@ $ RUST_LOG=info cargo run --release --bin average -F cuda -- --out metrics.csv a
 ```
 
 ### Bonsai
+
 ```console
 $ RISC0_DEV_MODE=false BONSAI_API_URL=<API> BONSAI_API_KEY=<API_KEY> RUST_LOG=debug cargo run --release --bin average -- --out metrics-bonsai.csv all
 ```

--- a/benchmarks/methods/Cargo.toml
+++ b/benchmarks/methods/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-benchmark-methods"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 edition = "2021"
 
 [package.metadata.risc0]

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-benchmark-lib"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 dependencies = [
  "risc0-zkvm",
  "serde",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-benchmark-methods-guest"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/benchmarks/methods/guest/Cargo.toml
+++ b/benchmarks/methods/guest/Cargo.toml
@@ -1,27 +1,34 @@
 [package]
 name = "risc0-benchmark-methods-guest"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 edition = "2021"
 
 [workspace]
 
 [dependencies]
 blake3 = { version = "1.4", default-features = false }
-ed25519-dalek = {version = "2.0.0-rc.3", default-features = false}
+ed25519-dalek = { version = "2.0.0-rc.3", default-features = false }
 hex-literal = "0.4"
-k256 = { version = "=0.13.1", features = ["arithmetic", "serde", "expose-field", "std", "ecdsa"], default_features = false }
+k256 = { version = "=0.13.1", features = [
+  "arithmetic",
+  "serde",
+  "expose-field",
+  "std",
+  "ecdsa",
+], default_features = false }
 nalgebra = "0.32"
 risc0-benchmark-lib = { path = "../../shared", default-features = false }
-risc0-zkvm = { path = "../../../risc0/zkvm", default-features = false, features = ["std"] }
+risc0-zkvm = { path = "../../../risc0/zkvm", default-features = false, features = [
+  "std",
+] }
 risc0-zkp = { path = "../../../risc0/zkp", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 starknet-crypto = "0.6"
 
-
 [patch.crates-io]
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.2-risc0" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.0-risczero.1" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.1-risc0"  }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.1-risc0" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.6-risczero.0" }
 
 [profile.release]

--- a/benchmarks/shared/Cargo.toml
+++ b/benchmarks/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-benchmark-lib"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/bonsai/Cargo.lock
+++ b/bonsai/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-alpha.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "env_logger",
  "httpmock",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "cc",
  "directories",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core 0.6.4",
@@ -3905,14 +3905,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "risc0-build-kernel",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "env_logger",
  "risc0-build",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.10",

--- a/bonsai/Cargo.lock
+++ b/bonsai/Cargo.lock
@@ -1263,6 +1263,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "downloader"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,12 +3866,14 @@ version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
+ "downloader",
  "log",
  "rand 0.8.5",
  "rayon",
  "risc0-circuit-recursion-sys",
  "risc0-core",
  "risc0-zkp",
+ "sha2 0.10.8",
  "tracing",
  "zip",
 ]

--- a/bonsai/examples/governance/Cargo.lock
+++ b/bonsai/examples/governance/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-alpha.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "cc",
  "directories",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3567,14 +3567,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "risc0-build-kernel",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/bonsai/examples/governance/Cargo.lock
+++ b/bonsai/examples/governance/Cargo.lock
@@ -1106,6 +1106,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "downloader"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3525,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cust",
+ "downloader",
  "log",
  "metal",
  "rand",
@@ -3518,6 +3533,7 @@ dependencies = [
  "risc0-circuit-recursion-sys",
  "risc0-core",
  "risc0-zkp",
+ "sha2 0.10.8",
  "tracing",
  "zip",
 ]

--- a/bonsai/examples/governance/methods/guest/Cargo.lock
+++ b/bonsai/examples/governance/methods/guest/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/bonsai/sdk/Cargo.toml
+++ b/bonsai/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bonsai-sdk"
 description = "Bonsai Software Development Kit"
-version = "0.5.0-alpha.1"
+version = "0.5.0-rc.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-alpha.1"
+version = "0.5.0-rc.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "cycle-counter"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 dependencies = [
  "bevy-methods",
  "chess-core",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "cc",
  "directories",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3641,14 +3641,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "risc0-build-kernel",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 
 [[package]]
 name = "rkyv"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1209,6 +1209,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "downloader"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,6 +3599,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cust",
+ "downloader",
  "log",
  "metal",
  "rand",
@@ -3592,6 +3607,7 @@ dependencies = [
  "risc0-circuit-recursion-sys",
  "risc0-core",
  "risc0-zkp",
+ "sha2",
  "tracing",
  "zip",
 ]

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/browser-verify/README.md
+++ b/examples/browser-verify/README.md
@@ -3,24 +3,30 @@
 Verify a RISC Zero program in your browser using WASM!
 
 ## Quickstart
-In addition to [Rust] and [Node.js], you will need
-```
+
+In addition to [Rust] and [Node.js], you will need to run from the root of the repository:
+
+```bash
 cargo xtask install
 cargo xtask gen-receipt
 ```
 
 Next, install the `cargo-risczero` tool and install the toolchain with:
+
 ```bash
 cargo install cargo-risczero
 cargo risczero install
 ```
+
 ### Running a test of in-browser verification
 
-From this directory, run
-```
+From this directory, run:
+
+```bash
 npm install
 npm test -- --$BROWSER
 ```
+
 where `$BROWSER` is one of
 - `chrome`
 - `firefox`

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/cycle-counter/Cargo.toml
+++ b/examples/cycle-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cycle-counter"
-version = "0.19.0-alpha.1"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]
@@ -24,7 +24,9 @@ prorata-core = { path = "../prorata/core" }
 prorata-methods = { path = "../prorata/methods" }
 rand = "0.8"
 rand_core = "0.6.4"
-risc0-zkvm = { path = "../../risc0/zkvm", default-features = false, features = ["prove"] }
+risc0-zkvm = { path = "../../risc0/zkvm", default-features = false, features = [
+  "prove",
+] }
 rmp-serde = "1.1"
 rust_decimal = { version = "1.29", features = ["serde-str"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -206,7 +206,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -249,7 +249,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/profiling/methods/Cargo.toml
+++ b/examples/profiling/methods/Cargo.toml
@@ -3,6 +3,9 @@ name = "fibonacci-methods"
 version = "0.1.0"
 edition = "2021"
 
+[package.metadata.release]
+release = false
+
 [build-dependencies]
 risc0-build = { path = "../../../risc0/build" }
 

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/profiling/methods/guest/Cargo.toml
+++ b/examples/profiling/methods/guest/Cargo.toml
@@ -3,11 +3,16 @@ name = "fibonacci-guest"
 version = "0.1.0"
 edition = "2021"
 
+[package.metadata.release]
+release = false
+
 [workspace]
 
 [dependencies]
 nalgebra = "0.32"
-risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = ["std"] }
+risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = [
+  "std",
+] }
 
 [profile.release]
-debug=1
+debug = 1

--- a/examples/profiling/methods/guest/Cargo.toml
+++ b/examples/profiling/methods/guest/Cargo.toml
@@ -3,9 +3,6 @@ name = "fibonacci-guest"
 version = "0.1.0"
 edition = "2021"
 
-[package.metadata.release]
-release = false
-
 [workspace]
 
 [dependencies]

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -198,7 +198,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/external/substrate/Cargo.toml
+++ b/external/substrate/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Minimal Substrate runtime for testing compatibility"
 publish = false
 
+[package.metadata.release]
+release = false
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,15 +233,15 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "0c2c5757ed3660fbbef3913f4c53b1a9ce0901644235f3d31773b54aa560c601",
+            "0f8b677ef65dc3d5fc81f33a726a140c0803a3dc42e515e3c45698a145b1e463",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "20c2fd911a152f63383433d4883d136124a9210ec6c55ef74c8223d4c5891384",
+            "d00515a17d77992621ce5fb6cc3ae122950cde263656a206f613350f39bf16cb",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "939f653333d373eba57e649cc7d1c4852df44530566955fe20f377e071e8b78c",
+            "d5ffdd5c44ddba973a380434966d0fb94f95b448c92da014466311c27ce917f2",
         );
     }
 }

--- a/risc0/circuit/recursion/Cargo.toml
+++ b/risc0/circuit/recursion/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
+exclude = ["src/recursion_zkr.zip"]
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
@@ -34,6 +35,10 @@ test-log = "0.2"
 tracing-forest = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[build-dependencies]
+downloader = { version = "0.2", features = ["verify"], optional = true }
+sha2 = { version = "0.10", optional = true }
+
 [features]
 cuda = [
   "dep:cust",
@@ -50,8 +55,10 @@ metal = [
   "risc0-zkp/metal",
 ]
 prove = [
+  "dep:downloader",
   "dep:rand",
   "dep:rayon",
+  "dep:sha2",
   "dep:zip",
   "risc0-zkp/prove",
   "risc0-circuit-recursion-sys",

--- a/risc0/circuit/recursion/build.rs
+++ b/risc0/circuit/recursion/build.rs
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
+use std::{
+    env,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use downloader::{verify, Download, DownloadSummary, Downloader};
+
+const SRC_PATH: &str = "src/recursion_zkr.zip";
+const GIT_COMMIT: &str = "505295b963c97db2afffe58f4b0cb4721e396b90";
 
 fn main() {
     if env::var("CARGO_FEATURE_CUDA").is_ok() {
@@ -28,4 +37,37 @@ fn main() {
         );
         println!("cargo:rustc-env=RECURSION_METAL_PATH={metal_bin}");
     }
+
+    if env::var("CARGO_FEATURE_PROVE").is_ok() {
+        let src_path = PathBuf::from_str(SRC_PATH).unwrap();
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let out_dir = Path::new(&out_dir);
+        if std::fs::metadata(&src_path).is_ok() {
+            let tgt_path = out_dir.join("recursion_zkr.zip");
+            std::fs::copy(&src_path, &tgt_path).unwrap();
+        } else {
+            let mut downloader = Downloader::builder()
+                .download_folder(out_dir)
+                .build()
+                .unwrap();
+            let url = format!("https://github.com/risc0/risc0/raw/{GIT_COMMIT}/risc0/circuit/recursion/src/recursion_zkr.zip");
+            eprintln!("Downloading {url}");
+            let dl = Download::new(&url).verify(verify::with_digest::<sha2::Sha256>(
+                decode_hex("a01d63a6d87cd914fff6f70477565905e824a8108052199e4f432b381f7e7567")
+                    .unwrap(),
+            ));
+            let results = downloader.download(&[dl]).unwrap();
+            for result in results {
+                let summary: DownloadSummary = result.unwrap();
+                eprintln!("{summary}");
+            }
+        }
+    }
+}
+
+fn decode_hex(s: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+        .collect()
 }

--- a/risc0/circuit/recursion/build.rs
+++ b/risc0/circuit/recursion/build.rs
@@ -52,6 +52,12 @@ fn download_zkr() {
         let tgt_path = out_dir.join("recursion_zkr.zip");
         std::fs::copy(&src_path, &tgt_path).unwrap();
     } else {
+        fn decode_hex(s: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
+            (0..s.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+                .collect()
+        }
         let mut downloader = Downloader::builder()
             .download_folder(out_dir)
             .build()
@@ -67,11 +73,4 @@ fn download_zkr() {
             eprintln!("{summary}");
         }
     }
-}
-
-fn decode_hex(s: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
-    (0..s.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
-        .collect()
 }

--- a/risc0/circuit/recursion/src/zkr.rs
+++ b/risc0/circuit/recursion/src/zkr.rs
@@ -19,7 +19,7 @@ use std::io::Read;
 use anyhow::{Context, Result};
 use risc0_zkp::core::digest::Digest;
 
-const ZKR_ZIP: &[u8] = include_bytes!("recursion_zkr.zip");
+const ZKR_ZIP: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/recursion_zkr.zip"));
 const CONTROL_ID_SUFFIX: &str = ".control_id";
 
 pub fn get_zkr(name: &str) -> Result<Vec<u32>> {

--- a/risc0/fault/guest/Cargo.lock
+++ b/risc0/fault/guest/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "env_logger",
  "risc0-build",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -397,7 +397,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "elf",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "log",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "env_logger",
  "risc0-build",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-alpha.1"
+version = "0.19.0-rc.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/website/doc-test/Cargo.toml
+++ b/website/doc-test/Cargo.toml
@@ -6,6 +6,9 @@ license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 
+[package.metadata.release]
+release = false
+
 [dependencies]
 fibonacci-methods = { path = "../../examples/profiling/methods" }
 risc0-zkvm = { workspace = true, features = ["prove", "profiler"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,7 +14,7 @@ risc0-zkp = { workspace = true }
 risc0-zkvm = { workspace = true, features = ["prove"] }
 risc0-zkvm-methods = { path = "../risc0/zkvm/methods" }
 tempfile = "3.5"
-which = "4.4"
+which = "5.0"
 xshell = "0.2"
 
 [package.metadata.release]


### PR DESCRIPTION
The `recursion_zkr.zip` file is too large to publish to crates.io. Thus this adjusts the build script for `risc0-circuit-recursion` to download this file from LFS if the file isn't present locally on disk.