### PR TITLE
allocator: fix dead code and honor alignment requests larger than WORD_SIZE

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,15 +233,15 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "5da14c3a9cfe2fcae7261c30349e034a2c0d3fd730bc2ad26670ccfc3bd2a9cd",
+            "f95f1a062cc386bcebe950e093c05b2064d0938d63c5522e7762618200204b29",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "c9c5515b3ce24519fef4fa31e3ce21ad2c6dd6c929488ba326501f046daebdf5",
+            "d79504add318b06cb7150c0434b7fafaffe8c93c001271bb3c3d956b7b6a476f",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "d9b1851f6fe353ab54427920822fe4b6e70769c9f74028e5aa33044e014ff95a",
+            "0cdb7e93db5ce17d5646c7330fa3ffc86ef4433733a2965422a232e4ee330547",
         );
     }
 }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -241,7 +241,7 @@ mod test {
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "cbf8d6310a3e1159a36804d1964e2d95ef87e24015ff33ca7d05ca28b0fbcc21"
+            "cbf8d6310a3e1159a36804d1964e2d95ef87e24015ff33ca7d05ca28b0fbcc21",
         );
     }
 }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,15 +233,15 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "b878dff7d006162aa90e0274fc9a38e309208800818cae8a04e00ca5f58f5a67",
+            "77f1b664212b5b02dbfa7d31ba5d960a5457efb7ff17ef1f3d2197b4548319bc",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "a6b43db4f3fccde98cf22bbe28d90cec97e56ed4ad8a1537cfb9dbd3cb24376f",
+            "ae0ad33e492946ffcd0d7e8b895e795768ec3b74171361b929c0176329c8d214",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "892bb3ecb5f4e916136cdcdc463c75459cd8d68e6c9f13fa936c903a830f1ae8",
+            "cbf8d6310a3e1159a36804d1964e2d95ef87e24015ff33ca7d05ca28b0fbcc21"
         );
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -32,7 +32,7 @@ use risc0_zkvm::{
 use risc0_zkvm_methods::multi_test::{MultiTestSpec, SYS_MULTI_TEST};
 use risc0_zkvm_platform::{
     fileno,
-    memory::{self, SYSTEM},
+    memory::{self, SYSTEM}, PAGE_SIZE,
     syscall::{bigint, sys_bigint, sys_log, sys_read, sys_read_words, sys_write},
 };
 
@@ -266,6 +266,20 @@ pub fn main() {
         MultiTestSpec::SysLogInvalidAddr => unsafe {
             let addr: *const u8 = SYSTEM.start() as _;
             sys_log(addr, 100);
+        },
+        MultiTestSpec::AlignedAlloc => {
+            #[repr(align(1024))]
+            struct AlignTest1 { pub _test: u32 }
+
+            impl AlignTest1 {
+                pub fn new(_test: u32) -> Self {
+                    AlignTest1{_test}
+                }
+            }
+
+            let a = &AlignTest1::new(54) as *const _;
+            let b = &AlignTest1::new(60) as *const _;
+            assert_eq!(PAGE_SIZE, b as usize - a as usize);
         },
     }
 }

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -87,6 +87,7 @@ pub enum MultiTestSpec {
     RsaCompat,
     SysLogInvalidAddr,
     TooManySha,
+    AlignedAlloc,
 }
 
 declare_syscall!(pub SYS_MULTI_TEST);

--- a/risc0/zkvm/platform/src/syscall.rs
+++ b/risc0/zkvm/platform/src/syscall.rs
@@ -672,13 +672,14 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
         heap_pos = unsafe { (&_end) as *const u8 as usize };
     }
 
+    // Honor requested alignment if larger than word size.
+    // Note: align is typically a power of two.
+    let align = usize::max(align, WORD_SIZE);
+
     let offset = heap_pos & (align - 1);
     if offset != 0 {
         heap_pos += align - offset;
     }
-
-    // Ensure all allocations are minimally aligned to a word boundary.
-    let align = usize::min(align, WORD_SIZE);
 
     let ptr = heap_pos as *mut u8;
     heap_pos += bytes;

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -1164,7 +1164,7 @@ mod docker {
         let err = run_session(0, 16, 0).err().unwrap();
         assert!(err.to_string().contains("Session limit exceeded"));
 
-        assert!(run_session(0, 16, 1).is_ok());
+        assert!(run_session(0, 16, 2).is_ok());
 
         let err = run_session(1 << 16, 16, 1).err().unwrap();
         assert!(err.to_string().contains("Session limit exceeded"));

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -1050,6 +1050,11 @@ fn post_state_digest_randomization() {
 }
 
 #[test]
+fn aligned_alloc() {
+    run_test(MultiTestSpec::AlignedAlloc);
+}
+
+#[test]
 #[should_panic(expected = "cycle count too large")]
 fn too_many_sha() {
     run_test(MultiTestSpec::TooManySha);


### PR DESCRIPTION
There are cases where guest code might request allocations with alignments greater than WORD_SIZE. For example, aligning a struct to a page boundary could help with locality when accessing those structures.

Fixes: https://github.com/risc0/risc0/issues/1209