### PR TITLE
fix: remove unnecessary loads in ecall_sha

### DIFF
--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -621,7 +621,7 @@ impl<'a> ExecutorImpl<'a> {
         tracing::debug!("Initial sha state: {state:08x?}");
         for _ in 0..count {
             let mut block = [0u32; BLOCK_WORDS];
-            for (i, word) in block.iter_mut().enumerate() {
+            for (i, word) in block.iter_mut().take(DIGEST_WORDS).enumerate() {
                 *word = self
                     .monitor
                     .load_u32_from_guest_addr(block1_ptr + (i * WORD_SIZE) as u32)?;


### PR DESCRIPTION
Currently this will read past the first digest until the block is full (2*digest). In the case that the second block is directly after the first, this read is just redundant. In the case that they are not, when reading just one, there are unnecessary reads done past the first block/digest.

I might be missing something here, but checking manually and running some basic tests work, so just opening this to see if and what changes/breaks to see if I am missing something.