### PR TITLE
fix: avoid blocking on stdio with no input

### DIFF
--- a/risc0/zkvm/src/host/client/env.rs
+++ b/risc0/zkvm/src/host/client/env.rs
@@ -89,13 +89,11 @@ impl<'a> ExecutorEnvBuilder<'a> {
     pub fn build(&mut self) -> Result<ExecutorEnv<'a>> {
         let inner = self.inner.clone();
 
-        if !inner.input.is_empty() {
-            let reader = Cursor::new(inner.input.clone());
-            inner
-                .posix_io
-                .borrow_mut()
-                .with_read_fd(fileno::STDIN, reader);
-        }
+        let reader = Cursor::new(inner.input.clone());
+        inner
+            .posix_io
+            .borrow_mut()
+            .with_read_fd(fileno::STDIN, reader);
 
         Ok(inner)
     }


### PR DESCRIPTION
Closes #1016 

The workflow I tested was just a simple template program with an `env::read` added in. I wasn't able to replicate the issue of it hanging when not enough input provided, only when no input was provided, so maybe there is another workflow that I'm not seeing.

If it's intentional not to overwrite the stdin reader on empty input, possibly this API should be changed to express the difference between empty input and no overwriting.

As mentioned in the issue comment, it seems like https://github.com/risc0/risc0/blob/e48f779d2ce66b0af274ca4881c8da5df405cebe/risc0/zkvm/src/host/client/posix_io.rs#L37 is a bit out of place, and should either be documented why that's the default, or have more explicit initialization to avoid this ambiguity.