### PR TITLE
updating link to calculator

### DIFF
--- a/website/api/security-model.md
+++ b/website/api/security-model.md
@@ -111,7 +111,7 @@ For a detailed discussion of the security of BN254, we refer readers to the disc
 [receipt claim]: ../../terminology#receipt-claim
 [RISC Zero zkVM: Scalable, Transparent Arguments of RISC-V Integrity]: ./proof-system-in-detail.pdf
 [RISC Zero zkVM]: ../zkvm
-[security calculator]: https://github.com/risc0/risc0/pull/1593
+[security calculator]: https://github.com/risc0/risc0/pull/1661
 [this article by Justin Thaler]: https://a16zcrypto.com/posts/article/snark-security-and-performance/
 [bits]: https://a16zcrypto.com/posts/article/snark-security-and-performance/
 [Verifier Contract]: ../blockchain-integration/contracts/verifier

--- a/website/api_versioned_docs/version-0.21/security-model.md
+++ b/website/api_versioned_docs/version-0.21/security-model.md
@@ -111,7 +111,7 @@ For a detailed discussion of the security of BN254, we refer readers to the disc
 [receipt claim]: ../terminology#receipt-claim
 [RISC Zero zkVM: Scalable, Transparent Arguments of RISC-V Integrity]: ./proof-system-in-detail.pdf
 [RISC Zero zkVM]: ./zkvm
-[security calculator]: https://github.com/risc0/risc0/blob/main/risc0/zkp/src/prove/soundness.rs
+[security calculator]: https://github.com/risc0/risc0/pull/1661
 [this article by Justin Thaler]: https://a16zcrypto.com/posts/article/snark-security-and-performance/
 [bits]: https://a16zcrypto.com/posts/article/snark-security-and-performance/
 [Verifier Contract]: ./blockchain-integration/contracts/verifier


### PR DESCRIPTION
Since the calculator is not included in a stable release yet, the links in the security model doc are pointing to the most recent PR. 
Note that this PR removes a pointer to `main` that apparently slipped through CI at some point in the past week or two. 