### PR TITLE
Specify `sccache` idle timeout to fix build issues

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -8,6 +8,8 @@ inputs:
 
 runs:
   using: composite
+  env:
+    SCCACHE_IDLE_TIMEOUT: 1200
   steps:
     - if: runner.os == 'Linux' && runner.arch == 'X64'
       run: |


### PR DESCRIPTION
Specifying sccache idle timeout to 20 minutes (1200 sec), up from 10 minutes (600 sec is the default)