### PR TITLE
feat: Profiling the exec's memory and elapsed time

### DIFF
--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -51,6 +51,7 @@ serde = { version = "1.0", default-features = false, features = [
   "alloc",
   "derive",
 ] }
+sysinfo = "0.29.1"
 
 # TODO(nils): Change these `target_os` checks to `target_vendor` checks when we
 # have a real target triple.


### PR DESCRIPTION
cd examples/hello-world
cargo run --features "prove"
The log will be like:
Memory used before exec: Ok(37126144)
Memory used after exec: Ok(53264384)
exec elapse = 105 ms
Memory usage after proving: Ok(475447296)
proving peak mem = 472385488, prove elapse = 37568 ms
I know the factors of 391, and I can prove it!

It means that, in exec, only ~20MB is used (However, the peak memory is not clear yet). The time is only 105 ms, much less than total proving time 37 sec.

