### PR TITLE
Rename get_cycle_count to cycle_count

### DIFF
--- a/examples/ecdsa/methods/guest/src/bin/benchmark.rs
+++ b/examples/ecdsa/methods/guest/src/bin/benchmark.rs
@@ -32,11 +32,11 @@ fn bench<T>(name: &str, func: impl Fn() -> T) {
     // order to exclude paged-in operations from the benchmark count.
     black_box(func());
 
-    let start = env::get_cycle_count();
+    let start = env::cycle_count();
 
     black_box(func());
 
-    let end = env::get_cycle_count();
+    let end = env::cycle_count();
     println!("{}: {} cycles", name, end - start)
 }
 

--- a/examples/smartcore-ml/methods/guest/src/main.rs
+++ b/examples/smartcore-ml/methods/guest/src/main.rs
@@ -76,7 +76,7 @@ pub fn main() {
         env::commit(&y_hat);
     }
     // Logging the total cycle count is optional, though it's quite useful for benchmarking
-    // the various operations in the guest code. env::get_cycle_count() can be
+    // the various operations in the guest code. env::cycle_count() can be
     // called anywhere in the guest, multiple times. So if we are interested in
     // knowing how many cycles the inference computation takes, we can calculate
     // total cycles before and after model.predict() and the difference between
@@ -84,6 +84,6 @@ pub fn main() {
     // code.
     println!(
         "Total cycles for guest code execution: {}",
-        env::get_cycle_count()
+        env::cycle_count()
     );
 }

--- a/examples/xgboost/methods/guest/src/main.rs
+++ b/examples/xgboost/methods/guest/src/main.rs
@@ -51,5 +51,5 @@ pub fn main() {
     env::commit(&answer);
 
     // If you want to obtain total cycle count to bechnmark performance, you can use the code below.
-    println!("cycles: {}", env::get_cycle_count());
+    println!("cycles: {}", env::cycle_count());
 }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,7 +233,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "1179a5fefa42c0ffd9c9defacb007f0e5c3b91b008726f1c334333e62998b1fd",
+            "66f36413a9473d0d1d98caf01377ede9f8dc20b56e1584c24bda924254d0d74f",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
@@ -241,7 +241,7 @@ mod test {
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "fcc440cb194deb4741cc6c919acad75cf95c8b548191b90ebd748fe644bd26fc",
+            "6ac797046e2287c3526eb8e111a6c31c6eacbe9f37a4cdc8d2b727170de51904",
         );
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -60,13 +60,13 @@ pub fn main() {
             // see when it's a custom circuit.
             let a: &Digest = &Digest::from([1, 2, 3, 4, 5, 6, 7, 8]);
 
-            let count1 = env::get_cycle_count();
+            let count1 = env::cycle_count();
             memory_barrier(&count1);
-            let count2 = env::get_cycle_count();
+            let count2 = env::cycle_count();
             memory_barrier(&count2);
             let result = sha::Impl::hash_pair(a, a);
             memory_barrier(&result);
-            let count3 = env::get_cycle_count();
+            let count3 = env::cycle_count();
             memory_barrier(&count3);
 
             let overhead = count2 - count1;
@@ -197,14 +197,14 @@ pub fn main() {
             env::commit_slice(&buf);
         }
         MultiTestSpec::BusyLoop { cycles } => {
-            let mut last_cycles = env::get_cycle_count();
+            let mut last_cycles = env::cycle_count();
 
             // Count all the cycles that have happened so far before we got to this point.
             env::log("Busy loop starting!");
             let mut tot_cycles = last_cycles;
 
             while tot_cycles < cycles as usize {
-                let now_cycles = env::get_cycle_count();
+                let now_cycles = env::cycle_count();
                 if now_cycles <= last_cycles {
                     // Cycle count may have reset or wrapped around.
                     // Since we don't know which, just start counting

--- a/risc0/zkvm/src/guest/env.rs
+++ b/risc0/zkvm/src/guest/env.rs
@@ -329,7 +329,9 @@ pub fn commit_slice<T: Pod>(slice: &[T]) {
 
 /// Return the number of processor cycles that have occurred since the guest
 /// began.
-pub fn get_cycle_count() -> usize {
+///
+/// WARNING: The cycle count is provided by the host and is not checked by the zkVM circuit.
+pub fn cycle_count() -> usize {
     sys_cycle_count()
 }
 

--- a/website/api/zkvm/developer-guide/guest-code-101.md
+++ b/website/api/zkvm/developer-guide/guest-code-101.md
@@ -47,12 +47,12 @@ To support various use cases, there are a number of functions that can be called
 There are also a number of functions available to support with debugging and performance analysis. As above, we refer to the [`guest` module] for a full list, but include some highlights here:
 
 - **Count Cycles** <br/>
-  [`env::get_cycle_count`]
+  [`env::cycle_count`]
 
 - **Print a debug message**<br/>
   [`env::log`]
 
-[`env::get_cycle_count`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.get_cycle_count.html
+[`env::cycle_count`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.cycle_count.html
 [`env::log`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.log.html
 
 For more information on optimization & performance, see our pages on [Cryptography Acceleration](acceleration.md) and [Benchmarking](../benchmarks.md).

--- a/website/api/zkvm/developer-guide/optimization.md
+++ b/website/api/zkvm/developer-guide/optimization.md
@@ -53,7 +53,7 @@ This is generally referred to as [Amdahl’s Law](https://en.wikipedia.org/wiki/
 
 Starting simple, measure by adding an `eprintln!` line to your guest code to measure how long an operation takes, and how many times it is called.
 
-Using [`env::get_cycle_count()`] will tell you the current number of execution cycles that have occurred in your program.
+Using [`env::cycle_count()`] will tell you the current number of execution cycles that have occurred in your program.
 
 As an example:
 
@@ -62,12 +62,12 @@ As an example:
 ```rust no_run title="methods/guest/src/main.rs"
 # use risc0_zkvm::guest::env;
 fn my_operation_to_measure() {
-  let start = env::get_cycle_count();
+  let start = env::cycle_count();
 
   // potentially expensive or frequently called code
   // ...
 
-  let end = env::get_cycle_count();
+  let end = env::cycle_count();
   eprintln!("my_operation_to_measure: {}", end - start);
 }
 ```
@@ -75,7 +75,7 @@ fn my_operation_to_measure() {
 When you run your guest, you’ll see a printout of the cycle count each time that function is called.
 You can then analyze this data easily with a tool like [`counts`].
 
-[`env::get_cycle_count()`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.get_cycle_count.html
+[`env::cycle_count()`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.cycle_count.html
 [`counts`]: https://github.com/nnethercote/counts/
 
 ### Profiling

--- a/website/api/zkvm/developer-guide/optimization.md
+++ b/website/api/zkvm/developer-guide/optimization.md
@@ -75,7 +75,7 @@ fn my_operation_to_measure() {
 When you run your guest, you’ll see a printout of the cycle count each time that function is called.
 You can then analyze this data easily with a tool like [`counts`].
 
-[`env::cycle_count()`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.cycle_count.html
+[`env::cycle_count()`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.cycle_count.html
 [`counts`]: https://github.com/nnethercote/counts/
 
 ### Profiling
@@ -115,7 +115,7 @@ Documentation for `pprof`: [github.com/google/pprof](https://github.com/google/p
 [perf]: https://perf.wiki.kernel.org/index.php/Main_Page
 [Sampling CPU profilers]: https://nikhilism.com/post/2018/sampling-profiler-internals-introduction/
 [flamegraph]: https://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html
-[ECDSA verification example]: https://github.com/risc0/risc0/tree/v0.19.0/examples/ecdsa
+[ECDSA verification example]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
 [installing Go]: https://go.dev/doc/install
 
 ## Key Differences
@@ -278,10 +278,10 @@ let env = ExecutorEnv::builder()
 ```
 
 [`env::read`]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/guest/env/fn.read.html
-[snippet from the password checker example]: https://github.com/risc0/risc0/blob/v0.19.0/examples/password-checker/methods/guest/src/main.rs#L24
-[`env::read_slice`]: https://docs.rs/risc0-zkvm/0.19/risc0_zkvm/guest/env/fn.read_slice.html
+[snippet from the password checker example]: https://github.com/risc0/risc0/blob/main/examples/password-checker/methods/guest/src/main.rs#L24
+[`env::read_slice`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.read_slice.html
 [CBOR]: https://cbor.io/
-[snippet from the Bonsai Governance example]: https://github.com/risc0/risc0/blob/v0.19.0/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs#L88-L90
+[snippet from the Bonsai Governance example]: https://github.com/risc0/risc0/blob/main/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs#L88-L90
 
 ### When you only need part of the input data, try Merklizing it
 
@@ -294,7 +294,7 @@ The guest verifies that the chunk is indeed part of the image by verifying the M
 If you are writing a guest with a large input, and only part of it is needed for the computation, consider splitting it into some notion of a chunks and building it as a Merkle tree.
 You can use the [code for Where’s Waldo] as a starting point.
 
-[Where’s Waldo]: https://github.com/risc0/risc0/tree/v0.19.0/examples/waldo
+[Where’s Waldo]: https://github.com/risc0/risc0/tree/main/examples/waldo
 [code for Where’s Waldo]: https://github.com/risc0/risc0/blob/main/examples/waldo/core/src/merkle.rs
 
 ### Cryptography in the guest can utilize accelerator circuits
@@ -447,7 +447,7 @@ A short description and associated cycle counts are listed below.
     In zkVM execution, executions are generally short and all execution is synchronous and is not subject to any deviations in behavior due to measurement overhead.
 <!-- prettier-ignore-end -->
 
-[^3]: An implementation of cycle-accounting for paging operations is implemented in the [Executor](https://github.com/risc0/risc0/blob/v0.19.0/risc0/zkvm/src/host/server/exec/monitor.rs#L30-L39). (Link is to v0.19.0)
+[^3]: An implementation of cycle-accounting for paging operations is implemented in the [Executor](https://github.com/risc0/risc0/blob/main/risc0/zkvm/src/host/server/exec/monitor.rs#L30-L39).
 [^4]:
     This is similar to the cryptography support such as [AES-NI](https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors) or the [SHA extensions](https://en.wikipedia.org/wiki/Intel_SHA_extensions) for x86 processors.
     In both cases, the circuitry is extended to compute otherwise expensive operations in fewer instruction cycles.


### PR DESCRIPTION
Rust naming guidelines recommend C-GETTER conventions for "getter function". This PR renames `env::get_cycle_count` to `env::cycle_count` to follow these guidelines

https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter
