### PR TITLE
Revert "risc0-build: move the env var check for RISC0_SKIP_BUILD (#1419)"

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -24,6 +24,8 @@ use risc0_zkvm_platform::{
 };
 use tempfile::tempdir;
 
+use crate::get_env_var;
+
 const DOCKER_IGNORE: &str = r#"
 **/Dockerfile
 **/.git
@@ -36,6 +38,10 @@ const TARGET_DIR: &str = "target/riscv-guest/riscv32im-risc0-zkvm-elf/docker";
 
 /// Build the package in the manifest path using a docker environment.
 pub fn docker_build(manifest_path: &Path, src_dir: &Path, features: &[String]) -> Result<()> {
+    if !get_env_var("RISC0_SKIP_BUILD").is_empty() {
+        return Ok(());
+    }
+
     let manifest_path = manifest_path
         .canonicalize()
         .context(format!("manifest_path: {manifest_path:?}"))?;

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -396,6 +396,10 @@ fn build_guest_package<P>(
 ) where
     P: AsRef<Path>,
 {
+    if !get_env_var("RISC0_SKIP_BUILD").is_empty() {
+        return;
+    }
+
     fs::create_dir_all(target_dir.as_ref()).unwrap();
 
     let mut cmd = if let Some(lib) = runtime_lib {
@@ -525,9 +529,6 @@ fn get_guest_dir() -> PathBuf {
 pub fn embed_methods_with_options(
     mut guest_pkg_to_options: HashMap<&str, GuestOptions>,
 ) -> Vec<GuestListEntry> {
-    if !get_env_var("RISC0_SKIP_BUILD").is_empty() {
-        return Vec::new();
-    }
     let out_dir_env = env::var_os("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir_env); // $ROOT/target/$profile/build/$crate/out
     let guest_dir = get_guest_dir();


### PR DESCRIPTION
This reverts commit c68575c3bea0f2bcf275dbc60d99fc59dd73dbdd and moves the logic to skip build inside docker and non-docker build functions.

Moving the env var to the embed_methods results in skipping the embedding of methods in addition to skipping the build. By doing this, RISC0_SKIP_BUILD will only skip the build and continue to embed the methods.rs file containing the ELF and image ID.