### PR TITLE
zkVM: update expected panic string to be compatible with new toolchains

### DIFF
--- a/risc0/zkvm/src/host/api/tests.rs
+++ b/risc0/zkvm/src/host/api/tests.rs
@@ -306,7 +306,7 @@ fn lift_resolve() {
 }
 
 #[test]
-#[should_panic(expected = "Guest panicked: panicked at 'MultiTestSpec::Panic invoked'")]
+#[should_panic(expected = "MultiTestSpec::Panic invoked")]
 fn guest_error_forwarding() {
     let env = ExecutorEnv::builder()
         .write(&MultiTestSpec::Panic)


### PR DESCRIPTION
Newer toolchains have a more detailed panic message in the guest including the line number of the panic. Without this change the 1.75.0 toolchain will fail the `guest_error_forwarding` test like so:

```
running 1 test
test host::api::tests::guest_error_forwarding - should panic ... FAILED

failures:

---- host::api::tests::guest_error_forwarding stdout ----
thread 'host::api::tests::guest_error_forwarding' panicked at risc0/zkvm/src/host/api/tests.rs:146:22:
called `Result::unwrap()` on an `Err` value: Guest panicked: panicked at src/bin/multi_test.rs:99:13:
MultiTestSpec::Panic invoked
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
note: panic did not contain expected string
      panic message: `"called `Result::unwrap()` on an `Err` value: Guest panicked: panicked at src/bin/multi_test.rs:99:13:\nMultiTestSpec::Panic invoked"`,
 expected substring: `"Guest panicked: panicked at 'MultiTestSpec::Panic invoked'"`
```

Update the expected panic message so it works for older and newer toolchains.