### PR TITLE
Begin deprecation of Session::resolve (#1378)

### DIFF
--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -563,12 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,7 +919,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/bonsai/examples/governance/methods/guest/Cargo.lock
+++ b/bonsai/examples/governance/methods/guest/Cargo.lock
@@ -462,12 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,7 +706,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/compact_proof/seal_to_json/src/tests.rs
+++ b/compact_proof/seal_to_json/src/tests.rs
@@ -43,14 +43,14 @@ fn stark2snark() {
     tracing::info!("execute");
     let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
     let session = exec.run().unwrap();
-    let segments = session.resolve().unwrap();
-    assert_eq!(segments.len(), 1);
+    assert_eq!(session.segments.len(), 1);
+    let segment = session.segments.first().unwrap().resolve().unwrap();
 
     tracing::info!("prove");
     let opts = ProverOpts::default();
     let ctx = VerifierContext::default();
     let prover = get_prover_server(&opts).unwrap();
-    let segment_receipt = prover.prove_segment(&ctx, &segments[0]).unwrap();
+    let segment_receipt = prover.prove_segment(&ctx, &segment).unwrap();
 
     tracing::info!("lift");
     let lift_receipt = lift(&segment_receipt).unwrap();

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -666,12 +666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +952,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -384,12 +384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,7 +595,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -429,12 +429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,7 +674,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -354,12 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,7 +556,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "risc0-binfmt",

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -462,12 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +709,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -502,12 +502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,7 +876,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -346,12 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,7 +555,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "risc0-binfmt",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -347,12 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,7 +572,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -459,12 +459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,7 +798,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -356,12 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,7 +594,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -364,12 +364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,7 +638,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -374,12 +374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,7 +614,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -355,12 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,7 +566,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -365,12 +365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "inventory"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,7 +633,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -346,12 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,7 +548,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "risc0-binfmt",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -383,12 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "image"
 version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,7 +650,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -347,12 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,7 +564,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -347,12 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,7 +558,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -400,12 +400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,7 +647,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -765,12 +765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,7 +1385,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/risc0/binfmt/src/image.rs
+++ b/risc0/binfmt/src/image.rs
@@ -310,6 +310,14 @@ impl MemoryImage {
     pub fn compute_id(&self) -> Result<Digest> {
         Ok(compute_image_id(&self.compute_root_hash()?, self.pc))
     }
+
+    /// Return the [SystemState] for this image.
+    pub fn get_system_state(&self) -> Result<SystemState> {
+        Ok(SystemState {
+            merkle_root: self.compute_root_hash()?,
+            pc: self.pc,
+        })
+    }
 }
 
 fn hash_page_bytes(page: &[u8]) -> Result<Digest> {

--- a/risc0/binfmt/src/sys_state.rs
+++ b/risc0/binfmt/src/sys_state.rs
@@ -20,8 +20,6 @@ use core::fmt;
 use risc0_zkp::core::{digest::Digest, hash::sha::Sha256};
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(target_os = "zkvm"))]
-use crate::MemoryImage;
 use crate::{tagged_struct, Digestible};
 
 /// Represents the public state of a segment, needed for continuations and
@@ -56,18 +54,6 @@ impl Digestible for SystemState {
     /// Hash the [crate::SystemState] to get a digest of the struct.
     fn digest<S: Sha256>(&self) -> Digest {
         tagged_struct::<S>("risc0.SystemState", &[self.merkle_root], &[self.pc])
-    }
-}
-
-#[cfg(not(target_os = "zkvm"))]
-impl From<&MemoryImage> for SystemState {
-    fn from(image: &MemoryImage) -> Self {
-        Self {
-            pc: image.pc,
-            merkle_root: image
-                .compute_root_hash()
-                .expect("failed to compute root hash"),
-        }
     }
 }
 

--- a/risc0/zkp/src/hal/cuda.rs
+++ b/risc0/zkp/src/hal/cuda.rs
@@ -323,7 +323,7 @@ struct RawBuffer {
 
 impl RawBuffer {
     pub fn new(name: &'static str, size: usize) -> Self {
-        tracing::debug!("alloc: {size} bytes, {name}");
+        tracing::trace!("alloc: {size} bytes, {name}");
         TRACKER.lock().unwrap().alloc(size);
         Self {
             name,
@@ -334,7 +334,7 @@ impl RawBuffer {
 
 impl Drop for RawBuffer {
     fn drop(&mut self) {
-        tracing::debug!("free: {} bytes, {}", self.buf.len(), self.name);
+        tracing::trace!("free: {} bytes, {}", self.buf.len(), self.name);
         TRACKER.lock().unwrap().free(self.buf.len());
     }
 }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -65,6 +65,7 @@ crypto-bigint = { version = "0.5", default-features = false, features = [
   "rand",
 ], optional = true }
 elf = { version = "0.7", default-features = false, optional = true }
+human-repr = { version = "1.0", optional = true }
 lazy-regex = { version = "3.1", optional = true }
 num-bigint = { version = "0.4", default-features = false }
 num-derive = { version = "0.4" }
@@ -80,7 +81,6 @@ tracing = { version = "0.1", default-features = false, features = [
   "attributes",
 ] }
 typetag = { version = "0.2", optional = true }
-human-repr = "1.0"
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -141,6 +141,7 @@ prove = [
   "dep:bytes",
   "dep:crypto-bigint",
   "dep:elf",
+  "dep:human-repr",
   "dep:lazy-regex",
   "dep:num-traits",
   "dep:prost",

--- a/risc0/zkvm/examples/fib.rs
+++ b/risc0/zkvm/examples/fib.rs
@@ -32,6 +32,10 @@ struct Args {
     #[arg(short = 'f', long)]
     hashfn: Option<String>,
 
+    /// Enable tracing forest
+    #[arg(short, long, default_value_t = false)]
+    tree: bool,
+
     #[arg(short, long, default_value_t = false)]
     skip_prover: bool,
 }
@@ -46,12 +50,18 @@ struct Metrics {
 }
 
 fn main() {
+    let args = Args::parse();
+
     tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
         .with(EnvFilter::from_default_env())
-        .with(tracing_forest::ForestLayer::default())
+        .with(if args.tree {
+            Some(tracing_forest::ForestLayer::default())
+        } else {
+            None
+        })
         .init();
 
-    let args = Args::parse();
     let mut opts = ProverOpts::default();
     if let Some(hashfn) = args.hashfn {
         opts.hashfn = hashfn;
@@ -69,8 +79,6 @@ fn top(prover: Rc<dyn ProverServer>, iterations: u32, skip_prover: bool) -> Metr
         .unwrap();
     let mut exec = ExecutorImpl::from_elf(env, FIB_ELF).unwrap();
     let session = exec.run().unwrap();
-    let segments = session.resolve().unwrap();
-    let (total_cycles, user_cycles) = session.get_cycles().unwrap();
     let seal = if skip_prover {
         0
     } else {
@@ -87,9 +95,9 @@ fn top(prover: Rc<dyn ProverServer>, iterations: u32, skip_prover: bool) -> Metr
     };
 
     Metrics {
-        segments: segments.len(),
-        user_cycles,
-        total_cycles,
+        segments: session.segments.len(),
+        user_cycles: session.user_cycles,
+        total_cycles: session.total_cycles,
         seal,
     }
 }

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -444,12 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,7 +832,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "risc0-binfmt",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -346,12 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,7 +548,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "risc0-binfmt",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -422,12 +422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "human-repr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +748,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "hex",
- "human-repr",
  "num-bigint",
  "num-derive",
  "num-traits",

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -136,8 +136,6 @@ fn generate_busy_loop_segments(hashfn: &str) -> (Session, Vec<SegmentReceipt>) {
     tracing::info!("Executing rv32im");
     let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
     let session = exec.run().unwrap();
-    let segments = session.resolve().unwrap();
-    tracing::info!("Got {} segments", segments.len());
 
     let opts = crate::ProverOpts {
         hashfn: hashfn.to_string(),
@@ -147,9 +145,11 @@ fn generate_busy_loop_segments(hashfn: &str) -> (Session, Vec<SegmentReceipt>) {
 
     tracing::info!("Proving rv32im");
     let ctx = VerifierContext::default();
-    let segment_receipts = segments
+    let segment_receipts = session
+        .segments
         .iter()
-        .map(|x| prover.prove_segment(&ctx, x).unwrap())
+        .map(|x| x.resolve().unwrap())
+        .map(|x| prover.prove_segment(&ctx, &x).unwrap())
         .collect();
     tracing::info!("Done proving rv32im");
 

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -21,7 +21,7 @@ use addr2line::{
     gimli::{EndianRcSlice, RunTimeEndian},
     Frame, LookupResult, ObjectContext,
 };
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use crypto_bigint::{CheckedMul, Encoding, NonZero, U256, U512};
 use human_repr::HumanDuration;
 use risc0_binfmt::{MemoryImage, Program, SystemState};
@@ -135,6 +135,12 @@ pub struct ExecutorImpl<'a> {
     profiler: Option<Rc<RefCell<Profiler>>>,
 }
 
+#[derive(Default)]
+struct SessionCycles {
+    user: u64,
+    total: u64,
+}
+
 impl<'a> ExecutorImpl<'a> {
     /// Construct a new [ExecutorImpl] from a [MemoryImage] and entry point.
     ///
@@ -246,20 +252,18 @@ impl<'a> ExecutorImpl<'a> {
         F: FnMut(Segment) -> Result<Box<dyn SegmentRef>>,
     {
         let (Some(ExitCode::SystemSplit | ExitCode::Paused(_)) | None) = self.exit_code else {
-            return Err(anyhow!(
+            bail!(
                 "cannot resume an execution which exited with {:?}",
                 self.exit_code
-            )
-            .into());
+            );
         };
 
         let start_time = std::time::Instant::now();
 
-        self.pc = self
-            .pre_image
-            .as_ref()
-            .ok_or_else(|| anyhow!("attempted to run the executor with no pre_image"))?
-            .pc;
+        let pre_image = self.pre_image.as_ref().context("missing pre_image")?;
+        let pre_state = pre_image.get_system_state()?;
+
+        self.pc = pre_image.pc;
         self.monitor.clear_session()?;
 
         let journal = Journal::default();
@@ -268,15 +272,18 @@ impl<'a> ExecutorImpl<'a> {
             .borrow_mut()
             .with_write_fd(fileno::JOURNAL, journal.clone());
 
-        let mut run_loop = || -> Result<(ExitCode, Segment, MemoryImage)> {
+        let mut run_loop = || -> Result<(ExitCode, Segment, MemoryImage, SessionCycles)> {
+            let mut session_cycles = SessionCycles::default();
+
             loop {
                 if let Some(exit_code) = self.step()? {
                     let total_cycles = self.total_cycles();
                     tracing::debug!("exit_code: {exit_code:?}, total_cycles: {total_cycles}");
                     assert!(total_cycles <= self.segment_limit);
-                    let pre_image = self.pre_image.take().ok_or_else(|| {
-                        anyhow!("attempted to run the executor with no pre_image")
-                    })?;
+                    let pre_image = self
+                        .pre_image
+                        .take()
+                        .context("attempted to run the executor with no pre_image")?;
                     let post_image = self.monitor.build_image(self.pc)?;
                     let syscalls = mem::take(&mut self.syscalls);
                     let faults = mem::take(&mut self.monitor.faults);
@@ -284,7 +291,7 @@ impl<'a> ExecutorImpl<'a> {
                     let cycles = self.body_cycles.try_into()?;
                     let segment = Segment::new(
                         pre_image,
-                        SystemState::from(&post_image),
+                        post_image.get_system_state()?,
                         // NOTE: On the last segment, the output is added outside this loop, before
                         // it is sent to the callback and pushed into the Session object.
                         None,
@@ -299,6 +306,8 @@ impl<'a> ExecutorImpl<'a> {
                             .context("Too many segments to fit in u32")?,
                         cycles,
                     );
+                    session_cycles.user += cycles as u64;
+                    session_cycles.total += 1 << po2;
                     match exit_code {
                         ExitCode::SystemSplit => {
                             let segment_ref = callback(segment)?;
@@ -312,11 +321,11 @@ impl<'a> ExecutorImpl<'a> {
                             let mut resume_pre_image = post_image.clone();
                             resume_pre_image.pc += WORD_SIZE as u32;
                             self.split(Some(resume_pre_image.into()))?;
-                            return Ok((exit_code, segment, post_image));
+                            return Ok((exit_code, segment, post_image, session_cycles));
                         }
                         ExitCode::Halted(inner) => {
                             tracing::debug!("Halted({inner}): {}", self.segment_cycle);
-                            return Ok((exit_code, segment, post_image));
+                            return Ok((exit_code, segment, post_image, session_cycles));
                         }
                         _ => bail!("execution reached unexpected exit code {:?}", exit_code),
                     };
@@ -324,7 +333,7 @@ impl<'a> ExecutorImpl<'a> {
             }
         };
 
-        let (exit_code, mut final_segment, post_image) = run_loop()?;
+        let (exit_code, mut final_segment, post_image, session_cycles) = run_loop()?;
         let elapsed = start_time.elapsed();
 
         // Take (clear out) the list of accessed assumptions.
@@ -337,8 +346,7 @@ impl<'a> ExecutorImpl<'a> {
             .and_then(|output_digest| (output_digest != Digest::ZERO).then(|| journal.buf.take()));
         if !exit_code.expects_output() && session_journal.is_some() {
             tracing::debug!(
-                "dropping non-empty journal due to exit code {:?}: 0x{}",
-                exit_code,
+                "dropping non-empty journal due to exit code {exit_code:?}: 0x{}",
                 hex::encode(journal.buf.borrow().as_slice())
             );
         };
@@ -369,6 +377,21 @@ impl<'a> ExecutorImpl<'a> {
             .flatten()
             .transpose()?;
 
+        // NOTE: When a segment ends in a Halted(_) state, it may not update the post state
+        // digest. As a result, it will be the same are the pre_image. All other exit codes require
+        // the post state digest to reflect the final memory state.
+        // NOTE: The PC on the the post state is stored "+ 4". See ReceiptClaim for more detail.
+        let post_state = SystemState {
+            pc: post_image
+                .pc
+                .checked_add(WORD_SIZE as u32)
+                .context("invalid pc in session post image")?,
+            merkle_root: match exit_code {
+                ExitCode::Halted(_) => final_segment.pre_image.compute_root_hash()?,
+                _ => post_image.compute_root_hash()?,
+            },
+        };
+
         // Now that the Output has been populated, call the segment ref callback.
         let segment_ref = callback(final_segment)?;
         self.segments.push(segment_ref);
@@ -384,13 +407,15 @@ impl<'a> ExecutorImpl<'a> {
             exit_code,
             post_image,
             assumptions,
+            session_cycles.user,
+            session_cycles.total,
+            pre_state,
+            post_state,
         );
 
         tracing::info_span!("executor").in_scope(|| {
             tracing::info!("execution time: {}", elapsed.human_duration());
-            if let Err(error) = session.log() {
-                tracing::error!(?error, "failed to log session");
-            }
+            session.log();
         });
 
         Ok(session)
@@ -730,7 +755,7 @@ impl<'a> ExecutorImpl<'a> {
             let handler = self
                 .syscall_table
                 .get_syscall(&syscall_name)
-                .ok_or(anyhow!("Unknown syscall: {syscall_name:?}"))?;
+                .context(format!("Unknown syscall: {syscall_name:?}"))?;
             let (a0, a1) =
                 handler
                     .borrow_mut()

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -91,13 +91,13 @@ fn basic() {
     let mut exec = ExecutorImpl::new(env, image).unwrap();
     let session = exec.run().unwrap();
     assert_eq!(session.exit_code, ExitCode::Halted(0));
-    let segments = session.resolve().unwrap();
+    let segment = session.segments.first().unwrap().resolve().unwrap();
 
-    assert_eq!(segments.len(), 1);
-    assert_eq!(segments[0].exit_code, ExitCode::Halted(0));
-    assert_eq!(segments[0].pre_image.compute_id().unwrap(), pre_image_id);
-    assert_ne!(segments[0].post_state.digest(), pre_image_id);
-    assert_eq!(segments[0].index, 0);
+    assert_eq!(session.segments.len(), 1);
+    assert_eq!(segment.exit_code, ExitCode::Halted(0));
+    assert_eq!(segment.pre_image.compute_id().unwrap(), pre_image_id);
+    assert_ne!(segment.post_state.digest(), pre_image_id);
+    assert_eq!(segment.index, 0);
 }
 
 #[test]
@@ -126,7 +126,11 @@ fn system_split() {
     let mut exec = ExecutorImpl::new(env, image).unwrap();
     let session = exec.run().unwrap();
     assert_eq!(session.exit_code, ExitCode::Halted(0));
-    let segments = session.resolve().unwrap();
+    let segments: Vec<_> = session
+        .segments
+        .iter()
+        .map(|x| x.resolve().unwrap())
+        .collect();
 
     assert_eq!(segments.len(), 2);
     assert_eq!(segments[0].exit_code, ExitCode::SystemSplit);

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -429,7 +429,11 @@ mod docker {
             .unwrap();
         let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
         let session = exec.run().unwrap();
-        let segments = session.resolve().unwrap();
+        let segments: Vec<_> = session
+            .segments
+            .iter()
+            .map(|x| x.resolve().unwrap())
+            .collect();
         assert_eq!(segments.len(), COUNT);
 
         let (final_segment, segments) = segments.split_last().unwrap();

--- a/risc0/zkvm/src/receipt_claim.rs
+++ b/risc0/zkvm/src/receipt_claim.rs
@@ -396,6 +396,7 @@ where
 {
     /// Unpruned value.
     Value(T),
+
     /// Pruned value, which is a hash [Digest] of the value.
     Pruned(Digest),
 }


### PR DESCRIPTION
* Drop `Session::resolve` convienence; this function doesn't scale
* Avoid using resolve to compute cycle counts and pre/post states
* Use docker feature flag for stark2snark test