### PR TITLE
Docs: Add examples page into zkVM section

### DIFF
--- a/website/docs/zkvm/examples.md
+++ b/website/docs/zkvm/examples.md
@@ -1,0 +1,20 @@
+# Examples
+
+- **[Hello World]**: a recommended place to start. Prove a number is composite, and you know its factors without revealing them
+- **[JSON]**: prove the contents of some entry in a JSON file, while keeping the rest of the data private
+- **[Where's Waldo]**: prove that Waldo appears in a JPG file, while keeping the rest of the image private, additionally, there is [Where's Waldo blog]
+- **[ZK Checkmate]**: prove that you see a mate-in-one, without revealing the winning move
+- **[ZK Proof of Exploit]**: prove that you _could_ exploit an Ethereum account, without revealing the exploit
+- **[ECDSA signature verification]**: prove the validity of an ECDSA signature
+- **[zkEVM]**: demo of running EVM engine on the Risc Zero zkVM
+
+[Hello World]: https://github.com/risc0/risc0/tree/v0.18.0/examples/hello-world
+[JSON]: https://github.com/risc0/risc0/tree/main/examples/json
+[Where's Waldo]: https://github.com/risc0/risc0/tree/v0.18.0/examples/waldo
+[Where's Waldo blog]: https://risczero.com/news/waldo
+[ZK Checkmate]: https://github.com/risc0/risc0/tree/main/examples/chess
+[ZK Proof of Exploit]: https://risczero.com/news/zkpoex
+[ECDSA signature verification]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
+[zkEVM]: https://github.com/risc0/risc0/tree/v0.18.0/examples/zkevm-demo
+
+

--- a/website/docs/zkvm/examples.md
+++ b/website/docs/zkvm/examples.md
@@ -8,13 +8,11 @@
 - **[ECDSA signature verification]**: prove the validity of an ECDSA signature
 - **[zkEVM]**: demo of running EVM engine on the Risc Zero zkVM
 
-[Hello World]: https://github.com/risc0/risc0/tree/v0.18.0/examples/hello-world
+[Hello World]: https://github.com/risc0/risc0/tree/main/examples/hello-world
 [JSON]: https://github.com/risc0/risc0/tree/main/examples/json
-[Where's Waldo]: https://github.com/risc0/risc0/tree/v0.18.0/examples/waldo
+[Where's Waldo]: https://github.com/risc0/risc0/tree/main/examples/waldo
 [Where's Waldo blog]: https://risczero.com/news/waldo
 [ZK Checkmate]: https://github.com/risc0/risc0/tree/main/examples/chess
 [ZK Proof of Exploit]: https://risczero.com/news/zkpoex
 [ECDSA signature verification]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
-[zkEVM]: https://github.com/risc0/risc0/tree/v0.18.0/examples/zkevm-demo
-
-
+[zkEVM]: https://github.com/risc0/risc0/tree/main/examples/zkevm-demo

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -90,36 +90,9 @@ const sidebars = {
           id: "zkvm/benchmarks",
         },
         {
-          type: "category",
-          label: "Demo applications",
-          collapsed: false,
-          items: [
-            {
-              type: "link",
-              label: "Hello World",
-              href: "https://github.com/risc0/risc0/tree/v0.18.0/examples/hello-world",
-            },
-            {
-              type: "link",
-              label: "JSON",
-              href: "https://github.com/risc0/risc0/tree/v0.18.0/examples/json",
-            },
-            {
-              type: "link",
-              label: "zkEVM",
-              href: "https://github.com/risc0/risc0/tree/v0.18.0/examples/zkevm-demo",
-            },
-            {
-              type: "link",
-              label: "ECDSA Signature",
-              href: "https://github.com/risc0/risc0/tree/v0.18.0/examples/ecdsa",
-            },
-            {
-              type: "link",
-              label: "Where's Waldo",
-              href: "https://github.com/risc0/risc0/tree/v0.18.0/examples/waldo",
-            },
-          ],
+          type: "doc",
+          label: "Examples",
+          id: "zkvm/examples",
         },
         {
           type: "link",


### PR DESCRIPTION
Create zkVM examples page instead of a drop-down demo applications list to external pages
