### PR TITLE
feat: implement attribute entry macro to replace declarative macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "risc0/circuit/rv32im-sys",
   "risc0/core",
   "risc0/fault",
+  "risc0/macros",
   "risc0/r0vm",
   "risc0/sys",
   "risc0/tools",
@@ -19,7 +20,6 @@ members = [
   "risc0/zkvm/methods",
   "risc0/zkvm/platform",
   "risc0/zkvm/receipts",
-  "risc0/macros",
   "website/doc-test/main",
   "xtask",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ risc0-circuit-recursion-sys = { version = "0.21.0-alpha.1", default-features = f
 risc0-circuit-rv32im = { version = "0.21.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im" }
 risc0-circuit-rv32im-sys = { version = "0.21.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-core = { version = "0.21.0-alpha.1", default-features = false, path = "risc0/core" }
+risc0-macros = { version = "0.21.0-alpha.1", default-features = false, path = "risc0/macros" }
 risc0-r0vm = { version = "0.21.0-alpha.1", default-features = false, path = "risc0/r0vm" }
 risc0-sys = { version = "0.21.0-alpha.1", default-features = false, path = "risc0/sys" }
 risc0-zkp = { version = "0.21.0-alpha.1", default-features = false, path = "risc0/zkp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "risc0/zkvm/methods",
   "risc0/zkvm/platform",
   "risc0/zkvm/receipts",
+  "risc0/macros",
   "website/doc-test/main",
   "xtask",
 ]

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2321,6 +2321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-sppark"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2405,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/benchmarks/methods/guest/src/bin/big_blake2b.rs
+++ b/benchmarks/methods/guest/src/bin/big_blake2b.rs
@@ -17,8 +17,7 @@
 use risc0_zkp::core::hash::blake2b::{Blake2b, Blake2bCpuImpl};
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let data: Vec<u8> = env::read();
     let hash = Blake2bCpuImpl::blake2b(&data);

--- a/benchmarks/methods/guest/src/bin/big_blake3.rs
+++ b/benchmarks/methods/guest/src/bin/big_blake3.rs
@@ -16,8 +16,7 @@
 
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let data: Vec<u8> = env::read();
     let hash = blake3::hash(&data);

--- a/benchmarks/methods/guest/src/bin/big_keccak.rs
+++ b/benchmarks/methods/guest/src/bin/big_keccak.rs
@@ -17,8 +17,7 @@
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha3::{Digest as _, Keccak256};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let data: Vec<u8> = env::read();
     let hash = keccak(&data);

--- a/benchmarks/methods/guest/src/bin/big_sha2.rs
+++ b/benchmarks/methods/guest/src/bin/big_sha2.rs
@@ -16,8 +16,7 @@
 
 use risc0_zkvm::{guest::env, sha, sha::Sha256};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let data: Vec<u8> = env::read();
     let hash = sha::Impl::hash_bytes(&data);

--- a/benchmarks/methods/guest/src/bin/ecdsa_verify.rs
+++ b/benchmarks/methods/guest/src/bin/ecdsa_verify.rs
@@ -20,8 +20,7 @@ use k256::{
 };
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 fn main() {
     // Decode the verifying key, message, and signature from the inputs.
     let (iterations, encoded_verifying_key, message, signature): (

--- a/benchmarks/methods/guest/src/bin/ed25519_verify.rs
+++ b/benchmarks/methods/guest/src/bin/ed25519_verify.rs
@@ -17,8 +17,7 @@
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 fn main() {
     // Decode the verifying key, message, and signature from the inputs.
     let (iterations, encoded_verifying_key, message, signature_bytes): (

--- a/benchmarks/methods/guest/src/bin/iter_blake2b.rs
+++ b/benchmarks/methods/guest/src/bin/iter_blake2b.rs
@@ -17,8 +17,7 @@
 use risc0_zkp::core::hash::blake2b::{Blake2b, Blake2bCpuImpl};
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 

--- a/benchmarks/methods/guest/src/bin/iter_blake3.rs
+++ b/benchmarks/methods/guest/src/bin/iter_blake3.rs
@@ -15,8 +15,7 @@
 
 use risc0_zkvm::{guest::env, sha::Digest};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 

--- a/benchmarks/methods/guest/src/bin/iter_keccak.rs
+++ b/benchmarks/methods/guest/src/bin/iter_keccak.rs
@@ -17,8 +17,7 @@
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha3::{Digest as _, Keccak256};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 

--- a/benchmarks/methods/guest/src/bin/iter_pedersen.rs
+++ b/benchmarks/methods/guest/src/bin/iter_pedersen.rs
@@ -18,8 +18,7 @@ use core::hint::black_box;
 use risc0_zkvm::{guest::env, sha::Digest};
 use starknet_crypto::FieldElement;
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let (num_iter, _data): (u32, Vec<u8>) = env::read();
 

--- a/benchmarks/methods/guest/src/bin/iter_sha2.rs
+++ b/benchmarks/methods/guest/src/bin/iter_sha2.rs
@@ -16,8 +16,7 @@
 
 use risc0_zkvm::{guest::env, sha, sha::Sha256};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let (num_iter, data): (u32, Vec<u8>) = env::read();
 

--- a/benchmarks/methods/guest/src/bin/membership.rs
+++ b/benchmarks/methods/guest/src/bin/membership.rs
@@ -17,8 +17,7 @@
 use risc0_benchmark_lib::MembershipProof;
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let proof: MembershipProof = env::read();
     assert!(proof.verify());

--- a/benchmarks/methods/guest/src/bin/sudoku.rs
+++ b/benchmarks/methods/guest/src/bin/sudoku.rs
@@ -23,8 +23,7 @@ use risc0_zkvm::{
     sha::{Impl, Sha256},
 };
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let puzzle: Sudoku = env::read();
 

--- a/bonsai/Cargo.lock
+++ b/bonsai/Cargo.lock
@@ -4458,6 +4458,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-sppark"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4533,6 +4542,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/bonsai/examples/governance/Cargo.lock
+++ b/bonsai/examples/governance/Cargo.lock
@@ -3805,6 +3805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-sppark"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +3889,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/bonsai/examples/governance/methods/guest/Cargo.lock
+++ b/bonsai/examples/governance/methods/guest/Cargo.lock
@@ -676,6 +676,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -712,6 +721,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
+++ b/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
@@ -16,7 +16,6 @@
 
 use std::{collections::BTreeMap, io::Read};
 
-#[risc0_zkvm::entry]
 use k256::{
     ecdsa::{RecoveryId, Signature, VerifyingKey},
     elliptic_curve::sec1::ToEncodedPoint,
@@ -84,6 +83,7 @@ fn ecrecover(v: u8, rs: [u8; 64], digest: [u8; 32]) -> [u8; 20] {
         .unwrap()
 }
 
+#[risc0_zkvm::entry]
 fn main() {
     // Read data sent from the application contract.
     let mut input_bytes = Vec::<u8>::new();

--- a/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
+++ b/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
@@ -16,15 +16,15 @@
 
 use std::{collections::BTreeMap, io::Read};
 
-use risc0_zkvm::{
-    guest::env,
-    sha::rust_crypto::{Digest as _, Sha256},
-};
-risc0_zkvm::guest::entry!(main);
+#[risc0_zkvm::entry]
 use k256::{
     ecdsa::{RecoveryId, Signature, VerifyingKey},
     elliptic_curve::sec1::ToEncodedPoint,
     PublicKey,
+};
+use risc0_zkvm::{
+    guest::env,
+    sha::rust_crypto::{Digest as _, Sha256},
 };
 use tiny_keccak::{Hasher, Keccak};
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3815,6 +3815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-sppark"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,6 +3899,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -922,6 +922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -958,6 +967,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/bevy/methods/guest/src/main.rs
+++ b/examples/bevy/methods/guest/src/main.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 #![no_main]
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 use risc0_zkvm::guest::env;
 
 use bevy_core::Outputs;

--- a/examples/bevy/methods/guest/src/main.rs
+++ b/examples/bevy/methods/guest/src/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #![no_main]
-#[risc0_zkvm::entry]
+
 use risc0_zkvm::guest::env;
 
 use bevy_core::Outputs;
@@ -42,6 +42,7 @@ fn movement(mut query: Query<(&mut Position, &Velocity)>) {
     }
 }
 
+#[risc0_zkvm::entry]
 pub fn main() {
     let turns: u32 = env::read();
     let mut world = World::new();

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -565,6 +565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -601,6 +610,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/chess/methods/guest/src/main.rs
+++ b/examples/chess/methods/guest/src/main.rs
@@ -18,8 +18,7 @@ use chess_core::Inputs;
 use risc0_zkvm::guest::env;
 use shakmaty::{fen::Fen, san::San, CastlingMode, Chess, FromSetup, Move, Position, Setup};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let inputs: Inputs = env::read();
     let mv: String = inputs.mv;

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -526,6 +526,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -561,6 +570,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/digital-signature/methods/guest/src/main.rs
+++ b/examples/digital-signature/methods/guest/src/main.rs
@@ -19,8 +19,7 @@ use digital_signature_core::{SignMessageCommit, SigningRequest};
 use risc0_zkvm::guest::env;
 use risc0_zkvm::sha::{Impl, Sha256};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let request: SigningRequest = env::read();
     env::commit(&SignMessageCommit {

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -679,6 +679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -715,6 +724,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/ecdsa/methods/guest/src/bin/benchmark.rs
+++ b/examples/ecdsa/methods/guest/src/bin/benchmark.rs
@@ -106,8 +106,7 @@ fn benchmark_group() {
     });
 }
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 fn main() {
     benchmark_field();
     benchmark_scalar();

--- a/examples/ecdsa/methods/guest/src/bin/ecdsa_verify.rs
+++ b/examples/ecdsa/methods/guest/src/bin/ecdsa_verify.rs
@@ -20,8 +20,7 @@ use k256::{
 };
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 fn main() {
     // Decode the verifying key, message, and signature from the inputs.
     let (encoded_verifying_key, message, signature): (EncodedPoint, Vec<u8>, Signature) =

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -525,6 +525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -560,6 +569,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/hello-world/methods/guest/src/main.rs
+++ b/examples/hello-world/methods/guest/src/main.rs
@@ -17,8 +17,7 @@
 
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     // Load the first number from the host
     let a: u64 = env::read();

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -542,6 +542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -578,6 +587,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/json/methods/guest/src/main.rs
+++ b/examples/json/methods/guest/src/main.rs
@@ -21,8 +21,7 @@ use risc0_zkvm::{
     sha::{Impl, Sha256},
 };
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let data: String = env::read();
     let sha = *Impl::hash_bytes(&data.as_bytes());

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -768,6 +768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.40",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -804,6 +813,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/jwt-validator/methods/guest/src/main.rs
+++ b/examples/jwt-validator/methods/guest/src/main.rs
@@ -17,8 +17,7 @@
 use jwt_core::Validator;
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 static PUBLIC_KEY: &str = r#"
     {
       "alg": "RS256",

--- a/examples/jwt-validator/methods/guest/src/main.rs
+++ b/examples/jwt-validator/methods/guest/src/main.rs
@@ -17,7 +17,6 @@
 use jwt_core::Validator;
 use risc0_zkvm::guest::env;
 
-#[risc0_zkvm::entry]
 static PUBLIC_KEY: &str = r#"
     {
       "alg": "RS256",
@@ -32,6 +31,7 @@ static PUBLIC_KEY: &str = r#"
     }
 "#;
 
+#[risc0_zkvm::entry]
 pub fn main() {
     // read the token input
     let token: String = env::read();

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -564,6 +564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -600,6 +609,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/password-checker/methods/guest/src/main.rs
+++ b/examples/password-checker/methods/guest/src/main.rs
@@ -19,7 +19,6 @@ use pbkdf2::pbkdf2_hmac_array;
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha2::Sha256;
 
-#[risc0_zkvm::entry]
 /// Constant policy, compiled into the guest, for this example.
 ///
 /// Note that the policy gets included in the program, and so is reflected in
@@ -37,6 +36,7 @@ const POLICY: PasswordPolicy = PasswordPolicy {
 /// times short. Using a higher iteration count would be required for a real deployment.
 const PBKDF2_SHA256_ITERATIONS: u32 = 10;
 
+#[risc0_zkvm::entry]
 pub fn main() {
     let request: PasswordRequest = env::read();
 

--- a/examples/password-checker/methods/guest/src/main.rs
+++ b/examples/password-checker/methods/guest/src/main.rs
@@ -19,8 +19,7 @@ use pbkdf2::pbkdf2_hmac_array;
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha2::Sha256;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 /// Constant policy, compiled into the guest, for this example.
 ///
 /// Note that the policy gets included in the program, and so is reflected in

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -608,6 +608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -644,6 +653,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/profiling/methods/guest/src/bin/fibonacci.rs
+++ b/examples/profiling/methods/guest/src/bin/fibonacci.rs
@@ -17,8 +17,7 @@
 use nalgebra::Matrix2;
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let iterations: u32 = env::read();
     let answer_1 = fibonacci_1(iterations);

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -584,6 +584,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -620,6 +629,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/prorata/methods/guest/src/main.rs
+++ b/examples/prorata/methods/guest/src/main.rs
@@ -17,8 +17,7 @@
 use prorata_core::AllocationQuery;
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     // Load the amount, recipients, and target user sent from the host:
     let query: AllocationQuery = env::read();

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -536,6 +536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -572,6 +581,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/sha/methods/guest/src/bin/hash.rs
+++ b/examples/sha/methods/guest/src/bin/hash.rs
@@ -19,8 +19,7 @@ use risc0_zkvm::{
     sha::{Impl, Sha256},
 };
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 // Example of using the risc0_zkvm::sha module to hash data.
 pub fn main() {
     let data: String = env::read();

--- a/examples/sha/methods/guest/src/bin/hash.rs
+++ b/examples/sha/methods/guest/src/bin/hash.rs
@@ -19,8 +19,8 @@ use risc0_zkvm::{
     sha::{Impl, Sha256},
 };
 
-#[risc0_zkvm::entry]
 // Example of using the risc0_zkvm::sha module to hash data.
+#[risc0_zkvm::entry]
 pub fn main() {
     let data: String = env::read();
     let digest = Impl::hash_bytes(&data.as_bytes());

--- a/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
+++ b/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
@@ -18,8 +18,8 @@
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha2::{Digest as _, Sha256};
 
-#[risc0_zkvm::entry]
 // Example of using RustCrypto with RISC Zero accelerator support.
+#[risc0_zkvm::entry]
 pub fn main() {
     let data: String = env::read();
     let digest = Sha256::digest(&data.as_bytes());

--- a/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
+++ b/examples/sha/methods/guest/src/bin/hash_rust_crypto.rs
@@ -18,8 +18,7 @@
 use risc0_zkvm::{guest::env, sha::Digest};
 use sha2::{Digest as _, Sha256};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 // Example of using RustCrypto with RISC Zero accelerator support.
 pub fn main() {
     let data: String = env::read();

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -603,6 +603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -639,6 +648,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/smartcore-ml/methods/guest/src/main.rs
+++ b/examples/smartcore-ml/methods/guest/src/main.rs
@@ -24,8 +24,7 @@ use smartcore::{
     tree::decision_tree_classifier::DecisionTreeClassifier,
 };
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     // Read in is_svm boolean to ensure the correct code block is executed
     let is_svm: bool = env::read();

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -518,6 +518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -553,6 +562,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/voting-machine/methods/guest/src/bin/freeze.rs
+++ b/examples/voting-machine/methods/guest/src/bin/freeze.rs
@@ -22,8 +22,7 @@ use risc0_zkvm::{
 };
 use voting_machine_core::{FreezeVotingMachineCommit, FreezeVotingMachineParams};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let params: FreezeVotingMachineParams = env::read();
     let result = params.process();

--- a/examples/voting-machine/methods/guest/src/bin/init.rs
+++ b/examples/voting-machine/methods/guest/src/bin/init.rs
@@ -22,8 +22,7 @@ use risc0_zkvm::{
 };
 use voting_machine_core::{InitializeVotingMachineCommit, VotingMachineState};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let state: VotingMachineState = env::read();
     env::commit(&InitializeVotingMachineCommit {

--- a/examples/voting-machine/methods/guest/src/bin/submit.rs
+++ b/examples/voting-machine/methods/guest/src/bin/submit.rs
@@ -22,8 +22,7 @@ use risc0_zkvm::{
 };
 use voting_machine_core::{SubmitBallotCommit, SubmitBallotParams};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let params: SubmitBallotParams = env::read();
     let result = params.process();

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -620,6 +620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.29",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -656,6 +665,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/waldo/methods/guest/src/main.rs
+++ b/examples/waldo/methods/guest/src/main.rs
@@ -21,8 +21,7 @@ use waldo_core::{
     Journal, PrivateInput,
 };
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     // Read a Merkle proof from the host.
     let input: PrivateInput = env::read();

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -534,6 +534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -570,6 +579,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/wasm/methods/guest/src/main.rs
+++ b/examples/wasm/methods/guest/src/main.rs
@@ -15,8 +15,7 @@
 #![no_main]
 #![allow(unused_imports)]
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 use risc0_zkvm::guest::env;
 use wasmi::{Caller, Engine, Func, Linker, Module, Store};
 

--- a/examples/wasm/methods/guest/src/main.rs
+++ b/examples/wasm/methods/guest/src/main.rs
@@ -15,10 +15,10 @@
 #![no_main]
 #![allow(unused_imports)]
 
-#[risc0_zkvm::entry]
 use risc0_zkvm::guest::env;
 use wasmi::{Caller, Engine, Func, Linker, Module, Store};
 
+#[risc0_zkvm::entry]
 pub fn main() {
     let engine = Engine::default();
 

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -528,6 +528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -564,6 +573,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/wordle/methods/guest/src/main.rs
+++ b/examples/wordle/methods/guest/src/main.rs
@@ -18,8 +18,7 @@ use risc0_zkvm::guest::env;
 use risc0_zkvm::sha::{Impl, Sha256};
 use wordle_core::{GameState, LetterFeedback, WordFeedback, WORD_LENGTH};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let secret: String = env::read();
     let guess: String = env::read();
@@ -45,7 +44,7 @@ pub fn main() {
     for i in 0..WORD_LENGTH {
         if secret.as_bytes()[i] != guess.as_bytes()[i] {
             secret_unmatched.push(secret.as_bytes()[i] as char);
-       }
+        }
     }
 
     // second round for distinguishing partial matches from misses

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -617,6 +617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -653,6 +662,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/xgboost/methods/guest/src/main.rs
+++ b/examples/xgboost/methods/guest/src/main.rs
@@ -17,8 +17,7 @@ use forust_ml::{GradientBooster, Matrix};
 use risc0_zkvm::guest::env;
 use rmp_serde;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     // read the input data
     let input: Vec<f64> = env::read();

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -1355,6 +1355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -1391,6 +1400,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/examples/zkevm-demo/methods/guest/src/bin/evm.rs
+++ b/examples/zkevm-demo/methods/guest/src/bin/evm.rs
@@ -18,8 +18,7 @@
 use risc0_zkvm::guest::env;
 use zkevm_core::{Env, EvmResult, ExecutionResult, ZkDb, EVM};
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let env: Env = env::read();
     let db: ZkDb = env::read();

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,15 +233,15 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "a99254cb6991d6212fc3f7ea23093062b7bb6fbaaa545d33baf5a6dfa768fbc6",
+            "b9f9b0c99c4bad560e1c0cf3b909c6da8536070b5c2f67516d97ed79dc6aa75f",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "f98a7b541e9488a5065a0b67f246e5fc4ad41182d2487c7a0c47607c96766471",
+            "e2371580a4c6dd66b9b22c3130b31b292eeeb4423e7312ca2097a748994b76a8",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "160d9e2e1cefb1c0a62597548a0385c40ba64125a1ddcbda912f38c5821458e0",
+            "f21df1c9b3a10a64a217607c4ec4fed3a1439ab322cfd6eb243852dba7cee1d1",
         );
     }
 }

--- a/risc0/fault/guest/Cargo.lock
+++ b/risc0/fault/guest/Cargo.lock
@@ -533,6 +533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -569,6 +578,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/risc0/macros/Cargo.toml
+++ b/risc0/macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "risc0-macros"
+description = "Procedural macros for risc0"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1"
+syn = { version = "2.0", features = ["full"] }

--- a/risc0/macros/src/entry.rs
+++ b/risc0/macros/src/entry.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use proc_macro2::TokenStream;
 use quote::quote_spanned;
 use syn::{spanned::Spanned, ItemFn, ReturnType};

--- a/risc0/macros/src/entry.rs
+++ b/risc0/macros/src/entry.rs
@@ -69,12 +69,12 @@ mod tests {
         };
 
         let expected = quote! {
-            const __ZKVM_ENTRY: fn() = foo;
+            const ZKVM_ENTRY: fn() = foo;
 
-            mod __zkvm_generated_main {
+            mod zkvm_generated_main {
                 #[no_mangle]
                 fn main() {
-                    super::__ZKVM_ENTRY()
+                    super::ZKVM_ENTRY()
                 }
             }
 
@@ -95,12 +95,12 @@ mod tests {
         };
 
         let expected = quote! {
-            const __ZKVM_ENTRY: fn() = foo;
+            const ZKVM_ENTRY: fn() = foo;
 
-            mod __zkvm_generated_main {
+            mod zkvm_generated_main {
                 #[no_mangle]
                 fn main() {
-                    super::__ZKVM_ENTRY()
+                    super::ZKVM_ENTRY()
                 }
             }
 

--- a/risc0/macros/src/entry.rs
+++ b/risc0/macros/src/entry.rs
@@ -1,0 +1,133 @@
+use proc_macro2::TokenStream;
+use quote::quote_spanned;
+use syn::{spanned::Spanned, ItemFn, ReturnType};
+
+pub(super) fn function(input: ItemFn) -> TokenStream {
+    let fn_name = &input.sig.ident;
+    let inputs = &input.sig.inputs;
+    let output = &input.sig.output;
+
+    // Check for function parameters for better spanned error
+    if !inputs.is_empty() {
+        return quote_spanned! {inputs.span()=>
+            compile_error!("The `#[entry]` function should not have parameters");
+        };
+    }
+
+    // Check for non-unit return type for a better spanned error
+    if let ReturnType::Type(_, ty) = output {
+        // Allow explicit unit type as return
+        if !matches!(**ty, syn::Type::Tuple(ref tuple) if tuple.elems.is_empty()) {
+            return quote_spanned! {output.span()=>
+                compile_error!("The `#[entry]` function must return `()`");
+            };
+        }
+    }
+
+    let result = quote_spanned! {input.sig.span()=>
+        // Type check the given path
+        const __ZKVM_ENTRY: fn() = #fn_name;
+
+        // Include generated main in a module so we don't conflict
+        // with any other definitions of "main" in this file.
+        mod __zkvm_generated_main {
+            #[no_mangle]
+            fn main() {
+                super::__ZKVM_ENTRY()
+            }
+        }
+        #input
+    };
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::{parse_quote, ItemFn};
+
+    #[test]
+    fn basic_function() {
+        let input: ItemFn = parse_quote! {
+            #[entry]
+            fn foo() {}
+        };
+
+        let expected = quote! {
+            const __ZKVM_ENTRY: fn() = foo;
+
+            mod __zkvm_generated_main {
+                #[no_mangle]
+                fn main() {
+                    super::__ZKVM_ENTRY()
+                }
+            }
+
+            #[entry]
+            fn foo() {}
+        };
+
+        let actual = super::function(input);
+
+        assert_eq!(expected.to_string(), actual.to_string());
+    }
+
+    #[test]
+    fn basic_function_with_explicit_unit_return() {
+        let input: ItemFn = parse_quote! {
+            #[entry]
+            fn foo() -> () {}
+        };
+
+        let expected = quote! {
+            const __ZKVM_ENTRY: fn() = foo;
+
+            mod __zkvm_generated_main {
+                #[no_mangle]
+                fn main() {
+                    super::__ZKVM_ENTRY()
+                }
+            }
+
+            #[entry]
+            fn foo() -> () {}
+        };
+
+        let actual = super::function(input);
+
+        assert_eq!(expected.to_string(), actual.to_string());
+    }
+
+    #[test]
+    fn function_with_parameters_should_fail() {
+        let input: ItemFn = parse_quote! {
+            #[entry]
+            fn foo(param: i32) {}
+        };
+
+        let actual = super::function(input);
+
+        // Check if the generated code contains the expected compile error
+        assert!(actual.to_string().contains("compile_error"),);
+        assert!(actual
+            .to_string()
+            .contains("The `#[entry]` function should not have parameters"),);
+    }
+
+    #[test]
+    fn function_with_return_should_fail() {
+        let input: ItemFn = parse_quote! {
+            #[entry]
+            fn foo() -> u8 {}
+        };
+
+        let actual = super::function(input);
+
+        // Check if the generated code contains the expected compile error
+        assert!(actual.to_string().contains("compile_error"),);
+        assert!(actual
+            .to_string()
+            .contains("The `#[entry]` function must return `()`"),);
+    }
+}

--- a/risc0/macros/src/entry.rs
+++ b/risc0/macros/src/entry.rs
@@ -40,14 +40,14 @@ pub(super) fn function(input: ItemFn) -> TokenStream {
 
     let result = quote_spanned! {input.sig.span()=>
         // Type check the given path
-        const __ZKVM_ENTRY: fn() = #fn_name;
+        const ZKVM_ENTRY: fn() = #fn_name;
 
         // Include generated main in a module so we don't conflict
         // with any other definitions of "main" in this file.
-        mod __zkvm_generated_main {
+        mod zkvm_generated_main {
             #[no_mangle]
             fn main() {
-                super::__ZKVM_ENTRY()
+                super::ZKVM_ENTRY()
             }
         }
         #input

--- a/risc0/macros/src/lib.rs
+++ b/risc0/macros/src/lib.rs
@@ -1,0 +1,31 @@
+use proc_macro::TokenStream;
+
+mod entry;
+
+fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {
+    tokens.extend(TokenStream::from(error.into_compile_error()));
+    tokens
+}
+
+/// The `#[entry]` attribute can be used to declare the entry point of a risc0 program.
+///
+/// # Example
+///
+/// ```ignore
+/// #[risc0_zkvm::entry]
+/// fn some_method() {
+///     println!("Hello, world!");
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn entry(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // If any of the steps for this macro fail, we still want to expand to an item that is as close
+    // to the expected output as possible. This helps out IDEs such that completions and other
+    // related features keep working.
+    let input: syn::ItemFn = match syn::parse(item.clone()) {
+        Ok(it) => it,
+        Err(e) => return token_stream_with_error(item, e),
+    };
+
+    entry::function(input).into()
+}

--- a/risc0/macros/src/lib.rs
+++ b/risc0/macros/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use proc_macro::TokenStream;
 
 mod entry;

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -40,6 +40,7 @@ getrandom = { version = "0.2", features = ["custom"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 risc0-binfmt = { workspace = true }
 risc0-core = { workspace = true }
+risc0-macros = { workspace = true }
 risc0-zkp = { workspace = true }
 risc0-zkvm-platform = { workspace = true, features = [
   "rust-runtime",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -801,6 +801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -836,6 +845,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/risc0/zkvm/methods/guest/src/bin/hello_commit.rs
+++ b/risc0/zkvm/methods/guest/src/bin/hello_commit.rs
@@ -17,8 +17,7 @@
 
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     env::commit_slice(b"hello world");
 }

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -37,7 +37,6 @@ use risc0_zkvm_platform::{
     PAGE_SIZE,
 };
 
-#[risc0_zkvm::entry]
 #[inline(never)]
 #[no_mangle]
 fn profile_test_func1() {
@@ -50,6 +49,7 @@ fn profile_test_func2() {
     unsafe { asm!("nop") }
 }
 
+#[risc0_zkvm::entry]
 pub fn main() {
     let impl_select: MultiTestSpec = env::read();
     match impl_select {

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -32,12 +32,12 @@ use risc0_zkvm::{
 use risc0_zkvm_methods::multi_test::{MultiTestSpec, SYS_MULTI_TEST};
 use risc0_zkvm_platform::{
     fileno,
-    memory::{self, SYSTEM}, PAGE_SIZE,
+    memory::{self, SYSTEM},
     syscall::{bigint, sys_bigint, sys_log, sys_read, sys_read_words, sys_write},
+    PAGE_SIZE,
 };
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 #[inline(never)]
 #[no_mangle]
 fn profile_test_func1() {
@@ -269,17 +269,19 @@ pub fn main() {
         },
         MultiTestSpec::AlignedAlloc => {
             #[repr(align(1024))]
-            struct AlignTest1 { pub _test: u32 }
+            struct AlignTest1 {
+                pub _test: u32,
+            }
 
             impl AlignTest1 {
                 pub fn new(_test: u32) -> Self {
-                    AlignTest1{_test}
+                    AlignTest1 { _test }
                 }
             }
 
             let a = &AlignTest1::new(54) as *const _;
             let b = &AlignTest1::new(60) as *const _;
             assert_eq!(PAGE_SIZE, b as usize - a as usize);
-        },
+        }
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/slice_io.rs
+++ b/risc0/zkvm/methods/guest/src/bin/slice_io.rs
@@ -20,8 +20,7 @@ use alloc::vec;
 
 use risc0_zkvm::guest::{env, env::Read};
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let mut len: u32 = 0;
     env::stdin().read_slice(core::slice::from_mut(&mut len));

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -518,6 +518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -553,6 +562,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/risc0/zkvm/methods/rand/src/bin/rand.rs
+++ b/risc0/zkvm/methods/rand/src/bin/rand.rs
@@ -21,8 +21,7 @@ use alloc::vec;
 
 use getrandom::getrandom;
 
-risc0_zkvm::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     // This should panic
     let rand_buf = &mut vec![0u8; 8];

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -717,6 +717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-macros"
+version = "0.21.0-alpha.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "risc0-zkp"
 version = "0.21.0-alpha.1"
 dependencies = [
@@ -753,6 +762,7 @@ dependencies = [
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
+ "risc0-macros",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -42,6 +42,9 @@ pub use bytes::Bytes;
 pub use risc0_binfmt::SystemState;
 pub use risc0_zkvm_platform::{declare_syscall, memory::GUEST_MAX_MEM, PAGE_SIZE};
 
+// Re-export to match previous export from having delcarative macro defined in this crate
+pub use self::guest::entry;
+
 #[cfg(feature = "fault-proof")]
 pub use self::fault_monitor::FaultCheckMonitor;
 #[cfg(all(not(target_os = "zkvm"), feature = "prove"))]

--- a/templates/rust-starter/methods/guest/src/main.rs
+++ b/templates/rust-starter/methods/guest/src/main.rs
@@ -6,8 +6,7 @@
 
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     // TODO: Implement your guest code here
 

--- a/tools/crates-validator/src/lib.rs
+++ b/tools/crates-validator/src/lib.rs
@@ -187,8 +187,7 @@ const MAIN_RS_TEMPLATE: &str = r#"
 
 {{ use_lines }}
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     {{ main_body }}
 }

--- a/tools/smoke-test/methods/guest/src/main.rs
+++ b/tools/smoke-test/methods/guest/src/main.rs
@@ -18,8 +18,7 @@
 use core::hint::black_box;
 use risc0_zkvm::guest::env;
 
-risc0_zkvm::guest::entry!(main);
-
+#[risc0_zkvm::entry]
 pub fn main() {
     let iterations: u32 = env::read();
 

--- a/website/api/zkvm/developer-guide/guest-code-101.md
+++ b/website/api/zkvm/developer-guide/guest-code-101.md
@@ -67,8 +67,8 @@ In our [template] and [examples], there's a bit of boilerplate code before `main
 - `#![no_main]` <br/>
   The guest code is never launched as a standalone Rust executable, so we specify `#![no_main]`.
 
-- `risc0_zkvm_guest::entry!(main);` <br/>
-  We must make the guest code available for the host to launch, and to do that we must specify which function to call when the host starts executing this guest code. We use the `risc0_zkvm_guest::entry!` macro to indicate the initial guest function to call, which in this case is `main`.
+- `#[risc0_zkvm::entry]` <br/>
+  We must make the guest code available for the host to launch, and to do that we must specify which function to call when the host starts executing this guest code. We use the `entry` attribute macro to indicate the initial guest function to call, which in this case is `main`.
 
 ## Happy Building!
 


### PR DESCRIPTION
Closes #1259 

There's not really a way to make this a non-breaking change without deprecations unless we want this macro to be in a different namespace. Assuming this breaking change might be acceptable.