### PR TITLE
dev website fixes

### DIFF
--- a/risc0/cargo-risczero/README.md
+++ b/risc0/cargo-risczero/README.md
@@ -77,7 +77,7 @@ Use the `build` command to build guest code for the zkVM target `riscv32im-risc0
 
 The compiled ELF is saved in: `./target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/`
 
-With this containerized build process, we ensure that all builds of your guest code, regardless of the machine or local environment, will produce the same ImageID. The ImageID, and its importance to [security,](https://dev.risczero.com/tech_faq#security) is explained in more detail in our [developer FAQ.](https://dev.risczero.com/tech_faq#zkvm-application-design)
+With this containerized build process, we ensure that all builds of your guest code, regardless of the machine or local environment, will produce the same ImageID. The ImageID, and its importance to [security,](https://dev.risczero.com/faq#security) is explained in more detail in our [developer FAQ.](https://dev.risczero.com/faq#zkvm-application-design)
 
 Note: The build command requires the docker CLI installed and in your PATH.
 

--- a/website/api_versioned_docs/version-0.19/bonsai/bonsai-on-eth.md
+++ b/website/api_versioned_docs/version-0.19/bonsai/bonsai-on-eth.md
@@ -23,5 +23,5 @@ You may also want to check out our [Bonsai Quick Start](quickstart.md) page.
 [verified proofs]: https://risczero.com/news/on-chain-verification
 [zk coprocessor]: https://twitter.com/RiscZero/status/1677316664772132864
 [Bonsai Foundry Template]: https://github.com/risc0/bonsai-foundry-template
-[smart contract]: https://github.com/risc0/bonsai-foundry-template/tree/main/contracts
-[program]: https://github.com/risc0/bonsai-foundry-template/tree/main/methods/guest/src/bin
+[smart contract]: https://github.com/risc0/bonsai-foundry-template/tree/release-0.19/contracts
+[program]: https://github.com/risc0/bonsai-foundry-template/tree/release-0.19/methods/guest/src/bin

--- a/website/api_versioned_docs/version-0.19/bonsai/bonsai-overview.md
+++ b/website/api_versioned_docs/version-0.19/bonsai/bonsai-overview.md
@@ -82,4 +82,4 @@ We're building technology that allows anyone to generate highly performant zero-
 [Bonsai Quick Start]: quickstart.md
 [Bonsai as a zk coprocessor]: https://twitter.com/RiscZero/status/1677316664772132864
 [Bonfire Wallet]: https://twitter.com/RiscZero/status/1673692915401629698
-[Governance Showcase]: https://github.com/risc0/risc0/tree/main/bonsai/examples/governance#readme
+[Governance Showcase]: https://github.com/risc0/risc0/tree/release-0.19/bonsai/examples/governance#readme

--- a/website/api_versioned_docs/version-0.19/introduction.md
+++ b/website/api_versioned_docs/version-0.19/introduction.md
@@ -71,11 +71,11 @@ These applications include:
 - **[ECDSA signature verification]**: prove the validity of an ECDSA signature
 
 [April 2022]: https://www.risczero.com/news/announce
-[JSON]: https://github.com/risc0/risc0/tree/main/examples/json
+[JSON]: https://github.com/risc0/risc0/tree/release-0.19/examples/json
 [Where's Waldo]: https://risczero.com/news/waldo
-[ZK Checkmate]: https://github.com/risc0/risc0/tree/main/examples/chess
+[ZK Checkmate]: https://github.com/risc0/risc0/tree/release-0.19/examples/chess
 [ZK Proof of Exploit]: https://risczero.com/news/zkpoex
-[ECDSA signature verification]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
+[ECDSA signature verification]: https://github.com/risc0/risc0/tree/release-0.19/examples/ecdsa
 
 These examples are all made possible by **leveraging a mature software ecosystem**: over 70% of the [top 1000 Rust crates] work out-of-the-box in the zkVM.
 Being able to import Rust crates is a game changer for the ZK software world: projects that would take months or years to build on other platforms can be solved trivially on our platform.
@@ -100,4 +100,4 @@ Follow us on [Twitter](https://twitter.com/risczero) and [YouTube](https://www.y
 [The RISC Zero zkVM]: zkvm/zkvm_overview.md
 [Bonsai]: bonsai/bonsai-overview.md
 [The RISC Zero Proof System]: /proof-system
-[computational receipt]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html
+[computational receipt]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/struct.Receipt.html

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/acceleration.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/acceleration.md
@@ -27,7 +27,7 @@ tag = "sha2-v0.10.6-risczero.0"
 
 When using cryptography indirectly, e.g. via the `cookie`, `oauth2`, or `revm`, crates it may be possible to enable acceleration support without code changes by applying a [Cargo patch system](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section).
 
-An example of how to use these crates to accelerate ECDSA signature verification can be in the [ECDSA example](https://github.com/risc0/risc0/tree/v0.18.0/examples/ecdsa). Note the [use of the patched versions](https://github.com/risc0/risc0/blob/v0.18.0/examples/ecdsa/methods/guest/Cargo.toml#L13-L18) of `sha2`, `crypto-bigint` and `k256` crates used in the guest's `Cargo.toml`.
+An example of how to use these crates to accelerate ECDSA signature verification can be in the [ECDSA example](https://github.com/risc0/risc0/tree/release-0.19/examples/ecdsa). Note the [use of the patched versions](https://github.com/risc0/risc0/blob/release-0.19/examples/ecdsa/methods/guest/Cargo.toml#L13-L18) of `sha2`, `crypto-bigint` and `k256` crates used in the guest's `Cargo.toml`.
 
 ## Adding Accelerator Support To Crates
 

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/guest-code-101.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/guest-code-101.md
@@ -24,23 +24,23 @@ To support various use cases, there are a number of functions that can be called
 - **Reading inputs** <br/>
   [`env::read`], [`env::read_slice`], and [`env::stdin`]
 
-[`env::read`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.read.html
-[`env::read_slice`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.read_slice.html
-[`env::stdin`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.stdin.html
+[`env::read`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.read.html
+[`env::read_slice`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.read_slice.html
+[`env::stdin`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.stdin.html
 
 - **Writing private outputs to [host]**<br/>
   [`env::write`], [`env::write_slice`], [`env::stdout`], [`env::stderr`]
 
-[`env::write`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.write.html
-[`env::write_slice`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.write_slice.html
-[`env::stdout`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.stdout.html
-[`env::stderr`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.stderr.html
+[`env::write`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.write.html
+[`env::write_slice`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.write_slice.html
+[`env::stdout`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.stdout.html
+[`env::stderr`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.stderr.html
 
 - **Committing private outputs [journal]**<br/>
   `env::commit`, `env::commit_slice`
 
-[`env::commit`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.commit.html
-[`env::commit_slice`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.commit_slice.html
+[`env::commit`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.commit.html
+[`env::commit_slice`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.commit_slice.html
 
 ## Tools for Debugging & Optimization
 
@@ -52,8 +52,8 @@ There are also a number of functions available to support with debugging and per
 - **Print a debug message**<br/>
   [`env::log`]
 
-[`env::get_cycle_count`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.get_cycle_count.html
-[`env::log`]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/env/fn.log.html
+[`env::get_cycle_count`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.get_cycle_count.html
+[`env::log`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.log.html
 
 For more information on optimization & performance, see our pages on [Cryptography Acceleration](acceleration.md) and [Benchmarking](../benchmarks.md).
 
@@ -79,20 +79,20 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 
 [guest]: /terminology#guest
 [guest code]: /terminology#guest
-[`guest` module]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest
+[`guest` module]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest
 [host]: /terminology#host
 [`risc0-zkvm` Rust crate]: https://docs.rs/risc0-zkvm
 [journal]: /terminology#journal
 [method]: /terminology#method
 [zkVM Quick Start]: ../quickstart.md
 [zkVM Overview]: ../zkvm_overview.md
-[Hello World demo]: https://github.com/risc0/risc0/tree/main/examples/hello-world
-[risc0/examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples
-[guest environment commands]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/index.html
+[Hello World demo]: https://github.com/risc0/risc0/tree/release-0.19/examples/hello-world
+[risc0/examples]: https://github.com/risc0/risc0/tree/v0.19/examples
+[guest environment commands]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/index.html
 [zkVM Application]: ../zkvm_overview.md
 [zkVM]: ../zkvm_overview.md
 [Bonsai]: ../../bonsai/bonsai-overview.md
-[template]: https://github.com/risc0/risc0/tree/v0.18.0/templates/rust-starter
-[examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[template]: https://github.com/risc0/risc0/tree/v0.19/templates/rust-starter
+[examples]: https://github.com/risc0/risc0/tree/v0.19/examples
 [these docs]: https://github.com/risc0/website
 [Discord]: https://discord.gg/risczero

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/guest-code-101.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/guest-code-101.md
@@ -87,12 +87,12 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [zkVM Quick Start]: ../quickstart.md
 [zkVM Overview]: ../zkvm_overview.md
 [Hello World demo]: https://github.com/risc0/risc0/tree/release-0.19/examples/hello-world
-[risc0/examples]: https://github.com/risc0/risc0/tree/v0.19/examples
+[risc0/examples]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [guest environment commands]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/index.html
 [zkVM Application]: ../zkvm_overview.md
 [zkVM]: ../zkvm_overview.md
 [Bonsai]: ../../bonsai/bonsai-overview.md
-[template]: https://github.com/risc0/risc0/tree/v0.19/templates/rust-starter
-[examples]: https://github.com/risc0/risc0/tree/v0.19/examples
+[template]: https://github.com/risc0/risc0/tree/release-0.19/templates/rust-starter
+[examples]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [these docs]: https://github.com/risc0/website
 [Discord]: https://discord.gg/risczero

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/host-code-101.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/host-code-101.md
@@ -69,15 +69,15 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 
 [Bonsai]: ../../bonsai/bonsai-overview.md
 [Discord]: https://discord.gg/risczero
-[examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[examples]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [execute]: /terminology#execute
 [execution environment]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.ExecutorEnv.html
 [executor]: /terminology#executor
 [guest]: /terminology#guest
-[`guest` module]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest
+[`guest` module]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest
 [guest program]: /terminology#guest-program
-[Hello World demo]: https://github.com/risc0/risc0/tree/v0.18.0/examples/hello-world
-[Hello World Tutorial]: https://github.com/risc0/risc0/blob/v0.18.0/examples/hello-world/tutorial
+[Hello World demo]: https://github.com/risc0/risc0/tree/release-0.19/examples/hello-world
+[Hello World Tutorial]: https://github.com/risc0/risc0/blob/release-0.19/examples/hello-world/tutorial
 [host]: /terminology#host
 [journal]: /terminology#journal
 [JSON demo]: https://github.com/risc0/risc0/blob/main/examples/json/src/main.rs
@@ -90,7 +90,7 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [`risc0-zkvm` Rust crate]: https://docs.rs/risc0-zkvm
 [these docs]: https://github.com/risc0/website
 [verifies]: /terminology#verify
-[verifying receipts]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/struct.Receipt.html#method.verify
+[verifying receipts]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/struct.Receipt.html#method.verify
 [zkVM Quick Start]: ../quickstart.md
 [zkVM Overview]: ../zkvm_overview.md
 [zkVM Application]: ../zkvm_overview.md

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/profiling.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/profiling.md
@@ -23,7 +23,7 @@ Here's are the step to enable profiling:
 1. Enable the `profile` feature of the `zkvm` in your `Cargo.toml`.
 
 ```toml
-risc0-zkvm = { version = "0.18", features = ["profiler"] }
+risc0-zkvm = { version = "0.19", features = ["profiler"] }
 ```
 
 2. Initialize the profiler with your guest code.

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/receipts.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/receipts.md
@@ -69,11 +69,11 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [Image ID]: /terminology#image-id
 [Sessions]: /terminology#session
 [segments]: /terminology#segment
-[receipt.verify()]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html#method.verify
-[receipt.journal]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html#structfield.journal
+[receipt.verify()]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/struct.Receipt.html#method.verify
+[receipt.journal]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/struct.Receipt.html#structfield.journal
 [verify]: /terminology#verify
 [Verifying]: /terminology#verify
-[examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[examples]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [these docs]: https://github.com/risc0/website
 [Discord]: https://discord.gg/risczero
 [zkVM Quick Start]: ../quickstart.md

--- a/website/api_versioned_docs/version-0.19/zkvm/examples.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/examples.md
@@ -8,11 +8,11 @@
 - **[ECDSA signature verification]**: prove the validity of an ECDSA signature
 - **[zkEVM]**: demo of running EVM engine on the Risc Zero zkVM
 
-[Hello World]: https://github.com/risc0/risc0/tree/main/examples/hello-world
-[JSON]: https://github.com/risc0/risc0/tree/main/examples/json
-[Where's Waldo]: https://github.com/risc0/risc0/tree/main/examples/waldo
+[Hello World]: https://github.com/risc0/risc0/tree/release-0.19/examples/hello-world
+[JSON]: https://github.com/risc0/risc0/tree/release-0.19/examples/json
+[Where's Waldo]: https://github.com/risc0/risc0/tree/release-0.19/examples/waldo
 [Where's Waldo blog]: https://risczero.com/news/waldo
-[ZK Checkmate]: https://github.com/risc0/risc0/tree/main/examples/chess
+[ZK Checkmate]: https://github.com/risc0/risc0/tree/release-0.19/examples/chess
 [ZK Proof of Exploit]: https://risczero.com/news/zkpoex
-[ECDSA signature verification]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
-[zkEVM]: https://github.com/risc0/risc0/tree/main/examples/zkevm-demo
+[ECDSA signature verification]: https://github.com/risc0/risc0/tree/release-0.19/examples/ecdsa
+[zkEVM]: https://github.com/risc0/risc0/tree/release-0.19/examples/zkevm-demo

--- a/website/api_versioned_docs/version-0.19/zkvm/install.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/install.md
@@ -2,7 +2,7 @@
 
 These instructions tell you how to install (or update) RISC Zero tools so you can build your own RISC Zero zkVM projects. By following these instructions, you will install the [`cargo risczero`] tool for creating and building RISC Zero zkVM projects, as well as the RISC Zero toolchain used to build zkVM guest programs in Rust.
 
-[`cargo risczero`]: https://docs.rs/cargo-risczero/*/cargo_risczero/index.html
+[`cargo risczero`]: https://docs.rs/cargo-risczero/0.19
 
 ## Prerequisites
 
@@ -35,7 +35,7 @@ rustup toolchain list --verbose | grep risc0
 
 which should list `risc0` along with its path.
 
-[`install` command]: https://docs.rs/cargo-risczero/*/cargo_risczero/index.html#install
+[`install` command]: https://docs.rs/cargo-risczero/0.19/cargo_risczero/index.html#install
 
 ## Update
 

--- a/website/api_versioned_docs/version-0.19/zkvm/quickstart.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/quickstart.md
@@ -99,10 +99,10 @@ Options such as GPU acceleration and skipping the proof generation are documente
 [Bonsai]: ../bonsai/bonsai-overview.md
 [install]: ./install.md
 [feature flags]: https://github.com/risc0/risc0#feature-flags
-[zkVM demo applications]: https://github.com/risc0/risc0/tree/v0.19.0/examples
+[zkVM demo applications]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [cargo risczero]: https://docs.rs/cargo-risczero/0.19
 [Hello World tutorial]: https://github.com/risc0/risc0/tree/release-0.19/examples/hello-world/tutorial.md
-[demo applications]: https://github.com/risc0/risc0/tree/v0.19.0/examples
+[demo applications]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [Bonsai Quick Start]: ../bonsai/quickstart.md
 [request access]: https://bonsai.xyz/apply
 [dev-mode]: ./dev-mode.md

--- a/website/api_versioned_docs/version-0.19/zkvm/quickstart.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/quickstart.md
@@ -26,7 +26,7 @@ If you need to install Rust or encounter problems, take a look at our [full inst
 ## 2. Initialize a New Project
 
 Once you've installed the toolchain, you can initialize a new project using the [starter template] by running:
-[starter template]: https://github.com/risc0/risc0/tree/main/templates/rust-starter
+[starter template]: https://github.com/risc0/risc0/tree/release-0.19/templates/rust-starter
 
 ```bash
 cargo risczero new my_project
@@ -84,7 +84,7 @@ The readme files on the [zkVM demo applications] show `cargo` commands for local
 ### Remote Proving
 
 To run the zkVM remotely using [Bonsai], [request access] and set the environment variables `BONSAI_API_KEY=<YOUR_API_KEY>` and `BONSAI_API_URL=<BONSAI_URL>`.
-Additional information is available in the [starter template](https://github.com/risc0/risc0/tree/main/templates/rust-starter#running-proofs-remotely-on-bonsai)
+Additional information is available in the [starter template](https://github.com/risc0/risc0/tree/release-0.19/templates/rust-starter#running-proofs-remotely-on-bonsai)
 
 ### Other options
 
@@ -100,8 +100,8 @@ Options such as GPU acceleration and skipping the proof generation are documente
 [install]: ./install.md
 [feature flags]: https://github.com/risc0/risc0#feature-flags
 [zkVM demo applications]: https://github.com/risc0/risc0/tree/v0.19.0/examples
-[cargo risczero]: https://docs.rs/cargo-risczero/*/cargo_risczero
-[Hello World tutorial]: https://github.com/risc0/risc0/tree/main/examples/hello-world/tutorial.md
+[cargo risczero]: https://docs.rs/cargo-risczero/0.19
+[Hello World tutorial]: https://github.com/risc0/risc0/tree/release-0.19/examples/hello-world/tutorial.md
 [demo applications]: https://github.com/risc0/risc0/tree/v0.19.0/examples
 [Bonsai Quick Start]: ../bonsai/quickstart.md
 [request access]: https://bonsai.xyz/apply

--- a/website/api_versioned_docs/version-0.19/zkvm/zkvm_overview.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/zkvm_overview.md
@@ -21,8 +21,8 @@ Our demos show how to:
 [revm]: https://github.com/bluealloy/revm
 [ethers]: https://github.com/ethers-io/ethers.js
 [alloy]: https://github.com/alloy-rs
-[prove mate-in-one]: https://github.com/risc0/risc0/tree/v0.18.0/examples/chess#zk-checkmate
-[proofs about private data]: https://github.com/risc0/risc0/tree/main/examples/json#json-example
+[prove mate-in-one]: https://github.com/risc0/risc0/tree/release-0.19/examples/chess#zk-checkmate
+[proofs about private data]: https://github.com/risc0/risc0/tree/release-0.19/examples/json#json-example
 [prove you can find Waldo]: https://www.risczero.com/news/waldo
 [prove correct construction of Ethereum blocks]: https://risczero.com/news/zeth-release
 
@@ -103,6 +103,6 @@ Read the [article](https://risczero.com/news/zeth-release).
 [zero-knowledge virtual machine]: /terminology#zero-knowledge-virtual-machine-zkvm
 [zkvm]: https://github.com/risc0/risc0#readme
 [zkVM Quick Start]: ./quickstart.md
-[zkVM example applications]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[zkVM example applications]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [session]: /terminology#session
 [Host Code 101]: developer-guide/host-code-101.md

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -247,7 +247,7 @@ Because the data structures supporting all three of these need to match very car
 Q:
 How can we use the ImageID to determine if an application is altered before execution?
 </summary>
-A: The ImageID is determined from an application's compiled binary (ELF),  explained in detail <a href="https://dev.risczero.com/tech_faq#image-id">above.</a>
+A: The ImageID is determined from an application's compiled binary (ELF),  explained in detail <a href="https://dev.risczero.com/faq#image-id">above.</a>
 
 Someone wishing to confirm that a receipt corresponds to specific Rust source code can locally reproduce a binary targeting the RISC Zero zkVM using our reproducible build tool and verify that the resulting ImageID matches the ImageID in the receipt.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,15 +76,15 @@ export default async function createConfigAsync() {
         {
           createRedirects(path) {
             if (path.includes("/api/bonsai")) {
-              return [path.replace("/api/bonsai", "/bonsai"),]
+              return [path.replace("/api/bonsai", "/bonsai")];
             }
             if (path.includes("/api/zkvm")) {
-              return [path.replace("/api/zkvm", "/zkvm")]
+              return [path.replace("/api/zkvm", "/zkvm")];
             }
             return undefined;
           },
-        }
-      ]
+        },
+      ],
     ],
 
     stylesheets: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -71,6 +71,20 @@ export default async function createConfigAsync() {
           },
         },
       ],
+      [
+        "@docusaurus/plugin-client-redirects",
+        {
+          createRedirects(path) {
+            if (path.includes("/api/bonsai")) {
+              return [path.replace("/api/bonsai", "/bonsai"),]
+            }
+            if (path.includes("/api/zkvm")) {
+              return [path.replace("/api/zkvm", "/zkvm")]
+            }
+            return undefined;
+          },
+        }
+      ]
     ],
 
     stylesheets: [

--- a/website/sidebarsApi.js
+++ b/website/sidebarsApi.js
@@ -47,7 +47,7 @@ export default {
         {
           type: "doc",
           label: "Dev Mode",
-          id: "zkvm/dev-mode"
+          id: "zkvm/dev-mode",
         },
         {
           type: "link",

--- a/website/sidebarsApi.js
+++ b/website/sidebarsApi.js
@@ -45,6 +45,11 @@ export default {
           id: "zkvm/quickstart",
         },
         {
+          type: "doc",
+          label: "Dev Mode",
+          id: "zkvm/dev-mode"
+        },
+        {
           type: "link",
           label: "API Reference Docs",
           href: "https://docs.rs/risc0-zkvm/",


### PR DESCRIPTION
* Add redirects for links to `/api` content
* Update current version links (i.e. main/0.18 -> 0.19)