### PR TITLE
Only use local recursion_zkr.zip if it matches the hash

### DIFF
--- a/risc0/circuit/recursion/build.rs
+++ b/risc0/circuit/recursion/build.rs
@@ -52,11 +52,21 @@ fn download_zkr() {
     let src_path = PathBuf::from_str(src_path.as_str()).unwrap();
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir);
+    let out_path = out_dir.join(FILENAME);
+
+    if std::fs::metadata(&out_path).is_ok() {
+        let data = std::fs::read(&out_path).unwrap();
+        if sha2::Sha256::digest(data).to_vec() == decode_hex(SHA256_HASH).unwrap() {
+            return;
+        }
+    } else {
+        std::fs::remove_file(out_path).unwrap();
+    }
+
     if std::fs::metadata(&src_path).is_ok() {
         let data = std::fs::read(&src_path).unwrap();
         if sha2::Sha256::digest(data).to_vec() == decode_hex(SHA256_HASH).unwrap() {
-            let tgt_path = out_dir.join(FILENAME);
-            std::fs::copy(&src_path, &tgt_path).unwrap();
+            std::fs::copy(&src_path, &out_path).unwrap();
             return;
         }
     }

--- a/risc0/circuit/recursion/build.rs
+++ b/risc0/circuit/recursion/build.rs
@@ -58,9 +58,9 @@ fn download_zkr() {
         let data = std::fs::read(&out_path).unwrap();
         if sha2::Sha256::digest(data).to_vec() == decode_hex(SHA256_HASH).unwrap() {
             return;
+        } else {
+            std::fs::remove_file(&out_path).unwrap();
         }
-    } else {
-        std::fs::remove_file(out_path).unwrap();
     }
 
     if std::fs::metadata(&src_path).is_ok() {


### PR DESCRIPTION
This resolves the remaining problem in #1344 

The problem is that, if one uses git path as dependency (see https://github.com/risc0/risc0/issues/1142), cargo does not do git-lfs, and therefore the `recursion_zkr.zip` would remain as a lfs metadata file instead of the actual file. This causes some errors in the upstream, where the recursion prover would complain that the zip archive for the recursion circuits could not be decompressed.

```
thread '<unnamed>' panicked at /Users/cusgadmin/.cargo/git/checkouts/risc0-b4649977e2e81438/341a014/risc0/circuit/recursion/src/zkr.rs:29:71:
called `Result::unwrap()` on an `Err` value: InvalidArchive("Could not find central directory end")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "/Users/cusgadmin/RustroverProjects/r0prover-python/test/test.py", line 33, in <module>
    receipt_1_lifted = l2_r0prover.lift_segment_receipt(receipt_1)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: InvalidArchive("Could not find central directory end")
```

This PR aims to solve this remaining issue systematically. There are a few steps.

**First.** Now, if the build script finds that the local recursion_zkr.zip does not match the expected hash value (which can be due to many reasons, including the lfs metadata issue mentioned above, or the zip file is obsolete), then the build script would choose to download the new zip from S3 bucket.

```diff
+       if sha2::Sha256::digest(data).to_vec() == decode_hex(SHA256_HASH).unwrap() {
            let tgt_path = out_dir.join(FILENAME);
            std::fs::copy(&src_path, &tgt_path).unwrap();
+           return;
+       }
```

**Second.** One thing about the `downloader` crate is that it would refuse to download a file that overwrites the existing one, as it always uses "create_new". This, however, may happen if the user runs the build script again.
https://github.com/hunger/downloader/blob/main/src/backend.rs#L91

To handle this situation, we also check the output file. If a valid downloaded version of `recursion_zkr.zip` exists, then we do not need to download again. If it exists but it does not match, the file must be deleted, in order to allow `downloader` to download the new one at the same path.

Local test shows that this can fix the issue, enabling the upstream to correctly run the recursion prover.

My own **_negative_** test (through println and panic) shows that this would not unnecessarily download the zip from S3 bucket if the local file actually matches the hash---this may need someone from the RISC Zero team to have an independent check.