### PR TITLE
Fix entrypoint for the staticlib build of risc0-zkvm-platform

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,15 +233,15 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "34665bc4830b602b7d1733df0a70bdbec21b796a9ee05371d49e40ef2527d301",
+            "b878dff7d006162aa90e0274fc9a38e309208800818cae8a04e00ca5f58f5a67",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "4076e323377cf083699a20181bf3bb76f14d69de1fce90683335469054c238b3",
+            "a6b43db4f3fccde98cf22bbe28d90cec97e56ed4ad8a1537cfb9dbd3cb24376f",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "3149778c9959f5ef1bb6117a5d4651c67e81efe41fb017ef6b27e5271634371c",
+            "892bb3ecb5f4e916136cdcdc463c75459cd8d68e6c9f13fa936c903a830f1ae8",
         );
     }
 }

--- a/risc0/zkvm/platform/src/rust_rt.rs
+++ b/risc0/zkvm/platform/src/rust_rt.rs
@@ -25,9 +25,7 @@ use core::{
     panic::PanicInfo,
 };
 
-use crate::syscall::sys_alloc_aligned;
-#[cfg(feature = "panic-handler")]
-use crate::syscall::sys_panic;
+use crate::syscall::{sys_alloc_aligned, sys_panic};
 
 extern crate alloc;
 

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -131,7 +131,7 @@ macro_rules! entry {
 
 #[cfg(target_os = "zkvm")]
 #[no_mangle]
-unsafe extern "C" fn __start() {
+unsafe extern "C" fn __start() -> ! {
     env::init();
 
     {
@@ -142,6 +142,7 @@ unsafe extern "C" fn __start() {
     }
 
     env::finalize(true, 0);
+    unreachable!();
 }
 
 #[cfg(target_os = "zkvm")]


### PR DESCRIPTION
Currently, the entrypoint defined in the `rust_rt.rs` file of `risc0-zkvm-platform` passes a null pointer to the `sys_halt` function to stop the program. When written, this was not detected as an error because there existed a bug in the `Executor` and no usage every attempted to prove a program linked with this entrypoint. The `rust_rt.rs` file contains functionality to create a statically linkable runtime for use in building programs that are not zkVM aware. Right now the only usage of this is to build and run Rust tests with `cargo risczero test`.

This PR fixes the entrypoint to pass a pointer to a constant array of `[0u32; 8]`. It also refactors the entrypoint assembly to match the one `risc0-zkvm::guest`, defining the `__start` symbol. It also refines the definition of the `__start` symbol in both locations to encode that it does not return. Returning from the `__start` symbol would cause undefined behavior.

This PR does not de-duplicate these two definitions. We still have some work to do on this front, but this PR does not seem like the time to address this.
