### PR TITLE
DRAFT: Implement syscall for receipt verification

### DIFF
--- a/risc0/zkvm/src/host/receipt.rs
+++ b/risc0/zkvm/src/host/receipt.rs
@@ -120,6 +120,15 @@ pub struct Receipt {
     pub journal: Journal,
 }
 
+/// A receipt and its associated image ID.
+#[derive(Serialize, serde::Deserialize)]
+pub struct ReceiptWithImageId {
+    /// The [Receipt].
+    pub receipt: crate::Receipt,
+    /// The image ID.
+    pub image_id: Digest,
+}
+
 impl Receipt {
     /// Construct a new Receipt
     pub fn new(inner: InnerReceipt, journal: Vec<u8>) -> Self {


### PR DESCRIPTION
# Description
This commit implements a new syscall allowing the guest to verify a specific receipt, rather than simply verifying that *some* receipt is known which satisfies the claim.

This commit implements the requisite syscall but omits the crucial step of recursively invoking the Rust verifier when the host claims that the provided receipt is invalid. This omission is intentional, since the Risc0 verifier currently does not run on Risc0.