### PR TITLE
Fix FpExt Multiply and Inversion

### DIFF
--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -674,8 +674,9 @@ impl ops::MulAssign for ExtElem {
         // Reduce the degree using the irreducible polynomial
         let upper = 2 * EXT_SIZE - 2;
         for i in (EXT_SIZE..=upper).rev() {
-            for j in 0..IRREDUCIBLE.len() {
-                c[i - EXT_SIZE] += c[i] * IRREDUCIBLE[j];
+            for j in 0..(IRREDUCIBLE.len() - 1) {
+                // Perhaps there's a minor perf gain to be had by storing NEG_IRREDUCIBLE instead of IRREDUCIBLE itself
+                c[i - EXT_SIZE] += c[i] * -IRREDUCIBLE[j];
             }
             c[i] = Elem::ZERO;
         }

--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -672,11 +672,23 @@ impl ops::MulAssign for ExtElem {
         let mut c = Self::naive_mul(a, b);
 
         // Reduce the degree using the irreducible polynomial
+        // Specifically, for irreducible polynomials whose leading coefficient is 1, we have
+        //   x^EXT_SIZE = -IRREDUCIBLE_WITHOUT_LEADING_TERM
+        // as the defining identity for the quotient group.
+        // Thus, for every term of degree i >= EXT_SIZE, we substitute
+        //   c_i * x^i = c_i * x^(i - EXT_SIZE) * x^EXT_SIZE
+        //             = c_i * x^(i - EXT_SIZE) * -IRREDUCIBLE_WITHOUT_LEADING_TERM
+        //             = c_i * sum_j=0^(EXT_SIZE - 1) -IRREDUCIBLE_WITHOUT_LEADING_TERM * x^(i - EXT_SIZE + j)
+        // So, we can zero out the x^i term by adding c[i] * -IRREDUCIBLE[j] to c[i - EXT_SIZE + j] for j < EXT_SIZE
+        assert_eq!(IRREDUCIBLE.len(), EXT_SIZE + 1);
+        assert_eq!(IRREDUCIBLE[EXT_SIZE], Elem::from_u64(1));
         let upper = 2 * EXT_SIZE - 2;
-        for i in (EXT_SIZE..=upper).rev() {
+        for i_rev in (0..EXT_SIZE - 1).rev() {
+            // We need to iterate from high degree to low, otherwise we might add to coefficients we've already zeroed out
+            let i = upper - i_rev;
             for j in 0..(IRREDUCIBLE.len() - 1) {
                 // Perhaps there's a minor perf gain to be had by storing NEG_IRREDUCIBLE instead of IRREDUCIBLE itself
-                c[i - EXT_SIZE] += c[i] * -IRREDUCIBLE[j];
+                c[i - EXT_SIZE + j] += c[i] * -IRREDUCIBLE[j];
             }
             c[i] = Elem::ZERO;
         }

--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -681,7 +681,7 @@ impl ops::MulAssign for ExtElem {
         //             = c_i * sum_j=0^(EXT_SIZE - 1) -IRREDUCIBLE_WITHOUT_LEADING_TERM * x^(i - EXT_SIZE + j)
         // So, we can zero out the x^i term by adding c[i] * -IRREDUCIBLE[j] to c[i - EXT_SIZE + j] for j < EXT_SIZE
         assert_eq!(IRREDUCIBLE.len(), EXT_SIZE + 1);
-        assert_eq!(IRREDUCIBLE[EXT_SIZE], Elem::from_u64(1));
+        assert_eq!(IRREDUCIBLE[EXT_SIZE], Elem::new(1));
         let upper = 2 * EXT_SIZE - 2;
         for i_rev in (0..EXT_SIZE - 1).rev() {
             // We need to iterate from high degree to low, otherwise we might add to coefficients we've already zeroed out

--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -771,28 +771,28 @@ mod tests {
         // ```
 
         let a = ExtElem::new([
-            Elem::new(1),
-            Elem::new(2),
-            Elem::new(3),
-            Elem::new(4),
             Elem::new(5),
+            Elem::new(4),
+            Elem::new(3),
+            Elem::new(2),
+            Elem::new(1),
         ]);
         let b = ExtElem::new([
-            Elem::new(6),
-            Elem::new(7),
-            Elem::new(8),
-            Elem::new(9),
             Elem::new(10),
+            Elem::new(9),
+            Elem::new(8),
+            Elem::new(7),
+            Elem::new(6),
         ]);
 
         assert_eq!(
             a * b,
             ExtElem::new([
-                Elem::new(110),
-                Elem::new(102),
-                Elem::new(68),
-                Elem::new(2),
                 Elem::new(2013265831),
+                Elem::new(2),
+                Elem::new(68),
+                Elem::new(102),
+                Elem::new(110),
             ])
         );
     }

--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -789,7 +789,7 @@ mod tests {
             a * b,
             ExtElem::new([
                 Elem::new(2013265831),
-                Elem::new(2),
+                Elem::new(5),
                 Elem::new(68),
                 Elem::new(102),
                 Elem::new(110),

--- a/risc0/core/src/inverse.rs
+++ b/risc0/core/src/inverse.rs
@@ -49,21 +49,21 @@ impl<T: Elem> ExtensionField<T> {
         c
     }
 
-    fn mul(&self, a: &[T], b: &[T]) -> Vec<T> {
-        let mut c = self.naive_mul(a, b);
+    // fn mul(&self, a: &[T], b: &[T]) -> Vec<T> {
+    //     let mut c = self.naive_mul(a, b);
 
-        // Reduce the degree using the irreducible polynomial
-        let upper = 2 * self.degree - 2;
-        for i in (self.degree..=upper).rev() {
-            let x = c[i];
-            for j in 0..self.degree {
-                c[i - self.degree] += x * self.irreducible[j];
-            }
-            c[i] = T::ZERO;
-        }
-        c.truncate(self.degree);
-        c
-    }
+    //     // Reduce the degree using the irreducible polynomial
+    //     let upper = 2 * self.degree - 2;
+    //     for i in (self.degree..=upper).rev() {
+    //         let x = c[i];
+    //         for j in 0..self.degree {
+    //             c[i - self.degree] += x * self.irreducible[j];
+    //         }
+    //         c[i] = T::ZERO;
+    //     }
+    //     c.truncate(self.degree);
+    //     c
+    // }
 
     fn mul_elem(&self, a: T, b: &[T]) -> Vec<T> {
         let mut c = self.zero();
@@ -82,10 +82,10 @@ impl<T: Elem> ExtensionField<T> {
 
         while Self::degree(&r1) > 0 {
             let quot = self.div(&r0, &r1);
-            let r2 = f.sub(&r0, &f.mul(&quot, &r1));
+            let r2 = f.sub(&r0, &f.naive_mul(&quot, &r1));
             r0 = r1;
             r1 = r2;
-            let t2 = f.sub(&t0, &f.mul(&quot, &t1));
+            let t2 = f.sub(&t0, &f.naive_mul(&quot, &t1));
             t0 = t1;
             t1 = t2;
         }

--- a/risc0/core/src/inverse.rs
+++ b/risc0/core/src/inverse.rs
@@ -134,7 +134,10 @@ impl<T: Elem> ExtensionField<T> {
     }
 
     fn degree(x: &[T]) -> usize {
-        x.iter().rev().position(|x| *x != T::ZERO).unwrap_or(0)
+        match x.iter().skip(1).rev().position(|x| *x != T::ZERO) {
+            Some(i) => x.len() - 1 - i,
+            None => 0,
+        }
     }
 }
 

--- a/risc0/core/src/inverse.rs
+++ b/risc0/core/src/inverse.rs
@@ -49,22 +49,6 @@ impl<T: Elem> ExtensionField<T> {
         c
     }
 
-    // fn mul(&self, a: &[T], b: &[T]) -> Vec<T> {
-    //     let mut c = self.naive_mul(a, b);
-
-    //     // Reduce the degree using the irreducible polynomial
-    //     let upper = 2 * self.degree - 2;
-    //     for i in (self.degree..=upper).rev() {
-    //         let x = c[i];
-    //         for j in 0..self.degree {
-    //             c[i - self.degree] += x * self.irreducible[j];
-    //         }
-    //         c[i] = T::ZERO;
-    //     }
-    //     c.truncate(self.degree);
-    //     c
-    // }
-
     fn mul_elem(&self, a: T, b: &[T]) -> Vec<T> {
         let mut c = self.zero();
         for i in 0..self.degree {


### PR DESCRIPTION
Fix bugs in multiply, degree, and inversion functions in the FpExt refactor. Tests now pass.

Note that the test from `galois` needed to be changed, as we use the opposite order for our polynomials (we use increasing degree, they use decreasing degree) and there was a typo in one of the outputs.