### PR TITLE
chore: put template hints inside a MD comment

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,15 +6,15 @@ labels: bug
 ---
 
 ## Bug Report
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 ## Steps to Reproduce
-1. ...
-2. ...
-3. ...
+1.
+2.
+3.
 
 ## Expected behavior
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 ## Your Environment
 - risc0-zkvm version:
@@ -22,4 +22,4 @@ A clear and concise description of what you expected to happen.
 - Platform/OS:
 
 ## Additional context
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,10 +6,10 @@ labels: enhancement
 ---
 
 ## Feature
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ## Motivation
-Why should this feature be implemented?
+<!-- Why should this feature be implemented? -->
 
 ## Implementation
-What needs to be built for the feature to be supported?
+<!-- What needs to be built for the feature to be supported? -->


### PR DESCRIPTION
It's a bit annoying to have to delete the hint/description lines for issues