### PR TITLE
fix: always show version picker, even on mobile

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,206 +9,207 @@ import rustCode from "./src/remark/rust";
 const baseUrl = process.env.BASE_URL ?? "/";
 
 export default async function createConfigAsync() {
-  /** @type {import('@docusaurus/types').Config} */
-  return {
-    title: "RISC Zero Developer Docs",
-    tagline: "Hyper-Efficient General Purpose Zero-Knowledge Computing.",
-    favicon: "img/logo.png",
+	/** @type {import('@docusaurus/types').Config} */
+	return {
+		title: "RISC Zero Developer Docs",
+		tagline: "Hyper-Efficient General Purpose Zero-Knowledge Computing.",
+		favicon: "img/logo.png",
 
-    url: "https://dev.risczero.com",
-    baseUrl: baseUrl,
+		url: "https://dev.risczero.com",
+		baseUrl: baseUrl,
 
-    organizationName: "risc0",
-    projectName: "devdocs",
+		organizationName: "risc0",
+		projectName: "devdocs",
 
-    onBrokenLinks: "throw",
-    onBrokenMarkdownLinks: "throw",
+		onBrokenLinks: "throw",
+		onBrokenMarkdownLinks: "throw",
 
-    i18n: {
-      defaultLocale: "en",
-      locales: ["en"],
-    },
+		i18n: {
+			defaultLocale: "en",
+			locales: ["en"],
+		},
 
-    markdown: {
-      mermaid: true,
-    },
-    themes: ["@docusaurus/theme-mermaid"],
+		markdown: {
+			mermaid: true,
+		},
+		themes: ["@docusaurus/theme-mermaid"],
 
-    presets: [
-      [
-        "classic",
-        /** @type {import('@docusaurus/preset-classic').Options} */
-        ({
-          docs: {
-            routeBasePath: "/",
-            sidebarPath: require.resolve("./sidebars.js"),
-            remarkPlugins: [math, rustCode],
-            rehypePlugins: [katex],
-          },
-          blog: false,
-          pages: {},
-          theme: {
-            customCss: require.resolve("./src/css/custom.css"),
-          },
-        }),
-      ],
-    ],
+		presets: [
+			[
+				"classic",
+				/** @type {import('@docusaurus/preset-classic').Options} */
+				({
+					docs: {
+						routeBasePath: "/",
+						sidebarPath: require.resolve("./sidebars.js"),
+						remarkPlugins: [math, rustCode],
+						rehypePlugins: [katex],
+					},
+					blog: false,
+					pages: {},
+					theme: {
+						customCss: require.resolve("./src/css/custom.css"),
+					},
+				}),
+			],
+		],
 
-    plugins: [
-      [
-        "@docusaurus/plugin-content-docs",
-        {
-          id: "api",
-          path: "api",
-          routeBasePath: "api",
-          sidebarPath: "./sidebarsApi.js",
-          remarkPlugins: [math, rustCode],
-          rehypePlugins: [katex],
-          editUrl: ({ locale, docPath }) => {
-            // We want users to submit updates to the upstream/next version!
-            // Otherwise we risk losing the update on the next release.
-            return `https://github.com/risc0/risc0/edit/main/website/api/${docPath}`;
-          },
-        },
-      ],
-      [
-        "@docusaurus/plugin-client-redirects",
-        {
-          createRedirects(path) {
-            if (path.includes("/api/generating-proofs/remote-proving")) {
-              return [
-                path.replace(
-                  "/api/generating-proofs/remote-proving",
-                  "/bonsai",
-                ),
-                path.replace(
-                  "/api/generating-proofs/remote-proving",
-                  "/bonsai/quickstart",
-                ),
-              ];
-            }
-            if (path.includes("/api/zkvm")) {
-              return [path.replace("/api/zkvm", "/zkvm")];
-            }
-            return undefined;
-          },
-          redirects: [{ from: "/tech_faq", to: "/faq" }],
-        },
-      ],
-    ],
+		plugins: [
+			[
+				"@docusaurus/plugin-content-docs",
+				{
+					id: "api",
+					path: "api",
+					routeBasePath: "api",
+					sidebarPath: "./sidebarsApi.js",
+					remarkPlugins: [math, rustCode],
+					rehypePlugins: [katex],
+					editUrl: ({ locale, docPath }) => {
+						// We want users to submit updates to the upstream/next version!
+						// Otherwise we risk losing the update on the next release.
+						return `https://github.com/risc0/risc0/edit/main/website/api/${docPath}`;
+					},
+				},
+			],
+			[
+				"@docusaurus/plugin-client-redirects",
+				{
+					createRedirects(path) {
+						if (path.includes("/api/generating-proofs/remote-proving")) {
+							return [
+								path.replace(
+									"/api/generating-proofs/remote-proving",
+									"/bonsai",
+								),
+								path.replace(
+									"/api/generating-proofs/remote-proving",
+									"/bonsai/quickstart",
+								),
+							];
+						}
+						if (path.includes("/api/zkvm")) {
+							return [path.replace("/api/zkvm", "/zkvm")];
+						}
+						return undefined;
+					},
+					redirects: [{ from: "/tech_faq", to: "/faq" }],
+				},
+			],
+		],
 
-    stylesheets: [
-      {
-        href: "https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css",
-        type: "text/css",
-        integrity:
-          "sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM",
-        crossorigin: "anonymous",
-      },
-    ],
+		stylesheets: [
+			{
+				href: "https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css",
+				type: "text/css",
+				integrity:
+					"sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM",
+				crossorigin: "anonymous",
+			},
+		],
 
-    scripts: [
-      {
-        src: "https://plausible.io/js/script.js",
-        "data-domain": "risczero.com",
-        defer: true,
-      },
-    ],
+		scripts: [
+			{
+				src: "https://plausible.io/js/script.js",
+				"data-domain": "risczero.com",
+				defer: true,
+			},
+		],
 
-    themeConfig:
-      /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-      ({
-        image: "img/logo.png",
-        navbar: {
-          title: "RISC Zero",
-          logo: {
-            alt: "RISC Zero Logo",
-            src: "img/logo.png",
-            href: "https://risczero.com/",
-          },
-          items: [
-            {
-              position: "left",
-              label: "Introduction",
-              to: "/api",
-            },
-            {
-              position: "left",
-              label: "Terminology",
-              to: "/terminology",
-            },
-            {
-              position: "left",
-              label: "FAQ",
-              to: "/faq",
-            },
-            {
-              position: "left",
-              label: "Education Hub",
-              to: "/education",
-            },
-            {
-              type: "docsVersionDropdown",
-              position: "right",
-              docsPluginId: "api",
-            },
-            {
-              href: "https://github.com/risc0",
-              position: "right",
-              label: "GitHub",
-            },
-            {
-              type: "dropdown",
-              position: "right",
-              label: "Community",
-              items: [
-                {
-                  label: "Discord",
-                  href: "https://discord.gg/risczero",
-                },
-                {
-                  label: "Twitter",
-                  href: "https://twitter.com/risczero",
-                },
-                {
-                  label: "YouTube",
-                  href: "https://www.youtube.com/@risczero",
-                },
-                {
-                  label: "Stack Overflow",
-                  href: "https://stackoverflow.com/questions/tagged/risczero",
-                },
-                {
-                  label: "Contributor's Guide",
-                  to: "contributors-guide",
-                },
-              ],
-            },
-          ],
-        },
-        footer: {
-          style: "dark",
-          links: [{}],
-          copyright: `Copyright © ${new Date().getFullYear()} RISC Zero, Inc. Built with Docusaurus.`,
-        },
-        prism: {
-          additionalLanguages: ["bash", "rust", "toml"],
-          theme: prismThemes.github,
-          darkTheme: prismThemes.dracula,
-        },
-        colorMode: {
-          defaultMode: "dark",
-          respectPrefersColorScheme: false,
-        },
-        algolia: {
-          appId: "TQC8F4X8Z5",
-          apiKey: "96f324a5e3029cd7b5ba98c91068a7a3", // Public API key
-          indexName: "risczero",
-          searchPagePath: "search",
+		themeConfig:
+			/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+			({
+				image: "img/logo.png",
+				navbar: {
+					title: "RISC Zero",
+					logo: {
+						alt: "RISC Zero Logo",
+						src: "img/logo.png",
+						href: "https://risczero.com/",
+					},
+					items: [
+						{
+							position: "left",
+							label: "Introduction",
+							to: "/api",
+						},
+						{
+							position: "left",
+							label: "Terminology",
+							to: "/terminology",
+						},
+						{
+							position: "left",
+							label: "FAQ",
+							to: "/faq",
+						},
+						{
+							position: "left",
+							label: "Education Hub",
+							to: "/education",
+						},
+						{
+							type: "docsVersionDropdown",
+							position: "right",
+							docsPluginId: "api",
+							class: "docsVersionDropdown",
+						},
+						{
+							href: "https://github.com/risc0",
+							position: "right",
+							label: "GitHub",
+						},
+						{
+							type: "dropdown",
+							position: "right",
+							label: "Community",
+							items: [
+								{
+									label: "Discord",
+									href: "https://discord.gg/risczero",
+								},
+								{
+									label: "Twitter",
+									href: "https://twitter.com/risczero",
+								},
+								{
+									label: "YouTube",
+									href: "https://www.youtube.com/@risczero",
+								},
+								{
+									label: "Stack Overflow",
+									href: "https://stackoverflow.com/questions/tagged/risczero",
+								},
+								{
+									label: "Contributor's Guide",
+									to: "contributors-guide",
+								},
+							],
+						},
+					],
+				},
+				footer: {
+					style: "dark",
+					links: [{}],
+					copyright: `Copyright © ${new Date().getFullYear()} RISC Zero, Inc. Built with Docusaurus.`,
+				},
+				prism: {
+					additionalLanguages: ["bash", "rust", "toml"],
+					theme: prismThemes.github,
+					darkTheme: prismThemes.dracula,
+				},
+				colorMode: {
+					defaultMode: "dark",
+					respectPrefersColorScheme: false,
+				},
+				algolia: {
+					appId: "TQC8F4X8Z5",
+					apiKey: "96f324a5e3029cd7b5ba98c91068a7a3", // Public API key
+					indexName: "risczero",
+					searchPagePath: "search",
 
-          // Leaving at the default of `true` for now
-          contextualSearch: true,
-        },
-      }),
-  };
+					// Leaving at the default of `true` for now
+					contextualSearch: true,
+				},
+			}),
+	};
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -64,12 +64,12 @@
 }
 
 @media (max-width: 996px) {
-  .navbarSearchContainer_node_modules-\@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module  {
-    position: relative !important;
-    right: 0 !important;
+  .navbar__items--right > div:has(.DocSearch-Button)  {
+    position: relative;
+    right: 0;
   }
 
-  .navbar__items--right > .navbar__item:first-child {
+  .navbar__item:has(.docsVersionDropdown) {
     display: block; /* so the version picker always shows up, even on small screens */
   }
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -62,3 +62,14 @@
 .anchor {
   scroll-margin-top: 50pt;
 }
+
+@media (max-width: 996px) {
+  .navbarSearchContainer_node_modules-\@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module  {
+    position: relative !important;
+    right: 0 !important;
+  }
+
+  .navbar__items--right > .navbar__item:first-child {
+    display: block; /* so the version picker always shows up, even on small screens */
+  }
+}


### PR DESCRIPTION
Resolves: https://github.com/risc0/risc0/issues/1541

Context: previously, on mobile you needed to click on
* 1. mobile menu
* 2. "Back to main menu"

in order to see the version picker:

## Before:

<img width="350" alt="image" src="https://github.com/risc0/risc0/assets/19141346/89abf958-eb3b-44a9-a286-5984f7bd9f61">
<img width="345" alt="image" src="https://github.com/risc0/risc0/assets/19141346/8cfc7323-689c-4500-985a-b5eab8526eb5">

---

This PR makes it so the version picker shows up at all times on medium/small screens:

## After:

<img width="768" alt="image" src="https://github.com/risc0/risc0/assets/19141346/bf8e06b2-256b-4016-9742-d80c67e3cada">
<img width="435" alt="image" src="https://github.com/risc0/risc0/assets/19141346/2dde361c-1aa3-4b92-a4b3-5d47a1ae36d7">

Sadly, this isn't something that is officially supported by Docusaurus, so we need to roll out our own CSS rules for it.
