### PR TITLE
guest: make relax architecture version for memcpy and memset

### DIFF
--- a/risc0/zkvm/src/guest/memcpy.s
+++ b/risc0/zkvm/src/guest/memcpy.s
@@ -203,7 +203,7 @@
 // obstacle to adoption, that text has been removed.
 	.text
 	.attribute	4, 16
-	.attribute	5, "rv32i2p0_m2p0"
+	.attribute	5, "rv32im"
 	.file	"musl_memcpy.c"
 	.globl	memcpy
 	.p2align	2

--- a/risc0/zkvm/src/guest/memset.s
+++ b/risc0/zkvm/src/guest/memset.s
@@ -203,7 +203,7 @@
 // obstacle to adoption, that text has been removed.
 	.text
 	.attribute	4, 16
-	.attribute	5, "rv32i2p0_m2p0"
+	.attribute	5, "rv32im"
 	.file	"musl_memset.c"
 	.globl	memset
 	.p2align	2


### PR DESCRIPTION
Projects such as llvm require code to conform to rv32i2p1_m2p0 and no longer support rv32i2p0_m2p0. This breaks compilation when these files are linked by llvm giving errors like so:

```
error: invalid arch name 'rv32i2p0_m2p0', unsupported version number 2.0 for extension 'i'
        .attribute      5, "rv32i2p0_m2p0"
                           ^
```

This change relaxes the architecture versioning by dropping the version numbers for each feature and using `rv32im` instead. By doing so, we will be able to use newer versions of rust and llvm to generate the guest code.