### PR TITLE
Fix argument hanlding in client/server mode

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -56,3 +56,4 @@ experimental = [
 ]
 metal = ["risc0-zkvm/metal"]
 r0vm = ["dep:risc0-r0vm"]
+profiler = ["risc0-zkvm/profiler", "risc0-r0vm?/profiler"]

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -561,6 +561,7 @@ fn build_env<'a>(
 ) -> Result<ExecutorEnv<'a>> {
     let mut env_builder = ExecutorEnv::builder();
     env_builder.env_vars(request.env_vars.clone());
+    env_builder.args(&request.args);
     for fd in request.read_fds.iter() {
         let proxy = PosixIoProxy::new(*fd, conn.try_clone()?);
         let reader = BufReader::new(proxy);


### PR DESCRIPTION
On `main` arguments are not piped from the protobuf `ExecutorEnv` to the built env.

This PR fixes this issue, and additionally fixes a small number of other issues affecting `cargo risczero test`; discovered while working on https://github.com/risc0/RustCrypto-crypto-bigint/pull/3
