### PR TITLE
allow configuring rust toolchain branch

### DIFF
--- a/risc0/cargo-risczero/src/commands/build_toolchain.rs
+++ b/risc0/cargo-risczero/src/commands/build_toolchain.rs
@@ -85,7 +85,7 @@ impl BuildToolchain {
 
         if !path.join(".git").is_dir() {
             Command::new("git")
-                .args(["clone", "--branch", tag, source])
+                .args(["clone", source])
                 .arg(path)
                 .run_verbose()?;
         } else {

--- a/risc0/cargo-risczero/src/commands/build_toolchain.rs
+++ b/risc0/cargo-risczero/src/commands/build_toolchain.rs
@@ -32,8 +32,8 @@ const CONFIG_TOML: &'static str = include_str!("config.toml");
 /// `cargo risczero build-toolchain`
 #[derive(Parser)]
 pub struct BuildToolchain {
-    #[arg(long)]
-    git_tag: Option<String>,
+    #[arg(long, default_value = RUST_BRANCH)]
+    git_branch: String,
 }
 
 /// Output info of a successful rust toolchain build.
@@ -57,8 +57,7 @@ impl BuildToolchain {
 
         let is_ci = std::env::var("CI").is_ok();
         if !is_ci {
-            let git_tag = self.git_tag.as_deref().unwrap_or(RUST_BRANCH);
-            self.prepare_git_repo(ToolchainRepo::Rust.url(), git_tag, &rust_dir)?;
+            self.prepare_git_repo(ToolchainRepo::Rust.url(), &self.git_branch, &rust_dir)?;
         }
 
         let out = self.build_toolchain(&rust_dir)?;

--- a/risc0/cargo-risczero/src/commands/build_toolchain.rs
+++ b/risc0/cargo-risczero/src/commands/build_toolchain.rs
@@ -86,16 +86,13 @@ impl BuildToolchain {
 
         if !path.join(".git").is_dir() {
             Command::new("git")
-                .args([
-                    "clone",
-                    "--branch",
-                    tag,
-                    "--single-branch",
-                    "--depth",
-                    "1",
-                    source,
-                ])
+                .args(["clone", "--branch", tag, source])
                 .arg(path)
+                .run_verbose()?;
+        } else {
+            Command::new("git")
+                .args(["fetch", "origin", tag])
+                .current_dir(path)
                 .run_verbose()?;
         }
 


### PR DESCRIPTION
Not sure if this is correct, just opening for visibility to help unblock someone needing to build the toolchain given the updated Rust version (1.70 too low).

~~Also changes the clone to minimize data fetched.~~ Removed this for simplicity, it was causing weird edge case issues

Ignore this PR, unless you also want this.

Tested with:
```
cargo install --force --path risc0/cargo-risczero
cargo risczero build-toolchain --git-tag v2024-04-22.0
```