### PR TITLE
Avoid exhausting disk space by dropping segments in dev mode prover

### DIFF
--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -23,7 +23,6 @@ use bytes::Bytes;
 use prost::Message;
 use risc0_binfmt::{MemoryImage, Program};
 use risc0_zkvm_platform::{memory::GUEST_MAX_MEM, PAGE_SIZE};
-use serde::{Deserialize, Serialize};
 
 use super::{malformed_err, path_to_string, pb, ConnectionWrapper, Connector, TcpConnector};
 use crate::{
@@ -31,26 +30,15 @@ use crate::{
     host::{
         client::{env::TraceCallback, slice_io::SliceIo},
         recursion::SuccinctReceipt,
+        server::session::EmptySegmentRef,
     },
-    ExecutorEnv, ExecutorImpl, ProverOpts, Segment, SegmentReceipt, SegmentRef, TraceEvent,
-    VerifierContext,
+    ExecutorEnv, ExecutorImpl, ProverOpts, Segment, SegmentReceipt, TraceEvent, VerifierContext,
 };
 
 /// A server implementation for handling requests by clients of the zkVM.
 pub struct Server {
     connector: Box<dyn Connector>,
 }
-
-#[derive(Clone, Serialize, Deserialize)]
-struct EmptySegmentRef;
-
-#[typetag::serde]
-impl SegmentRef for EmptySegmentRef {
-    fn resolve(&self) -> Result<Segment> {
-        Err(anyhow!("Segment resolution not supported"))
-    }
-}
-
 impl pb::api::Binary {
     fn as_image(&self) -> Result<MemoryImage> {
         let bytes = self.asset.as_ref().ok_or(malformed_err())?.as_bytes()?;

--- a/risc0/zkvm/src/host/server/session.rs
+++ b/risc0/zkvm/src/host/server/session.rs
@@ -333,3 +333,13 @@ impl FileSegmentRef {
         Ok(Self { path })
     }
 }
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct EmptySegmentRef;
+
+#[typetag::serde]
+impl SegmentRef for EmptySegmentRef {
+    fn resolve(&self) -> Result<Segment> {
+        Err(anyhow!("Segment resolution not supported"))
+    }
+}


### PR DESCRIPTION
A user on Discord "proving" a very large program in dev mode ran into an issue where their disk space was exhausted, requiring a restart to make they system usable again.

This PR addresses this issue by specializing the implementation of the `Prover::prove` method on the `DevModeProver` to pass a drop-segment callback to the executor. This avoids saving the segments to disk when they will not end up being used, saving disk space and potentially improving execution performance.
