### PR TITLE
adding button for getting started

### DIFF
--- a/website/api/introduction.md
+++ b/website/api/introduction.md
@@ -2,10 +2,13 @@
 slug: ./
 ---
 
+:::tip[**Ready to start building?**]
+
+Check out our [Getting Started][docs-getting-started] page.
+
+:::
+
 # Introduction
-
-Welcome to the [RISC Zero][external-risc-zero] documentation!
-
 RISC Zero is creating the infrastructure & tooling necessary for
 developers around the globe to build software that leverages ZK technology.
 
@@ -19,8 +22,4 @@ allowing a skeptical third party to verify correct execution — and the verifie
 doesn't need to repeat the original computation or even see the inputs to the
 program!
 
-**Ready to start building?** <br/>
-Check out our [Getting Started][docs-getting-started] page.
-
 [docs-getting-started]: ./getting-started.md
-[external-risc-zero]: https://risczero.com

--- a/website/api/use-cases.md
+++ b/website/api/use-cases.md
@@ -1,5 +1,11 @@
 # Use Cases
 
+:::tip[**Ready to start building?**]
+
+Check out our [Getting Started][docs-getting-started] page.
+
+:::
+
 Verifiable computation is a game changer for the resilience and economics of
 operating the computing infrastructure we all rely on. It creates a number of
 emergent use cases which we are excited to enable. Key among these are:
@@ -44,13 +50,11 @@ In addition to being far easier to build on, we're also delivering on
 [performance]. The zkVM has GPU acceleration for CUDA and Metal, and with
 [continuations] we've enabled parallel proving of large programs.
 
-**Ready to start building?** <br/>
-Check out our [Getting Started] page.
-
 [Bonsai Pay]: https://risczero.com/news/bonsai-pay
 [chess]: https://github.com/risc0/risc0/tree/main/examples/chess
 [continuations]: https://risczero.com/news/continuations
 [crate-validation]: https://risc0.github.io/ghpages/dev/crate-validation/index.html
+[docs-getting-started]: ./getting-started.md
 [ecdsa]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
 [Getting Started]: ./getting-started.md
 [JSON]: https://github.com/risc0/risc0/tree/main/examples/json


### PR DESCRIPTION
Brian suggested that we replace the "welcome" line on the front page of dev docs with  a "bailout button" that routes to `getting started`. Not sure how to add buttons directly, but a link in an `admonition` is a step in the right direction. 

h/t @Cardosaum for the tip on docusaurus admonitions