### PR TITLE
Fix: prove -> prove_elf 

### DIFF
--- a/examples/bevy/src/main.rs
+++ b/examples/bevy/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, BEVY_GUEST_ELF).unwrap();
+    let receipt = prover.prove_elf(env, BEVY_GUEST_ELF).unwrap();
 
     // The prover already runs a verify internally and so it's redundant to verify
     // again here. However, this is how other users would verify the receipt:

--- a/examples/chess/src/main.rs
+++ b/examples/chess/src/main.rs
@@ -63,7 +63,7 @@ fn chess(inputs: &Inputs) -> Receipt {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    prover.prove(env, CHECKMATE_ELF).unwrap()
+    prover.prove_elf(env, CHECKMATE_ELF).unwrap()
 }
 
 #[cfg(test)]

--- a/examples/digital-signature/src/lib.rs
+++ b/examples/digital-signature/src/lib.rs
@@ -54,7 +54,7 @@ pub fn sign(pass_str: impl AsRef<[u8]>, msg_str: impl AsRef<[u8]>) -> Result<Sig
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, SIGN_ELF)?;
+    let receipt = prover.prove_elf(env, SIGN_ELF)?;
 
     Ok(SignatureWithReceipt { receipt })
 }

--- a/examples/ecdsa/src/main.rs
+++ b/examples/ecdsa/src/main.rs
@@ -40,7 +40,7 @@ fn prove_ecdsa_verification(
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    prover.prove(env, ECDSA_VERIFY_ELF).unwrap()
+    prover.prove_elf(env, ECDSA_VERIFY_ELF).unwrap()
 }
 
 fn main() {

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -36,7 +36,7 @@ pub fn multiply(a: u64, b: u64) -> (Receipt, u64) {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, MULTIPLY_ELF).unwrap();
+    let receipt = prover.prove_elf(env, MULTIPLY_ELF).unwrap();
 
     // Extract journal of receipt (i.e. output c, where c = a * b)
     let c: u64 = receipt.journal.decode().expect(

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -38,7 +38,7 @@ fn search_json(data: &str) -> Outputs {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, SEARCH_JSON_ELF).unwrap();
+    let receipt = prover.prove_elf(env, SEARCH_JSON_ELF).unwrap();
 
     receipt.journal.decode().unwrap()
 }

--- a/examples/jwt-validator/src/main.rs
+++ b/examples/jwt-validator/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
 
     let prover = default_prover();
 
-    let receipt = prover.prove(env, VALIDATOR_ELF).expect("failed to prove");
+    let receipt = prover.prove_elf(env, VALIDATOR_ELF).expect("failed to prove");
 
     receipt.verify(VALIDATOR_ID).unwrap();
 

--- a/examples/password-checker/src/main.rs
+++ b/examples/password-checker/src/main.rs
@@ -42,7 +42,7 @@ fn password_checker(request: PasswordRequest) -> Digest {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, PW_CHECKER_ELF).unwrap();
+    let receipt = prover.prove_elf(env, PW_CHECKER_ELF).unwrap();
 
     receipt.journal.decode().unwrap()
 }

--- a/examples/prorata/src/main.rs
+++ b/examples/prorata/src/main.rs
@@ -93,7 +93,7 @@ fn allocate(input: &str, output: &str, recipient: &str, amount: &Decimal) {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, PRORATA_GUEST_ELF).unwrap();
+    let receipt = prover.prove_elf(env, PRORATA_GUEST_ELF).unwrap();
 
     // Verify receipt to confirm that it is correctly formed. Not strictly
     // necessary.

--- a/examples/sha/src/main.rs
+++ b/examples/sha/src/main.rs
@@ -43,7 +43,7 @@ fn provably_hash(input: &str, use_rust_crypto: bool) -> (Digest, Receipt) {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, elf).unwrap();
+    let receipt = prover.prove_elf(env, elf).unwrap();
 
     let digest = receipt.journal.decode().unwrap();
     (digest, receipt)

--- a/examples/smartcore-ml/src/main.rs
+++ b/examples/smartcore-ml/src/main.rs
@@ -66,7 +66,7 @@ fn predict() -> Vec<u32> {
 
     // This initiates a session, runs the STARK prover on the resulting exection
     // trace, and produces a receipt.
-    let receipt = prover.prove(env, ML_TEMPLATE_ELF).unwrap();
+    let receipt = prover.prove_elf(env, ML_TEMPLATE_ELF).unwrap();
 
     // We read the result that the guest code committed to the journal. The
     // receipt can also be serialized and sent to a verifier.

--- a/examples/voting-machine/src/lib.rs
+++ b/examples/voting-machine/src/lib.rs
@@ -78,7 +78,7 @@ impl PollingStation {
         tracing::info!("init");
         let env = ExecutorEnv::builder().write(&self.state)?.build()?;
         let prover = default_prover();
-        let receipt = prover.prove(env, INIT_ELF)?;
+        let receipt = prover.prove_elf(env, INIT_ELF)?;
         Ok(InitMessage { receipt })
     }
 
@@ -91,7 +91,7 @@ impl PollingStation {
             .stdout(&mut output)
             .build()?;
         let prover = default_prover();
-        let receipt = prover.prove(env, SUBMIT_ELF)?;
+        let receipt = prover.prove_elf(env, SUBMIT_ELF)?;
         self.state = from_slice(&output)?;
         Ok(SubmitBallotMessage { receipt })
     }
@@ -105,7 +105,7 @@ impl PollingStation {
             .stdout(&mut output)
             .build()?;
         let prover = default_prover();
-        let receipt = prover.prove(env, FREEZE_ELF)?;
+        let receipt = prover.prove_elf(env, FREEZE_ELF)?;
         let result: FreezeVotingMachineResult = from_slice(&output)?;
         self.state = result.state;
         Ok(FreezeStationMessage { receipt })

--- a/examples/waldo/src/bin/prove.rs
+++ b/examples/waldo/src/bin/prove.rs
@@ -132,7 +132,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, IMAGE_CROP_ELF).unwrap();
+    let receipt = prover.prove_elf(env, IMAGE_CROP_ELF).unwrap();
 
     // Save the receipt to disk so it can be sent to the verifier.
     fs::write(&args.receipt, bincode::serialize(&receipt).unwrap())?;

--- a/examples/wasm/src/main.rs
+++ b/examples/wasm/src/main.rs
@@ -89,7 +89,7 @@ fn run_guest(iters: i32) -> i32 {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, WASM_INTERP_ELF).unwrap();
+    let receipt = prover.prove_elf(env, WASM_INTERP_ELF).unwrap();
 
     receipt.verify(WASM_INTERP_ID).expect(
         "Code you have proven should successfully verify; did you specify the correct image ID?",

--- a/examples/wordle/src/main.rs
+++ b/examples/wordle/src/main.rs
@@ -51,7 +51,7 @@ impl<'a> Server<'a> {
         let prover = default_prover();
 
         // Produce a receipt by proving the specified ELF binary.
-        prover.prove(env, WORDLE_GUEST_ELF).unwrap()
+        prover.prove_elf(env, WORDLE_GUEST_ELF).unwrap()
     }
 }
 

--- a/examples/xgboost/src/main.rs
+++ b/examples/xgboost/src/main.rs
@@ -55,7 +55,7 @@ fn predict() -> f64 {
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, XGBOOST_ELF).unwrap();
+    let receipt = prover.prove_elf(env, XGBOOST_ELF).unwrap();
 
     // We return the inference value committed to the journal.
     receipt.journal.decode().unwrap()

--- a/risc0/r0vm/tests/external_prover.rs
+++ b/risc0/r0vm/tests/external_prover.rs
@@ -25,7 +25,7 @@ fn prove_nothing() -> Result<Receipt> {
         .unwrap();
     let r0vm_path = cargo_bin("r0vm");
     let prover = ExternalProver::new("r0vm", r0vm_path);
-    prover.prove(env, MULTI_TEST_ELF)
+    prover.prove_elf(env, MULTI_TEST_ELF)
 }
 
 #[test_log::test]

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -221,7 +221,7 @@ fn generate_composition_receipt(hashfn: &str) -> Receipt {
         .unwrap();
 
     tracing::info!("Proving rv32im: sys_verify");
-    let composition_receipt = prover.prove(env, MULTI_TEST_ELF).unwrap();
+    let composition_receipt = prover.prove_elf(env, MULTI_TEST_ELF).unwrap();
     tracing::info!("Done proving rv32im: sys_verify");
 
     composition_receipt

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -58,7 +58,7 @@ fn prove_nothing(hashfn: &str) -> Result<Receipt> {
         hashfn: hashfn.to_string(),
         prove_guest_errors: false,
     };
-    get_prover_server(&opts).unwrap().prove(env, MULTI_TEST_ELF)
+    get_prover_server(&opts).unwrap().prove_elf(env, MULTI_TEST_ELF)
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn hashfn_blake2b() {
         .build()
         .unwrap();
     let prover = ProverImpl::new("cpu:blake2b", hal_pair);
-    prover.prove(env, MULTI_TEST_ELF).unwrap();
+    prover.prove_elf(env, MULTI_TEST_ELF).unwrap();
 }
 
 #[test]
@@ -480,7 +480,7 @@ mod sys_verify {
             .unwrap();
         let halt_receipt = get_prover_server(&opts)
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .unwrap();
 
         // Double check that the receipt verifies with the expected image ID and exit code.
@@ -506,7 +506,7 @@ mod sys_verify {
             .unwrap();
         let fault_receipt = get_prover_server(&opts)
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .unwrap();
 
         // Double check that the receipt verifies with the expected image ID and exit code.
@@ -540,7 +540,7 @@ mod sys_verify {
             .unwrap();
         get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()
             .verify(MULTI_TEST_ID)
             .unwrap();
@@ -554,7 +554,7 @@ mod sys_verify {
             .unwrap();
         assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
 
         // Test that providing an unresolved assumption results in a conditional
@@ -568,7 +568,7 @@ mod sys_verify {
         // TODO(#982) Conditional receipts currently return an error on verification.
         assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
 
         // TODO(#982) With conditional receipts, implement the following cases.
@@ -594,7 +594,7 @@ mod sys_verify {
             .unwrap();
         get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()
             .verify(MULTI_TEST_ID)
             .unwrap();
@@ -608,7 +608,7 @@ mod sys_verify {
             .unwrap();
         assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
 
         // Test that providing an unresolved assumption results in a conditional
@@ -622,7 +622,7 @@ mod sys_verify {
         // TODO(#982) Conditional receipts currently return an error on verification.
         assert!(get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .is_err());
     }
 
@@ -645,7 +645,7 @@ mod sys_verify {
             .unwrap();
         get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()
             .verify(MULTI_TEST_ID)
             .unwrap();
@@ -671,7 +671,7 @@ mod sys_verify {
             .unwrap();
         get_prover_server(&prover_opts_fast())
             .unwrap()
-            .prove(env, MULTI_TEST_ELF)
+            .prove_elf(env, MULTI_TEST_ELF)
             .unwrap()
             .verify(MULTI_TEST_ID)
             .unwrap();

--- a/templates/rust-starter/host/src/main.rs
+++ b/templates/rust-starter/host/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
 
     // Produce a receipt by proving the specified ELF binary.
     let receipt = prover
-        .prove(env, {{guest_elf}})
+        .prove_elf(env, {{guest_elf}})
         .unwrap();
 
     // TODO: Implement code for retrieving receipt journal here.

--- a/xtask/src/gen_receipt.rs
+++ b/xtask/src/gen_receipt.rs
@@ -29,7 +29,7 @@ impl GenReceipt {
         let opts = ProverOpts::default();
         let receipt = get_prover_server(&opts)
             .unwrap()
-            .prove(env, FIB_ELF)
+            .prove_elf(env, FIB_ELF)
             .unwrap();
         let receipt_bytes = bincode::serialize(&receipt).unwrap();
 


### PR DESCRIPTION
- `prove` requires multiple arguments including binaries image, verifier context, options and env
- `prove_elf` works with `env` and elf.