### PR TITLE
Make list of allowed ZKRs explicit in bootstrap

### DIFF
--- a/compact_proof/README.md
+++ b/compact_proof/README.md
@@ -12,6 +12,7 @@ which is suitable for publishing on-chain.
 ## Quickstart
 
 To install the necessary dependencies, run:
+
 ```bash
 ./scripts/install_prover.sh
 ```
@@ -21,19 +22,21 @@ To install the necessary dependencies, run:
 All the following commands must be run from the `compact_proof` directory.
 
 1. Run the ceremony (optional):
-```bash
-wget -O groth16/pot23.ptau https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_23.ptau
-docker build -f docker/ceremony.Dockerfile . -t snark-ceremony
-docker run --rm -v $(pwd)/groth16:/ceremony/groth16 snark-ceremony
-```
+
+   ```bash
+   wget -O groth16/pot23.ptau https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_23.ptau
+   docker build -f docker/ceremony.Dockerfile . -t snark-ceremony
+   docker run --rm -v $(pwd)/groth16:/ceremony/groth16 snark-ceremony
+   ```
 
 2. Build the prover image:
-```bash
-docker build -f docker/prover.Dockerfile . -t risc0-groth16-prover
-```
 
-> Note that the `prover.Dockerfile` downloads a proving key from an existing ceremony.
-> If a new ceremony is required, replace it with the new proving key generated in step 1.
+   ```bash
+   docker build -f docker/prover.Dockerfile . -t risc0-groth16-prover
+   ```
+
+   > Note that the `prover.Dockerfile` downloads a proving key from an existing ceremony.
+   > If a new ceremony is required, replace it with the new proving key generated in step 1.
 
 ## Proof Generation
 

--- a/risc0/circuit/recursion/src/control_id.rs
+++ b/risc0/circuit/recursion/src/control_id.rs
@@ -14,9 +14,9 @@
 
 /// Merkle root of the RECURSION_CONTROL_IDS
 pub const ALLOWED_IDS_ROOT: &str =
-    "4c0dca38ca3de35d11b1fc46095bda17d5b86a2ffeac0636e9403356b0b5a84f";
+    "89dfc82261b33a2174de881e8fc54017e2a21647850a8b73fa28c56b31bad34b";
 
-pub const RECURSION_CONTROL_IDS: [(&str, &str); 15] = [
+pub const RECURSION_CONTROL_IDS: [(&str, &str); 14] = [
     (
         "identity.zkr",
         "a09149331924d71cf14f5b613484540d681f1d63753e9919c87d72414c100e6c",
@@ -72,10 +72,6 @@ pub const RECURSION_CONTROL_IDS: [(&str, &str); 15] = [
     (
         "resolve.zkr",
         "61a2fa5df9c9686208e9a926098cf8270bbfe76b843a2f3708a251549f21a530",
-    ),
-    (
-        "test_recursion_circuit.zkr",
-        "ca7ade1f42976e5e103ad45c97e42963515f5b4b33076418e0a9390a576edd4e",
     ),
 ];
 


### PR DESCRIPTION
Currently, the `test_recursion_circuit` ZKR is included in the allowed list even though it is only for us in tests. The allowed set of ZKRs should only include operations that are meant to be applied to succinct and segment receipts. This PR adds an explicit list of the ZKRs to be included in the allowed set. This means that the test ZKR(s), and accelerators in the future, can be included in the zip, without being automatically included in the allowed set.
