### PR TITLE
Release 0.19.0-rc.3 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       image: nvidia/cuda:12.2.2-devel-ubi8
     env:
       OS: Linux
-      FEATURE: cuda
       RUSTC_WRAPPER: sccache
       TARGET: x86_64-unknown-linux-gnu
     steps:
@@ -34,16 +33,13 @@ jobs:
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
         with:
-          key: ${{ env.OS }}-${{ env.FEATURE }}
+          key: ${{ env.OS }}
       - run: yum -y install openssl-devel perl-core zlib-devel
       - run: cargo build -p cargo-risczero --release
       - run: |
           mkdir -p tmp/pkg
           cp target/release/cargo-risczero tmp/pkg
           cp target/release/r0vm tmp/pkg
-      - run: cargo build -p cargo-risczero --release -F $FEATURE
-      - run: |
-          cp target/release/r0vm tmp/pkg/r0vm-$FEATURE
           cd tmp/pkg && tar cv * | gzip -9 > ../cargo-risczero-$TARGET.tgz
       - uses: svenstaro/upload-release-action@v2
         with:
@@ -56,7 +52,6 @@ jobs:
     needs: release
     env:
       OS: macOS
-      FEATURE: metal
       RUSTC_WRAPPER: sccache
       TARGET: aarch64-apple-darwin
     steps:
@@ -64,15 +59,12 @@ jobs:
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
         with:
-          key: ${{ env.OS }}-${{ env.FEATURE }}
+          key: ${{ env.OS }}
       - run: cargo build -p cargo-risczero --release
       - run: |
           mkdir -p tmp/pkg
           cp target/release/cargo-risczero tmp/pkg
           cp target/release/r0vm tmp/pkg
-      - run: cargo build -p cargo-risczero --release -F $FEATURE
-      - run: |
-          cp target/release/r0vm tmp/pkg/r0vm-$FEATURE
           cd tmp/pkg && tar cv * | gzip -9 > ../cargo-risczero-$TARGET.tgz
       - uses: svenstaro/upload-release-action@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -36,20 +36,20 @@ repository = "https://github.com/risc0/risc0/"
 bonsai-ethereum-contracts = { version = "0.1.0", path = "bonsai/ethereum" }
 bonsai-ethereum-relay = { version = "0.1.0", default-features = false, path = "bonsai/ethereum-relay" }
 bonsai-rest-api-mock = { version = "0.1.0", default-features = false, path = "bonsai/rest-api-mock" }
-bonsai-sdk = { version = "0.5.0-rc.2", default-features = false, path = "bonsai/sdk" }
-risc0-binfmt = { version = "0.19.0-rc.2", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "0.19.0-rc.2", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "0.19.0-rc.2", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-recursion = { version = "0.19.0-rc.2", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "0.19.0-rc.2", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "0.19.0-rc.2", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "0.19.0-rc.2", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "0.19.0-rc.2", default-features = false, path = "risc0/core" }
-risc0-r0vm = { version = "0.19.0-rc.2", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "0.19.0-rc.2", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "0.19.0-rc.2", default-features = false, path = "risc0/zkp" }
-risc0-zkvm = { version = "0.19.0-rc.2", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "0.19.0-rc.2", default-features = false, path = "risc0/zkvm/platform" }
+bonsai-sdk = { version = "0.5.0-rc.3", default-features = false, path = "bonsai/sdk" }
+risc0-binfmt = { version = "0.19.0-rc.3", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "0.19.0-rc.3", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "0.19.0-rc.3", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-recursion = { version = "0.19.0-rc.3", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "0.19.0-rc.3", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "0.19.0-rc.3", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "0.19.0-rc.3", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "0.19.0-rc.3", default-features = false, path = "risc0/core" }
+risc0-r0vm = { version = "0.19.0-rc.3", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "0.19.0-rc.3", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "0.19.0-rc.3", default-features = false, path = "risc0/zkp" }
+risc0-zkvm = { version = "0.19.0-rc.3", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "0.19.0-rc.3", default-features = false, path = "risc0/zkvm/platform" }
 
 [profile.bench]
 lto = true

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -3094,7 +3094,7 @@ dependencies = [
  "rand_core",
  "risc0-benchmark-lib",
  "risc0-benchmark-methods",
- "risc0-zkp 0.19.0-rc.2",
+ "risc0-zkp 0.19.0-rc.3",
  "risc0-zkvm",
  "risc0-zkvm-methods",
  "serde",
@@ -3120,7 +3120,7 @@ dependencies = [
 name = "risc0-benchmark-methods"
 version = "0.1.0"
 dependencies = [
- "risc0-build 0.19.0-rc.2",
+ "risc0-build 0.19.0-rc.3",
 ]
 
 [[package]]
@@ -3139,13 +3139,13 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
  "log",
- "risc0-zkp 0.19.0-rc.2",
- "risc0-zkvm-platform 0.19.0-rc.2",
+ "risc0-zkp 0.19.0-rc.3",
+ "risc0-zkvm-platform 0.19.0-rc.3",
  "serde",
 ]
 
@@ -3165,14 +3165,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "docker-generate",
- "risc0-binfmt 0.19.0-rc.2",
- "risc0-zkp 0.19.0-rc.2",
- "risc0-zkvm-platform 0.19.0-rc.2",
+ "risc0-binfmt 0.19.0-rc.3",
+ "risc0-zkp 0.19.0-rc.3",
+ "risc0-zkvm-platform 0.19.0-rc.3",
  "serde",
  "serde_json",
  "tempfile",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "cc",
  "directories",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3202,8 +3202,8 @@ dependencies = [
  "rand",
  "rayon",
  "risc0-circuit-recursion-sys",
- "risc0-core 0.19.0-rc.2",
- "risc0-zkp 0.19.0-rc.2",
+ "risc0-core 0.19.0-rc.3",
+ "risc0-zkp 0.19.0-rc.3",
  "sha2",
  "tracing",
  "zip",
@@ -3211,16 +3211,16 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
- "risc0-core 0.19.0-rc.2",
+ "risc0-core 0.19.0-rc.3",
 ]
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cust",
@@ -3229,19 +3229,19 @@ dependencies = [
  "rand",
  "rayon",
  "risc0-circuit-rv32im-sys",
- "risc0-core 0.19.0-rc.2",
- "risc0-zkp 0.19.0-rc.2",
- "risc0-zkvm-platform 0.19.0-rc.2",
+ "risc0-core 0.19.0-rc.3",
+ "risc0-zkp 0.19.0-rc.3",
+ "risc0-zkvm-platform 0.19.0-rc.3",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
- "risc0-core 0.19.0-rc.2",
+ "risc0-core 0.19.0-rc.3",
 ]
 
 [[package]]
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "risc0-build-kernel",
 ]
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3309,9 +3309,9 @@ dependencies = [
  "rand",
  "rand_core",
  "rayon",
- "risc0-core 0.19.0-rc.2",
+ "risc0-core 0.19.0-rc.3",
  "risc0-sys",
- "risc0-zkvm-platform 0.19.0-rc.2",
+ "risc0-zkvm-platform 0.19.0-rc.3",
  "serde",
  "sha2",
  "tracing",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3340,12 +3340,12 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "rayon",
- "risc0-binfmt 0.19.0-rc.2",
+ "risc0-binfmt 0.19.0-rc.3",
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
- "risc0-core 0.19.0-rc.2",
- "risc0-zkp 0.19.0-rc.2",
- "risc0-zkvm-platform 0.19.0-rc.2",
+ "risc0-core 0.19.0-rc.3",
+ "risc0-zkp 0.19.0-rc.3",
+ "risc0-zkvm-platform 0.19.0-rc.3",
  "rrs-lib",
  "semver 1.0.19",
  "serde",
@@ -3357,12 +3357,12 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "env_logger",
- "risc0-build 0.19.0-rc.2",
+ "risc0-build 0.19.0-rc.3",
  "risc0-zkvm",
- "risc0-zkvm-platform 0.19.0-rc.2",
+ "risc0-zkvm-platform 0.19.0-rc.3",
  "serde",
 ]
 
@@ -3374,7 +3374,7 @@ checksum = "8524b46783b58b00e9b2a4712e837093c975b23cf25bfaf99e1cf69e9011bf6b"
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/bonsai/Cargo.lock
+++ b/bonsai/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 dependencies = [
  "env_logger",
  "httpmock",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "cc",
  "directories",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core 0.6.4",
@@ -3921,14 +3921,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "risc0-build-kernel",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "env_logger",
  "risc0-build",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.10",

--- a/bonsai/examples/governance/Cargo.lock
+++ b/bonsai/examples/governance/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "cc",
  "directories",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cust",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3583,14 +3583,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "risc0-build-kernel",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/bonsai/examples/governance/methods/guest/Cargo.lock
+++ b/bonsai/examples/governance/methods/guest/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/bonsai/sdk/Cargo.toml
+++ b/bonsai/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bonsai-sdk"
 description = "Bonsai Software Development Kit"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "cc",
  "directories",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cust",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3657,14 +3657,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "risc0-build-kernel",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 
 [[package]]
 name = "rkyv"

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -206,7 +206,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -249,7 +249,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -198,7 +198,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,15 +233,15 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "f75b50baca752b11f3b628aeabb59e999311b359aa2249775616d9d4f4678532",
+            "de9e5429782718e0160b172f92a3a1eda72474f5fe89413678bbbf10dc2c99bd",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "1265b99dba306d69db1aa2cc8fb16c6d43f64af4b88d72db31f533087925808b",
+            "d2259fe3f16fab0e24575331290e9f4a6011c736c47588f3d7570a394b83f99d",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "c1d72a789b0a9e42de655829ab55b828cdd67b898b5b7d405165ae2bbdb582c6",
+            "5e2662efeb66987668097cffea45adc5aa200dd694f79f686ae9a6194b113963",
         );
     }
 }

--- a/risc0/fault/guest/Cargo.lock
+++ b/risc0/fault/guest/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "env_logger",
  "risc0-build",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -397,7 +397,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "elf",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "log",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "env_logger",
  "risc0-build",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -139,7 +139,7 @@ impl ParentProcessConnector {
     fn spawn_fail(&self) -> String {
         format!(
             "Could not launch zkvm: \"{}\". \n
-            Use `cargo risczero install` to install the latest zkvm.",
+            Use `cargo binstall cargo-risczero` to install the latest zkvm.",
             self.server_path.to_string_lossy()
         )
     }
@@ -148,11 +148,7 @@ impl ParentProcessConnector {
 impl Connector for ParentProcessConnector {
     fn connect(&self) -> Result<ConnectionWrapper> {
         let addr = self.listener.local_addr()?;
-        let server_path = self
-            .server_path
-            .canonicalize()
-            .with_context(|| self.spawn_fail())?;
-        let child = Command::new(&server_path)
+        let child = Command::new(&self.server_path)
             .arg("--port")
             .arg(addr.port().to_string())
             .spawn()


### PR DESCRIPTION
* Fixes "Could not launch zkvm" error
* Drop GPU builds from release workflow
