### PR TITLE
replace markdown links with reference links

### DIFF
--- a/website/docs/contributors-guide.md
+++ b/website/docs/contributors-guide.md
@@ -1,22 +1,22 @@
 # Contributor's Guide
 
-_This page describes guidelines for community contributions to this [website](https://www.github.com/risc0/website); you may also be interested in contributing to the [main project codebase](https://github.com/risc0/risc0)._
+_This page describes guidelines for community contributions to this [website][7]; you may also be interested in contributing to the [main project codebase][0]._
 
 > `RISC Zero welcomes community participation!`
 >
-> - Make suggestions or report bugs via [GitHub issues](https://github.com/risc0/website/issues)
-> - Contribute website content or give feedback on [open pull requests](https://github.com/risc0/website/pulls)
-> - Contribute to the [main zkVM project](https://github.com/risc0/risc0)
-> - Contribute to our tutorials and how-to guides for our [templates](https://github.com/risc0/risc0/tree/main/templates) and [Rust examples](https://github.com/risc0/risc0/tree/v0.18.0/examples)
-> - Ask questions on [Discord](https://discord.gg/risczero)
+> - Make suggestions or report bugs via [GitHub issues][1]
+> - Contribute website content or give feedback on [open pull requests][2]
+> - Contribute to the [main zkVM project][0]
+> - Contribute to our tutorials and how-to guides for our [templates](https://github.com/risc0/risc0/tree/main/templates) and [Rust examples][4]
+> - Ask questions on [Discord][5]
 
 ## How To Contribute
 
-- All changes to this website are managed through GitHub pull requests, so you'll need a [GitHub Account](https://github.com) to contribute.
+- All changes to this website are managed through GitHub pull requests, so you'll need a [GitHub Account][6] to contribute.
 - You can suggest an edit directly via the `Edit this Page` button at the bottom of each page.
-- To create a new page, you can use the [GitHub browser interface](https://www.github.com/risc0/website); the content is in `src/pages` and `docs`.
-  - Please read about [the navbar and sidebars](./contributors-guide.md#navbar-and-sidebars) and [categories of documentation](./contributors-guide.md#categories-of-documentation) before creating a new page.
-- If you want to clone the repository and work locally, you may want to check out the [Docusaurus documentation](https://docusaurus.io/docs/installation).
+- To create a new page, you can use the [GitHub browser interface][7]; the content is in `src/pages` and `docs`.
+  - Please read about [the navbar and sidebars](./contributors-guide.md#navbar-and-sidebars) and [categories of documentation][8] before creating a new page.
+- If you want to clone the repository and work locally, you may want to check out the [Docusaurus documentation][9].
   We like to use `yarn start` to run a local build, especially when we're working with changes that involve links or sidebars.
 
 ## Style Guidelines
@@ -37,17 +37,17 @@ In order to achieve this objective, we rely on:
 
 ## Terminology Conventions
 
-[`RISC Zero Official Terminology`](./terminology.md)
+[`RISC Zero Official Terminology`][10]
 
 Our terminology and naming conventions are subject to ongoing evaluation, and we encourage conversation and questions on these topics.
-Please let us know via a [`GitHub issue`](https://github.com/risc0/website/issues) when you encounter terms that don't seem quite right.
+Please let us know via a [`GitHub issue`][1] when you encounter terms that don't seem quite right.
 
 ## Navbar and Sidebars
 
 - The navbar is defined in `docusaurus.config.js`. Any changes require manual configuration.
-  - [How to edit the navbar](https://docusaurus.io/docs/api/docusaurus-config)
+  - [How to edit the navbar][12]
 - The sidebars are defined in `sidebars.js`. Any new docs require manual configuration.
-  - [How to edit the sidebar](https://docusaurus.io/docs/sidebar)
+  - [How to edit the sidebar][13]
   - The default configuration (and our current configuration) is that `pages` do not have sidebars and `docs` do.
 
 ### Reference Docs
@@ -65,7 +65,7 @@ We typically organize reference docs according to the following sections; we use
 > - Content 3
 > - Suggested Reading
 
-_Changes to this organization can be proposed for discussion via a [GitHub issue](https://github.com/risc0/website/issues) or proposed for action via a PR on this page._
+_Changes to this organization can be proposed for discussion via a [GitHub issue][1] or proposed for action via a PR on this page._
 
 ### Explainer Docs
 
@@ -78,4 +78,21 @@ We're excited about the engagement we've seen so far, and we're looking forward 
 
 ## Questions?
 
-Find us on [Discord](https://discord.gg/risczero).
+Find us on [Discord][5].
+
+[0]: https://github.com/risc0/risc0
+[1]: https://github.com/risc0/website/issues
+[2]: https://github.com/risc0/website/pulls
+[3]: https://github.com/risc0/risc0
+[4]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[5]: https://discord.gg/risczero
+[6]: https://github.com
+[7]: https://www.github.com/risc0/website
+[8]: ./contributors-guide.md#categories-of-documentation
+[9]: https://docusaurus.io/docs/installation
+[10]: ./terminology.md
+[11]: https://github.com/risc0/website/issues
+[12]: https://docusaurus.io/docs/api/docusaurus-config
+[13]: https://docusaurus.io/docs/sidebar
+[14]: https://github.com/risc0/website/issues
+[15]: https://discord.gg/risczero

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -4,15 +4,15 @@
 
 ## Contents
 
-- [FAQ](#faq)
-  - [Contents](#contents)
-  - [ZK Basics](#zk-basics)
-  - [Building on the zkVM](#building-on-the-zkvm)
-    - [Code Troubleshooting](#code-troubleshooting)
-    - [zkVM Application Design](#zkvm-application-design)
-    - [Features, Performance, and Limitations](#features-performance-and-limitations)
-  - [The RISC Zero Circuits](#the-risc-zero-circuits)
-  - [Security](#security)
+- [FAQ][0]
+  - [Contents][1]
+  - [ZK Basics][2]
+  - [Building on the zkVM][3]
+    - [Code Troubleshooting][4]
+    - [zkVM Application Design][5]
+    - [Features, Performance, and Limitations][6]
+  - [The RISC Zero Circuits][7]
+  - [Security][8]
 
 ---
 
@@ -251,7 +251,7 @@ A: The ImageID is determined from an application's compiled binary (ELF),  expla
 
 Someone wishing to confirm that a receipt corresponds to specific Rust source code can locally reproduce a binary targeting the RISC Zero zkVM using our reproducible build tool and verify that the resulting ImageID matches the ImageID in the receipt.
 
-For example, building our [builtin zkVM test functions](https://github.com/risc0/risc0/tree/main/risc0/zkvm/methods/guest):
+For example, building our [builtin zkVM test functions][9]:
 
 ```bash
 cargo risczero build --manifest-path risc0/zkvm/methods/guest/Cargo.toml
@@ -266,7 +266,7 @@ ImageID: c7c399c25ecf26b79e987ed060efce1f0836a594ad1059b138b6ed2f123dad38 - "tar
 ImageID: a51a4b747f18b7e5f36a016bdd6f885e8293dbfca2759d6667a6df8edd5f2489 - "target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/risc0_zkvm_methods_guest/slice_io"
 ```
 
-These ImageIDs will stay consistent across all builds due to a containerized process working together with Cargo working norms. You can find more about our reproducible builds and how we test them in this [pull request.](https://github.com/risc0/risc0/pull/799)
+These ImageIDs will stay consistent across all builds due to a containerized process working together with Cargo working norms. You can find more about our reproducible builds and how we test them in this [pull request.][10]
 
 </details>
 <a class="anchor" id="tampering-with-code"></a>
@@ -281,3 +281,15 @@ A: Like other zk-STARKs, RISC Zero’s implementation makes it cryptographically
 - If the output is modified, then the journal’s hash will not match the hash recorded in the receipt.
 
 </details>
+
+[0]: #faq
+[1]: #contents
+[2]: #zk-basics
+[3]: #building-on-the-zkvm
+[4]: #code-troubleshooting
+[5]: #zkvm-application-design
+[6]: #features-performance-and-limitations
+[7]: #the-risc-zero-circuits
+[8]: #security
+[9]: https://github.com/risc0/risc0/tree/main/risc0/zkvm/methods/guest
+[10]: https://github.com/risc0/risc0/pull/799

--- a/website/docs/proof-system/proof-system-sequence-diagram.md
+++ b/website/docs/proof-system/proof-system-sequence-diagram.md
@@ -4,8 +4,8 @@ sidebar_position: 4
 
 # Proof System Sequence Diagram and Spec
 
-_The implementation in code for the RISC Zero prover can be seen [here](https://github.com/risc0/risc0/blob/v0.18.0/risc0/zkp/src/prove/prover.rs).
-In this document, we present an overview to the protocol, as well as a sequence diagram and a detailed description below. The [STARK by Hand](stark-by-hand.md) explainer and the [RISC Zero ZKP Whitepaper](https://dev.risczero.com/proof-system-in-detail.pdf) are good companions to this document._
+_The implementation in code for the RISC Zero prover can be seen [here][0].
+In this document, we present an overview to the protocol, as well as a sequence diagram and a detailed description below. The [STARK by Hand](stark-by-hand.md) explainer and the [RISC Zero ZKP Whitepaper][1] are good companions to this document._
 
 ## Overview
 
@@ -41,7 +41,7 @@ These enhancements are described well in [From AIRs to RAPs].
 We use this Auxiliary Execution Trace to support:
 
 1. A permutation argument for [memory verification](https://www.youtube.com/watch?v=dYuEPvRLwLo&list=PLcPzhUaCxlCiLk_VjLUNbmfb2mB1Y_N9N&index=5)<br/>
-   The permutation argument is currently implemented as a grand product accumulator argument, as in [PLONK](https://eprint.iacr.org/2019/953.pdf).
+   The permutation argument is currently implemented as a grand product accumulator argument, as in [PLONK][3].
    We plan to change this to a [log derivative] accumulator argument in the next version of the circuit.<br/>
    Here, operations corresonding to memory are committed to the main trace both in the original ordering and the permuted ordering, and grand product accumulators are committed in the auxiliary trace.
 
@@ -98,7 +98,7 @@ For a more formal articulation of the protocol, refer to the [ZKP Whitepaper].
 
 ### Extended Main Execution Trace
 
-- The Prover runs a computation in order to generate an [`Execution Trace`](what_is_a_trace).
+- The Prover runs a computation in order to generate an [`Execution Trace`][4].
   - The `trace` is organized into `columns`, and the columns are categorized as `control columns`, `data columns`, and `auxiliary/accum columns`.
     - The `control columns` handle system initialization and shutdown, the initial program code to load into memory before execution, and other control signals that don't depend on the program execution.
     - The `data columns` contain the input and the computation data, both of which are private. These columns are committed in two orderings:
@@ -169,3 +169,8 @@ Thanks for reading! If you have questions or feedback, we'd love to hear from yo
 [receipts]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html
 [ZKP Whitepaper]: https://dev.risczero.com/proof-system-in-detail.pdf
 [fast cryptographic operations]: /api/zkvm/developer-guide/acceleration
+[0]: https://github.com/risc0/risc0/blob/v0.18.0/risc0/zkp/src/prove/prover.rs
+[1]: https://dev.risczero.com/proof-system-in-detail.pdf
+[2]: https://www.youtube.com/watch?v=dYuEPvRLwLo&list=PLcPzhUaCxlCiLk_VjLUNbmfb2mB1Y_N9N&index=5
+[3]: https://eprint.iacr.org/2019/953.pdf
+[4]: what_is_a_trace

--- a/website/docs/proof-system/proof-system.md
+++ b/website/docs/proof-system/proof-system.md
@@ -30,15 +30,15 @@ The details of the RISC Zero ZK-STARK are described in our [ZKP Whitepaper] and 
 ### About the zkVM
 
 - [Video Explainer from zkHack](https://www.youtube.com/watch?v=8hwY88xJoyM&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=8)
-- [Written Explainer](/api/zkvm)
+- [Written Explainer][1]
 
 ### About STARKs
 
-- [STARKs reference doc](../reference-docs/about-starks.md)
+- [STARKs reference doc][2]
 - STARK by Hand Tutorial
-  - [Website version](./stark-by-hand.md)
+  - [Website version][3]
   - [Google Sheet version](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing)
-  - [Printable Version](assets/fibonacci-stark.pdf)
+  - [Printable Version][5]
 
 ### About RISC Zero
 
@@ -70,3 +70,15 @@ The details of the RISC Zero ZK-STARK are described in our [ZKP Whitepaper] and 
 [Sequence Diagram]: ./proof-system-sequence-diagram.md
 [RISC Zero Study Club]: https://dev.risczero.com/studyclub
 [YouTube channel]: https://www.youtube.com/@risczero
+[0]: https://www.youtube.com/watch?v=8hwY88xJoyM&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=8
+[1]: /api/zkvm
+[2]: ../reference-docs/about-starks.md
+[3]: ./stark-by-hand.md
+[4]: https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing
+[5]: assets/fibonacci-stark.pdf
+[6]: https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=5
+[7]: https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=2
+[8]: https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=3
+[9]: https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=4
+[10]: https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=1
+[11]: https://www.youtube.com/watch?v=hUl8ZB6hpUM&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=6

--- a/website/docs/proof-system/what_is_a_trace.md
+++ b/website/docs/proof-system/what_is_a_trace.md
@@ -19,7 +19,9 @@ to the program instructions and the underlying computer architecture.
 execution trace while preserving computational privacy.`
 
 _The core of a RISC Zero receipt is a
-[zk-STARK](../reference-docs/about-starks.md); for a more technical description
+[zk-STARK][0]; for a more technical description
 of how we turn an execution trace into a zk-STARK, see the [proof system
 sequence diagram](./proof-system-sequence-diagram) and our [STARK by
 Hand](./stark-by-hand) explainer._
+
+[0]: ../reference-docs/about-starks.md

--- a/website/docs/reference-docs/about-arithmetic-circuits.md
+++ b/website/docs/reference-docs/about-arithmetic-circuits.md
@@ -1,7 +1,7 @@
 # About Arithmetic Circuits
 
-[Arithmetic circuits](https://en.wikipedia.org/wiki/Arithmetic_circuit_complexity) consist of a collection of wires and gates, where the wires hold [elements of a finite field](about-finite-fields.md) and each gate computes either finite field addition or finite field multiplication.
-In contrast, in an [electronic circuit](https://en.wikipedia.org/wiki/Electronic_circuit), the wires either contain electrical signal or they don't, and each gate may compute a variety of logical operations.
+[Arithmetic circuits][3] consist of a collection of wires and gates, where the wires hold [elements of a finite field][0] and each gate computes either finite field addition or finite field multiplication.
+In contrast, in an [electronic circuit][1], the wires either contain electrical signal or they don't, and each gate may compute a variety of logical operations.
 
 Arithmetic circuits are central to zero-knowledge proof techniques: SNARKs and STARKs prove integrity of an execution of an arithmetic circuit.
 
@@ -12,17 +12,17 @@ Because arithmetic circuits consist only of addition and multiplication, the cir
 - $n$ is the number of inputs to the polynomial, and
 - the degree of $C$ is bounded by the number of multiplications in the circuit.
 
-![](assets/arithmeticcircuit.png)
+![][2]
 
-The circuit pictured above can be written as $C(x_1, x_2) = (x_1+x_2)\cdot x_2 \cdot (x_2+1)$. This simple example is drawn from [Wikipedia](https://en.wikipedia.org/wiki/Arithmetic_circuit_complexity).
+The circuit pictured above can be written as $C(x_1, x_2) = (x_1+x_2)\cdot x_2 \cdot (x_2+1)$. This simple example is drawn from [Wikipedia][3].
 
 ## Two Approaches to Building with ZK
 
 - Option 1: Build app-specific arithmetic circuits
 - Option 2: Build on top of a zero-knowledge virtual machine, which receives a binary file as an input and outputs a proof of execution.
 
-At RISC Zero, we adopt the latter approach: we've written a [RISC-V circuit](https://docs.rs/risc0-circuit-rv32im), which emulates rv32im.
-The rv32im circuit receives a RISC-V binary and some user specified input, and generates an [execution trace](../proof-system/what_is_a_trace.md).
+At RISC Zero, we adopt the latter approach: we've written a [RISC-V circuit][4], which emulates rv32im.
+The rv32im circuit receives a RISC-V binary and some user specified input, and generates an [execution trace][5].
 
 If the execution trace is valid, the [Prover](https://docs.rs/risc0-zkvm/*/risc0_zkvm/trait.Prover.html) generates a [receipt] that can be [verified] by a skeptical third party.
 
@@ -35,8 +35,17 @@ In addition to the rv32im circuit, we have built:
 
 ## Additional Resources
 
-- Wikipedia page on [arithmetic circuit complexity](https://en.wikipedia.org/wiki/Arithmetic_circuit_complexity)
+- Wikipedia page on [arithmetic circuit complexity][3]
 - [From programs to arithmetic circuits](https://www.youtube.com/watch?v=0M0pAubEjz8&list=PLBJMt6zV1c7Gh9Utg-Vng2V6EYVidTFCC&index=4): YouTube video from David Wong
 
 [verified]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html#method.verify
 [receipt]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html
+[0]: about-finite-fields.md
+[1]: https://en.wikipedia.org/wiki/Electronic_circuit
+[2]: assets/arithmeticcircuit.png
+[3]: https://en.wikipedia.org/wiki/Arithmetic_circuit_complexity
+[4]: https://docs.rs/risc0-circuit-rv32im
+[5]: ../proof-system/what_is_a_trace.md
+[6]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/trait.Prover.html
+[7]: https://en.wikipedia.org/wiki/Arithmetic_circuit_complexity
+[8]: https://www.youtube.com/watch?v=0M0pAubEjz8&list=PLBJMt6zV1c7Gh9Utg-Vng2V6EYVidTFCC&index=4

--- a/website/docs/reference-docs/about-finite-fields-exercises.md
+++ b/website/docs/reference-docs/about-finite-fields-exercises.md
@@ -8,12 +8,17 @@ This page contains a few practice problems to test your understanding of finite 
 
 2. Below is a multiplication table for $\mathbb{F}_7$. Find a generator for $\mathbb{F}_7$ and re-write the table in terms of the generator.
 
-   ![mod 7 multiplication table](assets/mod-7-multiplication.png)
+   ![mod 7 multiplication table][0]
 
 3. Write a multiplication table for the 9 elements in $\mathbb{F}_3[\sqrt2].$
 
 ## Links
 
-- [Main reference page](../reference-docs/about-finite-fields.md)
+- [Main reference page][1]
 - [Slides](https://drive.google.com/file/d/146BOC_hHH0703OcKT-LwjIb3S0NYkGh0/view) & [recording](https://www.youtube.com/watch?v=BKViygqOW3I&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=3) from RISC Zero Study Club
-- [RISC Zero Discord](https://discord.gg/risczero)
+- [RISC Zero Discord][3]
+
+[0]: assets/mod-7-multiplication.png
+[1]: ../reference-docs/about-finite-fields.md
+[2]: https://www.youtube.com/watch?v=BKViygqOW3I&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=3
+[3]: https://discord.gg/risczero

--- a/website/docs/reference-docs/about-finite-fields.md
+++ b/website/docs/reference-docs/about-finite-fields.md
@@ -1,7 +1,7 @@
 # About Finite Fields
 
 _RISC Zero's [computational receipts][receipt] are built by converting an assertion of computational integrity into an assertion about polynomials over finite fields.
-This document serves as a minimal introduction to finite fields, targeted at folks who have some exposure to modular arithmetic and who are curious to learn more about the [math and cryptography behind RISC Zero](../proof-system/proof-system.md)._
+This document serves as a minimal introduction to finite fields, targeted at folks who have some exposure to modular arithmetic and who are curious to learn more about the [math and cryptography behind RISC Zero][0]._
 
 ## Finite Fields 101: Reciprocals, Exponents, and Generators
 
@@ -49,10 +49,17 @@ More generally, multiplying by a 4th root of unity is a rotation of order 4.`
 
 ## Additional References:
 
-- [Slides](https://drive.google.com/file/d/146BOC_hHH0703OcKT-LwjIb3S0NYkGh0/view?usp=share_link), [video recording](https://www.youtube.com/watch?v=BKViygqOW3I&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=3), and [practice problems](./about-finite-fields-exercises) from RISC Zero Study Club
-- [David Forney's Introduction to Finite Fields (Chapter 7)](https://ocw.mit.edu/courses/6-451-principles-of-digital-communication-ii-spring-2005/pages/readings-and-lecture-notes/)
-- [Guruswami's Basics of Finite Fields](http://www.cs.cmu.edu/~venkatg/teaching/codingtheory-au14/notes/finite-fields.pdf)
-- [A. Sutherland's notes on finite fields and integer arithmetic](https://math.mit.edu/classes/18.783/2017/LectureNotes3.pdf)
-- [Splitting $x^{n}-1$ over a finite field](https://math.stackexchange.com/questions/2511486/)
+- [Slides](https://drive.google.com/file/d/146BOC_hHH0703OcKT-LwjIb3S0NYkGh0/view?usp=share_link), [video recording](https://www.youtube.com/watch?v=BKViygqOW3I&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=3), and [practice problems][2] from RISC Zero Study Club
+- [David Forney's Introduction to Finite Fields (Chapter 7)][3]
+- [Guruswami's Basics of Finite Fields][4]
+- [A. Sutherland's notes on finite fields and integer arithmetic][5]
+- [Splitting $x^{n}-1$ over a finite field][6]
 
 [receipt]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html
+[0]: ../proof-system/proof-system.md
+[1]: https://www.youtube.com/watch?v=mvmuCPvRoWQ
+[2]: ./about-finite-fields-exercises
+[3]: https://ocw.mit.edu/courses/6-451-principles-of-digital-communication-ii-spring-2005/pages/readings-and-lecture-notes/
+[4]: http://www.cs.cmu.edu/~venkatg/teaching/codingtheory-au14/notes/finite-fields.pdf
+[5]: https://math.mit.edu/classes/18.783/2017/LectureNotes3.pdf
+[6]: https://math.stackexchange.com/questions/2511486/

--- a/website/docs/reference-docs/about-ntts-and-fourier.md
+++ b/website/docs/reference-docs/about-ntts-and-fourier.md
@@ -4,7 +4,7 @@ Number theoretic transforms (`NTTs`) and inverse number theoretic transforms (`i
 
 ## Documentation
 
-Implementation and documentation for NTTs and iNTTs is in the `risc0-zkp-core` [Rust crate](https://github.com/risc0/risc0#rust-crates).
+Implementation and documentation for NTTs and iNTTs is in the `risc0-zkp-core` [Rust crate][0].
 
 ## Basic Function
 
@@ -18,7 +18,7 @@ Implementation and documentation for NTTs and iNTTs is in the `risc0-zkp-core` [
 
 ## Background
 
-NTTs are a [finite field](about-finite-fields.md) analog to Fourier transforms.
+NTTs are a [finite field][1] analog to Fourier transforms.
 Fourier transforms, FFTs, DFTs and NTTs are various methods of transforming a function from **evaluation form** to **coefficient form**.
 
 ### Coefficient Form
@@ -35,10 +35,18 @@ The polynomial associated with the array $(u_0,u_1,\ldots,u_{n-1})$ is the uniqu
 
 ## Suggested Reading and Videos
 
-- [Slides](https://docs.google.com/presentation/d/18EMbRUihd8lUOMd1cIvqpCL1qI0JcCqp/edit?usp=sharing&ouid=108906331404608387394&rtpof=true&sd=true) and [recording](https://youtu.be/Pct3rS4Y0IA) from RISC Zero Study Club.
+- [Slides](https://docs.google.com/presentation/d/18EMbRUihd8lUOMd1cIvqpCL1qI0JcCqp/edit?usp=sharing&ouid=108906331404608387394&rtpof=true&sd=true) and [recording][2] from RISC Zero Study Club.
 - NTTs are just a finite field version of the FFT algorithm; to translate from FFTs to NTTs, replace the complex root of unity with a finite field root of unity.
   - This [DFT video](https://www.youtube.com/watch?v=nl9TZanwbBk) and [FFT video](https://www.youtube.com/watch?v=E8HeD-MUrjY) from UW professor Steve Brunton are brief and instructive.
   - [3blue1brown video](https://www.youtube.com/watch?v=spUNpyF58BY) and [lecture](https://www.youtube.com/watch?v=g8RkArhtCc4) on FFTs
   - [Veritasium](https://www.youtube.com/watch?v=nmgFG7PUHfo) on FFTs
 
-For a deeper look into the algorithm at both a software and hardware level, we recommend this [FFT video from Reducible](https://www.youtube.com/watch?v=h7apO7q16V0). And here's [Vitalik's take](https://vitalik.ca/general/2019/05/12/fft.html) on FFTs/NTTs.
+For a deeper look into the algorithm at both a software and hardware level, we recommend this [FFT video from Reducible](https://www.youtube.com/watch?v=h7apO7q16V0). And here's [Vitalik's take][6] on FFTs/NTTs.
+
+[0]: https://github.com/risc0/risc0#rust-crates
+[1]: about-finite-fields.md
+[2]: https://youtu.be/Pct3rS4Y0IA
+[3]: https://www.youtube.com/watch?v=E8HeD-MUrjY
+[4]: https://www.youtube.com/watch?v=g8RkArhtCc4
+[5]: https://www.youtube.com/watch?v=nmgFG7PUHfo
+[6]: https://vitalik.ca/general/2019/05/12/fft.html

--- a/website/docs/reference-docs/about-plonk.md
+++ b/website/docs/reference-docs/about-plonk.md
@@ -1,7 +1,7 @@
 # About PLONK and PLOOKUP
 
-The [PLONK paper](https://eprint.iacr.org/2019/953) introduced an efficient technique for enforcing the validity of memory operations in arguments of computational integrity.
-Building on top of PLONK, the [PLOOKUP paper](https://eprint.iacr.org/2020/315.pdf) introduced a method of enforcing the validity of lookup operations.
+The [PLONK paper][0] introduced an efficient technique for enforcing the validity of memory operations in arguments of computational integrity.
+Building on top of PLONK, the [PLOOKUP paper][1] introduced a method of enforcing the validity of lookup operations.
 
 ## Relevance in RISC Zero
 
@@ -13,11 +13,11 @@ _Note: RISC Zero uses an AIR-based arithmetization and not a PLONK-based arithme
 
 ## Documentation
 
-Implementation and documentation for RISC Zero's use of PLONK and PLOOKUP are in [plonk.rs](https://github.com/risc0/risc0/blob/3d00debce414f96353b8295720be21029ca63347/risc0/zkvm/src/prove/plonk.rs) and [accum.rs](https://github.com/risc0/risc0/blob/3d00debce414f96353b8295720be21029ca63347/risc0/zkp/src/prove/accum.rs).
+Implementation and documentation for RISC Zero's use of PLONK and PLOOKUP are in [plonk.rs](https://github.com/risc0/risc0/blob/3d00debce414f96353b8295720be21029ca63347/risc0/zkvm/src/prove/plonk.rs) and [accum.rs][3].
 
 ## Basic Function
 
-PLONK makes uses of [accumulators](https://hackmd.io/@arielg/ByFgSDA7D) in order to ensure that one list is a permutation of another.
+PLONK makes uses of [accumulators][4] in order to ensure that one list is a permutation of another.
 PLOOKUP uses PLONK to ensure that one list is contained in another list.
 
 ## Suggested Reading and Videos
@@ -28,19 +28,34 @@ For general references, we recommend the following:
 ### Less Technical
 
 - [ZK Podcast episode](https://www.youtube.com/watch?v=n6_nicI4ckM&t=2629s) with the authors of the PLONK paper
-- [Vitalik's PLONK intro](https://vitalik.ca/general/2019/09/22/plonk.html)
-- [@0xtaetaehoho's PLONK Skilltree](https://twitter.com/0xtaetaehoho/status/1618979438913527814)
+- [Vitalik's PLONK intro][7]
+- [@0xtaetaehoho's PLONK Skilltree][8]
 
 ### Moderately Technical
 
 - [ZK Study Club on PLONK](https://www.youtube.com/watch?v=NqrVcDuQ8hM)
-- ZK Whiteboard sessions on [PLONK](https://zkhack.dev/whiteboard/module-five/) and on [lookup arguments](https://zkhack.dev/whiteboard/module-six/)
+- ZK Whiteboard sessions on [PLONK](https://zkhack.dev/whiteboard/module-five/) and on [lookup arguments][10]
 - [PLOOKUP presentation at zkSummit](https://www.youtube.com/watch?v=Vdlc1CmRYRY)
-- [Ariel Gabizon explains grand product arguments](https://hackmd.io/@arielg/ByFgSDA7D)
+- [Ariel Gabizon explains grand product arguments][4]
 
 ### Very Technical
 
-- [PLONK paper](https://eprint.iacr.org/2019/953)
-- [PLOOKUP paper](https://eprint.iacr.org/2020/315.pdf)
+- [PLONK paper][0]
+- [PLOOKUP paper][1]
 
 [receipt]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html
+[0]: https://eprint.iacr.org/2019/953
+[1]: https://eprint.iacr.org/2020/315.pdf
+[2]: https://www.youtube.com/watch?v=dYuEPvRLwLo&list=PLcPzhUaCxlCiLk_VjLUNbmfb2mB1Y_N9N&index=6
+[3]: https://github.com/risc0/risc0/blob/3d00debce414f96353b8295720be21029ca63347/risc0/zkp/src/prove/accum.rs
+[4]: https://hackmd.io/@arielg/ByFgSDA7D
+[5]: https://www.youtube.com/watch?v=od033ugtlYQ&list=PLcPzhUaCxlCgCvzkkaBWzVuHdBRsTNxj1&index=7
+[6]: https://www.youtube.com/watch?v=n6_nicI4ckM&t=2629s
+[7]: https://vitalik.ca/general/2019/09/22/plonk.html
+[8]: https://twitter.com/0xtaetaehoho/status/1618979438913527814
+[9]: https://www.youtube.com/watch?v=NqrVcDuQ8hM
+[10]: https://zkhack.dev/whiteboard/module-six/
+[11]: https://www.youtube.com/watch?v=Vdlc1CmRYRY
+[12]: https://hackmd.io/@arielg/ByFgSDA7D
+[13]: https://eprint.iacr.org/2019/953
+[14]: https://eprint.iacr.org/2020/315.pdf

--- a/website/docs/reference-docs/about-risc-v.md
+++ b/website/docs/reference-docs/about-risc-v.md
@@ -1,21 +1,28 @@
 # About RISC-V
 
-[RISC-V](https://en.wikipedia.org/wiki/RISC-V) is a minimal, modular [Von Neumann architecture](https://en.wikipedia.org/wiki/Von_Neumann_architecture).
+[RISC-V](https://en.wikipedia.org/wiki/RISC-V) is a minimal, modular [Von Neumann architecture][0].
 
 ## Relevance in RISC Zero
 
 The simplicity of RISC-V as well as the maturity of the RISC-V ecosystem makes it ideal for a zero-knowledge virtual machine.
-RISC Zero's [zkVM](/api/zkvm) implements the RISC-V rv32im specification, which consists of the rv32i base with the multiplication extension.
+RISC Zero's [zkVM][1] implements the RISC-V rv32im specification, which consists of the rv32i base with the multiplication extension.
 This means that developers can write code in languages such as Rust, Go, and C, compile the code to RISC-V assembly code, and execute it on the zkVM.
 
 ## Documentation
 
-The specification of rv32im is defined in [The RISC-V Instruction Set Manual, Volume I: User-Level ISA](https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf).
-A succinct summary of the architecture is available [here](https://github.com/jameslzhu/riscv-card/blob/master/riscv-card.pdf)
+The specification of rv32im is defined in [The RISC-V Instruction Set Manual, Volume I: User-Level ISA][2].
+A succinct summary of the architecture is available [here][3]
 
 ## Suggested Reading and Videos
 
 For more on how these ideas fit into RISC Zero's system, we recommend:
 
 - RISC Zero's talk from zk Summit 7: [Encoding Von-Neumann Architectures in Zero-Knowledge Proof Systems](https://www.youtube.com/watch?v=od033ugtlYQ&list=PLcPzhUaCxlCgCvzkkaBWzVuHdBRsTNxj1&index=7)
-- RISC Zero Study Club: What is RISC-V and what does it have to do with RISC Zero's zkVM -- [video](https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=5&t=1s) and [slides](https://drive.google.com/file/d/1p7E5Sgi__5_CevGKHpTwrlb0KWjSaYPU/view)
+- RISC Zero Study Club: What is RISC-V and what does it have to do with RISC Zero's zkVM -- [video](https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=5&t=1s) and [slides][5]
+
+[0]: https://en.wikipedia.org/wiki/Von_Neumann_architecture
+[1]: /api/zkvm
+[2]: https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf
+[3]: https://github.com/jameslzhu/riscv-card/blob/master/riscv-card.pdf
+[4]: https://www.youtube.com/watch?v=od033ugtlYQ&list=PLcPzhUaCxlCgCvzkkaBWzVuHdBRsTNxj1&index=7
+[5]: https://drive.google.com/file/d/1p7E5Sgi__5_CevGKHpTwrlb0KWjSaYPU/view

--- a/website/docs/reference-docs/about-rs-codes.md
+++ b/website/docs/reference-docs/about-rs-codes.md
@@ -1,21 +1,21 @@
 # About Reed Solomon Codes
 
-[Reed Solomon codes](https://en.wikipedia.org/wiki/Reed–Solomon_error_correction) (RS codes) are a family of [error correcting codes](https://en.wikipedia.org/wiki/Error_correction_code) based on polynomials over [finite fields](about-finite-fields.md).
+[Reed Solomon codes](https://en.wikipedia.org/wiki/Reed–Solomon_error_correction) (RS codes) are a family of [error correcting codes](https://en.wikipedia.org/wiki/Error_correction_code) based on polynomials over [finite fields][0].
 
 ## Documentation
 
-Implementation and documentation for Reed-Solomon encoding is in the `risc0-zkp-core` [Rust crate](https://github.com/risc0/risc0#rust-crates).
+Implementation and documentation for Reed-Solomon encoding is in the `risc0-zkp-core` [Rust crate][1].
 
 ## Basic Function
 
-A RISC Zero [receipt] demonstrates the validity of the associated [execution trace](../proof-system/what_is_a_trace.md) by encoding the execution instructions and the trace data into polynomials and then making various assertions about those polynomials.
+A RISC Zero [receipt] demonstrates the validity of the associated [execution trace][2] by encoding the execution instructions and the trace data into polynomials and then making various assertions about those polynomials.
 We refer to this process as _arithmetization of the trace_, and RISC Zero's arithmetization is based on Reed Solomon encoding.
 
 ## Background
 
-Adding a [parity bit](https://en.wikipedia.org/wiki/Parity_bit) to a binary string offers a form of error detection.
+Adding a [parity bit][3] to a binary string offers a form of error detection.
 Error correcting codes extend this line of thinking: when sending data that may get corrupted, we can allow the recipient to detect and correct errors by adding some error correcting bits.
-Reed-Solomon codes are an industry standard for error correction; they're used in many signal processing applications, including cell communication, QR codes, and [STARKs](about-starks.md).
+Reed-Solomon codes are an industry standard for error correction; they're used in many signal processing applications, including cell communication, QR codes, and [STARKs][4].
 
 In the context of RISC Zero's receipts, the relevance of Reed-Solomon codes is quite a bit more nuanced than the standard error correction use cases.
 The error amplification of Reed-Solomon encoding provides cryptographic soundness to RISC Zero's computational receipts.
@@ -26,10 +26,22 @@ This error amplification means that even a single error in the execution trace c
 
 - [Slides](https://drive.google.com/file/d/1p0AZ3E4kLIDmFslW_c47YGb-EgeXc_YZ/view), [recording](https://youtu.be/Yu9DHhdSqQo), and [practice problems](https://drive.google.com/file/d/1JtzBGxz1c-PDVIIRmWa85_A22NS9dlL-/view?usp=share_link) from RISC Zero Study Club
 - 3blue1brown has two videos that offer a great introduction to error correcting codes: [Part 1](https://www.youtube.com/watch?v=X8jsijhllIA) and [Part 2](https://www.youtube.com/watch?v=b3NxrZOu_CE&t=0s).
-- Mary Wootters has a fantastic course on Algebraic Coding Theory. The [YouTube](https://www.youtube.com/playlist?list=PLkvhuSoxwjI_UudECvFYArvG0cLbFlzSr) and the [course website](https://web.stanford.edu/class/cs250/) are both great resources.
+- Mary Wootters has a fantastic course on Algebraic Coding Theory. The [YouTube](https://www.youtube.com/playlist?list=PLkvhuSoxwjI_UudECvFYArvG0cLbFlzSr) and the [course website][7] are both great resources.
   - [Reed-Solomon Lesson](https://www.youtube.com/watch?v=yQkEnde2lNg&list=PLkvhuSoxwjI_UudECvFYArvG0cLbFlzSr&index=16)
-- The [Reed-Solomon paper](https://epubs.siam.org/doi/10.1137/0108018) is quite clear and only a few pages long.
-- The [Proximity Gaps for Reed-Solomon Codes](https://eprint.iacr.org/2020/654.pdf) paper is central to the soundness of the RISC Zero proof system.
+- The [Reed-Solomon paper][9] is quite clear and only a few pages long.
+- The [Proximity Gaps for Reed-Solomon Codes][10] paper is central to the soundness of the RISC Zero proof system.
   - See also [Dan Carmon's talk](https://www.youtube.com/watch?v=v0ZHUPzKotY) at the IEEE Symposium on the Foundations of Computer Science
 
 [receipt]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html
+[0]: about-finite-fields.md
+[1]: https://github.com/risc0/risc0#rust-crates
+[2]: ../proof-system/what_is_a_trace.md
+[3]: https://en.wikipedia.org/wiki/Parity_bit
+[4]: about-starks.md
+[5]: https://drive.google.com/file/d/1JtzBGxz1c-PDVIIRmWa85_A22NS9dlL-/view?usp=share_link
+[6]: https://www.youtube.com/watch?v=b3NxrZOu_CE&t=0s
+[7]: https://web.stanford.edu/class/cs250/
+[8]: https://www.youtube.com/watch?v=yQkEnde2lNg&list=PLkvhuSoxwjI_UudECvFYArvG0cLbFlzSr&index=16
+[9]: https://epubs.siam.org/doi/10.1137/0108018
+[10]: https://eprint.iacr.org/2020/654.pdf
+[11]: https://www.youtube.com/watch?v=v0ZHUPzKotY

--- a/website/docs/studyclub.md
+++ b/website/docs/studyclub.md
@@ -4,13 +4,13 @@ RISC Zero's Study Club sessions aim to introduce the pre-requisite concepts nece
 
 ## Upcoming Sessions
 
-- **October 25**: Intro to [Zeth](https://risczero.com/news/zeth-release), with Wolfgang Welz
+- **October 25**: Intro to [Zeth][0], with Wolfgang Welz
 - **November 1**: Use cases for ZK in blockchain, with Steven Li
 - **November 8**: zkVM Performance Optimization, with Victor Graf
 
 All sessions are hosted at **9am Pacific / 4PM UTC**. <br/>
 Join the session: [Zoom link] <br/>
-Join the conversation: [Discord](https://discord.gg/risczero)
+Join the conversation: [Discord][1]
 
 ## Past Sessions
 
@@ -41,3 +41,17 @@ You may also be interested in some of our other [talks and podcasts](https://www
 
 [Zoom Link]: https://zoom.us/j/95830917265
 [continuations]: https://www.risczero.com/news/continuations
+[0]: https://risczero.com/news/zeth-release
+[1]: https://discord.gg/risczero
+[2]: https://www.youtube.com/playlist?list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl
+[3]: https://www.youtube.com/watch?v=11DIflEwx50&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=5
+[4]: https://www.youtube.com/watch?v=h1qWnf-M5lo&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=9
+[5]: https://www.youtube.com/watch?v=g-GDvnJsZgg&list=PLcPzhUaCxlCiddOGuYdDbFlZhH8nwtR8D
+[6]: https://www.youtube.com/watch?v=hUl8ZB6hpUM&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=6
+[7]: https://www.youtube.com/watch?v=IFsxQUbI6x0&list=PLcPzhUaCxlChIKDDR_WghPQ1HeK01YHpa
+[8]: https://www.youtube.com/watch?v=NHAuw2mkg0o&list=PLcPzhUaCxlCgPFYnnhDbsE-7H3scbtjye
+[9]: https://www.youtube.com/watch?v=8AMiZdWA1eM&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=10
+[10]: https://www.youtube.com/watch?v=LgQQHd9SzMs&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=8&t=4s
+[11]: https://www.youtube.com/watch?v=YiYN6UgE8sQ&list=PLcPzhUaCxlCi6rRRiIlkzJ_YELUlKO4Mz
+[12]: https://www.youtube.com/watch?v=wqRuoyH3Mqk&list=PLcPzhUaCxlCjdhONxEYZ1dgKjZh3ZvPtl&index=8
+[13]: https://www.youtube.com/watch?v=saVD9qo3aJ0

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -148,7 +148,7 @@ the seal is the opaque blob that cryptographically attests to the validity of th
 [RISC-V]: #risc-v
 
 The 5th edition of UC Berkeley's reduced instruction set computer architecture.
-RISC Zero uses RISC-V, specifically the [rv32im instruction set](https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf), as the basis for the RISC Zero zkVM.
+RISC Zero uses RISC-V, specifically the [rv32im instruction set][0], as the basis for the RISC Zero zkVM.
 
 ### Seal
 
@@ -218,3 +218,4 @@ RISC Zero's zkVM implements the RISC-V instruction set architecture and uses a [
 [RISC Zero's ZKP Whitepaper]: https://risczero.com/proof-system-in-detail.pdf
 [Rust crate for zkVM guest]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest
 [Sequence Diagram for RISC Zero's STARK]: ./proof-system/proof-system-sequence-diagram.md
+[0]: https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf


### PR DESCRIPTION
This was done by using a simple rust program that utilizes the regex create and it captures more patterns than the js program I found on github.