### PR TITLE
Docker push CI for risc0-groth16-prover

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -18,6 +18,9 @@ jobs:
       # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
       - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - run: git lfs pull
       - name: docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -29,4 +29,3 @@ jobs:
         run: docker build . --file docker/prover.Dockerfile --tag risczero/risc0-groth16-prover:$RISC0_GROTH16_PROVER
       - name: Docker push
         run: docker push risczero/risc0-groth16-prover
-      

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -1,0 +1,32 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  RISC0_GROTH16_PROVER: v2024-02-07.1
+
+jobs:
+  groth16-prover-build:
+    runs-on: [self-hosted, prod, Linux, cpu, docker]
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
+      - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
+      - uses: actions/checkout@v4
+      - name: docker login
+        env:
+          DOCKER_USER: ${{secrets.DOCKER_USER}}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+      - name: Build the Docker image
+        working-directory: compact_proof
+        run: docker build . --file docker/prover.Dockerfile --tag risczero/risc0-groth16-prover:$RISC0_GROTH16_PROVER
+      - name: Docker push
+        run: docker push risczero/risc0-groth16-prover
+      

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -31,4 +31,4 @@ jobs:
         working-directory: compact_proof
         run: docker build . --file docker/prover.Dockerfile --tag risczero/risc0-groth16-prover:$RISC0_GROTH16_PROVER
       - name: Docker push
-        run: docker push risczero/risc0-groth16-prover
+        run: docker push risczero/risc0-groth16-prover:$RISC0_GROTH16_PROVER


### PR DESCRIPTION
This PR adds a GitHub workflow to build and push the `risc0-groth16-prover` docker image on Docker Hub.
Currently it only works **on dispatch**, but we can add more automation if needed.
Versioning is managed by the env `RISC0_GROTH16_PROVER` set to the same value as the proving key on S3, but we can use the `RISC0_VERSION` if we prefer.

For this workflow to work we need to create a CI/admin user on the [risczero](https://hub.docker.com/u/risczero) Docker Hub account add these secrets to our repo:
- `DOCKER_USER`
- `DOCKER_PASSWORD`