### PR TITLE
host-side risc0-zkvm: export `NullSegmentRef`

### DIFF
--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -102,7 +102,8 @@ pub use {
             exec::executor::ExecutorImpl,
             prove::{get_prover_server, HalPair, ProverServer},
             session::{
-                FileSegmentRef, Segment, SegmentRef, Session, SessionEvents, SimpleSegmentRef,
+                FileSegmentRef, NullSegmentRef, Segment, SegmentRef, Session, SessionEvents,
+                SimpleSegmentRef,
             },
         },
     },


### PR DESCRIPTION
Closes: #1536