### PR TITLE
'Enforce in CI that code does not contain a "DO NOT MERGE" comment'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
           python-version: "3.10"
       - run: python license-check.py
       - name: check for "D0 NOT MERGE" comments
-        run: grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD)
+        run: grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD); [ $? -eq 1 ]
 
   test:
     if: needs.changes.outputs.test == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
           python-version: "3.10"
       - run: python license-check.py
       - name: check for "D0 NOT MERGE" comments
-        run: grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD); [ $? -eq 1 ]
+        run: [ "$(grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD) | tee /dev/fd/2 | wc -l)" -eq "0" ]
 
   test:
     if: needs.changes.outputs.test == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,8 @@ jobs:
         with:
           python-version: "3.10"
       - run: python license-check.py
+      - name: check for "D0 NOT MERGE" comments
+        run: grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD)
 
   test:
     if: needs.changes.outputs.test == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,8 @@ jobs:
           python-version: "3.10"
       - run: python license-check.py
       - name: check for "D0 NOT MERGE" comments
-        run: [ "$(grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD) | tee /dev/fd/2 | wc -l)" -eq "0" ]
+        run: |
+          [ "$(grep -re 'DO[_ ]\?NOT[_ ]\?MERGE' $(git ls-tree --full-tree --name-only -r HEAD) | tee /dev/fd/2 | wc -l)" -eq "0" ]
 
   test:
     if: needs.changes.outputs.test == 'true'

--- a/risc0/zkvm/src/host/server/exec/syscall.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall.rs
@@ -317,7 +317,6 @@ impl SysVerify {
         image_id: &Digest,
         journal_digest: &Digest,
     ) -> Result<Option<(Digest, u32)>, PrunedValueError> {
-        // DO NOT MERGE: Check here that the cached assumption has no assumptions
         let assumption_journal_digest = claim
             .as_value()?
             .output


### PR DESCRIPTION
Adding comments with "DO NOT MERGE" is a personal practice that is supposed to remind myself and reviewers that something of importance needs to taken care of before merging the PR. I realized when I ran `grep` in my clone of this repo that a comment had slipped through and neither I nor the reviewer ensured I had removed it. The comment was addressed, so no harm done, but I would like to have a rule in CI to check for this.
