### PR TITLE
Fix issues in CI

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -50,8 +50,10 @@ runs:
     - run: |
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "CARGO_PROFILE_DEV_DEBUG=0" >> $GITHUB_ENV
+        echo "CC=sccache clang" >> $GITHUB_ENV
         echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
         echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+        echo "CXX=sccache clang++" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -50,10 +50,8 @@ runs:
     - run: |
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "CARGO_PROFILE_DEV_DEBUG=0" >> $GITHUB_ENV
-        echo "CC=sccache clang" >> $GITHUB_ENV
         echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
         echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-        echo "CXX=sccache clang++" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/workflows/bonsai.yml
+++ b/.github/workflows/bonsai.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_BUILD_LOCKED: 1
   RISC0_TOOLCHAIN_VERSION: test-release-2
 
@@ -64,8 +65,6 @@ jobs:
         run: cargo install --force --path risc0/cargo-risczero
 
       - run: cargo risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Lint
       - name: check solidity code formatting in bonsai/ethereum

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_TOOLCHAIN_VERSION: test-release-2
 
 jobs:
@@ -157,8 +158,6 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: build workspace
         run: cargo test -F $FEATURE -F fault-proof -F profiler -F prove --workspace --exclude doc-test --timings --no-run
       - name: test workspace
@@ -218,12 +217,10 @@ jobs:
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rustup
-      - uses: ./.github/actions/sccache
-        with:
-          key: ${{ matrix.os }}-${{ matrix.feature }}
+      # - uses: ./.github/actions/sccache
+      #   with:
+      #     key: ${{ matrix.os }}-${{ matrix.feature }}
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo build --release -p risc0-r0vm -F $FEATURE
       - name: build
         run: cargo test --locked -F $FEATURE --no-run
@@ -235,7 +232,7 @@ jobs:
         env:
           RISC0_PPROF_OUT: ${{ github.workspace }}/fibonacci.pb
         working-directory: examples/profiling
-      - run: sccache --show-stats
+      # - run: sccache --show-stats
 
   doc:
     if: needs.changes.outputs.doc == 'true'
@@ -251,8 +248,6 @@ jobs:
         with:
           key: macOS-default
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo doc --no-deps --exclude=risc0-zkvm-methods --workspace
       - run: sccache --show-stats
 
@@ -269,8 +264,6 @@ jobs:
         with:
           key: macOS-default
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo check
         working-directory: benchmarks
       - run: sccache --show-stats
@@ -293,8 +286,6 @@ jobs:
           key: ${{ matrix.os }}-default
       - run: cargo install --force --path risc0/cargo-risczero
       - run: cargo risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           cargo risczero new \
             --template templates/rust-starter \
@@ -351,8 +342,6 @@ jobs:
         with:
           key: Linux-default
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo xtask install
       - run: cargo xtask gen-receipt
       - run: |
@@ -374,8 +363,6 @@ jobs:
         with:
           key: Linux-default
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo test -p risc0-build -F docker
       - run: cargo test -p risc0-zkvm -F docker -F prove -- "docker::"
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -220,6 +220,7 @@ jobs:
       # - uses: ./.github/actions/sccache
       #   with:
       #     key: ${{ matrix.os }}-${{ matrix.feature }}
+      - run: env | sort
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
       - run: cargo build --release -p risc0-r0vm -F $FEATURE
       - name: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,9 +217,9 @@ jobs:
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rustup
-      # - uses: ./.github/actions/sccache
-      #   with:
-      #     key: ${{ matrix.os }}-${{ matrix.feature }}
+      - uses: ./.github/actions/sccache
+        with:
+          key: ${{ matrix.os }}-${{ matrix.feature }}
       - run: env | sort
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
       - run: cargo build --release -p risc0-r0vm -F $FEATURE
@@ -233,7 +233,7 @@ jobs:
         env:
           RISC0_PPROF_OUT: ${{ github.workspace }}/fibonacci.pb
         working-directory: examples/profiling
-      # - run: sccache --show-stats
+      - run: sccache --show-stats
 
   doc:
     if: needs.changes.outputs.doc == 'true'

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_TOOLCHAIN_VERSION: test-release-2
 
 jobs:
@@ -32,8 +33,6 @@ jobs:
           key: Linux-default
       - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
       - run: cargo run --bin cargo-risczero --no-default-features -- risczero install --version $RISC0_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: build
         run: cargo test -p doc-test --no-run
       - name: test

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2892,8 +2892,7 @@ dependencies = [
 [[package]]
 name = "protoc-prebuilt"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aee930fb53074ec083bf049aa6133bb1a93cce8fc39f83e07f36a0937304dd"
+source = "git+https://github.com/risc0/protoc-prebuilt.git?rev=14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701#14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701"
 dependencies = [
  "ureq",
  "zip",

--- a/bonsai/Cargo.lock
+++ b/bonsai/Cargo.lock
@@ -3359,8 +3359,7 @@ dependencies = [
 [[package]]
 name = "protoc-prebuilt"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aee930fb53074ec083bf049aa6133bb1a93cce8fc39f83e07f36a0937304dd"
+source = "git+https://github.com/risc0/protoc-prebuilt.git?rev=14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701#14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701"
 dependencies = [
  "ureq",
  "zip",

--- a/bonsai/examples/governance/Cargo.lock
+++ b/bonsai/examples/governance/Cargo.lock
@@ -3221,8 +3221,7 @@ dependencies = [
 [[package]]
 name = "protoc-prebuilt"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aee930fb53074ec083bf049aa6133bb1a93cce8fc39f83e07f36a0937304dd"
+source = "git+https://github.com/risc0/protoc-prebuilt.git?rev=14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701#14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701"
 dependencies = [
  "ureq",
  "zip",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3221,8 +3221,7 @@ dependencies = [
 [[package]]
 name = "protoc-prebuilt"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aee930fb53074ec083bf049aa6133bb1a93cce8fc39f83e07f36a0937304dd"
+source = "git+https://github.com/risc0/protoc-prebuilt.git?rev=14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701#14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701"
 dependencies = [
  "ureq",
  "zip",

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -23,9 +23,6 @@ dirs = "5.0"
 downloader = "0.2"
 flate2 = "1"
 fs2 = "0.4"
-# Force any openssl dependencies to use the "vendored" feature.
-# This is to allow cross builds to work in any environment.
-openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 reqwest-middleware = "0.2"
 reqwest-retry = "0.3"

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -12,9 +12,6 @@ bincode = "1.3"
 bytemuck = "1.12"
 clap = { version = "4", features = ["derive", "env"] }
 env_logger = "0.10"
-# Force any openssl dependencies to use the "vendored" feature.
-# This is to allow cross builds to work in any environment.
-openssl = { version = "0.10", features = ["vendored"] }
 risc0-zkvm = { workspace = true, features = ["prove"] }
 
 [dev-dependencies]

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -30,7 +30,7 @@ required-features = ["prove"]
 
 [build-dependencies]
 prost-build = { version = "0.12", optional = true }
-protoc-prebuilt = { version = "0.2", optional = true }
+protoc-prebuilt = { git = "https://github.com/risc0/protoc-prebuilt.git", rev = "14be7456835318f0f2bfd2ee1f0eb9d7ed5ef701", optional = true }
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }


### PR DESCRIPTION
* Avoid GitHub rate limiting for CI machines
* Drop `vendored` feature flag from `openssl` dependency. This works around some strange issue related to building openssl from source.
* Patch `protoc-prebuilt` to allow the use of GITHUB_TOKEN