### PR TITLE
Move inner receipt types into multiple implementation files

### DIFF
--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -22,7 +22,9 @@ use risc0_zkp::core::digest::Digest;
 use super::{malformed_err, path_to_string, pb, Asset, AssetRequest};
 use crate::{
     host::{
-        receipt::{decode_receipt_claim_from_seal, CompositeReceipt, InnerReceipt, SegmentReceipt},
+        receipt::{
+            segment::decode_receipt_claim_from_seal, CompositeReceipt, InnerReceipt, SegmentReceipt,
+        },
         recursion::SuccinctReceipt,
     },
     Assumptions, ExitCode, Journal, MaybePruned, Output, ProveInfo, ProverOpts, Receipt,

--- a/risc0/zkvm/src/host/receipt.rs
+++ b/risc0/zkvm/src/host/receipt.rs
@@ -14,20 +14,19 @@
 
 //! Manages the output and cryptographic data for a proven computation.
 
-mod segment;
+pub(crate) mod composite;
+pub(crate) mod segment;
 
 use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
 use core::fmt::Debug;
 
 use anyhow::Result;
-use risc0_binfmt::ExitCode;
 use risc0_circuit_recursion::control_id::{ALLOWED_CONTROL_ROOT, BN254_CONTROL_ID};
 use risc0_core::field::baby_bear::BabyBear;
 use risc0_groth16::{
     fr_from_hex_string, split_digest, verifier::prepared_verifying_key, Seal, Verifier,
 };
 use risc0_zkp::{
-    adapter::CircuitInfo as _,
     core::{
         digest::Digest,
         hash::{
@@ -35,7 +34,6 @@ use risc0_zkp::{
             HashSuite,
         },
     },
-    layout::Buffer,
     verify::VerificationError,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -46,7 +44,7 @@ use crate::{
     Assumptions, MaybePruned, Output, ReceiptClaim,
 };
 
-pub use self::segment::SegmentReceipt;
+pub use self::{composite::CompositeReceipt, segment::SegmentReceipt};
 pub use super::recursion::SuccinctReceipt;
 
 /// A receipt attesting to the execution of a guest program.
@@ -407,205 +405,6 @@ impl CompactReceipt {
     }
 }
 
-/// A receipt composed of one or more [SegmentReceipt] structs proving a single
-/// execution with continuations, and zero or more [Receipt] structs proving any
-/// assumptions.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(test, derive(PartialEq))]
-pub struct CompositeReceipt {
-    /// Segment receipts forming the proof of an execution with continuations.
-    pub segments: Vec<SegmentReceipt>,
-
-    /// An ordered list of assumptions, either proven or unresolved, made within
-    /// the continuation represented by the segment receipts. If any
-    /// assumptions are unresolved, this receipt is only _conditionally_
-    /// valid.
-    // TODO(#982): Allow for unresolved assumptions in this list.
-    pub assumptions: Vec<InnerReceipt>,
-
-    /// Digest of journal included in the final output of the continuation. Will
-    /// be `None` if the continuation has no output (e.g. it ended in `Fault`).
-    // NOTE: This field is needed in order to open the assumptions digest from
-    // the output digest.
-    // TODO: This field can potentially be removed since
-    // it can be included in the claim on the last segment receipt instead.
-    pub(crate) journal_digest: Option<Digest>,
-}
-
-impl CompositeReceipt {
-    /// Verify the integrity of this receipt, ensuring the claim is attested
-    /// to by the seal.
-    pub fn verify_integrity_with_context(
-        &self,
-        ctx: &VerifierContext,
-    ) -> Result<(), VerificationError> {
-        tracing::debug!("CompositeReceipt::verify_integrity_with_context");
-        // Verify the continuation, by verifying every segment receipt in order.
-        let (final_receipt, receipts) = self
-            .segments
-            .as_slice()
-            .split_last()
-            .ok_or(VerificationError::ReceiptFormatError)?;
-
-        // Verify each segment and its chaining to the next.
-        let mut expected_pre_state_digest = None;
-        for receipt in receipts {
-            receipt.verify_integrity_with_context(ctx)?;
-            tracing::debug!("claim: {:#?}", receipt.claim);
-            if let Some(id) = expected_pre_state_digest {
-                if id != receipt.claim.pre.digest() {
-                    return Err(VerificationError::ImageVerificationError);
-                }
-            }
-            if receipt.claim.exit_code != ExitCode::SystemSplit {
-                return Err(VerificationError::UnexpectedExitCode);
-            }
-            if !receipt.claim.output.is_none() {
-                return Err(VerificationError::ReceiptFormatError);
-            }
-            expected_pre_state_digest = Some(
-                receipt
-                    .claim
-                    .post
-                    .as_value()
-                    .map_err(|_| VerificationError::ReceiptFormatError)?
-                    .digest(),
-            );
-        }
-
-        // Verify the last receipt in the continuation.
-        final_receipt.verify_integrity_with_context(ctx)?;
-        tracing::debug!("final: {:#?}", final_receipt.claim);
-        if let Some(id) = expected_pre_state_digest {
-            if id != final_receipt.claim.pre.digest() {
-                return Err(VerificationError::ImageVerificationError);
-            }
-        }
-
-        // Verify all assumption receipts attached to this composite receipt.
-        for receipt in self.assumptions.iter() {
-            tracing::debug!("verifying assumption: {:?}", receipt.claim()?.digest());
-            receipt.verify_integrity_with_context(ctx)?;
-        }
-
-        // Verify decoded output digest is consistent with the journal_digest
-        // and assumptions.
-        self.verify_output_consistency(&final_receipt.claim)?;
-
-        Ok(())
-    }
-
-    /// Returns the [ReceiptClaim] for this [CompositeReceipt].
-    pub fn claim(&self) -> Result<ReceiptClaim, VerificationError> {
-        let first_claim = &self
-            .segments
-            .first()
-            .ok_or(VerificationError::ReceiptFormatError)?
-            .claim;
-        let last_claim = &self
-            .segments
-            .last()
-            .ok_or(VerificationError::ReceiptFormatError)?
-            .claim;
-
-        // After verifying the internal consistency of this receipt, we can use
-        // self.assumptions and self.journal_digest in place of
-        // last_claim.output, which is equal.
-        self.verify_output_consistency(last_claim)?;
-        let output: Option<Output> = last_claim
-            .output
-            .is_some()
-            .then(|| {
-                Ok(Output {
-                    journal: MaybePruned::Pruned(
-                        self.journal_digest
-                            .ok_or(VerificationError::ReceiptFormatError)?,
-                    ),
-                    // TODO(#982): Adjust this if unresolved assumptions are allowed on
-                    // CompositeReceipt.
-                    // NOTE: Proven assumptions are not included in the CompositeReceipt claim.
-                    assumptions: Assumptions(vec![]).into(),
-                })
-            })
-            .transpose()?;
-
-        Ok(ReceiptClaim {
-            pre: first_claim.pre.clone(),
-            post: last_claim.post.clone(),
-            exit_code: last_claim.exit_code,
-            input: first_claim.input,
-            output: output.into(),
-        })
-    }
-
-    /// Check that the output fields in the given receipt claim are
-    /// consistent with the exit code, and with the journal_digest and
-    /// assumptions encoded on self.
-    fn verify_output_consistency(&self, claim: &ReceiptClaim) -> Result<(), VerificationError> {
-        tracing::debug!(
-            "verify_output_consistency: exit_code = {:?}",
-            claim.exit_code
-        );
-        if claim.exit_code.expects_output() && claim.output.is_some() {
-            let self_output = Output {
-                journal: MaybePruned::Pruned(
-                    self.journal_digest
-                        .ok_or(VerificationError::ReceiptFormatError)?,
-                ),
-                assumptions: self.assumptions_claim()?.into(),
-            };
-
-            // If these digests do not match, this receipt is internally inconsistent.
-            if self_output.digest() != claim.output.digest() {
-                let empty_output = claim.output.is_none()
-                    && self
-                        .journal_digest
-                        .ok_or(VerificationError::ReceiptFormatError)?
-                        == Vec::<u8>::new().digest();
-                if !empty_output {
-                    tracing::debug!(
-                        "output digest does not match: expected {:?}; decoded {:?}",
-                        &self_output,
-                        &claim.output
-                    );
-                    return Err(VerificationError::ReceiptFormatError);
-                }
-            }
-        } else {
-            // Ensure all output fields are empty. If not, this receipt is internally
-            // inconsistent.
-            if claim.output.is_some() {
-                tracing::debug!("unexpected non-empty claim output: {:?}", &claim.output);
-                return Err(VerificationError::ReceiptFormatError);
-            }
-            if !self.assumptions.is_empty() {
-                tracing::debug!(
-                    "unexpected non-empty composite receipt assumptions: {:?}",
-                    &self.assumptions
-                );
-                return Err(VerificationError::ReceiptFormatError);
-            }
-            if self.journal_digest.is_some() {
-                tracing::debug!(
-                    "unexpected non-empty composite receipt journal_digest: {:?}",
-                    &self.journal_digest
-                );
-                return Err(VerificationError::ReceiptFormatError);
-            }
-        }
-        Ok(())
-    }
-
-    fn assumptions_claim(&self) -> Result<Assumptions, VerificationError> {
-        Ok(Assumptions(
-            self.assumptions
-                .iter()
-                .map(|a| Ok(a.claim()?.into()))
-                .collect::<Result<Vec<_>, _>>()?,
-        ))
-    }
-}
-
 /// An assumption attached to a guest execution as a result of calling
 /// `env::verify` or `env::verify_integrity`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -673,6 +472,7 @@ pub struct VerifierContext {
     /// A registry of hash functions to be used by the verification process.
     pub suites: BTreeMap<String, HashSuite<BabyBear>>,
 }
+
 impl Default for VerifierContext {
     fn default() -> Self {
         Self {

--- a/risc0/zkvm/src/host/receipt/compact.rs
+++ b/risc0/zkvm/src/host/receipt/compact.rs
@@ -1,0 +1,76 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt::Debug;
+
+use anyhow::Result;
+use hex::FromHex;
+use risc0_circuit_recursion::control_id::{ALLOWED_CONTROL_ROOT, BN254_CONTROL_ID};
+use risc0_groth16::{fr_from_hex_string, split_digest, Seal, Verifier};
+use risc0_zkp::{core::digest::Digest, verify::VerificationError};
+use serde::{Deserialize, Serialize};
+
+// Make succinct receipt available through this `receipt` module.
+use crate::{sha::Digestible, ReceiptClaim};
+
+pub use super::metadata::CompactReceiptVerifierInfo;
+
+/// A receipt composed of a Groth16 over the BN_254 curve
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct CompactReceipt {
+    /// A Groth16 proof of a zkVM execution with the associated claim.
+    pub seal: Vec<u8>,
+
+    /// [ReceiptClaim] containing information about the execution that this
+    /// receipt proves.
+    pub claim: ReceiptClaim,
+}
+
+impl CompactReceipt {
+    /// Information about the parameters used to verify the receipt. Includes parameters that are
+    /// useful in deciding whether the verifier is compatible with a given receipt.
+    pub fn verifier_info() -> CompactReceiptVerifierInfo {
+        CompactReceiptVerifierInfo {
+            control_root: Digest::from_hex(ALLOWED_CONTROL_ROOT).unwrap(),
+            bn254_control_id: Digest::from_hex(BN254_CONTROL_ID).unwrap(),
+            verifying_key: risc0_groth16::VERIFYING_KEY.clone(),
+        }
+    }
+
+    /// Verify the integrity of this receipt, ensuring the claim is attested
+    /// to by the seal.
+    pub fn verify_integrity(&self) -> Result<(), VerificationError> {
+        let (a0, a1) = split_digest(
+            Digest::from_hex(ALLOWED_CONTROL_ROOT)
+                .map_err(|_| VerificationError::ReceiptFormatError)?,
+        )
+        .map_err(|_| VerificationError::ReceiptFormatError)?;
+        let (c0, c1) =
+            split_digest(self.claim.digest()).map_err(|_| VerificationError::ReceiptFormatError)?;
+        let id_p254_hash = fr_from_hex_string(BN254_CONTROL_ID)
+            .map_err(|_| VerificationError::ReceiptFormatError)?;
+        Verifier::new(
+            &Seal::from_vec(&self.seal).map_err(|_| VerificationError::ReceiptFormatError)?,
+            &[a0, a1, c0, c1, id_p254_hash],
+            &risc0_groth16::VERIFYING_KEY,
+        )
+        .map_err(|_| VerificationError::ReceiptFormatError)?
+        .verify()
+        .map_err(|_| VerificationError::InvalidProof)?;
+
+        // Everything passed
+        Ok(())
+    }
+}

--- a/risc0/zkvm/src/host/receipt/compact.rs
+++ b/risc0/zkvm/src/host/receipt/compact.rs
@@ -17,14 +17,14 @@ use core::fmt::Debug;
 use anyhow::Result;
 use hex::FromHex;
 use risc0_circuit_recursion::control_id::{ALLOWED_CONTROL_ROOT, BN254_CONTROL_ID};
-use risc0_groth16::{fr_from_hex_string, split_digest, Seal, Verifier};
+use risc0_groth16::{
+    fr_from_hex_string, split_digest, verifier::prepared_verifying_key, Seal, Verifier,
+};
 use risc0_zkp::{core::digest::Digest, verify::VerificationError};
 use serde::{Deserialize, Serialize};
 
 // Make succinct receipt available through this `receipt` module.
 use crate::{sha::Digestible, ReceiptClaim};
-
-pub use super::metadata::CompactReceiptVerifierInfo;
 
 /// A receipt composed of a Groth16 over the BN_254 curve
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -39,16 +39,6 @@ pub struct CompactReceipt {
 }
 
 impl CompactReceipt {
-    /// Information about the parameters used to verify the receipt. Includes parameters that are
-    /// useful in deciding whether the verifier is compatible with a given receipt.
-    pub fn verifier_info() -> CompactReceiptVerifierInfo {
-        CompactReceiptVerifierInfo {
-            control_root: Digest::from_hex(ALLOWED_CONTROL_ROOT).unwrap(),
-            bn254_control_id: Digest::from_hex(BN254_CONTROL_ID).unwrap(),
-            verifying_key: risc0_groth16::VERIFYING_KEY.clone(),
-        }
-    }
-
     /// Verify the integrity of this receipt, ensuring the claim is attested
     /// to by the seal.
     pub fn verify_integrity(&self) -> Result<(), VerificationError> {
@@ -63,8 +53,8 @@ impl CompactReceipt {
             .map_err(|_| VerificationError::ReceiptFormatError)?;
         Verifier::new(
             &Seal::from_vec(&self.seal).map_err(|_| VerificationError::ReceiptFormatError)?,
-            &[a0, a1, c0, c1, id_p254_hash],
-            &risc0_groth16::VERIFYING_KEY,
+            vec![a0, a1, c0, c1, id_p254_hash],
+            prepared_verifying_key().map_err(|_| VerificationError::ReceiptFormatError)?,
         )
         .map_err(|_| VerificationError::ReceiptFormatError)?
         .verify()

--- a/risc0/zkvm/src/host/receipt/composite.rs
+++ b/risc0/zkvm/src/host/receipt/composite.rs
@@ -21,10 +21,7 @@ use risc0_zkp::{core::digest::Digest, verify::VerificationError};
 use serde::{Deserialize, Serialize};
 
 // Make succinct receipt available through this `receipt` module.
-use super::{
-    metadata::CompositeReceiptVerifierInfo, CompactReceipt, InnerReceipt, SegmentReceipt,
-    SuccinctReceipt, VerifierContext,
-};
+use super::{InnerReceipt, SegmentReceipt, VerifierContext};
 use crate::{sha::Digestible, Assumptions, MaybePruned, Output, ReceiptClaim};
 
 /// A receipt composed of one or more [SegmentReceipt] structs proving a single
@@ -53,16 +50,6 @@ pub struct CompositeReceipt {
 }
 
 impl CompositeReceipt {
-    /// Information about the parameters used to verify the receipt. Includes parameters that are
-    /// useful in deciding whether the verifier is compatible with a given receipt.
-    pub fn verifier_info() -> CompositeReceiptVerifierInfo {
-        CompositeReceiptVerifierInfo {
-            segment: SegmentReceipt::verifier_info(),
-            succinct: SuccinctReceipt::verifier_info(),
-            compact: CompactReceipt::verifier_info(),
-        }
-    }
-
     /// Verify the integrity of this receipt, ensuring the claim is attested
     /// to by the seal.
     pub fn verify_integrity_with_context(

--- a/risc0/zkvm/src/host/receipt/composite.rs
+++ b/risc0/zkvm/src/host/receipt/composite.rs
@@ -1,0 +1,237 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloc::{vec, vec::Vec};
+use core::fmt::Debug;
+
+use anyhow::Result;
+use risc0_binfmt::ExitCode;
+use risc0_zkp::{core::digest::Digest, verify::VerificationError};
+use serde::{Deserialize, Serialize};
+
+// Make succinct receipt available through this `receipt` module.
+use super::{
+    metadata::CompositeReceiptVerifierInfo, CompactReceipt, InnerReceipt, SegmentReceipt,
+    SuccinctReceipt, VerifierContext,
+};
+use crate::{sha::Digestible, Assumptions, MaybePruned, Output, ReceiptClaim};
+
+/// A receipt composed of one or more [SegmentReceipt] structs proving a single
+/// execution with continuations, and zero or more [Receipt] structs proving any
+/// assumptions.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct CompositeReceipt {
+    /// Segment receipts forming the proof of an execution with continuations.
+    pub segments: Vec<SegmentReceipt>,
+
+    /// An ordered list of assumptions, either proven or unresolved, made within
+    /// the continuation represented by the segment receipts. If any
+    /// assumptions are unresolved, this receipt is only _conditionally_
+    /// valid.
+    // TODO(#982): Allow for unresolved assumptions in this list.
+    pub assumptions: Vec<InnerReceipt>,
+
+    /// Digest of journal included in the final output of the continuation. Will
+    /// be `None` if the continuation has no output (e.g. it ended in `Fault`).
+    // NOTE: This field is needed in order to open the assumptions digest from
+    // the output digest.
+    // TODO: This field can potentially be removed since
+    // it can be included in the claim on the last segment receipt instead.
+    pub(crate) journal_digest: Option<Digest>,
+}
+
+impl CompositeReceipt {
+    /// Information about the parameters used to verify the receipt. Includes parameters that are
+    /// useful in deciding whether the verifier is compatible with a given receipt.
+    pub fn verifier_info() -> CompositeReceiptVerifierInfo {
+        CompositeReceiptVerifierInfo {
+            segment: SegmentReceipt::verifier_info(),
+            succinct: SuccinctReceipt::verifier_info(),
+            compact: CompactReceipt::verifier_info(),
+        }
+    }
+
+    /// Verify the integrity of this receipt, ensuring the claim is attested
+    /// to by the seal.
+    pub fn verify_integrity_with_context(
+        &self,
+        ctx: &VerifierContext,
+    ) -> Result<(), VerificationError> {
+        tracing::debug!("CompositeReceipt::verify_integrity_with_context");
+        // Verify the continuation, by verifying every segment receipt in order.
+        let (final_receipt, receipts) = self
+            .segments
+            .as_slice()
+            .split_last()
+            .ok_or(VerificationError::ReceiptFormatError)?;
+
+        // Verify each segment and its chaining to the next.
+        let mut expected_pre_state_digest = None;
+        for receipt in receipts {
+            receipt.verify_integrity_with_context(ctx)?;
+            tracing::debug!("claim: {:#?}", receipt.claim);
+            if let Some(id) = expected_pre_state_digest {
+                if id != receipt.claim.pre.digest() {
+                    return Err(VerificationError::ImageVerificationError);
+                }
+            }
+            if receipt.claim.exit_code != ExitCode::SystemSplit {
+                return Err(VerificationError::UnexpectedExitCode);
+            }
+            if !receipt.claim.output.is_none() {
+                return Err(VerificationError::ReceiptFormatError);
+            }
+            expected_pre_state_digest = Some(
+                receipt
+                    .claim
+                    .post
+                    .as_value()
+                    .map_err(|_| VerificationError::ReceiptFormatError)?
+                    .digest(),
+            );
+        }
+
+        // Verify the last receipt in the continuation.
+        final_receipt.verify_integrity_with_context(ctx)?;
+        tracing::debug!("final: {:#?}", final_receipt.claim);
+        if let Some(id) = expected_pre_state_digest {
+            if id != final_receipt.claim.pre.digest() {
+                return Err(VerificationError::ImageVerificationError);
+            }
+        }
+
+        // Verify all assumption receipts attached to this composite receipt.
+        for receipt in self.assumptions.iter() {
+            tracing::debug!("verifying assumption: {:?}", receipt.claim()?.digest());
+            receipt.verify_integrity_with_context(ctx)?;
+        }
+
+        // Verify decoded output digest is consistent with the journal_digest
+        // and assumptions.
+        self.verify_output_consistency(&final_receipt.claim)?;
+
+        Ok(())
+    }
+
+    /// Returns the [ReceiptClaim] for this [CompositeReceipt].
+    pub fn claim(&self) -> Result<ReceiptClaim, VerificationError> {
+        let first_claim = &self
+            .segments
+            .first()
+            .ok_or(VerificationError::ReceiptFormatError)?
+            .claim;
+        let last_claim = &self
+            .segments
+            .last()
+            .ok_or(VerificationError::ReceiptFormatError)?
+            .claim;
+
+        // After verifying the internal consistency of this receipt, we can use
+        // self.assumptions and self.journal_digest in place of
+        // last_claim.output, which is equal.
+        self.verify_output_consistency(last_claim)?;
+        let output: Option<Output> = last_claim
+            .output
+            .is_some()
+            .then(|| {
+                Ok(Output {
+                    journal: MaybePruned::Pruned(
+                        self.journal_digest
+                            .ok_or(VerificationError::ReceiptFormatError)?,
+                    ),
+                    // TODO(#982): Adjust this if unresolved assumptions are allowed on
+                    // CompositeReceipt.
+                    // NOTE: Proven assumptions are not included in the CompositeReceipt claim.
+                    assumptions: Assumptions(vec![]).into(),
+                })
+            })
+            .transpose()?;
+
+        Ok(ReceiptClaim {
+            pre: first_claim.pre.clone(),
+            post: last_claim.post.clone(),
+            exit_code: last_claim.exit_code,
+            input: first_claim.input.clone(),
+            output: output.into(),
+        })
+    }
+
+    /// Check that the output fields in the given receipt claim are
+    /// consistent with the exit code, and with the journal_digest and
+    /// assumptions encoded on self.
+    fn verify_output_consistency(&self, claim: &ReceiptClaim) -> Result<(), VerificationError> {
+        tracing::debug!(
+            "verify_output_consistency: exit_code = {:?}",
+            claim.exit_code
+        );
+        if claim.exit_code.expects_output() && claim.output.is_some() {
+            let self_output = Output {
+                journal: MaybePruned::Pruned(
+                    self.journal_digest
+                        .ok_or(VerificationError::ReceiptFormatError)?,
+                ),
+                assumptions: self.assumptions_claim()?.into(),
+            };
+
+            // If these digests do not match, this receipt is internally inconsistent.
+            if self_output.digest() != claim.output.digest() {
+                let empty_output = claim.output.is_none()
+                    && self
+                        .journal_digest
+                        .ok_or(VerificationError::ReceiptFormatError)?
+                        == Vec::<u8>::new().digest();
+                if !empty_output {
+                    tracing::debug!(
+                        "output digest does not match: expected {:?}; decoded {:?}",
+                        &self_output,
+                        &claim.output
+                    );
+                    return Err(VerificationError::ReceiptFormatError);
+                }
+            }
+        } else {
+            // Ensure all output fields are empty. If not, this receipt is internally
+            // inconsistent.
+            if claim.output.is_some() {
+                tracing::debug!("unexpected non-empty claim output: {:?}", &claim.output);
+                return Err(VerificationError::ReceiptFormatError);
+            }
+            if !self.assumptions.is_empty() {
+                tracing::debug!(
+                    "unexpected non-empty composite receipt assumptions: {:?}",
+                    &self.assumptions
+                );
+                return Err(VerificationError::ReceiptFormatError);
+            }
+            if self.journal_digest.is_some() {
+                tracing::debug!(
+                    "unexpected non-empty composite receipt journal_digest: {:?}",
+                    &self.journal_digest
+                );
+                return Err(VerificationError::ReceiptFormatError);
+            }
+        }
+        Ok(())
+    }
+
+    fn assumptions_claim(&self) -> Result<Assumptions, VerificationError> {
+        Ok(Assumptions(
+            self.assumptions
+                .iter()
+                .map(|a| Ok(a.claim()?.into()))
+                .collect::<Result<Vec<_>, _>>()?,
+        ))
+    }
+}

--- a/risc0/zkvm/src/host/receipt/segment.rs
+++ b/risc0/zkvm/src/host/receipt/segment.rs
@@ -1,0 +1,175 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloc::{collections::BTreeSet, string::String, vec::Vec};
+use core::fmt::Debug;
+
+use anyhow::Result;
+use hex::FromHex;
+use risc0_binfmt::{ExitCode, SystemState};
+use risc0_circuit_rv32im::{
+    control_id::{BLAKE2B_CONTROL_ID, POSEIDON2_CONTROL_ID, SHA256_CONTROL_ID},
+    layout, CircuitImpl, CIRCUIT,
+};
+use risc0_zkp::{
+    adapter::{CircuitInfo as _, PROOF_SYSTEM_INFO},
+    core::digest::Digest,
+    layout::Buffer,
+    verify::VerificationError,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+// Make succinct receipt available through this `receipt` module.
+use super::{metadata::SegmentReceiptVerifierInfo, VerifierContext};
+use crate::{
+    sha::{Digestible, Sha256},
+    MaybePruned, ReceiptClaim,
+};
+
+/// A receipt attesting to the execution of a Segment.
+///
+/// A SegmentReceipt attests that a Segment was executed in a manner
+/// consistent with the [ReceiptClaim] included in the receipt.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct SegmentReceipt {
+    /// The cryptographic data attesting to the validity of the code execution.
+    ///
+    /// This data is used by the ZKP Verifier (as called by
+    /// [SegmentReceipt::verify_integrity_with_context]) to cryptographically prove that this
+    /// Segment was faithfully executed. It is largely opaque cryptographic data, but contains a
+    /// non-opaque claim component, which can be conveniently accessed with
+    /// [SegmentReceipt::claim].
+    pub seal: Vec<u32>,
+
+    /// Segment index within the [Receipt]
+    pub index: u32,
+
+    /// Name of the hash function used to create this receipt.
+    pub hashfn: String,
+
+    /// [ReceiptClaim] containing information about the execution that this receipt proves.
+    pub claim: ReceiptClaim,
+}
+
+impl SegmentReceipt {
+    fn allowed_control_ids() -> impl Iterator<Item = Digest> {
+        POSEIDON2_CONTROL_ID
+            .into_iter()
+            .chain(SHA256_CONTROL_ID)
+            .chain(BLAKE2B_CONTROL_ID)
+            .map(|x| Digest::from_hex(x).unwrap())
+    }
+
+    /// Information about the parameters used to verify the receipt. Includes parameters that are
+    /// useful in deciding whether the verifier is compatible with a given receipt.
+    pub fn verifier_info() -> SegmentReceiptVerifierInfo {
+        SegmentReceiptVerifierInfo {
+            control_ids: BTreeSet::from_iter(Self::allowed_control_ids()),
+            proof_system_info: PROOF_SYSTEM_INFO,
+            circuit_info: risc0_circuit_rv32im::CircuitImpl::CIRCUIT_INFO,
+        }
+    }
+
+    /// Verify the integrity of this receipt, ensuring the claim is attested
+    /// to by the seal.
+    pub fn verify_integrity_with_context(
+        &self,
+        ctx: &VerifierContext,
+    ) -> Result<(), VerificationError> {
+        tracing::debug!("SegmentReceipt::verify_integrity_with_context");
+        let check_code = |_, control_id: &Digest| -> Result<(), VerificationError> {
+            Self::allowed_control_ids()
+                .find(|x| x == control_id)
+                .map(|_| ())
+                .ok_or(VerificationError::ControlVerificationError {
+                    control_id: *control_id,
+                })
+        };
+        let suite = ctx
+            .suites
+            .get(&self.hashfn)
+            .ok_or(VerificationError::InvalidHashSuite)?;
+        risc0_zkp::verify::verify(&CIRCUIT, suite, &self.seal, check_code)?;
+
+        // Receipt is consistent with the claim encoded on the seal. Now check against the
+        // claim on the struct.
+        let decoded_claim = decode_receipt_claim_from_seal(&self.seal)?;
+        if decoded_claim.digest() != self.claim.digest() {
+            tracing::debug!(
+                "decoded segment receipt claim does not match claim field:\ndecoded: {:#?},\nexpected: {:#?}",
+                decoded_claim,
+                self.claim,
+            );
+            return Err(VerificationError::ReceiptFormatError);
+        }
+        Ok(())
+    }
+
+    /// Return the seal for this receipt, as a vector of bytes.
+    pub fn get_seal_bytes(&self) -> Vec<u8> {
+        self.seal.iter().flat_map(|x| x.to_le_bytes()).collect()
+    }
+}
+
+fn decode_system_state_from_io(
+    io: layout::OutBuffer,
+    sys_state: &layout::SystemState,
+) -> Result<SystemState, VerificationError> {
+    let bytes: Vec<u8> = io
+        .tree(sys_state.image_id)
+        .get_bytes()
+        .or(Err(VerificationError::ReceiptFormatError))?;
+    let pc = io
+        .tree(sys_state.pc)
+        .get_u32()
+        .or(Err(VerificationError::ReceiptFormatError))?;
+    let merkle_root = Digest::try_from(bytes).or(Err(VerificationError::ReceiptFormatError))?;
+    Ok(SystemState { pc, merkle_root })
+}
+
+pub(crate) fn decode_receipt_claim_from_seal(
+    seal: &[u32],
+) -> Result<ReceiptClaim, VerificationError> {
+    let elems = bytemuck::checked::cast_slice(&seal[..CircuitImpl::OUTPUT_SIZE]);
+    let io = layout::OutBuffer(elems);
+    let body = layout::LAYOUT.mux.body;
+    let pre = decode_system_state_from_io(io, body.global.pre)?;
+    let post = decode_system_state_from_io(io, body.global.post)?;
+
+    let input_bytes: Vec<u8> = io
+        .tree(body.global.input)
+        .get_bytes()
+        .or(Err(VerificationError::ReceiptFormatError))?;
+    let input = Digest::try_from(input_bytes).or(Err(VerificationError::ReceiptFormatError))?;
+
+    let output_bytes: Vec<u8> = io
+        .tree(body.global.output)
+        .get_bytes()
+        .or(Err(VerificationError::ReceiptFormatError))?;
+    let output = Digest::try_from(output_bytes).or(Err(VerificationError::ReceiptFormatError))?;
+
+    let sys_exit = io.get_u64(body.global.sys_exit_code) as u32;
+    let user_exit = io.get_u64(body.global.user_exit_code) as u32;
+    let exit_code =
+        ExitCode::from_pair(sys_exit, user_exit).or(Err(VerificationError::ReceiptFormatError))?;
+
+    Ok(ReceiptClaim {
+        pre: pre.into(),
+        post: post.into(),
+        exit_code,
+        input: MaybePruned::Pruned(input),
+        output: MaybePruned::Pruned(output),
+    })
+}

--- a/risc0/zkvm/src/host/receipt/segment.rs
+++ b/risc0/zkvm/src/host/receipt/segment.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{collections::BTreeSet, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use core::fmt::Debug;
 
 use anyhow::Result;
@@ -23,19 +23,13 @@ use risc0_circuit_rv32im::{
     layout, CircuitImpl, CIRCUIT,
 };
 use risc0_zkp::{
-    adapter::{CircuitInfo as _, PROOF_SYSTEM_INFO},
-    core::digest::Digest,
-    layout::Buffer,
-    verify::VerificationError,
+    adapter::CircuitInfo as _, core::digest::Digest, layout::Buffer, verify::VerificationError,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 // Make succinct receipt available through this `receipt` module.
-use super::{metadata::SegmentReceiptVerifierInfo, VerifierContext};
-use crate::{
-    sha::{Digestible, Sha256},
-    MaybePruned, ReceiptClaim,
-};
+use super::VerifierContext;
+use crate::{sha::Digestible, MaybePruned, ReceiptClaim};
 
 /// A receipt attesting to the execution of a Segment.
 ///
@@ -70,16 +64,6 @@ impl SegmentReceipt {
             .chain(SHA256_CONTROL_ID)
             .chain(BLAKE2B_CONTROL_ID)
             .map(|x| Digest::from_hex(x).unwrap())
-    }
-
-    /// Information about the parameters used to verify the receipt. Includes parameters that are
-    /// useful in deciding whether the verifier is compatible with a given receipt.
-    pub fn verifier_info() -> SegmentReceiptVerifierInfo {
-        SegmentReceiptVerifierInfo {
-            control_ids: BTreeSet::from_iter(Self::allowed_control_ids()),
-            proof_system_info: PROOF_SYSTEM_INFO,
-            circuit_info: risc0_circuit_rv32im::CircuitImpl::CIRCUIT_INFO,
-        }
     }
 
     /// Verify the integrity of this receipt, ensuring the claim is attested
@@ -169,7 +153,7 @@ pub(crate) fn decode_receipt_claim_from_seal(
         pre: pre.into(),
         post: post.into(),
         exit_code,
-        input: MaybePruned::Pruned(input),
+        input,
         output: MaybePruned::Pruned(output),
     })
 }

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -147,7 +147,7 @@ where
     fn prove_segment(&self, ctx: &VerifierContext, segment: &Segment) -> Result<SegmentReceipt> {
         use risc0_circuit_rv32im::prove::{engine::SegmentProverImpl, SegmentProver as _};
 
-        use crate::host::receipt::decode_receipt_claim_from_seal;
+        use crate::host::receipt::segment::decode_receipt_claim_from_seal;
 
         let hashfn = self.hal_pair.hal.get_hash_suite().name.clone();
 


### PR DESCRIPTION
This is a non-functional change PR to move the inner receipt types, `SegmentReceipt`, `CompositeReceipt`, and `CompactReceipt`, into individual implementation files.

This refactor forms a basis for functionality to be added in https://github.com/risc0/risc0/pull/1764