### PR TITLE
Better Error Message

### DIFF
--- a/bonsai/sdk/src/alpha.rs
+++ b/bonsai/sdk/src/alpha.rs
@@ -485,7 +485,7 @@ impl Client {
             .send()?;
 
         if !res.status().is_success() {
-            if res.status().as_u16() == 404 {
+            if res.status() == reqwest::StatusCode::NOT_FOUND {
                 return Err(SdkErr::ReceiptNotFound);
             }
             let body = res.text()?;

--- a/bonsai/sdk/src/alpha.rs
+++ b/bonsai/sdk/src/alpha.rs
@@ -484,11 +484,11 @@ impl Client {
             .get(format!("{}/receipts/{}", self.url, session_id.uuid))
             .send()?;
 
-        if !resp.status().is_success() {
-            if resp.status().as_u16() == 404 {
+        if !res.status().is_success() {
+            if res.status().as_u16() == 404 {
                 return Err(SdkErr::ReceiptNotFound);
             }
-            let body = resp.text()?;
+            let body = res.text()?;
             return Err(SdkErr::InternalServerErr(body));
         }
 


### PR DESCRIPTION
This PR updates the `receipt_download` function to filter for 404 errors, and return an appropriate response.