### PR TITLE
Add compress to the Prover trait

### DIFF
--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -68,14 +68,19 @@ impl Client {
     }
 
     /// Prove the specified ELF binary.
-    pub fn prove(&self, env: &ExecutorEnv<'_>, opts: ProverOpts, binary: Asset) -> Result<Receipt> {
+    pub fn prove(
+        &self,
+        env: &ExecutorEnv<'_>,
+        opts: &ProverOpts,
+        binary: Asset,
+    ) -> Result<Receipt> {
         let mut conn = self.connect()?;
 
         let request = pb::api::ServerRequest {
             kind: Some(pb::api::server_request::Kind::Prove(
                 pb::api::ProveRequest {
                     env: Some(self.make_execute_env(env, binary.try_into()?)?),
-                    opts: Some(opts.into()),
+                    opts: Some(opts.clone().into()),
                     receipt_out: Some(pb::api::AssetRequest {
                         kind: Some(pb::api::asset_request::Kind::Inline(())),
                     }),
@@ -133,7 +138,7 @@ impl Client {
     /// Prove the specified segment.
     pub fn prove_segment(
         &self,
-        opts: ProverOpts,
+        opts: &ProverOpts,
         segment: Asset,
         receipt_out: AssetRequest,
     ) -> Result<SegmentReceipt> {
@@ -142,7 +147,7 @@ impl Client {
         let request = pb::api::ServerRequest {
             kind: Some(pb::api::server_request::Kind::ProveSegment(
                 pb::api::ProveSegmentRequest {
-                    opts: Some(opts.into()),
+                    opts: Some(opts.clone().into()),
                     segment: Some(segment.try_into()?),
                     receipt_out: Some(receipt_out.try_into()?),
                 },
@@ -178,7 +183,7 @@ impl Client {
     /// used as the input to all other recursion programs (e.g. join, resolve, and identity_p254).
     pub fn lift(
         &self,
-        opts: ProverOpts,
+        opts: &ProverOpts,
         receipt: Asset,
         receipt_out: AssetRequest,
     ) -> Result<SuccinctReceipt> {
@@ -186,7 +191,7 @@ impl Client {
 
         let request = pb::api::ServerRequest {
             kind: Some(pb::api::server_request::Kind::Lift(pb::api::LiftRequest {
-                opts: Some(opts.into()),
+                opts: Some(opts.clone().into()),
                 receipt: Some(receipt.try_into()?),
                 receipt_out: Some(receipt_out.try_into()?),
             })),
@@ -219,7 +224,7 @@ impl Client {
     /// the same session can be compressed into a single receipt for the entire session.
     pub fn join(
         &self,
-        opts: ProverOpts,
+        opts: &ProverOpts,
         left_receipt: Asset,
         right_receipt: Asset,
         receipt_out: AssetRequest,
@@ -228,7 +233,7 @@ impl Client {
 
         let request = pb::api::ServerRequest {
             kind: Some(pb::api::server_request::Kind::Join(pb::api::JoinRequest {
-                opts: Some(opts.into()),
+                opts: Some(opts.clone().into()),
                 left_receipt: Some(left_receipt.try_into()?),
                 right_receipt: Some(right_receipt.try_into()?),
                 receipt_out: Some(receipt_out.try_into()?),
@@ -264,7 +269,7 @@ impl Client {
     /// unconditional receipt.
     pub fn resolve(
         &self,
-        opts: ProverOpts,
+        opts: &ProverOpts,
         conditional_receipt: Asset,
         assumption_receipt: Asset,
         receipt_out: AssetRequest,
@@ -274,7 +279,7 @@ impl Client {
         let request = pb::api::ServerRequest {
             kind: Some(pb::api::server_request::Kind::Resolve(
                 pb::api::ResolveRequest {
-                    opts: Some(opts.into()),
+                    opts: Some(opts.clone().into()),
                     conditional_receipt: Some(conditional_receipt.try_into()?),
                     assumption_receipt: Some(assumption_receipt.try_into()?),
                     receipt_out: Some(receipt_out.try_into()?),
@@ -310,7 +315,7 @@ impl Client {
     /// produced with Poseidon over the BN254 base field compared to using Posidon over BabyBear.
     pub fn identity_p254(
         &self,
-        opts: ProverOpts,
+        opts: &ProverOpts,
         receipt: Asset,
         receipt_out: AssetRequest,
     ) -> Result<SuccinctReceipt> {
@@ -319,7 +324,7 @@ impl Client {
         let request = pb::api::ServerRequest {
             kind: Some(pb::api::server_request::Kind::IdentiyP254(
                 pb::api::IdentityP254Request {
-                    opts: Some(opts.into()),
+                    opts: Some(opts.clone().into()),
                     receipt: Some(receipt.try_into()?),
                     receipt_out: Some(receipt_out.try_into()?),
                 },

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -18,7 +18,10 @@ use anyhow::{anyhow, bail, ensure, Context, Result};
 use bonsai_sdk::alpha::Client;
 
 use super::Prover;
-use crate::{compute_image_id, sha::Digestible, ExecutorEnv, ProverOpts, Receipt, VerifierContext};
+use crate::{
+    compute_image_id, sha::Digestible, ExecutorEnv, InnerReceipt, ProverOpts, Receipt,
+    VerifierContext,
+};
 
 /// An implementation of a [Prover] that runs proof workloads via Bonsai.
 ///
@@ -123,6 +126,21 @@ impl Prover for BonsaiProver {
                         .unwrap_or("Bonsai workflow missing error_msg".into()),
                 );
             }
+        }
+    }
+
+    fn compress(&self, _: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
+        match receipt.inner {
+            InnerReceipt::Succinct(_) | InnerReceipt::Compact(_) => Ok(receipt.clone()),
+            // NOTE: Bonsai always returns a SuccinctReceipt, and does not support compression of
+            // SegmentReceipts uploaded by clients. It would be possible to support this, but there
+            // is not an apperent reason to do so.
+            InnerReceipt::Composite(_) => Err(anyhow!(
+                "BonsaiProver does not support compress on a composite receipt"
+            )),
+            InnerReceipt::Fake { .. } => Err(anyhow!(
+                "BonsaiProver does not support compress on a composite receipt"
+            )),
         }
     }
 }

--- a/risc0/zkvm/src/host/client/prove/external.rs
+++ b/risc0/zkvm/src/host/client/prove/external.rs
@@ -14,12 +14,13 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{ensure, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 
 use super::{Executor, Prover, ProverOpts};
 use crate::{
-    compute_image_id, host::api::AssetRequest, sha::Digestible, ApiClient, Asset, ExecutorEnv,
-    Receipt, SessionInfo, VerifierContext,
+    compute_image_id, host::api::AssetRequest, sha::Digestible, ApiClient, Asset, CompositeReceipt,
+    ExecutorEnv, InnerReceipt, Receipt, SegmentReceipt, SessionInfo, SuccinctReceipt,
+    VerifierContext,
 };
 
 /// An implementation of a [Prover] that runs proof workloads via an external
@@ -36,6 +37,47 @@ impl ExternalProver {
             name: name.to_string(),
             r0vm_path: r0vm_path.as_ref().to_path_buf(),
         }
+    }
+
+    /// Internal implementation of the compress function.
+    fn compress_internal(
+        client: &ApiClient,
+        opts: &ProverOpts,
+        receipt: &CompositeReceipt,
+    ) -> Result<SuccinctReceipt> {
+        // Compress all receipts in the top-level session into one succinct receipt for the session.
+        let continuation_receipt = receipt
+            .segments
+            .iter()
+            .try_fold(
+                None,
+                |left: Option<SuccinctReceipt>, right: &SegmentReceipt| -> Result<_> {
+                    Ok(Some(match left {
+                        Some(left) => client.join(opts, &left, &client.lift(opts, right)?)?,
+                        None => client.lift(opts, right)?,
+                    }))
+                },
+            )?
+            .ok_or(anyhow!(
+                "malformed composite receipt has no continuation segment receipts"
+            ))?;
+
+        // Compress assumptions and resolve them to get the final succinct receipt.
+        receipt.assumptions.iter().try_fold(
+            continuation_receipt,
+            |conditional: SuccinctReceipt, assumption: &InnerReceipt| match assumption {
+                InnerReceipt::Succinct(assumption) => client.resolve(opts, &conditional, assumption),
+                InnerReceipt::Composite(assumption) => {
+                    client.resolve(opts, &conditional, &Self::compress_internal(client, opts, assumption)?)
+                }
+                InnerReceipt::Fake { .. } => bail!(
+                    "compressing composite receipts with fake receipt assumptions is not supported"
+                ),
+                InnerReceipt::Compact(_) => bail!(
+                    "compressing composite receipts with Compact receipt assumptions is not supported"
+                ),
+            },
+        )
     }
 }
 
@@ -70,6 +112,24 @@ impl Prover for ExternalProver {
 
     fn get_name(&self) -> String {
         self.name.clone()
+    }
+
+    fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
+        match receipt.inner {
+            InnerReceipt::Succinct(_) | InnerReceipt::Compact(_) => Ok(receipt.clone()),
+            InnerReceipt::Composite(ref composite) => {
+                let client = ApiClient::new_sub_process(&self.r0vm_path)?;
+                Ok(Receipt {
+                    inner: InnerReceipt::Succinct(Self::compress_internal(
+                        &client, opts, composite,
+                    )?),
+                    journal: receipt.journal.clone(),
+                })
+            }
+            InnerReceipt::Fake { .. } => {
+                bail!("ExternalProver cannot compress a fake receipt")
+            }
+        }
     }
 }
 

--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 use super::{Executor, Prover, ProverOpts};
 use crate::{
-    get_prover_server, host::server::session::NullSegmentRef, ExecutorEnv, ExecutorImpl, Receipt,
-    SegmentInfo, SessionInfo, VerifierContext,
+    get_prover_server, host::server::session::NullSegmentRef, ExecutorEnv, ExecutorImpl,
+    InnerReceipt, Receipt, SegmentInfo, SessionInfo, VerifierContext,
 };
 
 /// A [Prover] implementation that selects a [crate::ProverServer] by calling
@@ -48,6 +48,19 @@ impl Prover for LocalProver {
 
     fn get_name(&self) -> String {
         self.name.clone()
+    }
+
+    fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
+        match receipt.inner {
+            InnerReceipt::Succinct(_) | InnerReceipt::Compact(_) => Ok(receipt.clone()),
+            InnerReceipt::Composite(ref inner) => Ok(Receipt {
+                inner: InnerReceipt::Succinct(get_prover_server(opts)?.compress(&inner)?),
+                journal: receipt.journal.clone(),
+            }),
+            InnerReceipt::Fake { .. } => {
+                bail!("BonsaiProver does not support compress on a composite receipt")
+            }
+        }
     }
 }
 

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -86,9 +86,10 @@ pub trait Prover {
     /// may contain an arbitrary number of receipts assembled into continuations and compositions.
     /// Together, these receipts collectively prove a top-level
     /// [ReceiptClaim](crate::ReceiptClaim). This function compresses all of the constituent
-    /// receipts of a [CompositeReceipt] into a single [SuccinctReceipt] that proves the same
-    /// top-level claim. It accomplishes this by iterative application of the recursion programs
-    /// including lift, join, and resolve.
+    /// receipts of a [CompositeReceipt](crate::CompositeReceipt) into a single
+    /// [SuccinctReceipt](crate::SuccinctReceipt) that proves the same top-level claim. It
+    /// accomplishes this by iterative application of the recursion programs including lift, join,
+    /// and resolve.
     ///
     /// If the receipt is succinct, this function will do nothing (i.e. it is idemopotent).
     fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt>;

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -79,6 +79,19 @@ pub trait Prover {
         elf: &[u8],
         opts: &ProverOpts,
     ) -> Result<Receipt>;
+
+    /// Compress a [Receipt], guaranteeing that the resulting receipt is of constant size.
+    ///
+    /// Proving will, by default, produce a [CompositeReceipt](crate::CompositeReceipt), which
+    /// may contain an arbitrary number of receipts assembled into continuations and compositions.
+    /// Together, these receipts collectively prove a top-level
+    /// [ReceiptClaim](crate::ReceiptClaim). This function compresses all of the constituent
+    /// receipts of a [CompositeReceipt] into a single [SuccinctReceipt] that proves the same
+    /// top-level claim. It accomplishes this by iterative application of the recursion programs
+    /// including lift, join, and resolve.
+    ///
+    /// If the receipt is succinct, this function will do nothing (i.e. it is idemopotent).
+    fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt>;
 }
 
 /// An Executor can execute a given ELF binary.

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -27,8 +27,8 @@ use super::{
     ProverOpts as RecursionProverOpts,
 };
 use crate::{
-    get_prover_server, ExecutorEnv, ExecutorImpl, InnerReceipt, ProverOpts, Receipt,
-    SegmentReceipt, Session, VerifierContext,
+    default_prover, get_prover_server, ExecutorEnv, ExecutorImpl, InnerReceipt, ProverOpts,
+    Receipt, SegmentReceipt, Session, VerifierContext,
 };
 
 // Failure on older mac minis in the lab with Intel UHD 630 graphics:
@@ -249,8 +249,16 @@ fn test_recursion_lift_resolve_e2e() {
 
     let receipt = Receipt::new(
         InnerReceipt::Succinct(succinct_receipt),
-        composition_receipt.journal.bytes,
+        composition_receipt.clone().journal.bytes,
     );
 
     receipt.verify(MULTI_TEST_ID).unwrap();
+
+    // These tests take a long time. Since we have the composition receipt, test the prover trait's compress function
+    let prover = default_prover();
+
+    let succinct_receipt = prover
+        .compress(&ProverOpts::default(), &composition_receipt)
+        .unwrap();
+    succinct_receipt.verify(MULTI_TEST_ID).unwrap();
 }


### PR DESCRIPTION
This PR adds the compress method to the Prover trait, which was previously only available on the ProverServer and supersedes #1518. This PR contains work that is largely based on Victor's prior work.