### PR TITLE
backport: tests: forward risc0-groth16's `docker` flag from zkVM

### DIFF
--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -95,7 +95,6 @@ serial_test = "3.0"
 tar = "0.4"
 tempfile = "3"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
-risc0-groth16 = { workspace = true, features = ["docker"] }
 
 [features]
 client = [
@@ -129,7 +128,7 @@ disable-dev-mode = []
 # system will generate binaries that not identical across all architectures.
 # While this is acceptable for most tests, the tests counting cycles and
 # segments will fail intermittently.
-docker = []
+docker = ["risc0-groth16/docker"]
 # The zkVM exposes a getrandom implementation that panics by default. This will
 # expose a getrandom implementation that uses the `sys_random` ecall.
 getrandom = ["risc0-zkvm-platform/getrandom"]


### PR DESCRIPTION
Rather than making this a dev-dependency, forward this feature flag from risc0-zkvm's the docker feature flag.