### PR TITLE
fix: migrate to using enum for directory

### DIFF
--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -51,7 +51,7 @@ use super::{monitor::MemoryMonitor, profiler::Profiler, syscall::SyscallTable};
 use crate::{
     align_up,
     host::{
-        client::exec::TraceEvent,
+        client::{env::DirectoryPath, exec::TraceEvent},
         receipt::Assumption,
         server::opcode::{MajorType, OpCode},
     },
@@ -231,11 +231,11 @@ impl<'a> ExecutorImpl<'a> {
     /// of the execution.
     pub fn run(&mut self) -> Result<Session> {
         if self.env.segment_path.is_none() {
-            self.env.segment_path = Some(tempdir()?.into_path());
+            self.env.segment_path = Some(Rc::new(DirectoryPath::TempDir(tempdir()?)));
         }
 
-        let path = self.env.segment_path.clone().unwrap();
-        self.run_with_callback(|segment| Ok(Box::new(FileSegmentRef::new(&segment, &path)?)))
+        let dir = self.env.segment_path.clone().unwrap();
+        self.run_with_callback(|segment| Ok(Box::new(FileSegmentRef::new(&segment, dir.path())?)))
     }
 
     /// Run the executor until [ExitCode::Halted], [ExitCode::Paused], or


### PR DESCRIPTION
Closes #1223 

Going to have another look through later to see if there is a cleaner way to handle this, and see if there is a clean way to handle warn logging on delete fail. I didn't love the implications of adding the warn log to the error:

```diff
diff --git a/risc0/zkvm/src/host/client/env.rs b/risc0/zkvm/src/host/client/env.rs
index 0ac1e3c6..157c082b 100644
--- a/risc0/zkvm/src/host/client/env.rs
+++ b/risc0/zkvm/src/host/client/env.rs
@@ -101,6 +101,16 @@ pub struct ExecutorEnv<'a> {
     pub(crate) pprof_out: Option<PathBuf>,
 }
 
+impl Drop for ExecutorEnv<'_> {
+    fn drop(&mut self) {
+        if let Some(DirectoryPath::TempDir(dir)) = self.segment_path.take().as_deref() {
+            if let Err(e) = std::fs::remove_dir_all(dir.path()) {
+                tracing::warn!("failed to close tempdir: {:?}", e);
+            }
+        }
+    }
+}
+
 impl<'a> ExecutorEnv<'a> {
     /// Construct a [ExecutorEnvBuilder].
     ///
diff --git a/risc0/zkvm/src/host/client/prove/bonsai.rs b/risc0/zkvm/src/host/client/prove/bonsai.rs
index af1c7ada..bda1193e 100644
--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -57,7 +57,7 @@ impl Prover for BonsaiProver {
         client.upload_img(&image_id_hex, elf.to_vec())?;
 
         // upload input data
-        let input_id = client.upload_input(env.input)?;
+        let input_id = client.upload_input(env.input.clone())?;
 
         // upload receipts
         let mut receipts_ids: Vec<String> = vec![];
```