### PR TITLE
fix: Add exponential backoff to bonsai proof polling

### DIFF
--- a/bonsai/Cargo.lock
+++ b/bonsai/Cargo.lock
@@ -402,6 +402,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.10",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +580,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "backoff",
  "bincode",
  "bonsai-ethereum-contracts",
  "bonsai-rest-api-mock",

--- a/bonsai/ethereum-relay/Cargo.toml
+++ b/bonsai/ethereum-relay/Cargo.toml
@@ -36,6 +36,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 utoipa = { version = "3.0", features = ["axum_extras", "time", "uuid"] }
 utoipa-swagger-ui = { version = "3.0", features = ["axum", "debug-embed"] }
 validator = { version = "0.16", features = ["derive"] }
+backoff = { version = "0.4", features = ["tokio"] }
 
 [dev-dependencies]
 bincode = "1"

--- a/bonsai/ethereum-relay/src/uploader/pending_proofs/pending_proof_request_future.rs
+++ b/bonsai/ethereum-relay/src/uploader/pending_proofs/pending_proof_request_future.rs
@@ -14,13 +14,14 @@
 
 use std::pin::Pin;
 
+use backoff::{future::retry, Error as BackoffError, ExponentialBackoff};
 use bonsai_sdk::{
     alpha::{responses::SessionStatusRes, Client, SessionId},
     alpha_async::session_status,
 };
 use futures::{
     task::{Context, Poll},
-    Future,
+    Future, FutureExt,
 };
 use pin_project::pin_project;
 use tracing::error;
@@ -50,8 +51,7 @@ impl Error {
     }
 }
 
-type PollingBonsaiFuture =
-    Pin<Box<dyn Future<Output = Result<SessionStatusRes, Error>> + Sync + Send>>;
+type PollingBonsaiFuture = Pin<Box<dyn Future<Output = Result<SessionStatusRes, Error>> + Send>>;
 
 enum PendingProofRequestState {
     // Inital state. The Proof Request has been submitted to Bonsai
@@ -86,26 +86,25 @@ impl Future for PendingProofRequest {
         loop {
             match this.state {
                 PendingProofRequestState::Pending => {
-                    // Transition state to ask Bonsai for the proof request's
-                    // status
-                    let bonsai_get_receipt_fut =
-                        get_receipt_info(this.bonsai_client.clone(), this.pending_proof_id.clone());
+                    // Clone necessary data for the async closure
+                    let bonsai_client_clone = this.bonsai_client.clone();
+                    let pending_proof_id_clone = this.pending_proof_id.clone();
 
-                    *this.state =
-                        PendingProofRequestState::PollingBonsai(Box::pin(bonsai_get_receipt_fut))
-                }
+                    // Set up the retry policy and create the future
+                    let retry_policy = ExponentialBackoff::default();
+                    let bonsai_get_receipt_fut = retry(retry_policy, move || {
+                        let client = bonsai_client_clone.clone();
+                        let id = pending_proof_id_clone.clone();
+                        async move {
+                            let receipt_response = get_receipt_info(client, id.clone())
+                                .await
+                                .map_err(BackoffError::permanent)?;
 
-                PendingProofRequestState::PollingBonsai(bonsai_get_receipt_fut) => {
-                    let response = futures::ready!(bonsai_get_receipt_fut.as_mut().poll(ctx));
-                    match response {
-                        Ok(receipt_response) => {
                             match (
                                 receipt_response.status.as_str(),
                                 receipt_response.receipt_url.is_some(),
                             ) {
-                                ("SUCCEEDED", true) => {
-                                    return Poll::Ready(Ok(this.pending_proof_id.clone()))
-                                }
+                                ("SUCCEEDED", true) => Ok(receipt_response),
                                 ("SUCCEEDED", false) => {
                                     // TODO: Should we consider this a failure
                                     // and retry, or should we just return an
@@ -113,35 +112,35 @@ impl Future for PendingProofRequest {
 
                                     // Bonsai returned the receipt in a inconsistent state,
                                     // we should assume the proof failed and return an error
-                                    error!(
-                                        "Bonsai returned a receipt with status SUCCEEDED but no receipt URL"
-                                    );
-                                    return Poll::Ready(Err(Error::ProofRequestError {
+                                    Err(BackoffError::permanent(Error::ProofRequestError {
                                         status: receipt_response.status,
-                                        id: this.pending_proof_id.clone(),
-                                    }));
+                                        id,
+                                    }))
                                 }
+                                // We treat "RUNNING" as a transient error to retry automatically
                                 ("RUNNING", _) => {
-                                    // Not done yet, still pending. Transition back to pending
-                                    *this.state = PendingProofRequestState::Pending;
-                                    ctx.waker().wake_by_ref();
-                                    return Poll::Pending;
+                                    Err(BackoffError::transient(Error::ProofRequestError {
+                                        status: "Proof request pending".to_string(),
+                                        id,
+                                    }))
                                 }
-                                _ => {
-                                    // TODO: Should we consider 'TIMED_OUT' a failure, or should we
-                                    // retry?
-
-                                    // The other status values indicate some type of error
-                                    return Poll::Ready(Err(Error::ProofRequestError {
-                                        status: receipt_response.status,
-                                        id: this.pending_proof_id.clone(),
-                                    }));
-                                }
+                                _ => Err(BackoffError::permanent(Error::ProofRequestError {
+                                    status: receipt_response.status,
+                                    id,
+                                })),
                             }
                         }
-                        Err(err) => {
-                            return Poll::Ready(Err(err));
-                        }
+                    })
+                    .boxed();
+
+                    // TODO this pending state does not need to be handled like this, refactor out
+                    *this.state = PendingProofRequestState::PollingBonsai(bonsai_get_receipt_fut);
+                }
+                PendingProofRequestState::PollingBonsai(ref mut bonsai_get_receipt_fut) => {
+                    let response = futures::ready!(bonsai_get_receipt_fut.as_mut().poll(ctx));
+                    match response {
+                        Ok(_) => return Poll::Ready(Ok(this.pending_proof_id.clone())),
+                        Err(e) => return Poll::Ready(Err(e)),
                     }
                 }
             }

--- a/bonsai/examples/governance/Cargo.lock
+++ b/bonsai/examples/governance/Cargo.lock
@@ -283,6 +283,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +437,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "backoff",
  "bincode",
  "bonsai-ethereum-contracts",
  "bonsai-rest-api-mock",


### PR DESCRIPTION
Currently, this future will essentially spin loop and spam requests to the service while the proof while waiting to be completed. This doesn't error for small proofs, but in my testing, this would consistently error if there was some combination of requests being sent too fast or there was a proof that took a long time to execute. This caused, on my OS, the error documented in the issue below as there were too many connections being opened.

Original issue: https://github.com/risc0/risc0/issues/842

Opening as a draft, as it's opinionated how this is fixed. I can also add an issue to this if it's helpful, but I figured in this case a hacky solution might make it more clear what the issue is.

What these changes are is just adding an exponential backoff to this request, which intuitively makes the most sense to me. Adding a `sleep` also works, but this is better to minimize latency for small proofs.