### PR TITLE
Add compress method to the Prover trait

### DIFF
--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -114,10 +114,12 @@ impl Prover for BonsaiProver {
         }
     }
 
-    fn compress(&self, receipt: &Receipt) -> Result<Receipt> {
+    fn compress(&self, _: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
         match receipt.inner {
             InnerReceipt::Succinct(_) | InnerReceipt::Compact(_) => Ok(receipt.clone()),
-            // DO NOT MERGE: Investigate whether this would be reasonable to support.
+            // NOTE: Bonsai always returns a SuccinctReceipt, and does not support compression of
+            // SegmentReceipts uploaded by clients. It would be possible to support this, but there
+            // is not an apperent reason to do so.
             InnerReceipt::Composite(_) => Err(anyhow!(
                 "BonsaiProver does not support compress on a composite receipt"
             )),

--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -50,14 +50,11 @@ impl Prover for LocalProver {
         self.name.clone()
     }
 
-    fn compress(&self, receipt: &Receipt) -> Result<Receipt> {
+    fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
         match receipt.inner {
             InnerReceipt::Succinct(_) | InnerReceipt::Compact(_) => Ok(receipt.clone()),
             InnerReceipt::Composite(ref inner) => Ok(Receipt {
-                // DO NOT MERGE: Decide how to handle prover options.
-                inner: InnerReceipt::Succinct(
-                    get_prover_server(&Default::default())?.compress(&inner)?,
-                ),
+                inner: InnerReceipt::Succinct(get_prover_server(opts)?.compress(&inner)?),
                 journal: receipt.journal.clone(),
             }),
             InnerReceipt::Fake { .. } => Err(anyhow!(

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -79,6 +79,19 @@ pub trait Prover {
         elf: &[u8],
         opts: &ProverOpts,
     ) -> Result<Receipt>;
+
+    /// Compress a [Receipt], guaranteeing that the resulting receipt is of constant size.
+    ///
+    /// Proving will, by default, will produce a [CompositeReceipt](crate::CompositeReceipt), which
+    /// may contain an arbitrary number of receipts assembled into continuations and compositions.
+    /// Together, these receipts collectively prove a top-level
+    /// [ReceiptClaim](crate::ReceiptClaim). This function compresses all of the constituent
+    /// receipts of a [CompositeReceipt] into a single [SuccinctReceipt] that proves the same
+    /// top-level claim. It accomplishes this by iterative application of the recursion programs
+    /// including lift, join, and resolve.
+    ///
+    /// If the receipt is succinct, this function will do nothing (i.e. it is idemopotent).
+    fn compress(&self, receipt: &Receipt) -> Result<Receipt>;
 }
 
 /// An Executor can execute a given ELF binary.

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -91,7 +91,7 @@ pub trait Prover {
     /// including lift, join, and resolve.
     ///
     /// If the receipt is succinct, this function will do nothing (i.e. it is idemopotent).
-    fn compress(&self, receipt: &Receipt) -> Result<Receipt>;
+    fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt>;
 }
 
 /// An Executor can execute a given ELF binary.

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -24,7 +24,7 @@ mod tests;
 
 use std::rc::Rc;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use cfg_if::cfg_if;
 use risc0_circuit_rv32im::CircuitImpl;
 use risc0_core::field::{
@@ -124,12 +124,12 @@ pub trait ProverServer {
                 InnerReceipt::Composite(assumption) => {
                     self.resolve(&conditional, &self.compress(assumption)?)
                 }
-                InnerReceipt::Fake { .. } => bail!(
+                InnerReceipt::Fake { .. } => Err(anyhow!(
                     "compressing composite receipts with fake receipt assumptions is not supported"
-                ),
-                InnerReceipt::Compact(_) => bail!(
+                )),
+                InnerReceipt::Compact(_) => Err(anyhow!(
                     "compressing composite receipts with Compact receipt assumptions is not supported"
-                )
+                ))
             },
         )
     }


### PR DESCRIPTION
This PR adds the `compress` method to the `Prover` trait, which was previously only available on the `ProverServer`
