### PR TITLE
Change default PosixIo to use an empty vec for stdin

### DIFF
--- a/risc0/r0vm/src/lib.rs
+++ b/risc0/r0vm/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fs, path::PathBuf, rc::Rc};
+use std::{fs, io, path::PathBuf, rc::Rc};
 
 use clap::{Args, Parser, ValueEnum};
 use risc0_zkvm::{
@@ -45,6 +45,8 @@ struct Cli {
     prove_guest_errors: bool,
 
     /// File to read initial input from.
+    ///
+    /// Reads input from stdin is an initial input file is not provided.
     #[arg(long)]
     initial_input: Option<PathBuf>,
 
@@ -122,6 +124,8 @@ pub fn main() {
 
         if let Some(input) = args.initial_input.as_ref() {
             builder.stdin(fs::File::open(input).unwrap());
+        } else {
+            builder.stdin(io::stdin());
         }
 
         #[cfg(feature = "profiler")]

--- a/risc0/r0vm/src/lib.rs
+++ b/risc0/r0vm/src/lib.rs
@@ -46,7 +46,7 @@ struct Cli {
 
     /// File to read initial input from.
     ///
-    /// Reads input from stdin is an initial input file is not provided.
+    /// Reads input from stdin if an initial input file is not provided.
     #[arg(long)]
     initial_input: Option<PathBuf>,
 

--- a/risc0/zkvm/src/host/client/posix_io.rs
+++ b/risc0/zkvm/src/host/client/posix_io.rs
@@ -15,7 +15,7 @@
 use std::{
     cell::RefCell,
     collections::BTreeMap,
-    io::{stderr, stdin, stdout, BufRead, BufReader, Write},
+    io::{stderr, stdout, BufRead, Cursor, Write},
     rc::Rc,
 };
 
@@ -34,7 +34,7 @@ impl<'a> Default for PosixIo<'a> {
             read_fds: Default::default(),
             write_fds: Default::default(),
         };
-        new.with_read_fd(fileno::STDIN, BufReader::new(stdin()))
+        new.with_read_fd(fileno::STDIN, Cursor::new(vec![]))
             .with_write_fd(fileno::STDOUT, stdout())
             .with_write_fd(fileno::STDERR, stderr());
         new


### PR DESCRIPTION
This PR changes the default `PosixIo` struct to hook the guest `stdin` to an empty vector, instead of the current default which is to use the host process `stdin`. This resolves issue #1016, where it is easy to accidentally cause a difficult to debug hand on the process by forgetting to add an `ExectorEnvBuilder::write` call, resulting in the executor performing a blocking read on stdin.

Note that if a developer does indeed want the host process `stdin` to be used as guest `stdin`, they can accomplish this by calling `builder.stdin(std::io::stdin())` while building the `ExectorEnv`.

Related: #1050
Resolves: #1016
