### PR TITLE
sys_log: add newline after printing message for cleanliness

### DIFF
--- a/risc0/zkvm/src/host/server/exec/syscall.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall.rs
@@ -618,7 +618,7 @@ impl<'a> PosixIo<'a> {
         let msg = format!("R0VM[{}] ", ctx.get_cycle().to_string());
         writer
             .borrow_mut()
-            .write_all(&[msg.as_bytes(), &from_guest].concat())?;
+            .write_all(&[msg.as_bytes(), &from_guest, "\n".as_bytes()].concat())?;
         Ok((0, 0))
     }
 }

--- a/risc0/zkvm/src/host/server/exec/syscall.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall.rs
@@ -618,7 +618,7 @@ impl<'a> PosixIo<'a> {
         let msg = format!("R0VM[{}] ", ctx.get_cycle().to_string());
         writer
             .borrow_mut()
-            .write_all(&[msg.as_bytes(), &from_guest, "\n".as_bytes()].concat())?;
+            .write_all(&[msg.as_bytes(), &from_guest, b"\n"].concat())?;
         Ok((0, 0))
     }
 }


### PR DESCRIPTION
`sys_log` doesn't insert a newline and makes the terminal output messy. Add a newline for cleaner output.