### PR TITLE
update bonsai methods' README

### DIFF
--- a/bonsai/examples/governance/methods/README.md
+++ b/bonsai/examples/governance/methods/README.md
@@ -3,6 +3,7 @@
 This directory contains the [zkVM] portion for the Bonasai Governance application. 
 To learn more about the code in this directory, we recommend [Guest Code 101] and the [Bonsai Foundry Template]. 
 
-[Guest Code 101]: https://dev.risczero.com/zkvm/developer-guide/guest-code-101
+[Guest Code 101]: https://dev.risczero.com/api/zkvm/guest-code-101
 [zkVM]: https://dev.risczero.com/zkvm
 [Bonsai]: https://dev.risczero.com/bonsai/
+[Bonsai Foundry Template]: https://github.com/risc0/bonsai-foundry-template


### PR DESCRIPTION
Current Guest Code 101 link leads to Page Not Found : https://dev.risczero.com/zkvm/developer-guide/guest-code-101

Also realized added an hyperlink to the Bonsai Template.

[Bonsai] is unused but I did not delete it