### PR TITLE
Revert "Pin rhai_codegen to fix build issues (#1398)"

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -31,8 +31,6 @@ reqwest = { version = "0.11", default-features = false, features = [
 ] }
 reqwest-middleware = "0.2"
 reqwest-retry = "0.3"
-# rhai depends on an incompatbile version of rhai_codgen, pin it here
-rhai_codegen = "=1.6.0"
 risc0-build = { workspace = true }
 risc0-r0vm = { workspace = true, optional = true }
 risc0-zkvm = { workspace = true, optional = true }


### PR DESCRIPTION
cargo-generate is fixed because rhai codegen was yanked and made into version 2.0 to follow semver. This allows us to revert commit
8650ac903bf10143e26fb11751555269e221abb3.