### PR TITLE
fix: delete `TempDir` when Session goes out of scope

### DIFF
--- a/risc0/groth16/tests/stark_to_snark.rs
+++ b/risc0/groth16/tests/stark_to_snark.rs
@@ -41,7 +41,7 @@ fn stark2snark() {
     let claim = receipt.get_claim().unwrap();
     let composite_receipt = receipt.inner.composite().unwrap();
     let succinct_receipt = prover.compress(composite_receipt).unwrap();
-    let journal = session.journal.unwrap().bytes;
+    let journal = session.journal.clone().unwrap().bytes;
 
     tracing::info!("identity_p254");
     let ident_receipt = identity_p254(&succinct_receipt).unwrap();

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -105,6 +105,7 @@ client = [
   "dep:prost-build",
   "dep:protobuf-src",
   "std",
+  "dep:tempfile",
 ]
 cuda = [
   "prove",

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -104,8 +104,8 @@ client = [
   "dep:prost",
   "dep:prost-build",
   "dep:protobuf-src",
-  "std",
   "dep:tempfile",
+  "std",
 ]
 cuda = [
   "prove",

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -322,7 +322,7 @@ impl Server {
                         pb::api::OnSessionDone {
                             session: Some(pb::api::SessionInfo {
                                 segments: session.segments.len().try_into()?,
-                                journal: session.journal.unwrap_or_default().bytes,
+                                journal: session.journal.clone().unwrap_or_default().bytes,
                                 exit_code: Some(session.exit_code.into()),
                             }),
                         },

--- a/risc0/zkvm/src/host/client/env.rs
+++ b/risc0/zkvm/src/host/client/env.rs
@@ -28,6 +28,7 @@ use bytemuck::Pod;
 use bytes::Bytes;
 use risc0_zkvm_platform::{self, fileno};
 use serde::Serialize;
+use tempfile::TempDir;
 
 use crate::serde::to_vec;
 use crate::{
@@ -351,9 +352,9 @@ impl<'a> ExecutorEnvBuilder<'a> {
     }
 
     /// Set the path where segments will be stored.
-    pub fn segment_path<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
-        self.inner.segment_path = Some(path.as_ref().to_path_buf());
-        self
+    pub fn segment_path<P: AsRef<Path>>(&mut self, path: P) -> Result<&mut Self> {
+        self.inner.segment_path = Some(TempDir::new_in(path.as_ref())?.into_path());
+        Ok(self)
     }
 
     /// Enable the profiler and output results to the specified path.

--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -56,7 +56,8 @@ impl Executor for LocalProver {
         let mut exec = ExecutorImpl::from_elf(env, elf)?;
         let session = exec.run()?;
         let mut segments = Vec::new();
-        for segment in session.segments {
+        let ref session_segments = session.segments;
+        for segment in session_segments {
             let segment = segment.resolve()?;
             segments.push(SegmentInfo {
                 po2: segment.po2,
@@ -65,7 +66,7 @@ impl Executor for LocalProver {
         }
         Ok(SessionInfo {
             segments,
-            journal: session.journal.unwrap_or_default().into(),
+            journal: session.journal.clone().unwrap_or_default().into(),
             exit_code: session.exit_code,
         })
     }

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -192,7 +192,7 @@ fn test_recursion_lift_join_identity_e2e() {
     // Validate the Session rollup + journal data
     let rollup_receipt = Receipt::new(
         InnerReceipt::Succinct(rollup),
-        session.journal.unwrap().bytes,
+        session.journal.clone().unwrap().bytes,
     );
     rollup_receipt.verify(MULTI_TEST_ID).unwrap();
 }

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -411,6 +411,7 @@ impl<'a> ExecutorImpl<'a> {
             session_cycles.total,
             pre_state,
             post_state,
+            self.env.segment_path.clone(),
         );
 
         tracing::info_span!("executor").in_scope(|| {

--- a/risc0/zkvm/src/host/server/session.rs
+++ b/risc0/zkvm/src/host/server/session.rs
@@ -80,6 +80,22 @@ pub struct Session {
 
     /// The system state of the final [MemoryImage] at the end of execution.
     pub post_state: SystemState,
+
+    /// Path of temporary segment storage used internally.
+    temp_segment_dir: Option<PathBuf>,
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        if let Some(path) = &self.temp_segment_dir {
+            if let Err(e) = std::fs::remove_dir_all(path.clone()) {
+                tracing::warn!(
+                    "Failed to delete directory {} used for temporary segment storage. {e}",
+                    path.display()
+                );
+            }
+        }
+    }
 }
 
 /// A reference to a [Segment].
@@ -147,6 +163,7 @@ impl Session {
         total_cycles: u64,
         pre_state: SystemState,
         post_state: SystemState,
+        temp_segment_dir: Option<PathBuf>,
     ) -> Self {
         Self {
             segments,
@@ -159,6 +176,7 @@ impl Session {
             total_cycles,
             pre_state,
             post_state,
+            temp_segment_dir,
         }
     }
 

--- a/xtask/src/bootstrap_groth16.rs
+++ b/xtask/src/bootstrap_groth16.rs
@@ -206,7 +206,7 @@ fn generate_receipt() -> (Receipt, Digest) {
     let receipt = prover.prove_session(&ctx, &session).unwrap();
     let claim = receipt.get_claim().unwrap();
     let succinct_receipt = receipt.inner.succinct().unwrap();
-    let journal = session.journal.unwrap().bytes;
+    let journal = session.journal.clone().unwrap().bytes;
 
     tracing::info!("identity_p254");
     let ident_receipt = identity_p254(&succinct_receipt).unwrap();


### PR DESCRIPTION
This solves the problem where the temporary directory used for storing segments are not deleted after proving. One solution is to represent the directory as `Rc<TempDir>` instead of a `PathBuf` and have `Session` or `SegmentRef` hold a reference to the `TempDir`. Once the session goes out of scope, the `TempDir` gets deleted. I've discovered that adding `TempDir` as a field of `Session` doesn't work because `TempDir` does not implement Serialize or Deserialize while Session and `SegmentRef` implement these traits.

This solution adds the `PathBuf` of the `TempDir` to `Session` and implements a `Drop` trait that removes this directory when Session goes out of scope. I've also noticed that in the case where the user defines the segment path, we're using that path to store the segments. This changes this execution path by creating a `TempDir` inside the user- defined directory so that it does not accidentally delete the user's directory upon termination.

fixes: #1223 