### PR TITLE
Wrong ZKR hash for the deflate-compressed recursion_zkr.zip

### DIFF
--- a/risc0/circuit/recursion/build.rs
+++ b/risc0/circuit/recursion/build.rs
@@ -45,7 +45,7 @@ fn download_zkr() {
 
     const FILENAME: &str = "recursion_zkr.zip";
     const SRC_PATH: &str = "src/recursion_zkr.zip";
-    const SHA256_HASH: &str = "af7843e15818ef2ebd04fb455caeb42aaa3b70582f519a040adb870318797990";
+    const SHA256_HASH: &str = "ae5736a42189aec2f04936c3aee4b5441e48b26b4fa1fae28657cf50cdf3cae4";
 
     let src_path = env::var("RECURSION_SRC_PATH").unwrap_or(SRC_PATH.to_string());
     let src_path = PathBuf::from_str(src_path.as_str()).unwrap();


### PR DESCRIPTION
There seems to be mismatching of the ZKR hash in the build script and the one in the Git.

The one in the Git, committed on Dec 21, is
https://github.com/risc0/risc0/blob/main/risc0/circuit/recursion/src/recursion_zkr.zip
ae5736a42189aec2f04936c3aee4b5441e48b26b4fa1fae28657cf50cdf3cae4

The leftover ZKR hash, committed on Dec 19, is
af7843e15818ef2ebd04fb455caeb42aaa3b70582f519a040adb870318797990

This is breaking, because the previous version is compressed under the zstd algorithm, while the new version is compressed under the deflate algorithm.

At this moment, if one uses the version compiled from the source, Rust would complain that it does not recognize the compression algorithm:
```
Traceback (most recent call last):
  File "/Users/cusgadmin/RustroverProjects/r0prover-python/test/test.py", line 33, in <module>
    receipt_1_lifted = l2_r0prover.lift_segment_receipt(receipt_1)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Failed to read lift_20.zkr

Caused by:
    unsupported Zip archive: Compression method not supported
```

This is because the new version of risc0 is compiled with only the deflate support of ZIP, and it is being asked to decompress the previous version of the ZIP file, which is zstd.