### PR TITLE
Update `db-dump` and fix schema incompatibility

### DIFF
--- a/tools/crates-validator/Cargo.lock
+++ b/tools/crates-validator/Cargo.lock
@@ -172,16 +172,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -215,7 +215,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "db-dump"
-version = "0.4.10"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964337f3f98e39999bb3fa10d3b93796eb285b6e969760de06a088418361b7e4"
+checksum = "08ce908474957c3f12cd3cab5e6d87c2435b52930c9806f1ade8a2d7806cb974"
 dependencies = [
  "chrono",
  "csv",
@@ -484,7 +484,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1067,18 +1067,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1248,7 +1248,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.39",
+ "syn 2.0.59",
  "unicode-ident",
 ]
 
@@ -1350,29 +1350,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1544,7 +1544,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1631,7 +1631,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1686,7 +1686,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1749,7 +1749,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1919,7 +1919,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
  "wasm-bindgen-shared",
 ]
 
@@ -1953,7 +1953,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.59",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/tools/crates-validator/Cargo.toml
+++ b/tools/crates-validator/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "main"
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"
-db-dump = "~0.4.10"
+db-dump = "0.7.0"
 handlebars = "4.3"
 indicatif = "0.17"
 reqwest = { version = "0.11", default-features = false, features = [

--- a/tools/crates-validator/src/gen_profiles/mod.rs
+++ b/tools/crates-validator/src/gen_profiles/mod.rs
@@ -24,6 +24,7 @@ use std::{
 use anyhow::{Context, Result};
 use db_dump::{
     categories::{CategoryId, Row as CategoryRow},
+    crate_downloads::Row as CrateDownloadsRow,
     crates::{CrateId, Row as CrateRow},
     crates_categories::Row as CratesCategoriesRow,
     versions::Row as VersionRow,
@@ -66,6 +67,7 @@ pub struct ProcessDatabase {
     versions: BTreeMap<CrateId, VersionRow>,
     categories: HashMap<CategoryId, String>,
     crates_categories: HashMap<CrateId, CategoryId>,
+    crate_downloads: HashMap<CrateId, u64>,
 }
 pub struct FilterSelectedCrates {
     profile_config: ProfileConfig,
@@ -177,6 +179,7 @@ impl StateMachine<DownloadDatabase> {
         let mut crates = Vec::new();
         let mut categories = HashMap::new();
         let mut crates_categories = HashMap::new();
+        let mut crate_downloads = HashMap::new();
 
         debug!("Loading...");
         let crate_name = &self.args.name;
@@ -213,16 +216,25 @@ impl StateMachine<DownloadDatabase> {
             crates_categories.insert(row.crate_id, row.category_id);
         };
 
+        let handle_crate_downloads = |row: CrateDownloadsRow| {
+            crate_downloads.insert(row.crate_id, row.downloads);
+        };
+
         db_dump::Loader::new()
             .crates_categories(handle_crates_categories)
             .categories(handle_categories)
             .crates(handle_crates)
             .versions(handle_versions)
+            .crate_downloads(handle_crate_downloads)
             .load(self.state.database_path)
             .context("Failed to load database")?;
 
         debug!("Sorting...");
-        crates.sort_by(|r1, r2| r2.downloads.cmp(&r1.downloads));
+        crates.sort_by(|r1, r2| {
+            let r1_downloads = crate_downloads.get(&r1.id).unwrap_or(&0);
+            let r2_downloads = crate_downloads.get(&r2.id).unwrap_or(&0);
+            r2_downloads.cmp(r1_downloads)
+        });
 
         Ok(StateMachine {
             args: self.args,
@@ -232,6 +244,7 @@ impl StateMachine<DownloadDatabase> {
                 versions,
                 categories,
                 crates_categories,
+                crate_downloads,
             },
         })
     }
@@ -259,7 +272,11 @@ impl StateMachine<ProcessDatabase> {
                     &self.args.categories,
                     &self.state.crates_categories,
                 );
-                categories.sort_by(|r1, r2| r2.downloads.cmp(&r1.downloads));
+                categories.sort_by(|r1, r2| {
+                    let r1_downloads = self.state.crate_downloads.get(&r1.id).unwrap_or(&0);
+                    let r2_downloads = self.state.crate_downloads.get(&r2.id).unwrap_or(&0);
+                    r2_downloads.cmp(r1_downloads)
+                });
                 match self.args.category_count_limit {
                     Some(limit) => categories.into_iter().take(limit).collect(),
                     None => categories,


### PR DESCRIPTION
This solves the Nightly CI failing. 

The issue arose from the fact that the db we download from crates.io had a schema update, and we had to update the code to conform to this new schema. 