### PR TITLE
Update verifier contract address on docs

### DIFF
--- a/website/api/blockchain-integration/contracts/verifier.md
+++ b/website/api/blockchain-integration/contracts/verifier.md
@@ -56,7 +56,7 @@ You can choose to use this contract or deploy your own.
 
 | Contract                      | Network   | Address                                                        |
 | ----------------------------- | --------- | -------------------------------------------------------------- |
-| [RiscZeroGroth16Verifier.sol] | [Sepolia] | [0x83C2e9CD64B2A16D3908E94C7654f3864212E2F8][sepolia-verifier] |
+| [RiscZeroGroth16Verifier.sol] | [Sepolia] | [0xe57255C10291771A2E14f7eb257555AE82D78302][sepolia-verifier] |
 
 [RiscZeroGroth16Verifier.sol]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/groth16/RiscZeroGroth16Verifier.sol
 [IRiscZeroVerifier.sol]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/IRiscZeroVerifier.sol


### PR DESCRIPTION
After changing the deployed contract on Sepolia, we have to update the docs so users can find it. 