### PR TITLE
change `sys_cycle_count` to return `u64`

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "74350e96811aad0e399203ae327c4f1ae93914a3366c2d39f90f341262900bf5",
+            "d7124613e7a4ed48b9414d918e522342ec1021f1f7f4cf8ec4db1151756d44a1",
         );
     }
 }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "381583621d5f32fa0cc4a0d13018dc98ef46c1b4f50defaa65469f1d1dfa5074",
+            "39a629a6f931e0d63186a44a0c36948d693d901a6b19a9903d3558d94dceb08a",
         );
     }
 }

--- a/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
@@ -89,8 +89,7 @@ pub trait SyscallContext {
     }
 
     /// Returns the current cycle count.
-    // TODO(breaking change): use `u64`
-    fn get_cycle(&self) -> usize;
+    fn get_cycle(&self) -> u64;
 }
 
 pub struct ExecutorResult {
@@ -712,8 +711,8 @@ impl<'a, 'b, S: Syscall> EmuContext for Executor<'a, 'b, S> {
 }
 
 impl<'a, 'b, S: Syscall> SyscallContext for Executor<'a, 'b, S> {
-    fn get_cycle(&self) -> usize {
-        self.cycles.user
+    fn get_cycle(&self) -> u64 {
+        self.cycles.user as u64
     }
 
     fn peek_register(&mut self, idx: usize) -> Result<u32> {

--- a/risc0/circuit/rv32im/src/trace.rs
+++ b/risc0/circuit/rv32im/src/trace.rs
@@ -25,8 +25,7 @@ pub enum TraceEvent {
     /// An instruction has started at the given program counter
     InstructionStart {
         /// Cycle number since startup
-        // TODO(breaking change): use `u64`
-        cycle: u32,
+        cycle: u64,
         /// Program counter of the instruction being executed
         pc: u32,
         /// Encoded instruction being executed.

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -216,7 +216,7 @@ fn main() {
             env::log("Busy loop starting!");
             let mut tot_cycles = last_cycles;
 
-            while tot_cycles < cycles as usize {
+            while tot_cycles < cycles {
                 let now_cycles = env::cycle_count();
                 if now_cycles <= last_cycles {
                     // Cycle count may have reset or wrapped around.

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -79,7 +79,7 @@ pub enum MultiTestSpec {
     },
     BusyLoop {
         /// Busy loop until the guest has run for at least this number of cycles
-        cycles: u32,
+        cycles: u64,
     },
     LibM,
     Oom,

--- a/risc0/zkvm/platform/src/syscall.rs
+++ b/risc0/zkvm/platform/src/syscall.rs
@@ -429,9 +429,9 @@ pub unsafe extern "C" fn sys_log(msg_ptr: *const u8, len: usize) {
 }
 
 #[cfg_attr(feature = "export-syscalls", no_mangle)]
-pub extern "C" fn sys_cycle_count() -> usize {
-    let Return(a0, _) = unsafe { syscall_0(nr::SYS_CYCLE_COUNT, null_mut(), 0) };
-    a0 as usize
+pub extern "C" fn sys_cycle_count() -> u64 {
+    let Return(hi, lo) = unsafe { syscall_0(nr::SYS_CYCLE_COUNT, null_mut(), 0) };
+    ((hi as u64) << 32) + lo as u64
 }
 
 /// Reads the given number of bytes into the given buffer, posix-style.  Returns

--- a/risc0/zkvm/src/guest/env.rs
+++ b/risc0/zkvm/src/guest/env.rs
@@ -539,7 +539,7 @@ pub fn commit_slice<T: Pod>(slice: &[T]) {
 /// began.
 ///
 /// WARNING: The cycle count is provided by the host and is not checked by the zkVM circuit.
-pub fn cycle_count() -> usize {
+pub fn cycle_count() -> u64 {
     sys_cycle_count()
 }
 

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -235,7 +235,7 @@ message PosixCmd {
 
 message TraceEvent {
   message InstructionStart {
-    uint32 cycle = 1;
+    uint64 cycle = 1;
     uint32 pc = 2;
     uint32 insn = 3;
   }

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -237,7 +237,7 @@ struct ContextAdapter<'a> {
 }
 
 impl<'a> SyscallContext for ContextAdapter<'a> {
-    fn get_cycle(&self) -> usize {
+    fn get_cycle(&self) -> u64 {
         self.ctx.get_cycle()
     }
 

--- a/risc0/zkvm/src/host/server/exec/profiler.rs
+++ b/risc0/zkvm/src/host/server/exec/profiler.rs
@@ -140,8 +140,7 @@ pub struct Profiler {
     insn: u32,
 
     // Cycle count when the last instruction started
-    // TODO(breaking change): update to `u64`
-    cycle: u32,
+    cycle: u64,
 
     // Pop stack
     pop_stack: Vec<u32>,

--- a/risc0/zkvm/src/host/server/exec/syscall.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall.rs
@@ -55,7 +55,7 @@ pub trait Syscall {
 /// Access to memory and machine state for syscalls.
 pub trait SyscallContext {
     /// Returns the current cycle being executed.
-    fn get_cycle(&self) -> usize;
+    fn get_cycle(&self) -> u64;
 
     /// Loads the value of the given register, e.g. REG_A0.
     fn load_register(&mut self, idx: usize) -> u32;
@@ -130,7 +130,10 @@ impl Syscall for SysCycleCount {
         ctx: &mut dyn SyscallContext,
         _to_guest: &mut [u32],
     ) -> Result<(u32, u32)> {
-        Ok((ctx.get_cycle() as u32, 0))
+        let cycle = ctx.get_cycle();
+        let hi = (cycle >> 32) as u32;
+        let lo = cycle as u32;
+        Ok((hi, lo))
     }
 }
 

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -1208,7 +1208,7 @@ mod docker {
     #[test]
     fn session_limit() {
         fn run_session(
-            loop_cycles: u32,
+            loop_cycles: u64,
             segment_limit_po2: u32,
             session_count_limit: u64,
         ) -> anyhow::Result<Session> {


### PR DESCRIPTION
Changing `sys_cycle_count` resulted in various changes to the trait as well as several other type changes throughout the system including `SyscallContext`. I've addressed various other type errors as well as `TODO(breaking change): update to `u64`` comments. Tests have also been updated to reflect this type change.

Closes: #1673