### PR TITLE
Add check for github references in version api docs

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,4 +20,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - run: npx prettier website --check
+      - run: python website/github-link-version-check.py

--- a/website/api/zkvm/developer-guide/host-code-101.md
+++ b/website/api/zkvm/developer-guide/host-code-101.md
@@ -69,15 +69,15 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 
 [Bonsai]: ../../bonsai/bonsai-overview.md
 [Discord]: https://discord.gg/risczero
-[examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[examples]: https://github.com/risc0/risc0/tree/release-0.18/examples
 [execute]: /terminology#execute
 [execution environment]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.ExecutorEnv.html
 [executor]: /terminology#executor
 [guest]: /terminology#guest
 [`guest` module]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest
 [guest program]: /terminology#guest-program
-[Hello World demo]: https://github.com/risc0/risc0/tree/v0.18.0/examples/hello-world
-[Hello World Tutorial]: https://github.com/risc0/risc0/blob/v0.18.0/examples/hello-world/tutorial
+[Hello World demo]: https://github.com/risc0/risc0/tree/release-0.18/examples/hello-world
+[Hello World Tutorial]: https://github.com/risc0/risc0/blob/release-0.18/examples/hello-world/tutorial
 [host]: /terminology#host
 [journal]: /terminology#journal
 [JSON demo]: https://github.com/risc0/risc0/blob/main/examples/json/src/main.rs

--- a/website/api_versioned_docs/version-0.18/bonsai/bonsai-overview.md
+++ b/website/api_versioned_docs/version-0.18/bonsai/bonsai-overview.md
@@ -82,4 +82,4 @@ We're building technology that allows anyone to generate highly performant zero-
 [Bonsai Quick Start]: ../bonsai/quickstart
 [Bonsai as a zk coprocessor]: https://twitter.com/RiscZero/status/1677316664772132864
 [Bonfire Wallet]: https://twitter.com/RiscZero/status/1673692915401629698
-[Governance Showcase]: https://github.com/risc0/risc0/tree/main/bonsai/examples/governance#readme
+[Governance Showcase]: https://github.com/risc0/risc0/tree/release-0.18/bonsai/examples/governance#readme

--- a/website/api_versioned_docs/version-0.18/introduction.md
+++ b/website/api_versioned_docs/version-0.18/introduction.md
@@ -71,11 +71,11 @@ These applications include:
 - **[ECDSA signature verification]**: prove the validity of an ECDSA signature
 
 [April 2022]: https://www.risczero.com/news/announce
-[JSON]: https://github.com/risc0/risc0/tree/v0.18.0/examples/json
+[JSON]: https://github.com/risc0/risc0/tree/release-0.18/examples/json
 [Where's Waldo]: https://risczero.com/news/waldo
-[ZK Checkmate]: https://github.com/risc0/risc0/tree/v0.18.0/examples/chess
+[ZK Checkmate]: https://github.com/risc0/risc0/tree/release-0.18/examples/chess
 [ZK Proof of Exploit]: https://risczero.com/news/zkpoex
-[ECDSA signature verification]: https://github.com/risc0/risc0/tree/v0.18.0/examples/ecdsa
+[ECDSA signature verification]: https://github.com/risc0/risc0/tree/release-0.18/examples/ecdsa
 
 These examples are all made possible by **leveraging a mature software ecosystem**: over 70% of the [top 1000 Rust crates] work out-of-the-box in the zkVM.
 Being able to import Rust crates is a game changer for the ZK software world: projects that would take months or years to build on other platforms can be solved trivially on our platform.

--- a/website/api_versioned_docs/version-0.18/zkvm/developer-guide/acceleration.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/developer-guide/acceleration.md
@@ -26,7 +26,7 @@ sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.6
 
 When using cryptography indirectly, e.g. via the `cookie`, `oauth2`, or `revm`, crates it may be possible to enable acceleration support without code changes by applying a [Cargo patch system](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section).
 
-An example of how to use these crates to accelerate ECDSA signature verification can be in the [ECDSA example](https://github.com/risc0/risc0/tree/v0.18.0/examples/ecdsa). Note the [use of the patched versions](https://github.com/risc0/risc0/blob/v0.18.0/examples/ecdsa/methods/guest/Cargo.toml#L13-L18) of `sha2`, `crypto-bigint` and `k256` crates used in the guest's `Cargo.toml`.
+An example of how to use these crates to accelerate ECDSA signature verification can be in the [ECDSA example](https://github.com/risc0/risc0/tree/release-0.18/examples/ecdsa). Note the [use of the patched versions](https://github.com/risc0/risc0/blob/release-0.18/examples/ecdsa/methods/guest/Cargo.toml#L13-L18) of `sha2`, `crypto-bigint` and `k256` crates used in the guest's `Cargo.toml`.
 
 ## Adding Accelerator Support To Crates
 

--- a/website/api_versioned_docs/version-0.18/zkvm/developer-guide/guest-code-101.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/developer-guide/guest-code-101.md
@@ -86,13 +86,13 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [method]: /terminology#method
 [zkVM Quick Start]: ../quickstart.md
 [zkVM Overview]: ../zkvm_overview.md
-[Hello World demo]: https://github.com/risc0/risc0/tree/main/examples/hello-world
-[risc0/examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples/
+[Hello World demo]: https://github.com/risc0/risc0/tree/release-0.18/examples/hello-world
+[risc0/examples]: https://github.com/risc0/risc0/tree/release-0.18/examples/
 [guest environment commands]: https://docs.rs/risc0-zkvm/0.18.0/risc0_zkvm/guest/index.html
 [zkVM Application]: ../
 [zkVM]: ../
 [Bonsai]: ../../bonsai/
-[template]: https://github.com/risc0/risc0/tree/v0.18.0/templates/rust-starter
-[examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples/
+[template]: https://github.com/risc0/risc0/tree/release-0.18/templates/rust-starter
+[examples]: https://github.com/risc0/risc0/tree/release-0.18/examples/
 [these docs]: https://github.com/risc0/website
 [Discord]: https://discord.gg/risczero

--- a/website/api_versioned_docs/version-0.18/zkvm/developer-guide/host-code-101.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/developer-guide/host-code-101.md
@@ -69,18 +69,18 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 
 [Bonsai]: ../../bonsai/
 [Discord]: https://discord.gg/risczero
-[examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples/
+[examples]: https://github.com/risc0/risc0/tree/release-0.18/examples/
 [execute]: /terminology#execute
 [execution environment]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.ExecutorEnv.html
 [executor]: /terminology#executor
 [guest]: /terminology#guest
 [`guest` module]: https://docs.rs/risc0-zkvm/0.18/risc0_zkvm/guest
 [guest program]: /terminology#guest-program
-[Hello World demo]: https://github.com/risc0/risc0/tree/v0.18.0/examples/hello-world
-[Hello World Tutorial]: https://github.com/risc0/risc0/blob/v0.18.0/examples/hello-world/tutorial.md
+[Hello World demo]: https://github.com/risc0/risc0/tree/release-0.18/examples/hello-world
+[Hello World Tutorial]: https://github.com/risc0/risc0/blob/release-0.18/examples/hello-world/tutorial.md
 [host]: /terminology#host
 [journal]: /terminology#journal
-[JSON demo]: https://github.com/risc0/risc0/blob/main/examples/json/src/main.rs
+[JSON demo]: https://github.com/risc0/risc0/blob/release-0.18/examples/json/src/main.rs
 [method]: /terminology#method
 [prove]: /terminology#prove
 [Prover]: /terminology#prover

--- a/website/api_versioned_docs/version-0.18/zkvm/developer-guide/receipts.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/developer-guide/receipts.md
@@ -73,7 +73,7 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [receipt.journal]: https://docs.rs/risc0-zkvm/0.18/risc0_zkvm/struct.Receipt.html#structfield.journal
 [verify]: /terminology#verify
 [Verifying]: /terminology#verify
-[examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples/
+[examples]: https://github.com/risc0/risc0/tree/release-0.18/examples/
 [these docs]: https://github.com/risc0/website
 [Discord]: https://discord.gg/risczero
 [zkVM Quick Start]: ../quickstart

--- a/website/api_versioned_docs/version-0.18/zkvm/quickstart.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/quickstart.md
@@ -26,7 +26,7 @@ If you need to install Rust or encounter problems, take a look at our [full inst
 ## 2. Initialize a New Project
 
 Once you've installed the toolchain, you can initialize a new project using the [starter template] by running:
-[starter template]: https://github.com/risc0/risc0/tree/main/templates/rust-starter
+[starter template]: https://github.com/risc0/risc0/tree/release-0.18/templates/rust-starter
 
 ```bash
 cargo risczero new my_project
@@ -63,7 +63,7 @@ The readme files on the [zkVM demo applications] show `cargo` commands for local
 ### Remote Proving
 
 To run the zkVM remotely using [Bonsai], [request access] and set the environment variables `BONSAI_API_KEY=<YOUR_API_KEY>` and `BONSAI_API_URL=<BONSAI_URL>`.
-Additional information is available in the [starter template](https://github.com/risc0/risc0/tree/main/templates/rust-starter#running-proofs-remotely-on-bonsai)
+Additional information is available in the [starter template](https://github.com/risc0/risc0/tree/release-0.18/templates/rust-starter#running-proofs-remotely-on-bonsai)
 
 ### Other options
 
@@ -74,9 +74,9 @@ Options such as GPU acceleration and skipping the proof generation are documente
 [Bonsai]: ../bonsai/bonsai-overview.md
 [install]: ./install.md
 [feature flags]: https://github.com/risc0/risc0#feature-flags
-[zkVM demo applications]: https://github.com/risc0/risc0/tree/v0.18.0/examples/
+[zkVM demo applications]: https://github.com/risc0/risc0/tree/release-0.18/examples/
 [cargo risczero]: https://docs.rs/cargo-risczero
-[Hello World tutorial]: https://github.com/risc0/risc0/tree/main/examples/hello-world/tutorial.md
-[demo applications]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[Hello World tutorial]: https://github.com/risc0/risc0/tree/release-0.18/examples/hello-world/tutorial.md
+[demo applications]: https://github.com/risc0/risc0/tree/release-0.18/examples
 [Bonsai Quick Start]: ../../bonsai/quickstart
 [request access]: https://bonsai.xyz/apply

--- a/website/api_versioned_docs/version-0.18/zkvm/zkvm_overview.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/zkvm_overview.md
@@ -21,8 +21,8 @@ Our demos show how to:
 [revm]: https://github.com/bluealloy/revm
 [ethers]: https://github.com/ethers-io/ethers.js
 [alloy]: https://github.com/alloy-rs
-[prove mate-in-one]: https://github.com/risc0/risc0/tree/v0.18.0/examples/chess#zk-checkmate
-[proofs about private data]: https://github.com/risc0/risc0/tree/main/examples/json#json-example
+[prove mate-in-one]: https://github.com/risc0/risc0/tree/release-0.18/examples/chess#zk-checkmate
+[proofs about private data]: https://github.com/risc0/risc0/tree/release-0.18/examples/json#json-example
 [prove you can find Waldo]: https://www.risczero.com/news/waldo
 [prove correct construction of Ethereum blocks]: https://risczero.com/news/zeth-release
 
@@ -103,6 +103,6 @@ Read the [article](https://risczero.com/news/zeth-release).
 [zero-knowledge virtual machine]: /terminology#zero-knowledge-virtual-machine-zkvm
 [zkvm]: https://github.com/risc0/risc0#readme
 [zkVM Quick Start]: ./quickstart.md
-[zkVM example applications]: https://github.com/risc0/risc0/tree/v0.18.0/examples
+[zkVM example applications]: https://github.com/risc0/risc0/tree/release-0.18/examples
 [session]: /terminology#session
 [Host Code 101]: developer-guide/host-code-101

--- a/website/api_versioned_docs/version-0.19/bonsai/bonsai-on-eth.md
+++ b/website/api_versioned_docs/version-0.19/bonsai/bonsai-on-eth.md
@@ -30,8 +30,8 @@ At a high level, here's how it works:
    3. Sends the journal and image ID in a callback to your application contract.
 
 [Groth16 SNARK]: https://www.risczero.com/news/on-chain-verification
-[`BonsaiRelay` contract]: https://github.com/risc0/risc0/blob/main/bonsai/ethereum/contracts/BonsaiRelay.sol
-[`IRiscZeroVerifier` contract]: https://github.com/risc0/risc0/blob/main/bonsai/ethereum/contracts/IRiscZeroVerifier.sol
+[`BonsaiRelay` contract]: https://github.com/risc0/risc0/blob/release-0.19/bonsai/ethereum/contracts/BonsaiRelay.sol
+[`IRiscZeroVerifier` contract]: https://github.com/risc0/risc0/blob/release-0.19/bonsai/ethereum/contracts/IRiscZeroVerifier.sol
 [guest program]: /terminology#guest-program
 [receipt]: /terminology#receipt
 [zk coprocessor]: https://twitter.com/RiscZero/status/1677316664772132864
@@ -61,7 +61,7 @@ An example for sending a callback request via the REST API can be found in the [
 
 [REST]: https://en.wikipedia.org/wiki/REST
 [Bonsai Relay SDK]: https://docs.rs/crate/bonsai-ethereum-relay/latest
-[relay directory of the Bonsai Foundry Template]: https://github.com/risc0/bonsai-foundry-template/blob/main/relay/examples/offchain_request.rs
+[relay directory of the Bonsai Foundry Template]: https://github.com/risc0/bonsai-foundry-template/blob/release-0.19/relay/examples/offchain_request.rs
 
 ### On-chain Requests
 
@@ -73,7 +73,7 @@ With on-chain requests, the application smart contract can directly issue reques
 
 An example of sending a request on-chain can be found in the [starter contract of the Bonsai Foundry Template].
 
-[starter contract of the Bonsai Foundry Template]: https://github.com/risc0/bonsai-foundry-template/blob/main/contracts/BonsaiStarter.sol#L60-L68
+[starter contract of the Bonsai Foundry Template]: https://github.com/risc0/bonsai-foundry-template/blob/release-0.19/contracts/BonsaiStarter.sol#L60-L68
 
 ## Verifier Contract
 
@@ -93,6 +93,6 @@ The [Bonsai SDK] provides support for sending requests to the Bonsai proving ser
 You may also want to check out our [Bonsai Quick Start](quickstart.md) page and/or the [Bonsai Overview](../bonsai).
 
 [Bonsai SDK]: https://docs.rs/bonsai-sdk/latest/bonsai_sdk/
-[`IRiscZeroVerifier` interface]: https://github.com/risc0/risc0/blob/main/bonsai/ethereum/contracts/IRiscZeroVerifier.sol
-[`RiscZeroGroth16Verifier` contract]: https://github.com/risc0/risc0/blob/main/bonsai/ethereum/contracts/groth16/RiscZeroGroth16Verifier.sol
+[`IRiscZeroVerifier` interface]: https://github.com/risc0/risc0/blob/release-0.19/bonsai/ethereum/contracts/IRiscZeroVerifier.sol
+[`RiscZeroGroth16Verifier` contract]: https://github.com/risc0/risc0/blob/release-0.19/bonsai/ethereum/contracts/groth16/RiscZeroGroth16Verifier.sol
 [described above]: #bonsai-relay

--- a/website/api_versioned_docs/version-0.19/bonsai/bonsai-overview.md
+++ b/website/api_versioned_docs/version-0.19/bonsai/bonsai-overview.md
@@ -80,7 +80,7 @@ We're building technology that allows anyone to generate highly performant zero-
 [Bonsai REST API]: https://api.bonsai.xyz/swagger-ui/
 [Bonsai Quick Start]: quickstart.md
 [Bonsai as a zk coprocessor]: https://twitter.com/RiscZero/status/1677316664772132864
-[Governance Showcase]: https://github.com/risc0/risc0/tree/main/bonsai/examples/governance#readme
+[Governance Showcase]: https://github.com/risc0/risc0/tree/release-0.19/bonsai/examples/governance#readme
 [Zeth]: https://www.risczero.com/news/zeth-release
 [guest program]: /terminology#guest-program
 [receipt]: /terminology#receipt

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/host-code-101.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/host-code-101.md
@@ -80,7 +80,7 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [Hello World Tutorial]: https://github.com/risc0/risc0/blob/release-0.19/examples/hello-world/tutorial
 [host]: /terminology#host
 [journal]: /terminology#journal
-[JSON demo]: https://github.com/risc0/risc0/blob/main/examples/json/src/main.rs
+[JSON demo]: https://github.com/risc0/risc0/blob/release-0.19/examples/json/src/main.rs
 [method]: /terminology#method
 [prove]: /terminology#prove
 [Prover]: /terminology#prover

--- a/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
@@ -98,7 +98,7 @@ If you're ready to start building more complex projects, we recommend taking a l
 
 [Installation]: ../install
 [cargo risczero]: https://docs.rs/cargo-risczero
-[examples directory]: https://github.com/risc0/risc0/tree/main/examples
+[examples directory]: https://github.com/risc0/risc0/tree/release-0.19/examples
 [host]: /terminology#host-program
 [guest]: terminology#guest-program
 [receipt]: /terminology#receipt

--- a/website/github-link-version-check.py
+++ b/website/github-link-version-check.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import sys
+import os
+from pathlib import Path
+import subprocess
+import re
+
+EXTENSIONS = [
+    '.md',
+]
+
+VERSIONED_DOCS_DIR = "website/api_versioned_docs"
+VERSIONED_PATH_RE = re.compile(r"api_versioned_docs/version-(?P<version>\d+\.\d+)")
+GITHUB_LINK_RE = re.compile(r"github\.com/risc0/risc0/(?:tree|blob)/(?P<ref>\S+?)/")
+
+def check_file(root, file):
+    rel_path = file.relative_to(root)
+
+    match = VERSIONED_PATH_RE.search(str(rel_path))
+    if match is None:
+        print(f'{rel_path}: could not determine version from path')
+        return 1
+    version = match.group('version')
+    expected_ref = f"release-{version}"
+
+    status = 0
+    lines = file.read_text().splitlines()
+    for (linenum, line) in enumerate(lines, 1):
+        for link in GITHUB_LINK_RE.finditer(line):
+            ref = link.group('ref')
+            if ref != expected_ref:
+                print(f"{rel_path}:{linenum}\ngithub link to git ref {ref}; expected {expected_ref}\n")
+                status = 1
+    return status
+
+
+def repo_root():
+    """Return an absolute Path to the repo root"""
+    cmd = ["git", "rev-parse", "--show-toplevel"]
+    return Path(subprocess.check_output(cmd, encoding='UTF-8').strip())
+
+
+def tracked_files_in(directory):
+    """Yield file paths tracked by git within a directory"""
+    cmd = ["git", "ls-tree", "--full-tree", "--name-only", "-r", "HEAD", directory]
+    tree = subprocess.check_output(cmd, encoding='UTF-8').strip()
+    for path in tree.splitlines():
+        yield (repo_root() / Path(path)).absolute()
+
+
+def main():
+    root = repo_root()
+    ret = 0
+    for path in tracked_files_in(VERSIONED_DOCS_DIR):
+        if path.suffix in EXTENSIONS:
+            ret |= check_file(root, path)
+    sys.exit(ret)
+
+
+if __name__ == "__main__":
+    main()

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "fmt": "prettier . --write",
+    "check-github-link-versions": "python ./github-link-version-check.py",
+    "lint": "prettier . --check && python ./github-link-version-check.py",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",


### PR DESCRIPTION
Working on the docs, I noticed quite a few links to GitHub not using the correctly pinned version reference (I also contributed to this). I wrote up a quick script, starting from the `license-check.py` script, to look for github links in the versioned API docs and ensure they reference the release branch corresponding to their directory. I've added this rule as a check in CI.
