### PR TITLE
zkvm: use `u64` to keep track of cycles instead of `u32` or `usize`

### DIFF
--- a/examples/cycle-counter/src/lib.rs
+++ b/examples/cycle-counter/src/lib.rs
@@ -25,7 +25,7 @@ pub mod examples;
 
 pub struct Metrics {
     pub name: String,
-    pub cycles: u32,
+    pub cycles: u64,
 }
 
 impl Metrics {
@@ -70,7 +70,7 @@ pub fn init_logging() {
 #[derive(Serialize)]
 struct CsvRow<'a> {
     name: &'a str,
-    cycles: u32,
+    cycles: u64,
 }
 
 pub fn run_jobs<C: CycleCounter>(out_path: &PathBuf) -> Metrics {

--- a/risc0/circuit/rv32im/src/prove/emu/preflight/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/preflight/mod.rs
@@ -815,7 +815,9 @@ impl Segment {
         let mut emu = Emulator::new();
 
         preflight.pre_steps();
-        while preflight.trace.body.cycles.len() < self.insn_cycles && preflight.halted.is_none() {
+        while preflight.trace.body.cycles.len() < self.insn_cycles as usize
+            && preflight.halted.is_none()
+        {
             emu.step(&mut preflight)?;
             preflight.pager.commit_step();
         }

--- a/risc0/circuit/rv32im/src/prove/emu/rv32im.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/rv32im.rs
@@ -165,7 +165,7 @@ pub struct Instruction {
     pub opcode: u32,
     pub func3: u32,
     pub func7: u32,
-    pub cycles: usize,
+    pub cycles: u64,
 }
 
 impl DecodedInstruction {
@@ -217,7 +217,7 @@ const fn insn(
     opcode: u32,
     func3: i32,
     func7: i32,
-    cycles: usize,
+    cycles: u64,
 ) -> Instruction {
     Instruction {
         kind,

--- a/risc0/circuit/rv32im/src/prove/segment.rs
+++ b/risc0/circuit/rv32im/src/prove/segment.rs
@@ -38,7 +38,7 @@ pub struct Segment {
     pub post_state: SystemState,
     #[dbg(placeholder = "...")]
     pub syscalls: Vec<SyscallRecord>,
-    pub insn_cycles: usize,
+    pub insn_cycles: u64,
     pub po2: usize,
     pub exit_code: ExitCode,
     pub index: usize,

--- a/risc0/circuit/rv32im/src/trace.rs
+++ b/risc0/circuit/rv32im/src/trace.rs
@@ -25,8 +25,7 @@ pub enum TraceEvent {
     /// An instruction has started at the given program counter
     InstructionStart {
         /// Cycle number since startup
-        // TODO(breaking change): use `u64`
-        cycle: u32,
+        cycle: u64,
         /// Program counter of the instruction being executed
         pc: u32,
         /// Encoded instruction being executed.

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -79,7 +79,7 @@ pub enum MultiTestSpec {
     },
     BusyLoop {
         /// Busy loop until the guest has run for at least this number of cycles
-        cycles: u32,
+        cycles: u64,
     },
     LibM,
     Oom,

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -310,7 +310,7 @@ pub struct SegmentInfo {
 
     /// The number of user cycles without any overhead for continuations or po2
     /// padding.
-    pub cycles: u32,
+    pub cycles: u64,
 }
 
 impl Asset {

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -283,7 +283,7 @@ impl Server {
                                 segment: Some(pb::api::SegmentInfo {
                                     index: segment.index,
                                     po2: segment.inner.po2 as u32,
-                                    cycles: segment.inner.insn_cycles as u32,
+                                    cycles: segment.inner.insn_cycles,
                                     segment: Some(asset),
                                 }),
                             },

--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -71,7 +71,7 @@ impl Executor for LocalProver {
         let session = exec.run_with_callback(|segment| {
             segments.push(SegmentInfo {
                 po2: segment.inner.po2 as u32,
-                cycles: segment.inner.insn_cycles as u32,
+                cycles: segment.inner.insn_cycles,
             });
             Ok(Box::new(NullSegmentRef))
         })?;

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -170,7 +170,7 @@ message SessionInfo {
 message SegmentInfo {
   uint32 index = 1;
   uint32 po2 = 2;
-  uint32 cycles = 3;
+  uint64 cycles = 3;
   Asset segment = 4;
 }
 
@@ -235,7 +235,7 @@ message PosixCmd {
 
 message TraceEvent {
   message InstructionStart {
-    uint32 cycle = 1;
+    uint64 cycle = 1;
     uint32 pc = 2;
     uint32 insn = 3;
   }

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -237,7 +237,7 @@ struct ContextAdapter<'a> {
 }
 
 impl<'a> SyscallContext for ContextAdapter<'a> {
-    fn get_cycle(&self) -> usize {
+    fn get_cycle(&self) -> u64 {
         self.ctx.get_cycle()
     }
 

--- a/risc0/zkvm/src/host/server/exec/profiler.rs
+++ b/risc0/zkvm/src/host/server/exec/profiler.rs
@@ -140,8 +140,7 @@ pub struct Profiler {
     insn: u32,
 
     // Cycle count when the last instruction started
-    // TODO(breaking change): update to `u64`
-    cycle: u32,
+    cycle: u64,
 
     // Pop stack
     pop_stack: Vec<u32>,

--- a/risc0/zkvm/src/host/server/exec/syscall.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall.rs
@@ -55,7 +55,7 @@ pub trait Syscall {
 /// Access to memory and machine state for syscalls.
 pub trait SyscallContext {
     /// Returns the current cycle being executed.
-    fn get_cycle(&self) -> usize;
+    fn get_cycle(&self) -> u64;
 
     /// Loads the value of the given register, e.g. REG_A0.
     fn load_register(&mut self, idx: usize) -> u32;

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -1208,7 +1208,7 @@ mod docker {
     #[test]
     fn session_limit() {
         fn run_session(
-            loop_cycles: u32,
+            loop_cycles: u64,
             segment_limit_po2: u32,
             session_count_limit: u64,
         ) -> anyhow::Result<Session> {

--- a/tools/smoke-test/src/main.rs
+++ b/tools/smoke-test/src/main.rs
@@ -17,7 +17,7 @@ use risc0_zkvm::{default_prover, ExecutorEnv};
 
 fn main() {
     let segment_limit_po2 = 16; // 64k cycles
-    let cycles: u32 = 1 << segment_limit_po2;
+    let cycles: u64 = 1 << segment_limit_po2;
     let env = ExecutorEnv::builder()
         .write(&cycles)
         .unwrap()


### PR DESCRIPTION
closes: #1673 