### PR TITLE
ghpages: commit data to release branch as well as main

### DIFF
--- a/.github/workflows/bench_datasheet.yml
+++ b/.github/workflows/bench_datasheet.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout gh-pages repository
+      - name: Checkout gh-pages repository branch ${{ github.ref_name }}
         uses: actions/checkout@v4
         with:
           repository: risc0/ghpages

--- a/.github/workflows/bench_datasheet.yml
+++ b/.github/workflows/bench_datasheet.yml
@@ -2,7 +2,7 @@ name: Benchmark Datasheet
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release-* ]
     # Only run benchmarks on changes to following paths:
     paths:
       - 'risc0/**'
@@ -84,6 +84,7 @@ jobs:
         with:
           repository: risc0/ghpages
           token: ${{ secrets.BENCHMARK_TOKEN }}
+          ref: ${{ github.ref_name }}
       - name: Download benchmark
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
This workflow necessitates creating a release branch on ghpages to mirror the `risc0` repo.