### PR TITLE
CI: Update guest docker image

### DIFF
--- a/.github/workflows/bench_applications.yml
+++ b/.github/workflows/bench_applications.yml
@@ -29,7 +29,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 jobs:
   bench:

--- a/.github/workflows/bench_datasheet.yml
+++ b/.github/workflows/bench_datasheet.yml
@@ -22,7 +22,7 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_BUILD_LOCKED: 1
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 defaults:
   run:

--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   RISC0_BUILD_LOCKED: 1
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 jobs:
   bench:

--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -26,7 +26,7 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_BUILD_LOCKED: 1
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 defaults:
   run:

--- a/.github/workflows/bonsai.yml
+++ b/.github/workflows/bonsai.yml
@@ -18,7 +18,7 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_BUILD_LOCKED: 1
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 jobs:
   changes:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 defaults:
   run:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   RISC0_BUILD_LOCKED: 1
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 jobs:
   crates_validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
   TAG: v0.22.0-alpha.1
   VERSION: "0.22.0-alpha.1"
 

--- a/.github/workflows/risc0-ethereum.yml
+++ b/.github/workflows/risc0-ethereum.yml
@@ -26,7 +26,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
   RISC0_PATH: ${{ github.workspace }}/risc0
   RISC0_ETHEREUM_PATH: ${{ github.workspace }}/risc0-ethereum
   BONSAI_FOUNDRY_TEMPLATE_PATH: ${{ github.workspace }}/bonsai-foundry-template

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  RISC0_TOOLCHAIN_VERSION: v2024-02-08.1
+  RISC0_TOOLCHAIN_VERSION: v2024-04-22.0
 
 jobs:
   changes:

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -145,7 +145,7 @@ fn create_dockerfile(
     .join(" ");
 
     let build = DockerFile::new()
-        .from_alias("build", "risczero/risc0-guest-builder:v2024-02-08.1")
+        .from_alias("build", "risczero/risc0-guest-builder:v2024-04-22.0")
         .workdir("/src")
         .copy(".", ".")
         .env(manifest_env)

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "7efd4bd6d611bc603477298a6390c3e3eb6f1aaf2a5894ec4e778729b16ae2c4",
+            "b1c7c891fb49f6bec8ca4042a17b40851bb748d2ff6a50acbde024c7c9b53b87",
         );
     }
 }

--- a/risc0/cargo-risczero/docker/Dockerfile.release
+++ b/risc0/cargo-risczero/docker/Dockerfile.release
@@ -1,4 +1,4 @@
-# To build run: docker build -f Dockerfile.release --build-arg="RISC0_TOOLCHAIN_VERSION=v2024-02-08.1" -t risczero/risc0-guest-builder:v2024-02-08.1 .
+# To build run: docker build -f Dockerfile.release --build-arg="RISC0_TOOLCHAIN_VERSION=v2024-04-22.0" -t risczero/risc0-guest-builder:v2024-04-22.0 .
 FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
 
 ARG RISC0_TOOLCHAIN_VERSION=


### PR DESCRIPTION
This PR updates the guest docker images to use the updated 1.77.2 toolchain. Once this PR lands, I will mark this prerelease as the https://github.com/risc0/rust/releases/tag/v2024-04-22.0 as the latest release