### PR TITLE
Change runners to self-hosted so website preview jobs can use sccache in PRs from external contributors

### DIFF
--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -65,7 +65,7 @@ jobs:
   main:
     if: needs.changes.outputs.main == 'true'
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, prod, Linux, cpu]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -99,7 +99,7 @@ jobs:
   version-0_20:
     if: needs.changes.outputs.version-0_20 == 'true'
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, prod, Linux, cpu]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `main` and `version-0_20` jobs need to be changed to using self-hosted runners so PRs from external contributors can use the `sccache` like other workflows.

Until this is pushed, jobs like this will fail:
https://github.com/risc0/risc0/actions/runs/7972603437/job/21999427789?pr=1459#step:6:49