### PR TITLE
DevMode: discard segments during execution

### DIFF
--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -54,8 +54,12 @@ use crate::{
     host::{
         client::{env::SegmentPath, exec::TraceEvent},
         receipt::Assumption,
-        server::opcode::{MajorType, OpCode},
+        server::{
+            opcode::{MajorType, OpCode},
+            session::null_callback,
+        },
     },
+    is_dev_mode,
     sha::Digest,
     Assumptions, ExecutorEnv, ExitCode, FileSegmentRef, Loader, Output, Segment, SegmentRef,
     Session,
@@ -256,6 +260,11 @@ impl<'a> ExecutorImpl<'a> {
                 "cannot resume an execution which exited with {:?}",
                 self.exit_code
             );
+        };
+
+        let mut callback = |segment| match is_dev_mode() {
+            true => null_callback(),
+            false => callback(segment),
         };
 
         let start_time = std::time::Instant::now();

--- a/risc0/zkvm/src/host/server/session.rs
+++ b/risc0/zkvm/src/host/server/session.rs
@@ -290,6 +290,24 @@ impl Segment {
     }
 }
 
+const NULL_SEGMENT_REF: NullSegmentRef = NullSegmentRef {};
+
+/// Implementation of a [SegmentRef] that does not save the segment.
+///
+/// This is useful for DevMode where the segments aren't needed.
+#[derive(Serialize, Deserialize)]
+pub struct NullSegmentRef {}
+
+impl SegmentRef for NullSegmentRef {
+    fn resolve(&self) -> anyhow::Result<Segment> {
+        unimplemented!()
+    }
+}
+
+pub fn null_callback() -> Result<Box<dyn SegmentRef>> {
+    Ok(Box::new(NULL_SEGMENT_REF))
+}
+
 /// A very basic implementation of a [SegmentRef].
 ///
 /// The [Segment] itself is stored in this implementation.


### PR DESCRIPTION
Previously, DevMode kept segments in memory. However, this is not practical for very large workloads because the segments can take up a lot of space. This change drops segments from memory during devmode by introducing a new SegmentRef impl. I tried conditionally assigning different closures to the callback variable but I quickly ran into adding starting to complicate type signatures by adding `Box<dyn ...>`. This solution wraps the callback in another closure that checks for dev mode each time segments are resolved.