### PR TITLE
reproducible builds: update dockerfile to use new toolchain

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -128,7 +128,7 @@ fn create_dockerfile(
     .join(" ");
 
     let build = DockerFile::new()
-        .from_alias("build", "risczero/risc0-guest-builder:v0.17")
+        .from_alias("build", "risczero/risc0-guest-builder:v2024-01-31.1")
         .workdir("/src")
         .copy(".", ".")
         .env(manifest_env)

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -233,15 +233,15 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "191e6211f2fb68ba90905e25b33c9eb6e4bfda58e8d9239675a64b70e566acd6",
+            "231730a4e1e2186d2dd84e87d9c37621629252f2767c6710d9fe50dafd35443f",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "274e0d78546e14e09d3ad352e05adb84cb2c2dc81f8a85e3b8ccd32ce2f705b8",
+            "814a0b41fcd444bd108888eebc8634b09b15627cec05dead7bcc8874bc8e5a3a",
         );
         compare_image_id(
             "risc0_zkvm_methods_guest/slice_io",
-            "4652f8a5c183eb75106070c3b6693dcf6ad0362d67f70258e8b5014b1e3ac52c",
+            "1d031a0f7b8fc6ee88a659d8cb5b2f81d4806d61a8340c43fa72cee0fc5527a6",
         );
     }
 }

--- a/risc0/cargo-risczero/docker/Dockerfile.release
+++ b/risc0/cargo-risczero/docker/Dockerfile.release
@@ -1,5 +1,7 @@
-# To build run: docker build -f Dockerfile.release -t risczero/risc0-guest-builder:v2024-01-31.1
+# To build run: docker build -f Dockerfile.release --build-arg="RISCZERO_VERSION=v2024-01-31.1" -t risczero/risc0-guest-builder:v2024-01-31.1 .
 FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
+
+ARG RISCZERO_VERSION=
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config
@@ -7,6 +9,6 @@ RUN curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https:
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo install cargo-binstall
 RUN cargo binstall -y --force cargo-risczero
-RUN cargo risczero install --version v2024-01-31.1
+RUN cargo risczero install --version ${RISCZERO_VERSION}
 
 ENTRYPOINT [ "/bin/sh" ]

--- a/risc0/cargo-risczero/docker/Dockerfile.release
+++ b/risc0/cargo-risczero/docker/Dockerfile.release
@@ -1,7 +1,7 @@
-# To build run: docker build -f Dockerfile.release --build-arg="RISCZERO_VERSION=v2024-01-31.1" -t risczero/risc0-guest-builder:v2024-01-31.1 .
+# To build run: docker build -f Dockerfile.release --build-arg="RISC0_TOOLCHAIN_VERSION=v2024-01-31.1" -t risczero/risc0-guest-builder:v2024-01-31.1 .
 FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
 
-ARG RISCZERO_VERSION=
+ARG RISC0_TOOLCHAIN_VERSION=
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config
@@ -9,6 +9,6 @@ RUN curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https:
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo install cargo-binstall
 RUN cargo binstall -y --force cargo-risczero
-RUN cargo risczero install --version ${RISCZERO_VERSION}
+RUN cargo risczero install --version ${RISC0_TOOLCHAIN_VERSION}
 
 ENTRYPOINT [ "/bin/sh" ]

--- a/risc0/cargo-risczero/docker/Dockerfile.release
+++ b/risc0/cargo-risczero/docker/Dockerfile.release
@@ -1,11 +1,12 @@
-# To build run: docker build -f Dockerfile.release -t risczero/risc0-guest-builder:v0.17 .
+# To build run: docker build -f Dockerfile.release -t risczero/risc0-guest-builder:v2024-01-31.1
 FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config
 RUN curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https://sh.rustup.rs' | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN cargo install cargo-risczero
-RUN cargo risczero install --version test-release-2
+RUN cargo install cargo-binstall
+RUN cargo binstall -y --force cargo-risczero
+RUN cargo risczero install --version v2024-01-31.1
 
 ENTRYPOINT [ "/bin/sh" ]


### PR DESCRIPTION
This change downloads a newer version of cargo-risczero and to build using a newer toolchain version. This solution expects us to publish new docker images on every toolchain update. While this may create more burden on us, I think this is much more performant for users because they would not need to install the toolchain when running docker builds.