### PR TITLE
Change "corroborating receipt" to "assumption receipt"

### DIFF
--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -257,7 +257,7 @@ impl Client {
     }
 
     /// Run the resolve program to remove an assumption from a conditional [SuccinctReceipt] upon
-    /// verifying a corroborating [SuccinctReceipt] for the assumption.
+    /// verifying a [SuccinctReceipt] proving the validity of the assumption.
     ///
     /// By applying the resolve program, a conditional receipt (i.e. a receipt for an execution
     /// using the `env::verify` API to logically verify a receipt) can be made into an
@@ -266,7 +266,7 @@ impl Client {
         &self,
         opts: ProverOpts,
         conditional_receipt: Asset,
-        corroborating_receipt: Asset,
+        assumption_receipt: Asset,
         receipt_out: AssetRequest,
     ) -> Result<SuccinctReceipt> {
         let mut conn = self.connect()?;
@@ -276,7 +276,7 @@ impl Client {
                 pb::api::ResolveRequest {
                     opts: Some(opts.into()),
                     conditional_receipt: Some(conditional_receipt.try_into()?),
-                    corroborating_receipt: Some(corroborating_receipt.try_into()?),
+                    assumption_receipt: Some(assumption_receipt.try_into()?),
                     receipt_out: Some(receipt_out.try_into()?),
                 },
             )),

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -513,18 +513,16 @@ impl Server {
                 .as_bytes()?;
             let conditional_succinct_receipt: SuccinctReceipt =
                 bincode::deserialize(&conditional_receipt_bytes)?;
-            let corroborating_receipt_bytes = request
-                .corroborating_receipt
+            let assumption_receipt_bytes = request
+                .assumption_receipt
                 .ok_or(malformed_err())?
                 .as_bytes()?;
-            let corroborating_succinct_receipt: SuccinctReceipt =
-                bincode::deserialize(&corroborating_receipt_bytes)?;
+            let assumption_succinct_receipt: SuccinctReceipt =
+                bincode::deserialize(&assumption_receipt_bytes)?;
 
             let prover = get_prover_server(&opts)?;
-            let receipt = prover.resolve(
-                &conditional_succinct_receipt,
-                &corroborating_succinct_receipt,
-            )?;
+            let receipt =
+                prover.resolve(&conditional_succinct_receipt, &assumption_succinct_receipt)?;
 
             let succinct_receipt_pb: pb::core::SuccinctReceipt = receipt.into();
             let succinct_receipt_bytes = succinct_receipt_pb.encode_to_vec();

--- a/risc0/zkvm/src/host/api/tests.rs
+++ b/risc0/zkvm/src/host/api/tests.rs
@@ -116,16 +116,12 @@ impl TestClient {
         &self,
         opts: ProverOpts,
         conditional_receipt: Asset,
-        corroborating_receipt: Asset,
+        assumption_receipt: Asset,
     ) -> SuccinctReceipt {
         with_server(self.addr, || {
             let receipt_out = AssetRequest::Path(self.get_work_path());
-            self.client.resolve(
-                opts,
-                conditional_receipt,
-                corroborating_receipt,
-                receipt_out,
-            )
+            self.client
+                .resolve(opts, conditional_receipt, assumption_receipt, receipt_out)
         })
     }
 

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -94,7 +94,7 @@ message JoinResult {
 message ResolveRequest {
   ProverOpts opts = 1;
   Asset conditional_receipt = 2;
-  Asset corroborating_receipt = 3;
+  Asset assumption_receipt = 3;
   AssetRequest receipt_out = 4;
 }
 

--- a/risc0/zkvm/src/host/receipt.rs
+++ b/risc0/zkvm/src/host/receipt.rs
@@ -469,7 +469,7 @@ impl CompositeReceipt {
             }
         }
 
-        // Verify all corroborating receipts attached to this composite receipt.
+        // Verify all assumption receipts attached to this composite receipt.
         for receipt in self.assumptions.iter() {
             tracing::debug!("verifying assumption: {:?}", receipt.get_claim()?.digest());
             receipt.verify_integrity_with_context(ctx)?;

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -285,9 +285,9 @@ fn test_recursion_lift_resolve_e2e() {
     let resolved =
         lifted_assumptions
             .into_iter()
-            .fold(lifted_conditional, |conditional, corroborating| {
+            .fold(lifted_conditional, |conditional, assumption| {
                 tracing::info!("Resolve");
-                let resolved = resolve(&conditional, &corroborating).unwrap();
+                let resolved = resolve(&conditional, &assumption).unwrap();
                 resolved
                     .verify_integrity_with_context(&VerifierContext::default())
                     .unwrap();

--- a/risc0/zkvm/src/host/server/prove/dev_mode.rs
+++ b/risc0/zkvm/src/host/server/prove/dev_mode.rs
@@ -79,7 +79,7 @@ impl ProverServer for DevModeProver {
     fn resolve(
         &self,
         _conditional: &SuccinctReceipt,
-        _corroborating: &SuccinctReceipt,
+        _assumption: &SuccinctReceipt,
     ) -> Result<SuccinctReceipt> {
         unimplemented!("This is unsupported for dev mode.")
     }

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -79,11 +79,12 @@ pub trait ProverServer {
     /// Join two [SuccinctReceipt] into a [SuccinctReceipt]
     fn join(&self, a: &SuccinctReceipt, b: &SuccinctReceipt) -> Result<SuccinctReceipt>;
 
-    /// Resolve an assumption from a conditional [SuccinctReceipt] by providing a corroborating [SuccinctReceipt]
+    /// Resolve an assumption from a conditional [SuccinctReceipt] by providing a [SuccinctReceipt]
+    /// proving the validity of the assumption.
     fn resolve(
         &self,
         conditional: &SuccinctReceipt,
-        corroborating: &SuccinctReceipt,
+        assumption: &SuccinctReceipt,
     ) -> Result<SuccinctReceipt>;
 
     /// Convert a [SuccinctReceipt] with a poseidon hash function that uses a 254-bit field

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -185,9 +185,9 @@ where
     fn resolve(
         &self,
         conditional: &SuccinctReceipt,
-        corroborating: &SuccinctReceipt,
+        assumption: &SuccinctReceipt,
     ) -> Result<SuccinctReceipt> {
-        resolve(conditional, corroborating)
+        resolve(conditional, assumption)
     }
 
     fn identity_p254(&self, a: &SuccinctReceipt) -> Result<SuccinctReceipt> {


### PR DESCRIPTION
Although very clever, the term "corroborating receipt" was introducing uncessesary confusion.
This removes the use of the word "corroborating" with reference to receipts that attest the the validity of assumptions.
