### PR TITLE
Update p0tion hash

### DIFF
--- a/compact_proof/groth16/p0tionConfig.json
+++ b/compact_proof/groth16/p0tionConfig.json
@@ -14,7 +14,7 @@
       },
       "template": {
         "source": "https://github.com/risc0/risc0",
-        "commitHash": "60b9a10d381c5c027e40c8e7a7f71cfbdd0f4e78",
+        "commitHash": "41a0997a68ae288f5456238ca9ae9c2b68c37421",
         "paramsConfiguration": []
       },
       "verification": {


### PR DESCRIPTION
Update the commit hash for `risc0` in the p0tion configuration to a mainline commit that includes the verify circom files.

The description of https://github.com/risc0/risc0/pull/1175 has context for why this was needed.