### PR TITLE
Allow merge of ReceiptClaim objects with system exit code 2

### DIFF
--- a/examples/composition/methods/build.rs
+++ b/examples/composition/methods/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RISC Zero, Inc.
+// Copyright 2024 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/composition/methods/src/lib.rs
+++ b/examples/composition/methods/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 RISC Zero, Inc.
+// Copyright 2024 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/src/receipt_claim.rs
+++ b/risc0/zkvm/src/receipt_claim.rs
@@ -640,7 +640,9 @@ impl Merge for Option<Output> {
 
 impl Merge for ReceiptClaim {
     fn merge(&self, other: &Self) -> Result<Self, MergeInequalityError> {
-        if self.exit_code != other.exit_code || self.input != other.input {
+        // NOTE: ExitCodes are converted into their pairs first because this code is intended
+        // to accept SystemSplit, SessionLimit, and Fault as interchanable.
+        if self.exit_code.into_pair() != other.exit_code.into_pair() || self.input != other.input {
             return Err(MergeInequalityError(
                 self.digest::<sha::Impl>(),
                 other.digest::<sha::Impl>(),


### PR DESCRIPTION
This PR is a potential solution to https://github.com/risc0/risc0/issues/1306

The root cause of this issue is that we currently have three `ExitCode` values that map to the system exit code value of 2. These are `SystemSplit`, `Fault` and `SessionLimit`. From the circuit "point-of-view" all three of these are the same, and result in the system exit code 2, and user exit code 0. The host is allowed to pick any of these three to report on the receipt claim without changing the digest.

The solution in this PR is to adjust the equality check in the `Merge` trait implementation to accept two exit codes are equal if they are the same when encoded as a pair. This aligns with how `ExitCode` is treated elsewhere.

This issue is a symptom of the fact that our code does not ditinsguish between guest-reported/proven and host-reported/unproven exit codes. A more robust solution would be to remove the `Fault` and `SessionLimit` exit codes from the `ExitCode` enum, as they are not actually checked by the guest. In the future, with the introduction of a guest kernel, it will be possible to provable check that the system exited in a fault state, or that it reached some specified cycle count.

Resolves: https://github.com/risc0/risc0/issues/1306
