### PR TITLE
Improve CI build/test perf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,9 +129,8 @@ jobs:
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo test -F $FEATURE -F profiler --workspace --exclude doc-test
+      - run: cargo test -F $FEATURE -F fault-proof -F profiler -F prove --workspace --exclude doc-test
       - run: cargo test -p risc0-r0vm -F $FEATURE -F disable-dev-mode
-      - run: cargo test -p risc0-zkvm -F $FEATURE -F fault-proof -F prove
       - run: cargo test -p cargo-risczero -F experimental
         if: matrix.device == 'cpu'
       - run: cargo check -F $FEATURE --benches

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,10 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
+      check-benchmarks: ${{ steps.filter.outputs.check-benchmarks }}
       check_template: ${{ steps.filter.outputs.check_template }}
       crates-validator: ${{ steps.filter.outputs.crates-validator }}
+      doc: ${{ steps.filter.outputs.doc }}
       examples: ${{ steps.filter.outputs.examples }}
       test: ${{ steps.filter.outputs.test }}
       web: ${{ steps.filter.outputs.web }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,26 @@ jobs:
               - risc0/**
               - xtask/**
 
+  # see: https://github.com/orgs/community/discussions/26822
+  main-status-check:
+    needs:
+      - check
+      - check-benchmarks
+      - check_template
+      - crates-validator
+      - doc
+      - examples
+      - reproducible-build
+      - test
+      - web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all job status
+        # see https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/risc0/cargo-risczero/src/commands/new.rs
+++ b/risc0/cargo-risczero/src/commands/new.rs
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn basic_new() {
-        let new = NewCommand::parse_from(["new", "my_project"]);
+        let new = NewCommand::parse_from(["new", "--guest-name", "method", "my_project"]);
         assert_eq!(new.name, "my_project");
     }
 
@@ -252,6 +252,8 @@ mod tests {
             "",
             "--dest",
             &tmpdir.path().to_string_lossy(),
+            "--guest-name",
+            "method",
             proj_name,
         ]);
 
@@ -289,6 +291,8 @@ mod tests {
             "--no-git",
             "--use-git-branch",
             "main",
+            "--guest-name",
+            "method",
             proj_name,
         ]);
 
@@ -319,6 +323,8 @@ mod tests {
             "--dest",
             &tmpdir.path().to_string_lossy(),
             "--std",
+            "--guest-name",
+            "method",
             proj_name,
         ]);
 

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -289,10 +289,8 @@ fn session_events() {
 // They were built using the toolchain from:
 // https://github.com/risc0/toolchain/releases/tag/2022.03.25
 mod riscv {
-    use crate::{
-        host::server::prove::tests::prove_session_fast, ExecutorEnv, ExecutorImpl, MemoryImage,
-        Program,
-    };
+    use super::prove_session_fast;
+    use crate::{ExecutorEnv, ExecutorImpl, MemoryImage, Program};
 
     fn run_test(test_name: &str) {
         use std::io::Read;
@@ -391,6 +389,7 @@ mod docker {
     use risc0_zkvm_methods::{multi_test::MultiTestSpec, MULTI_TEST_ELF};
     use test_log::test;
 
+    use super::prove_session_fast;
     use crate::{ExecutorEnv, ExecutorImpl, ExitCode};
 
     #[test]

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -30,8 +30,23 @@ use super::{get_prover_server, HalPair, ProverImpl};
 use crate::{
     host::{server::testutils, CIRCUIT},
     serde::{from_slice, to_vec},
-    ExecutorEnv, ExecutorImpl, ExitCode, ProverOpts, ProverServer, Receipt, VerifierContext,
+    ExecutorEnv, ExecutorImpl, ExitCode, ProverOpts, ProverServer, Receipt, Session,
+    VerifierContext,
 };
+
+fn prover_opts_fast() -> ProverOpts {
+    ProverOpts {
+        hashfn: "sha-256".to_string(),
+        prove_guest_errors: false,
+    }
+}
+
+fn prove_session_fast(session: &Session) -> Receipt {
+    let prover = get_prover_server(&prover_opts_fast()).unwrap();
+    prover
+        .prove_session(&VerifierContext::default(), session)
+        .unwrap()
+}
 
 fn prove_nothing(hashfn: &str) -> Result<Receipt> {
     let env = ExecutorEnv::builder()
@@ -104,7 +119,7 @@ fn sha_basics() {
             .unwrap();
         let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
         let session = exec.run().unwrap();
-        let receipt = session.prove().unwrap();
+        let receipt = prove_session_fast(&session);
         hex::encode(Digest::try_from(receipt.journal.bytes).unwrap())
     }
 
@@ -140,7 +155,7 @@ fn sha_iter() {
         .unwrap();
     let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
     let session = exec.run().unwrap();
-    let receipt = session.prove().unwrap();
+    let receipt = prove_session_fast(&session);
     let digest = Digest::try_from(receipt.journal.bytes).unwrap();
     assert_eq!(
         hex::encode(digest),
@@ -166,7 +181,7 @@ fn bigint_accel() {
             .unwrap();
         let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
         let session = exec.run().unwrap();
-        let receipt = session.prove().unwrap();
+        let receipt = prove_session_fast(&session);
         let expected = case.expected();
         let expected: &[u8] = bytemuck::cast_slice(expected.as_slice());
         assert_eq!(receipt.journal.bytes, expected);
@@ -191,7 +206,7 @@ fn memory_io() {
             .unwrap();
         let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF)?;
         let session = exec.run()?;
-        let receipt = session.prove()?;
+        let receipt = prove_session_fast(&session);
         receipt.verify_integrity_with_context(&VerifierContext::default())?;
         Ok(receipt.get_metadata()?.exit_code)
     }
@@ -263,7 +278,7 @@ fn session_events() {
         on_post_prove_segment_flag: on_post_prove_segment_flag.clone(),
     };
     session.add_hook(logger);
-    session.prove().unwrap();
+    prove_session_fast(&session);
     assert_eq!(session.hooks.len(), 1);
     assert_eq!(on_pre_prove_segment_flag.take(), true);
     assert_eq!(on_post_prove_segment_flag.take(), true);
@@ -274,7 +289,10 @@ fn session_events() {
 // They were built using the toolchain from:
 // https://github.com/risc0/toolchain/releases/tag/2022.03.25
 mod riscv {
-    use crate::{ExecutorEnv, ExecutorImpl, MemoryImage, Program};
+    use crate::{
+        host::server::prove::tests::prove_session_fast, ExecutorEnv, ExecutorImpl, MemoryImage,
+        Program,
+    };
 
     fn run_test(test_name: &str) {
         use std::io::Read;
@@ -305,7 +323,8 @@ mod riscv {
             let env = ExecutorEnv::default();
             let mut exec = ExecutorImpl::new(env, image).unwrap();
             let session = exec.run().unwrap();
-            session.prove().unwrap();
+
+            prove_session_fast(&session);
         }
     }
 
@@ -387,7 +406,7 @@ mod docker {
         let session = exec.run().unwrap();
         assert_eq!(session.segments.len(), 1);
         assert_eq!(session.exit_code, ExitCode::Paused(0));
-        let receipt = session.prove().unwrap();
+        let receipt = prove_session_fast(&session);
         let segments = &receipt.inner.composite().unwrap().segments;
         assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].index, 0);
@@ -395,7 +414,7 @@ mod docker {
         // Run until sys_halt
         let session = exec.run().unwrap();
         assert_eq!(session.exit_code, ExitCode::Halted(0));
-        session.prove().unwrap();
+        prove_session_fast(&session);
     }
 
     #[test]
@@ -421,7 +440,7 @@ mod docker {
         }
         assert_eq!(final_segment.exit_code, ExitCode::Halted(0));
 
-        let receipt = session.prove().unwrap();
+        let receipt = prove_session_fast(&session);
         for (idx, receipt) in receipt
             .inner
             .composite()
@@ -441,19 +460,14 @@ mod sys_verify {
     };
     use test_log::test;
 
-    use super::get_prover_server;
+    use super::{get_prover_server, prover_opts_fast};
     use crate::{
         serde::to_vec, sha::Digestible, ExecutorEnv, ExecutorEnvBuilder, ExitCode, ProverOpts,
         Receipt,
     };
 
     fn prove_hello_commit() -> Receipt {
-        let opts = ProverOpts {
-            hashfn: "sha-256".to_string(),
-            prove_guest_errors: false,
-        };
-
-        let hello_commit_receipt = get_prover_server(&opts)
+        let hello_commit_receipt = get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(ExecutorEnv::default(), HELLO_COMMIT_ELF)
             .unwrap();
@@ -521,11 +535,6 @@ mod sys_verify {
 
     #[test]
     fn sys_verify() {
-        let opts = ProverOpts {
-            hashfn: "sha-256".to_string(),
-            prove_guest_errors: false,
-        };
-
         let spec = &MultiTestSpec::SysVerify {
             image_id: HELLO_COMMIT_ID.into(),
             journal: HELLO_COMMIT_RECEIPT.journal.bytes.clone(),
@@ -539,7 +548,7 @@ mod sys_verify {
             .add_assumption(HELLO_COMMIT_RECEIPT.clone().into())
             .build()
             .unwrap();
-        get_prover_server(&opts)
+        get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()
@@ -553,7 +562,7 @@ mod sys_verify {
             .unwrap()
             .build()
             .unwrap();
-        assert!(get_prover_server(&opts)
+        assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
@@ -567,7 +576,7 @@ mod sys_verify {
             .build()
             .unwrap();
         // TODO(#982) Conditional receipts currently return an error on verification.
-        assert!(get_prover_server(&opts)
+        assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
@@ -581,11 +590,6 @@ mod sys_verify {
 
     #[test]
     fn sys_verify_integrity() {
-        let opts = ProverOpts {
-            hashfn: "sha-256".to_string(),
-            prove_guest_errors: false,
-        };
-
         let spec = &MultiTestSpec::SysVerifyIntegrity {
             metadata_words: to_vec(&HELLO_COMMIT_RECEIPT.get_metadata().unwrap()).unwrap(),
         };
@@ -598,7 +602,7 @@ mod sys_verify {
             .add_assumption(HELLO_COMMIT_RECEIPT.clone().into())
             .build()
             .unwrap();
-        get_prover_server(&opts)
+        get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()
@@ -612,7 +616,7 @@ mod sys_verify {
             .unwrap()
             .build()
             .unwrap();
-        assert!(get_prover_server(&opts)
+        assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
@@ -626,7 +630,7 @@ mod sys_verify {
             .build()
             .unwrap();
         // TODO(#982) Conditional receipts currently return an error on verification.
-        assert!(get_prover_server(&opts)
+        assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
@@ -637,11 +641,6 @@ mod sys_verify {
         // Generate a receipt for a execution ending in a guest error indicated by
         // ExitCode::Halted(1).
         let halt_receipt = prove_halt(1);
-
-        let opts = ProverOpts {
-            hashfn: "sha-256".to_string(),
-            prove_guest_errors: false,
-        };
 
         let spec = &MultiTestSpec::SysVerifyIntegrity {
             metadata_words: to_vec(&halt_receipt.get_metadata().unwrap()).unwrap(),
@@ -654,7 +653,7 @@ mod sys_verify {
             .add_assumption(halt_receipt.into())
             .build()
             .unwrap();
-        get_prover_server(&opts)
+        get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()
@@ -669,11 +668,6 @@ mod sys_verify {
         // that ended in SystemSplit for which the host claims a fault is about to occur.
         let fault_receipt = prove_fault();
 
-        let opts = ProverOpts {
-            hashfn: "sha-256".to_string(),
-            prove_guest_errors: false,
-        };
-
         let spec = &MultiTestSpec::SysVerifyIntegrity {
             metadata_words: to_vec(&fault_receipt.get_metadata().unwrap()).unwrap(),
         };
@@ -685,7 +679,7 @@ mod sys_verify {
             .add_assumption(fault_receipt.into())
             .build()
             .unwrap();
-        get_prover_server(&opts)
+        get_prover_server(&prover_opts_fast())
             .unwrap()
             .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()


### PR DESCRIPTION
* Use SHA-256 for internal proving tests (2x faster than poseidon)
* Avoid hanging cargo-risczero tests waiting on stdin
* Avoid building `risc0-zkvm` twice with and without the "prove" feature