### PR TITLE
Add missing verify call to Groth16

### DIFF
--- a/risc0/zkvm/src/host/receipt.rs
+++ b/risc0/zkvm/src/host/receipt.rs
@@ -381,6 +381,8 @@ impl Groth16Receipt {
             &Groth16Seal::from_vec(&self.seal).map_err(|_| VerificationError::InvalidProof)?,
             self.meta.digest().into(),
         )
+        .map_err(|_| VerificationError::InvalidProof)?
+        .verify()
         .map_err(|_| VerificationError::InvalidProof)?;
 
         // Everything passed


### PR DESCRIPTION
As pointed by @nategraf we somehow missed to add the actual `verify` call in the `verify_integrity` function.