### PR TITLE
Add resolve method to Client interface

### DIFF
--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -170,7 +170,12 @@ impl Client {
         result
     }
 
-    /// Lift a [SegmentReceipt] into a [SuccinctReceipt].
+    /// Run the lift program to transform a [SegmentReceipt] into a [SuccinctReceipt].
+    ///
+    /// The lift program verifies the rv32im circuit STARK proof inside the recursion circuit,
+    /// resulting in a recursion circuit STARK proof. This recursion proof has a single
+    /// constant-time verification procedure, with respect to the original segment length, and is then
+    /// used as the input to all other recursion programs (e.g. join, resolve, and identity_p254).
     pub fn lift(
         &self,
         opts: ProverOpts,
@@ -208,7 +213,10 @@ impl Client {
         result
     }
 
-    /// Recursively join two receipts into a [SuccinctReceipt].
+    /// Run the join program to compress two [SuccinctReceipt]s in the same session into one.
+    ///
+    /// By repeated application of the join program, any number of receipts for execution spans within
+    /// the same session can be compressed into a single receipt for the entire session.
     pub fn join(
         &self,
         opts: ProverOpts,
@@ -248,7 +256,58 @@ impl Client {
         result
     }
 
-    /// Convert a [SuccinctReceipt] with a poseidon hash function that uses a 254-bit field
+    /// Run the resolve program to remove an assumption from a conditional [SuccinctReceipt] upon
+    /// verifying a corroborating [SuccinctReceipt] for the assumption.
+    ///
+    /// By applying the resolve program, a conditional receipt (i.e. a receipt for an execution
+    /// using the `env::verify` API to logically verify a receipt) can be made into an
+    /// unconditional receipt.
+    pub fn resolve(
+        &self,
+        opts: ProverOpts,
+        conditional_receipt: Asset,
+        corroborating_receipt: Asset,
+        receipt_out: AssetRequest,
+    ) -> Result<SuccinctReceipt> {
+        let mut conn = self.connect()?;
+
+        let request = pb::api::ServerRequest {
+            kind: Some(pb::api::server_request::Kind::Resolve(
+                pb::api::ResolveRequest {
+                    opts: Some(opts.into()),
+                    conditional_receipt: Some(conditional_receipt.try_into()?),
+                    corroborating_receipt: Some(corroborating_receipt.try_into()?),
+                    receipt_out: Some(receipt_out.try_into()?),
+                },
+            )),
+        };
+        tracing::trace!("tx: {request:?}");
+        conn.send(request)?;
+
+        let reply: pb::api::ResolveReply = conn.recv()?;
+
+        let result = match reply.kind.ok_or(malformed_err())? {
+            pb::api::resolve_reply::Kind::Ok(result) => {
+                let receipt_bytes = result.receipt.ok_or(malformed_err())?.as_bytes()?;
+                let receipt_pb = pb::core::SuccinctReceipt::decode(receipt_bytes)?;
+                receipt_pb.try_into()
+            }
+            pb::api::resolve_reply::Kind::Error(err) => Err(err.into()),
+        };
+
+        let code = conn.close()?;
+        if code != 0 {
+            bail!("Child finished with: {code}");
+        }
+
+        result
+    }
+
+    /// Prove the verification of a recursion receipt using the Poseidon254 hash function for FRI.
+    ///
+    /// The identity_p254 program is used as the last step in the prover pipeline before running the
+    /// Groth16 prover. In Groth16 over BN254, it is much more efficient to verify a STARK that was
+    /// produced with Poseidon over the BN254 base field compared to using Posidon over BabyBear.
     pub fn identity_p254(
         &self,
         opts: ProverOpts,

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -78,6 +78,8 @@ impl RootMessage for pb::api::LiftRequest {}
 impl RootMessage for pb::api::LiftReply {}
 impl RootMessage for pb::api::JoinRequest {}
 impl RootMessage for pb::api::JoinReply {}
+impl RootMessage for pb::api::ResolveRequest {}
+impl RootMessage for pb::api::ResolveReply {}
 impl RootMessage for pb::api::IdentityP254Request {}
 impl RootMessage for pb::api::IdentityP254Reply {}
 

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -257,6 +257,7 @@ impl Server {
             }
             pb::api::server_request::Kind::Lift(request) => self.on_lift(conn, request),
             pb::api::server_request::Kind::Join(request) => self.on_join(conn, request),
+            pb::api::server_request::Kind::Resolve(request) => self.on_resolve(conn, request),
             pb::api::server_request::Kind::IdentiyP254(request) => {
                 self.on_identity_p254(conn, request)
             }
@@ -491,6 +492,57 @@ impl Server {
 
         let msg = inner(request).unwrap_or_else(|err| pb::api::JoinReply {
             kind: Some(pb::api::join_reply::Kind::Error(pb::api::GenericError {
+                reason: err.to_string(),
+            })),
+        });
+
+        tracing::debug!("tx: {msg:?}");
+        conn.send(msg)
+    }
+
+    fn on_resolve(
+        &self,
+        mut conn: ConnectionWrapper,
+        request: pb::api::ResolveRequest,
+    ) -> Result<()> {
+        fn inner(request: pb::api::ResolveRequest) -> Result<pb::api::ResolveReply> {
+            let opts: ProverOpts = request.opts.ok_or(malformed_err())?.into();
+            let conditional_receipt_bytes = request
+                .conditional_receipt
+                .ok_or(malformed_err())?
+                .as_bytes()?;
+            let conditional_succinct_receipt: SuccinctReceipt =
+                bincode::deserialize(&conditional_receipt_bytes)?;
+            let corroborating_receipt_bytes = request
+                .corroborating_receipt
+                .ok_or(malformed_err())?
+                .as_bytes()?;
+            let corroborating_succinct_receipt: SuccinctReceipt =
+                bincode::deserialize(&corroborating_receipt_bytes)?;
+
+            let prover = get_prover_server(&opts)?;
+            let receipt = prover.resolve(
+                &conditional_succinct_receipt,
+                &corroborating_succinct_receipt,
+            )?;
+
+            let succinct_receipt_pb: pb::core::SuccinctReceipt = receipt.into();
+            let succinct_receipt_bytes = succinct_receipt_pb.encode_to_vec();
+            let asset = pb::api::Asset::from_bytes(
+                &request.receipt_out.ok_or(malformed_err())?,
+                succinct_receipt_bytes.into(),
+                "receipt.zkp",
+            )?;
+
+            Ok(pb::api::ResolveReply {
+                kind: Some(pb::api::resolve_reply::Kind::Ok(pb::api::ResolveResult {
+                    receipt: Some(asset),
+                })),
+            })
+        }
+
+        let msg = inner(request).unwrap_or_else(|err| pb::api::ResolveReply {
+            kind: Some(pb::api::resolve_reply::Kind::Error(pb::api::GenericError {
                 reason: err.to_string(),
             })),
         });

--- a/risc0/zkvm/src/host/api/tests.rs
+++ b/risc0/zkvm/src/host/api/tests.rs
@@ -20,7 +20,8 @@ use std::{
 
 use anyhow::Result;
 use risc0_zkvm_methods::{
-    multi_test::MultiTestSpec, MULTI_TEST_ELF, MULTI_TEST_ID, MULTI_TEST_PATH,
+    multi_test::MultiTestSpec, HELLO_COMMIT_ELF, HELLO_COMMIT_ID, MULTI_TEST_ELF, MULTI_TEST_ID,
+    MULTI_TEST_PATH,
 };
 use tempfile::{tempdir, TempDir};
 use test_log::test;
@@ -108,6 +109,23 @@ impl TestClient {
             let receipt_out = AssetRequest::Path(self.get_work_path());
             self.client
                 .join(opts, left_receipt, right_receipt, receipt_out)
+        })
+    }
+
+    fn resolve(
+        &self,
+        opts: ProverOpts,
+        conditional_receipt: Asset,
+        corroborating_receipt: Asset,
+    ) -> SuccinctReceipt {
+        with_server(self.addr, || {
+            let receipt_out = AssetRequest::Path(self.get_work_path());
+            self.client.resolve(
+                opts,
+                conditional_receipt,
+                corroborating_receipt,
+                receipt_out,
+            )
         })
     }
 
@@ -219,6 +237,76 @@ fn lift_join_identity() {
 
     let rollup_receipt = Receipt::new(InnerReceipt::Succinct(rollup), session.journal.bytes.into());
     rollup_receipt.verify(MULTI_TEST_ID).unwrap();
+}
+
+#[test]
+fn lift_resolve() {
+    let mut client = TestClient::new();
+
+    // Execute the hello commit guest to use as an assumption.
+    let hello_commit_binary = Asset::Inline(HELLO_COMMIT_ELF.into());
+    let assumption_session = client.execute(ExecutorEnv::default(), hello_commit_binary);
+    assert_eq!(assumption_session.segments.len(), 1);
+    assert_eq!(client.segments.len(), 1);
+
+    let opts = ProverOpts::default();
+
+    // Prove and lift the assumption.
+    let assumption_segment_receipt = client.prove_segment(opts.clone(), client.segments[0].clone());
+    assumption_segment_receipt
+        .verify_integrity_with_context(&VerifierContext::default())
+        .unwrap();
+    let assumption_succinct_receipt =
+        client.lift(opts.clone(), assumption_segment_receipt.try_into().unwrap());
+    assumption_succinct_receipt
+        .verify_integrity_with_context(&VerifierContext::default())
+        .unwrap();
+
+    // Drop the old client and create a new one to reset the segment list.
+    let mut client = TestClient::new();
+
+    // Execute the composition multitest
+    let env = ExecutorEnv::builder()
+        .add_assumption(assumption_succinct_receipt.claim.clone().into())
+        .write(&MultiTestSpec::SysVerify {
+            image_id: HELLO_COMMIT_ID.into(),
+            journal: b"hello world".to_vec(),
+        })
+        .unwrap()
+        .build()
+        .unwrap();
+    let multi_test_binary = Asset::Inline(MULTI_TEST_ELF.into());
+    let composition_session = client.execute(env, multi_test_binary);
+    assert_eq!(assumption_session.segments.len(), 1);
+    assert_eq!(client.segments.len(), 1);
+
+    // Prove and lift the composition
+    let composition_segment_receipt =
+        client.prove_segment(opts.clone(), client.segments[0].clone());
+    composition_segment_receipt
+        .verify_integrity_with_context(&VerifierContext::default())
+        .unwrap();
+    let composition_succinct_receipt = client.lift(
+        opts.clone(),
+        composition_segment_receipt.try_into().unwrap(),
+    );
+    composition_succinct_receipt
+        .verify_integrity_with_context(&VerifierContext::default())
+        .unwrap();
+
+    // Use resolve to create an unconditional succinct receipt
+    let succint_receipt = client.resolve(
+        opts.clone(),
+        composition_succinct_receipt.try_into().unwrap(),
+        assumption_succinct_receipt.try_into().unwrap(),
+    );
+
+    // Wrap into a Receipt and verify
+    let receipt = Receipt::new(
+        InnerReceipt::Succinct(succint_receipt),
+        composition_session.journal.bytes,
+    );
+    receipt.verify(MULTI_TEST_ID).unwrap();
 }
 
 #[test]

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -13,6 +13,7 @@ message ServerRequest {
     LiftRequest lift = 4;
     JoinRequest join = 5;
     IdentityP254Request identiy_p254 = 6;
+    ResolveRequest resolve = 7;
   }
 }
 
@@ -87,6 +88,24 @@ message JoinReply {
 }
 
 message JoinResult {
+  Asset receipt = 1;
+}
+
+message ResolveRequest {
+  ProverOpts opts = 1;
+  Asset conditional_receipt = 2;
+  Asset corroborating_receipt = 3;
+  AssetRequest receipt_out = 4;
+}
+
+message ResolveReply {
+  oneof kind {
+    ResolveResult ok = 1;
+    GenericError error = 2;
+  }
+}
+
+message ResolveResult {
   Asset receipt = 1;
 }
 
@@ -267,6 +286,7 @@ service Server {
   rpc prove_segment(ProveSegmentRequest) returns (ProveSegmentReply);
   rpc lift(LiftRequest) returns (LiftReply);
   rpc join(JoinRequest) returns (JoinReply);
+  rpc resolve(ResolveRequest) returns (ResolveReply);
 }
 
 service ExecuteCallback {

--- a/risc0/zkvm/src/host/server/prove/dev_mode.rs
+++ b/risc0/zkvm/src/host/server/prove/dev_mode.rs
@@ -76,6 +76,14 @@ impl ProverServer for DevModeProver {
         unimplemented!("This is unsupported for dev mode.")
     }
 
+    fn resolve(
+        &self,
+        _conditional: &SuccinctReceipt,
+        _corroborating: &SuccinctReceipt,
+    ) -> Result<SuccinctReceipt> {
+        unimplemented!("This is unsupported for dev mode.")
+    }
+
     fn identity_p254(&self, _a: &SuccinctReceipt) -> Result<SuccinctReceipt> {
         unimplemented!("This is unsupported for dev mode.")
     }

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -79,6 +79,13 @@ pub trait ProverServer {
     /// Join two [SuccinctReceipt] into a [SuccinctReceipt]
     fn join(&self, a: &SuccinctReceipt, b: &SuccinctReceipt) -> Result<SuccinctReceipt>;
 
+    /// Resolve an assumption from a conditional [SuccinctReceipt] by providing a corroborating [SuccinctReceipt]
+    fn resolve(
+        &self,
+        conditional: &SuccinctReceipt,
+        corroborating: &SuccinctReceipt,
+    ) -> Result<SuccinctReceipt>;
+
     /// Convert a [SuccinctReceipt] with a poseidon hash function that uses a 254-bit field
     fn identity_p254(&self, a: &SuccinctReceipt) -> Result<SuccinctReceipt>;
 }

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -29,7 +29,7 @@ use super::{exec::MachineContext, HalPair, ProverServer};
 use crate::{
     host::{
         receipt::{CompositeReceipt, InnerReceipt, SegmentReceipt, SuccinctReceipt},
-        recursion::{identity_p254, join, lift},
+        recursion::{identity_p254, join, lift, resolve},
         CIRCUIT,
     },
     sha::Digestible,
@@ -180,6 +180,14 @@ where
 
     fn join(&self, a: &SuccinctReceipt, b: &SuccinctReceipt) -> Result<SuccinctReceipt> {
         join(a, b)
+    }
+
+    fn resolve(
+        &self,
+        conditional: &SuccinctReceipt,
+        corroborating: &SuccinctReceipt,
+    ) -> Result<SuccinctReceipt> {
+        resolve(conditional, corroborating)
     }
 
     fn identity_p254(&self, a: &SuccinctReceipt) -> Result<SuccinctReceipt> {


### PR DESCRIPTION
This PR adds the `resolve` method to the `Client` API such that a succinct receipt can be generated by repeated calls to the lift, join, and resolve methods on `Client`.
