### PR TITLE
Include build from source directions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ other manner of problems.  Caveat emptor.
 
 To start your own project, you can use our `cargo risczero` tool to write the
 initial boilerplate and set up a standard directory structure.
+
 First, [install Rust][install-rust] if you don't already have it, then install
 the `cargo risczero` tool. We'll use `cargo binstall` to get `cargo-risczero`
 installed. See [cargo-binstall] for more details.
@@ -124,6 +125,27 @@ More details and options for `cargo risczero` are given in
 For more guidance on how to use RISC Zero, how RISC Zero projects are typically
 structured, and other resources useful to developers new to RISC Zero, see our
 [Getting Started page][quickstart].
+
+## Building from source
+
+You can also build from source instead downloading the latest release.
+You might want to do this if you are making changes to this code base, or want to try out a development version.
+
+First, install `git lfs` as you will need it to pull some of the files required to build the prover.
+See the instructions on the [Git LFS website](https://git-lfs.com/).
+
+Once you have cloned this repo and run `git lfs pull`, you can build `cargo risczero`.
+This will take some time, as it will need to build the prover.
+
+```sh
+cargo install --path ./risc0/cargo-risczero --features r0vm
+cargo risczero install
+```
+
+If you want to enable `metal` or `cuda` support, you can use the associated [feature flags](#feature-flags) described below.
+
+You now have a local build of `cargo risczero`.
+Note that your build may not be compatible with remote services such as Bonsai.
 
 ## Rust Binaries
 

--- a/README.md
+++ b/README.md
@@ -131,21 +131,8 @@ structured, and other resources useful to developers new to RISC Zero, see our
 You can also build from source instead downloading the latest release.
 You might want to do this if you are making changes to this code base, or want to try out a development version.
 
-First, install `git lfs` as you will need it to pull some of the files required to build the prover.
-See the instructions on the [Git LFS website](https://git-lfs.com/).
-
-Once you have cloned this repo and run `git lfs pull`, you can build `cargo risczero`.
-This will take some time, as it will need to build the prover.
-
-```sh
-cargo install --path ./risc0/cargo-risczero --features r0vm
-cargo risczero install
-```
-
-If you want to enable `metal` or `cuda` support, you can use the associated [feature flags](#feature-flags) described below.
-
-You now have a local build of `cargo risczero`.
-Note that your build may not be compatible with remote services such as Bonsai.
+Building from source requires some additional tools and steps.
+Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for the full instructions.
 
 ## Rust Binaries
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,6 @@ structured, and other resources useful to developers new to RISC Zero, see our
 
 ## Building from source
 
-You can also build from source instead downloading the latest release.
-You might want to do this if you are making changes to this code base, or want to try out a development version.
-
 Building from source requires some additional tools and steps.
 Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for the full instructions.
 


### PR DESCRIPTION
Include build from source directions in README, simply pointing to `CONTRIBUTING.md`. Developers ask somewhat often about errors caused by not running `git lfs pull` when they are building from source. It is my hope that this extra section will avoid running into those issues.