### PR TITLE
Simplify entrypoint and main for std guests

### DIFF
--- a/benchmarks/methods/guest/src/bin/big_blake2b.rs
+++ b/benchmarks/methods/guest/src/bin/big_blake2b.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkp::core::hash::blake2b::{Blake2b, Blake2bCpuImpl};
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let data: Vec<u8> = env::read();
     let hash = Blake2bCpuImpl::blake2b(&data);
     let digest: Digest = hash.into();

--- a/benchmarks/methods/guest/src/bin/big_blake3.rs
+++ b/benchmarks/methods/guest/src/bin/big_blake3.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let data: Vec<u8> = env::read();
     let hash = blake3::hash(&data);
     let digest = Digest::try_from(*hash.as_bytes()).unwrap();

--- a/benchmarks/methods/guest/src/bin/big_keccak.rs
+++ b/benchmarks/methods/guest/src/bin/big_keccak.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha3::{Digest as _, Keccak256};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let data: Vec<u8> = env::read();
     let hash = keccak(&data);
     let digest = Digest::try_from(hash).unwrap();

--- a/benchmarks/methods/guest/src/bin/big_sha2.rs
+++ b/benchmarks/methods/guest/src/bin/big_sha2.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::{guest::env, sha, sha::Sha256};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let data: Vec<u8> = env::read();
     let hash = sha::Impl::hash_bytes(&data);
     env::commit(hash)

--- a/benchmarks/methods/guest/src/bin/fibonacci.rs
+++ b/benchmarks/methods/guest/src/bin/fibonacci.rs
@@ -15,12 +15,12 @@
 use nalgebra::Matrix2;
 use risc0_zkvm::guest::env;
 
-pub fn main() {
+fn main() {
     let iterations: u32 = env::read();
     let answer = fibonacci(iterations);
     env::commit(&answer);
 }
 
-pub fn fibonacci(n: u32) -> u64 {
+fn fibonacci(n: u32) -> u64 {
     Matrix2::new(1, 1, 1, 0).pow(n - 1)[(0, 0)]
 }

--- a/benchmarks/methods/guest/src/bin/iter_blake2b.rs
+++ b/benchmarks/methods/guest/src/bin/iter_blake2b.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkp::core::hash::blake2b::{Blake2b, Blake2bCpuImpl};
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 
     let mut hash = Blake2bCpuImpl::blake2b(&data);

--- a/benchmarks/methods/guest/src/bin/iter_blake3.rs
+++ b/benchmarks/methods/guest/src/bin/iter_blake3.rs
@@ -11,13 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![no_main]
 
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 
     let mut output = blake3::hash(&data);

--- a/benchmarks/methods/guest/src/bin/iter_keccak.rs
+++ b/benchmarks/methods/guest/src/bin/iter_keccak.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha3::{Digest as _, Keccak256};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 
     let mut hash = keccak(&data);

--- a/benchmarks/methods/guest/src/bin/iter_pedersen.rs
+++ b/benchmarks/methods/guest/src/bin/iter_pedersen.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use core::hint::black_box;
 use risc0_zkvm::{guest::env, sha::Digest};
 use starknet_crypto::FieldElement;
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let (num_iter, _data): (u32, Vec<u8>) = env::read();
 
     let e0 = FieldElement::from_hex_be(

--- a/benchmarks/methods/guest/src/bin/iter_sha2.rs
+++ b/benchmarks/methods/guest/src/bin/iter_sha2.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::{guest::env, sha, sha::Sha256};
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 
     let mut hash = sha::Impl::hash_bytes(&data);

--- a/benchmarks/methods/guest/src/bin/membership.rs
+++ b/benchmarks/methods/guest/src/bin/membership.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_benchmark_lib::MembershipProof;
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::entry!(main);
-
-pub fn main() {
+fn main() {
     let proof: MembershipProof = env::read();
     assert!(proof.verify());
     env::commit(&(proof.leaf, proof.root))

--- a/benchmarks/methods/guest/src/bin/sudoku.rs
+++ b/benchmarks/methods/guest/src/bin/sudoku.rs
@@ -25,7 +25,7 @@ use risc0_zkvm::{
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     let puzzle: Sudoku = env::read();
 
     if !valid_solution(&puzzle) {

--- a/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
+++ b/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use std::{collections::BTreeMap, io::Read};
 
-use risc0_zkvm::{
-    guest::env,
-    sha::rust_crypto::{Digest as _, Sha256},
-};
-risc0_zkvm::guest::entry!(main);
 use k256::{
     ecdsa::{RecoveryId, Signature, VerifyingKey},
     elliptic_curve::sec1::ToEncodedPoint,
     PublicKey,
+};
+use risc0_zkvm::{
+    guest::env,
+    sha::rust_crypto::{Digest as _, Sha256},
 };
 use tiny_keccak::{Hasher, Keccak};
 

--- a/examples/bevy/methods/guest/src/main.rs
+++ b/examples/bevy/methods/guest/src/main.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-risc0_zkvm::guest::entry!(main);
-
 use risc0_zkvm::guest::env;
 
 use bevy_core::Outputs;

--- a/examples/bevy/methods/guest/src/main.rs
+++ b/examples/bevy/methods/guest/src/main.rs
@@ -40,7 +40,7 @@ fn movement(mut query: Query<(&mut Position, &Velocity)>) {
     }
 }
 
-pub fn main() {
+fn main() {
     let turns: u32 = env::read();
     let mut world = World::new();
     let entity = world

--- a/examples/chess/methods/guest/src/main.rs
+++ b/examples/chess/methods/guest/src/main.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use chess_core::Inputs;
 use risc0_zkvm::guest::env;
 use shakmaty::{fen::Fen, san::San, CastlingMode, Chess, FromSetup, Move, Position, Setup};
 
-risc0_zkvm::guest::entry!(main);
-
-pub fn main() {
+fn main() {
     let inputs: Inputs = env::read();
     let mv: String = inputs.mv;
     let initial_state: String = inputs.board;

--- a/examples/digital-signature/methods/guest/src/main.rs
+++ b/examples/digital-signature/methods/guest/src/main.rs
@@ -21,7 +21,7 @@ use risc0_zkvm::sha::{Impl, Sha256};
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     let request: SigningRequest = env::read();
     env::commit(&SignMessageCommit {
         identity: *Impl::hash_bytes(request.passphrase.as_bytes()),

--- a/examples/ecdsa/methods/guest/src/bin/benchmark.rs
+++ b/examples/ecdsa/methods/guest/src/bin/benchmark.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use core::{hint::black_box, ops::Add};
 
 use hex_literal::hex;
@@ -105,8 +103,6 @@ fn benchmark_group() {
         .to_affine()
     });
 }
-
-risc0_zkvm::guest::entry!(main);
 
 fn main() {
     benchmark_field();

--- a/examples/ecdsa/methods/guest/src/bin/ecdsa_verify.rs
+++ b/examples/ecdsa/methods/guest/src/bin/ecdsa_verify.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use k256::{
     ecdsa::{signature::Verifier, Signature, VerifyingKey},
     EncodedPoint,
 };
 use risc0_zkvm::guest::env;
-
-risc0_zkvm::guest::entry!(main);
 
 fn main() {
     // Decode the verifying key, message, and signature from the inputs.

--- a/examples/hello-world/methods/guest/src/main.rs
+++ b/examples/hello-world/methods/guest/src/main.rs
@@ -19,7 +19,7 @@ use risc0_zkvm::guest::env;
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     // Load the first number from the host
     let a: u64 = env::read();
     // Load the second number from the host

--- a/examples/json/methods/guest/src/main.rs
+++ b/examples/json/methods/guest/src/main.rs
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use json::parse;
 use json_core::Outputs;
 use risc0_zkvm::{
     guest::env,
     sha::{Impl, Sha256},
 };
-
-risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     let data: String = env::read();

--- a/examples/json/methods/guest/src/main.rs
+++ b/examples/json/methods/guest/src/main.rs
@@ -19,7 +19,7 @@ use risc0_zkvm::{
     sha::{Impl, Sha256},
 };
 
-pub fn main() {
+fn main() {
     let data: String = env::read();
     let sha = *Impl::hash_bytes(&data.as_bytes());
     let data = parse(&data).unwrap();

--- a/examples/jwt-validator/methods/guest/src/main.rs
+++ b/examples/jwt-validator/methods/guest/src/main.rs
@@ -29,7 +29,7 @@ static PUBLIC_KEY: &str = r#"
     }
 "#;
 
-pub fn main() {
+fn main() {
     // read the token input
     let token: String = env::read();
 

--- a/examples/jwt-validator/methods/guest/src/main.rs
+++ b/examples/jwt-validator/methods/guest/src/main.rs
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use jwt_core::Validator;
 use risc0_zkvm::guest::env;
-
-risc0_zkvm::guest::entry!(main);
 
 static PUBLIC_KEY: &str = r#"
     {

--- a/examples/password-checker/methods/guest/src/main.rs
+++ b/examples/password-checker/methods/guest/src/main.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use password_checker_core::PasswordRequest;
 use pbkdf2::pbkdf2_hmac_array;
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha2::Sha256;
-
-risc0_zkvm::guest::entry!(main);
 
 /// Constant policy, compiled into the guest, for this example.
 ///

--- a/examples/password-checker/methods/guest/src/main.rs
+++ b/examples/password-checker/methods/guest/src/main.rs
@@ -34,7 +34,7 @@ const POLICY: PasswordPolicy = PasswordPolicy {
 /// times short. Using a higher iteration count would be required for a real deployment.
 const PBKDF2_SHA256_ITERATIONS: u32 = 10;
 
-pub fn main() {
+fn main() {
     let request: PasswordRequest = env::read();
 
     if !POLICY.is_valid(&request.password) {

--- a/examples/profiling/methods/guest/src/bin/fibonacci.rs
+++ b/examples/profiling/methods/guest/src/bin/fibonacci.rs
@@ -15,7 +15,7 @@
 use nalgebra::Matrix2;
 use risc0_zkvm::guest::env;
 
-pub fn main() {
+fn main() {
     let iterations: u32 = env::read();
     let answer_1 = fibonacci_1(iterations);
     let answer_2 = fibonacci_2(iterations);

--- a/examples/profiling/methods/guest/src/bin/fibonacci.rs
+++ b/examples/profiling/methods/guest/src/bin/fibonacci.rs
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use nalgebra::Matrix2;
 use risc0_zkvm::guest::env;
-
-risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     let iterations: u32 = env::read();

--- a/examples/prorata/methods/guest/src/main.rs
+++ b/examples/prorata/methods/guest/src/main.rs
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use prorata_core::AllocationQuery;
 use risc0_zkvm::guest::env;
-
-risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     // Load the amount, recipients, and target user sent from the host:

--- a/examples/prorata/methods/guest/src/main.rs
+++ b/examples/prorata/methods/guest/src/main.rs
@@ -15,7 +15,7 @@
 use prorata_core::AllocationQuery;
 use risc0_zkvm::guest::env;
 
-pub fn main() {
+fn main() {
     // Load the amount, recipients, and target user sent from the host:
     let query: AllocationQuery = env::read();
 

--- a/examples/sha/methods/guest/src/bin/hash.rs
+++ b/examples/sha/methods/guest/src/bin/hash.rs
@@ -12,17 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::{
     guest::env,
     sha::{Impl, Sha256},
 };
 
-risc0_zkvm::guest::entry!(main);
-
 // Example of using the risc0_zkvm::sha module to hash data.
-pub fn main() {
+fn main() {
     let data: String = env::read();
     let digest = Impl::hash_bytes(&data.as_bytes());
     env::commit(&digest);

--- a/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
+++ b/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
@@ -17,7 +17,7 @@ use risc0_zkvm::{guest::env, sha::Digest};
 use sha2::{Digest as _, Sha256};
 
 // Example of using RustCrypto with RISC Zero accelerator support.
-pub fn main() {
+fn main() {
     let data: String = env::read();
     let digest = Sha256::digest(&data.as_bytes());
     let digest = Digest::try_from(digest.as_slice()).unwrap();

--- a/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
+++ b/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 // Also available as risc0_zkvm::sha::rust_crypto
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha2::{Digest as _, Sha256};
-
-risc0_zkvm::guest::entry!(main);
 
 // Example of using RustCrypto with RISC Zero accelerator support.
 pub fn main() {

--- a/examples/smartcore-ml/methods/guest/src/main.rs
+++ b/examples/smartcore-ml/methods/guest/src/main.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::guest::env;
 use smartcore::{
     linalg::basic::matrix::DenseMatrix,
@@ -23,8 +21,6 @@ use smartcore::{
     },
     tree::decision_tree_classifier::DecisionTreeClassifier,
 };
-
-risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     // Read in is_svm boolean to ensure the correct code block is executed

--- a/examples/smartcore-ml/methods/guest/src/main.rs
+++ b/examples/smartcore-ml/methods/guest/src/main.rs
@@ -22,7 +22,7 @@ use smartcore::{
     tree::decision_tree_classifier::DecisionTreeClassifier,
 };
 
-pub fn main() {
+fn main() {
     // Read in is_svm boolean to ensure the correct code block is executed
     let is_svm: bool = env::read();
 

--- a/examples/voting-machine/methods/guest/src/bin/freeze.rs
+++ b/examples/voting-machine/methods/guest/src/bin/freeze.rs
@@ -24,7 +24,7 @@ use voting_machine_core::{FreezeVotingMachineCommit, FreezeVotingMachineParams};
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     let params: FreezeVotingMachineParams = env::read();
     let result = params.process();
     env::write(&result.state);

--- a/examples/voting-machine/methods/guest/src/bin/init.rs
+++ b/examples/voting-machine/methods/guest/src/bin/init.rs
@@ -24,7 +24,7 @@ use voting_machine_core::{InitializeVotingMachineCommit, VotingMachineState};
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     let state: VotingMachineState = env::read();
     env::commit(&InitializeVotingMachineCommit {
         polls_open: state.polls_open,

--- a/examples/voting-machine/methods/guest/src/bin/submit.rs
+++ b/examples/voting-machine/methods/guest/src/bin/submit.rs
@@ -24,7 +24,7 @@ use voting_machine_core::{SubmitBallotCommit, SubmitBallotParams};
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     let params: SubmitBallotParams = env::read();
     let result = params.process();
     env::write(&result.state);

--- a/examples/waldo/methods/guest/src/main.rs
+++ b/examples/waldo/methods/guest/src/main.rs
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use image::{imageops, GenericImageView};
 use risc0_zkvm::guest::env;
 use waldo_core::{
     image::{ImageMask, ImageOracle, IMAGE_CHUNK_SIZE},
     Journal, PrivateInput,
 };
-
-risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     // Read a Merkle proof from the host.

--- a/examples/waldo/methods/guest/src/main.rs
+++ b/examples/waldo/methods/guest/src/main.rs
@@ -19,7 +19,7 @@ use waldo_core::{
     Journal, PrivateInput,
 };
 
-pub fn main() {
+fn main() {
     // Read a Merkle proof from the host.
     let input: PrivateInput = env::read();
 

--- a/examples/wasm/methods/guest/src/main.rs
+++ b/examples/wasm/methods/guest/src/main.rs
@@ -12,15 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-#![allow(unused_imports)]
-
-risc0_zkvm::guest::entry!(main);
-
 use risc0_zkvm::guest::env;
-use wasmi::{Caller, Engine, Func, Linker, Module, Store};
+use wasmi::{Engine, Linker, Module, Store};
 
-pub fn main() {
+fn main() {
     let engine = Engine::default();
 
     let wasm: Vec<u8> = env::read();

--- a/examples/wordle/methods/guest/src/main.rs
+++ b/examples/wordle/methods/guest/src/main.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-
 use risc0_zkvm::guest::env;
 use risc0_zkvm::sha::{Impl, Sha256};
 use wordle_core::{GameState, LetterFeedback, WordFeedback, WORD_LENGTH};
 
-risc0_zkvm::guest::entry!(main);
-
-pub fn main() {
+fn main() {
     let secret: String = env::read();
     let guess: String = env::read();
 
@@ -45,7 +41,7 @@ pub fn main() {
     for i in 0..WORD_LENGTH {
         if secret.as_bytes()[i] != guess.as_bytes()[i] {
             secret_unmatched.push(secret.as_bytes()[i] as char);
-       }
+        }
     }
 
     // second round for distinguishing partial matches from misses

--- a/examples/xgboost/methods/guest/src/main.rs
+++ b/examples/xgboost/methods/guest/src/main.rs
@@ -16,7 +16,7 @@ use forust_ml::{GradientBooster, Matrix};
 use risc0_zkvm::guest::env;
 use rmp_serde;
 
-pub fn main() {
+fn main() {
     // read the input data
     let input: Vec<f64> = env::read();
 

--- a/examples/xgboost/methods/guest/src/main.rs
+++ b/examples/xgboost/methods/guest/src/main.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
 use forust_ml::{GradientBooster, Matrix};
 use risc0_zkvm::guest::env;
 use rmp_serde;
-
-risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     // read the input data

--- a/examples/zkevm-demo/methods/guest/src/bin/evm.rs
+++ b/examples/zkevm-demo/methods/guest/src/bin/evm.rs
@@ -12,15 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_main]
-#![allow(unused_imports)]
-
 use risc0_zkvm::guest::env;
 use zkevm_core::{Env, EvmResult, ExecutionResult, ZkDb, EVM};
 
-risc0_zkvm::guest::entry!(main);
-
-pub fn main() {
+fn main() {
     let env: Env = env::read();
     let db: ZkDb = env::read();
 

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,7 +233,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "a99254cb6991d6212fc3f7ea23093062b7bb6fbaaa545d33baf5a6dfa768fbc6",
+            "0577d5559d28d3856d000fc5a7e77f5e376d9cd412729677ff0462919a1ebf8c",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",

--- a/risc0/fault/guest/src/bin/fault_checker.rs
+++ b/risc0/fault/guest/src/bin/fault_checker.rs
@@ -15,7 +15,7 @@
 use risc0_zkvm::{guest::env, FaultCheckMonitor};
 use rrs_lib::{instruction_executor::InstructionExecutor, HartState};
 
-pub fn main() {
+fn main() {
     let fault_monitor: FaultCheckMonitor = env::read();
 
     let mut instruction_executor = InstructionExecutor {

--- a/risc0/zkvm/methods/guest/src/bin/hello_commit.rs
+++ b/risc0/zkvm/methods/guest/src/bin/hello_commit.rs
@@ -19,6 +19,6 @@ use risc0_zkvm::guest::env;
 
 risc0_zkvm::entry!(main);
 
-pub fn main() {
+fn main() {
     env::commit_slice(b"hello world");
 }

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -32,8 +32,9 @@ use risc0_zkvm::{
 use risc0_zkvm_methods::multi_test::{MultiTestSpec, SYS_MULTI_TEST};
 use risc0_zkvm_platform::{
     fileno,
-    memory::{self, SYSTEM}, PAGE_SIZE,
+    memory::{self, SYSTEM},
     syscall::{bigint, sys_bigint, sys_log, sys_read, sys_read_words, sys_write},
+    PAGE_SIZE,
 };
 
 risc0_zkvm::entry!(main);
@@ -50,7 +51,7 @@ fn profile_test_func2() {
     unsafe { asm!("nop") }
 }
 
-pub fn main() {
+fn main() {
     let impl_select: MultiTestSpec = env::read();
     match impl_select {
         MultiTestSpec::DoNothing => {}
@@ -269,17 +270,19 @@ pub fn main() {
         },
         MultiTestSpec::AlignedAlloc => {
             #[repr(align(1024))]
-            struct AlignTest1 { pub _test: u32 }
+            struct AlignTest1 {
+                pub _test: u32,
+            }
 
             impl AlignTest1 {
                 pub fn new(_test: u32) -> Self {
-                    AlignTest1{_test}
+                    AlignTest1 { _test }
                 }
             }
 
             let a = &AlignTest1::new(54) as *const _;
             let b = &AlignTest1::new(60) as *const _;
             assert_eq!(PAGE_SIZE, b as usize - a as usize);
-        },
+        }
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/slice_io.rs
+++ b/risc0/zkvm/methods/guest/src/bin/slice_io.rs
@@ -22,7 +22,7 @@ use risc0_zkvm::guest::{env, env::Read};
 
 risc0_zkvm::entry!(main);
 
-pub fn main() {
+fn main() {
     let mut len: u32 = 0;
     env::stdin().read_slice(core::slice::from_mut(&mut len));
     let mut slice = vec![0u8; len as usize];

--- a/risc0/zkvm/methods/rand/src/bin/rand.rs
+++ b/risc0/zkvm/methods/rand/src/bin/rand.rs
@@ -23,7 +23,7 @@ use getrandom::getrandom;
 
 risc0_zkvm::entry!(main);
 
-pub fn main() {
+fn main() {
     // This should panic
     let rand_buf = &mut vec![0u8; 8];
     let _res = getrandom(rand_buf);

--- a/risc0/zkvm/methods/std/src/bin/bench.rs
+++ b/risc0/zkvm/methods/std/src/bin/bench.rs
@@ -18,7 +18,7 @@ use risc0_zkvm::{
 };
 use risc0_zkvm_methods::bench::{BenchmarkSpec, SpecWithIters};
 
-pub fn main() {
+fn main() {
     let SpecWithIters(spec, iters) = env::read();
     match spec {
         BenchmarkSpec::SimpleLoop => {

--- a/risc0/zkvm/methods/std/src/bin/fib.rs
+++ b/risc0/zkvm/methods/std/src/bin/fib.rs
@@ -14,13 +14,13 @@
 
 use risc0_zkvm::guest::env;
 
-pub fn main() {
+fn main() {
     let iterations: u32 = env::read();
     let answer = fibonacci(iterations);
     env::commit(&answer);
 }
 
-pub fn fibonacci(n: u32) -> u64 {
+fn fibonacci(n: u32) -> u64 {
     let (mut a, mut b) = (0, 1);
     for _ in 0..n {
         let c = a;

--- a/risc0/zkvm/methods/std/src/bin/standard_lib.rs
+++ b/risc0/zkvm/methods/std/src/bin/standard_lib.rs
@@ -16,7 +16,7 @@ use std::io::{stdin, stdout, Read, Write};
 
 use risc0_zkvm as _;
 
-pub fn main() {
+fn main() {
     let test_mode = std::env::var("TEST_MODE").unwrap();
 
     match test_mode.as_str() {

--- a/risc0/zkvm/methods/std/src/bin/test_feature.rs
+++ b/risc0/zkvm/methods/std/src/bin/test_feature.rs
@@ -17,7 +17,7 @@ use std::compile_error;
 
 use risc0_zkvm as _;
 
-pub fn main() {
+fn main() {
     #[cfg(not(all(feature = "test_feature1", feature = "test_feature2")))]
     compile_error!("Test feature was not found.");
 }

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -45,7 +45,7 @@
 //!
 //! risc0_zkvm::guest::entry!(main);
 //!
-//! pub fn main() {
+//! fn main() {
 //!     // Load the first number from the host
 //!     let a: u64 = env::read();
 //!     // Load the second number from the host

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -14,13 +14,10 @@
 
 //! The RISC Zero zkVM's guest-side RISC-V API.
 //!
-//! Code that is validated by the [RISC Zero zkVM](crate) is run inside the
-//! guest. In the minimal case, an entrypoint (the guest's "`main`" function)
-//! must be provided by using the [entry! macro](entry). In almost all
-//! practical cases, the guest will want to read private input data from the
-//! host and write public data to the journal. In the simplest case, this can be
-//! done with [env::read] and [env::commit], respectively; additional I/O
-//! functionality is also available in [mod@env].
+//! Code that is validated by the [RISC Zero zkVM](crate) is run inside the guest. In almost all
+//! practical cases, the guest will want to read private input data from the host and write public
+//! data to the journal. This can be done with [env::read] and [env::commit], respectively;
+//! additional I/O functionality is also available in [mod@env].
 //!
 //! ## Installation
 //!
@@ -39,10 +36,14 @@
 //! The following guest code[^starter-ex] proves a number is
 //! composite by multiplying two unsigned integers, and panicking if either is
 //! `1` or if the multiplication overflows:
+//!
 //! ```ignore
+//! #![no_main]
+//! #![no_std]
+//!
 //! use risc0_zkvm::guest::env;
 //!
-//! risc0_zkvm::entry!(main);
+//! risc0_zkvm::guest::entry!(main);
 //!
 //! pub fn main() {
 //!     // Load the first number from the host
@@ -58,9 +59,16 @@
 //!     env::commit(&product);
 //! }
 //! ```
-//! Notice how the [entry! macro](entry) is used to indicate the
-//! entrypoint, [env::read] is used to load the two factors, and [env::commit]
-//! is used to make their composite product publically available.
+//!
+//! Notice how [env::read] is used to load the two factors, and [env::commit] is used to make their
+//! composite product publically available. All input an output of your guest is private except for
+//! what is written to the journal with [env::commit].
+//!
+//! By default, the guest only has the Rust `core` libraries and not `std`. A partial
+//! implementation of the Rust standard libraries can be enabled with the `std` feature on this [crate].
+//! When this feature is not enabled, the lines including `#![no_std]` and `#![no_main]` are
+//! required, as well as the use of the [crate::guest::entry] macro. When `std` is enabled, these
+//! three lines can be omitted and many features of `std` can be used.
 //!
 //! If you encounter problems building zkVM guest code, you can see if we have a
 //! known workaround for your issue by looking in our
@@ -103,11 +111,21 @@ pub fn abort(msg: &str) -> ! {
     }
 }
 
-/// Used for defining a main entrypoint.
+/// Used for defining the guest's entrypoint and main function.
+///
+/// When `#![no_main]` is used, the programs entrypoint and main function is left undefined. The
+/// `entry` macro is required to indicate the main function and link it to an entrypoint provided
+/// by the RISC Zero SDK.
+///
+/// When `std` is enabled, the entrypoint will be linked automatically and this macro is not
+/// required.
 ///
 /// # Example
 ///
 /// ```ignore
+/// #![no_main]
+/// #![no_std]
+///
 /// risc0_zkvm::entry!(main);
 ///
 /// fn main() { }

--- a/templates/rust-starter/methods/guest/src/main.rs
+++ b/templates/rust-starter/methods/guest/src/main.rs
@@ -1,14 +1,16 @@
-#![no_main]
 {% unless risc0_std -%}
+#![no_main]
 // If you want to try std support, also update the guest Cargo.toml file
 #![no_std]  // std support is experimental
 {% endunless %}
 
 use risc0_zkvm::guest::env;
 
+{% unless risc0_std -%}
 risc0_zkvm::guest::entry!(main);
+{% endunless %}
 
-pub fn main() {
+fn main() {
     // TODO: Implement your guest code here
 
     // read the input

--- a/tools/crates-validator/src/lib.rs
+++ b/tools/crates-validator/src/lib.rs
@@ -189,7 +189,7 @@ const MAIN_RS_TEMPLATE: &str = r#"
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     {{ main_body }}
 }
 

--- a/tools/smoke-test/methods/guest/src/main.rs
+++ b/tools/smoke-test/methods/guest/src/main.rs
@@ -20,7 +20,7 @@ use risc0_zkvm::guest::env;
 
 risc0_zkvm::guest::entry!(main);
 
-pub fn main() {
+fn main() {
     let iterations: u32 = env::read();
 
     let mut sum = 0;

--- a/website/api/zkvm/developer-guide/guest-code-101.md
+++ b/website/api/zkvm/developer-guide/guest-code-101.md
@@ -37,7 +37,7 @@ To support various use cases, there are a number of functions that can be called
 [`env::stderr`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.stderr.html
 
 - **Committing public outputs to [journal]**<br/>
-  `env::commit`, `env::commit_slice`
+  [`env::commit`], [`env::commit_slice`]
 
 [`env::commit`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.commit.html
 [`env::commit_slice`]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/env/fn.commit_slice.html
@@ -83,12 +83,8 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [host]: /terminology#host
 [`risc0-zkvm` Rust crate]: https://docs.rs/risc0-zkvm
 [journal]: /terminology#journal
-[method]: /terminology#method
 [zkVM Quick Start]: ../quickstart.md
-[zkVM Overview]: ../zkvm_overview.md
 [Hello World demo]: https://github.com/risc0/risc0/tree/main/examples/hello-world
-[risc0/examples]: https://github.com/risc0/risc0/tree/v0.18.0/examples
-[guest environment commands]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest/index.html
 [zkVM Application]: ../zkvm_overview.md
 [zkVM]: ../zkvm_overview.md
 [Bonsai]: ../../bonsai/bonsai-overview.md

--- a/website/api/zkvm/tutorials/hello-world.md
+++ b/website/api/zkvm/tutorials/hello-world.md
@@ -46,7 +46,7 @@ In the code snippet below, the guest reads the `input` value from the host and t
 ```rust ignore
 use risc0_zkvm::guest::env;
 
-pub fn main() {
+fn main() {
     // read the input
     let input: u32 = env::read();
 

--- a/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
@@ -46,7 +46,7 @@ In the code snippet below, the guest reads the `input` value from the host and t
 ```rust ignore
 use risc0_zkvm::guest::env;
 
-pub fn main() {
+fn main() {
     // read the input
     let input: u32 = env::read();
 


### PR DESCRIPTION
I spent a momment to look into the minimal guest programs under `std` and `no_std` configurations, and found that in the `std` case we can drop the non-standard lines we use today. This PR changes the minimal `std` guest in our examples and templates to the following:

```rust
use risc0_zkvm::guest::env;

fn main() {
    env::commit("hello");
}
```

By contrast, here was the `std` guest we were using before:

```rust
#![no_main]

use risc0_zkvm::guest::env;

risc0_zkvm::guest::entry!(main);

fn main() {
    env::commit(&0xf00u64);
}
```

In the case of `no_std`, I attempted to improve upon the current minimal guest, and did find an alternative. What I discovered is that removing `#![mo_main]` means we will need to define a `start` langauge symbol. I found that the standard way to do that is with the `start` feature, resulting in the following guest.

```rust
#![no_std]
#![feature(start)]

use risc0_zkvm::guest::env;

#[start]
fn main(_: isize, _: *const *const u8) -> isize {
    env::commit("hello");
    0
}
```

Comapred with what we have, this seems less readable. As a result, I am not suggesting we change the minimal prgram from `no_std`. It will remain as:

```rust
#![no_std]
#![no_main]

use risc0_zkvm::guest::env;

risc0_zkvm::guest::entry!(main);

fn main() {
    env::commit(&0xf00u64);
}

```

This PR additionally removes the `pub` visibility modifier from all `main` functions except `r0vm`, as it is not needed.
