### PR TITLE
Add steel to local patch

### DIFF
--- a/.github/cargo_local_patch.py
+++ b/.github/cargo_local_patch.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         "risc0-forge-ffi": "risc0-ethereum/ffi",
         "risc0-ethereum-relay": "risc0-ethereum/relay",
         "risc0-ethereum-relay-test-methods": "risc0-ethereum/relay/tests/methods",
-        "risc0-ethereum-view-call": "risc0-ethereum/view-call",
+        "risc0-steel": "risc0-ethereum/steel",
     }
 
     main(os.path.normpath(args.directory), dep_path_mapping)


### PR DESCRIPTION
After renaming `risc0-ethereum-view-call` crate to `risc0-steel` we need to update the local patching for the risc0-ethereum CI on the risc0 monorepo