### PR TITLE
fix typo

### DIFF
--- a/website/api/zkvm/benchmarks.md
+++ b/website/api/zkvm/benchmarks.md
@@ -46,7 +46,7 @@ cargo bench --bench fib
 ```
 
 This will compute the 100th, 1000th, and 10000th Fibonacci numbers modulo 2^64 (ten times for each).
-It will report both time and throughput (how many numbers were added per second) with separate statisics for [execution] and [proving].
+It will report both time and throughput (how many numbers were added per second) with separate statistics for [execution] and [proving].
 As with the loop benchmark, the Fibonacci benchmark will use the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles

--- a/website/api_versioned_docs/version-0.18/zkvm/benchmarks.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/benchmarks.md
@@ -37,7 +37,7 @@ cargo bench --bench fib
 ```
 
 This will compute the 100th, 1000th, and 10000th Fibonacci numbers modulo 2^64 (ten times for each).
-It will report both time and throughput (how many numbers were added per second) with separate statisics for [execution] and [proving].
+It will report both time and throughput (how many numbers were added per second) with separate statistics for [execution] and [proving].
 As with the loop benchmark, the Fibonacci benchmark will use the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles

--- a/website/api_versioned_docs/version-0.19/zkvm/benchmarks.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/benchmarks.md
@@ -46,7 +46,7 @@ cargo bench --bench fib
 ```
 
 This will compute the 100th, 1000th, and 10000th Fibonacci numbers modulo 2^64 (ten times for each).
-It will report both time and throughput (how many numbers were added per second) with separate statisics for [execution] and [proving].
+It will report both time and throughput (how many numbers were added per second) with separate statistics for [execution] and [proving].
 As with the loop benchmark, the Fibonacci benchmark will use the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -22,7 +22,7 @@ The complexity of a [guest program]'s [execution] is measured in clock cycles as
 
 Generally, a single cycle corresponds to a single [RISC-V] operation. However, some operations require two cycles.
 
-<!-- TODO: Once the optimizaiton guide is in a release API doc, include this line.
+<!-- TODO: Once the optimization guide is in a release API doc, include this line.
 See the [Optimization Guide](/api/zkvm/developer-guide/optimization) for more information about the zkVM cycles and performance.
 -->
 


### PR DESCRIPTION
fix minor typos in terminology.md and benchmarks files