### PR TITLE
chore: Include proving server version in error message

### DIFF
--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -231,7 +231,9 @@ impl Server {
             .try_into()
             .map_err(|err: semver::Error| anyhow!(err))?;
         if !check_client_version(&client_version, &server_version) {
-            let msg = format!("incompatible client version: {client_version}");
+            let msg = format!(
+                "incompatible client version: {client_version}, server version: {server_version}"
+            );
             tracing::debug!("{msg}");
             bail!(msg);
         }


### PR DESCRIPTION
This makes it easier to debug the inconsistency, and install a matching version of `cargo-risczero` if incompatible. If there are rules around compatibility of versions, it can be included in this message, but I couldn't find any.