### PR TITLE
risc0-build: move the env var check for RISC0_SKIP_BUILD

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -389,10 +389,6 @@ fn build_guest_package<P>(
 ) where
     P: AsRef<Path>,
 {
-    if !get_env_var("RISC0_SKIP_BUILD").is_empty() {
-        return;
-    }
-
     fs::create_dir_all(target_dir.as_ref()).unwrap();
 
     let mut cmd = if let Some(lib) = runtime_lib {
@@ -520,6 +516,10 @@ fn get_guest_dir() -> PathBuf {
 /// Specify custom options for a guest package by defining its [GuestOptions].
 /// See [embed_methods].
 pub fn embed_methods_with_options(mut guest_pkg_to_options: HashMap<&str, GuestOptions>) {
+    if !get_env_var("RISC0_SKIP_BUILD").is_empty() {
+        return;
+    }
+
     let out_dir_env = env::var_os("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir_env); // $ROOT/target/$profile/build/$crate/out
     let guest_dir = get_guest_dir();


### PR DESCRIPTION
Skipping the guest build of the was this only supported for non-docker build environments. This change enables skipping the guest build by using the RISC0_SKIP_BUILD by moving the env var check to a higher-level function.