### PR TITLE
guest verify: accelerate sha256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4382,6 +4382,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "criterion",
  "cust",
  "digest",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2442,6 +2442,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "cust",
  "digest",
  "ff",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -913,6 +913,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "cust",
  "digest",
  "ff",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -559,6 +559,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -609,6 +609,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -559,6 +559,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -1380,6 +1380,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/risc0/binfmt/src/image.rs
+++ b/risc0/binfmt/src/image.rs
@@ -19,7 +19,7 @@ use alloc::{collections::BTreeMap, vec, vec::Vec};
 use anyhow::{ensure, Result};
 use risc0_zkp::core::{
     digest::Digest,
-    hash::sha::{cpu::Impl, Sha256, BLOCK_BYTES, SHA256_INIT},
+    hash::sha::{Impl, Sha256, BLOCK_BYTES, SHA256_INIT},
 };
 use risc0_zkvm_platform::{
     memory::{GUEST_MAX_MEM, MEM_SIZE, PAGE_TABLE},

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "62beebcb97bd295cf8ece734eb6469620f2a8a2dad27a7f26cc592eb20a967ba",
+            "52d1c3712b98e343e7ec5d167cdad6ba37dbfbfe63569b1175a151123261f461",
         );
     }
 }

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -15,6 +15,7 @@ harness = false
 anyhow = { version = "1.0", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
 bytemuck = { version = "1.12", features = ["derive"] }
+cfg-if = "1.0"
 cust = { version = "0.3", optional = true }
 digest = { version = "0.10", features = ["oid"] }
 ff = { version = "0.13", features = ["derive", "bits"], optional = true }

--- a/risc0/zkp/src/core/hash/sha/guest.rs
+++ b/risc0/zkp/src/core/hash/sha/guest.rs
@@ -221,7 +221,7 @@ fn update_u8(out_state: *mut Digest, mut in_state: *const Digest, bytes: &[u8], 
 
 /// A guest-side [Sha256] implementation.
 ///
-/// [Sha256]: risc0_zkp::core::hash::sha::Sha256
+/// [Sha256]: crate::core::hash::sha::Sha256
 #[derive(Debug, Clone, Default)]
 pub struct Impl {}
 

--- a/risc0/zkp/src/core/hash/sha/guest.rs
+++ b/risc0/zkp/src/core/hash/sha/guest.rs
@@ -16,16 +16,15 @@
 
 use alloc::vec::Vec;
 
-use risc0_zkp::core::{
+use crate::core::{
     digest::Digest,
     hash::sha::{Block, BLOCK_WORDS, SHA256_INIT},
 };
 use risc0_zkvm_platform::{
+    align_up,
     syscall::{sys_sha_buffer, sys_sha_compress},
     WORD_SIZE,
 };
-
-use crate::align_up;
 
 // FIP 180-4 specifies that the bit-string being hashed should have a `1`
 // appended to it before padding.
@@ -226,7 +225,7 @@ fn update_u8(out_state: *mut Digest, mut in_state: *const Digest, bytes: &[u8], 
 #[derive(Debug, Clone, Default)]
 pub struct Impl {}
 
-impl risc0_zkp::core::hash::sha::Sha256 for Impl {
+impl crate::core::hash::sha::Sha256 for Impl {
     type DigestPtr = &'static mut Digest;
 
     fn hash_bytes(bytes: &[u8]) -> Self::DigestPtr {

--- a/risc0/zkp/src/core/hash/sha/rng.rs
+++ b/risc0/zkp/src/core/hash/sha/rng.rs
@@ -19,16 +19,7 @@ use alloc::boxed::Box;
 use rand_core::{impls, Error, RngCore};
 use risc0_core::field::{Elem, Field};
 
-// Pick the appropriate implementation of SHA-256 depending on whether we are
-// in the zkVM guest.
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "zkvm")] {
-        use crate::core::hash::sha::guest::Impl;
-    } else {
-        use crate::core::hash::sha::cpu::Impl;
-    }
-}
-use super::{Digest, Sha256, DIGEST_WORDS};
+use super::{Impl, Digest, Sha256, DIGEST_WORDS};
 use crate::core::hash::Rng;
 
 /// A random number generator driven by a [Sha256].

--- a/risc0/zkp/src/core/hash/sha/rng.rs
+++ b/risc0/zkp/src/core/hash/sha/rng.rs
@@ -19,7 +19,7 @@ use alloc::boxed::Box;
 use rand_core::{impls, Error, RngCore};
 use risc0_core::field::{Elem, Field};
 
-use super::{Impl, Digest, Sha256, DIGEST_WORDS};
+use super::{Digest, Impl, Sha256, DIGEST_WORDS};
 use crate::core::hash::Rng;
 
 /// A random number generator driven by a [Sha256].

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest",
  "hex",
  "paste",

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -80,7 +80,7 @@
 #![deny(missing_docs)]
 
 pub mod env;
-pub mod sha;
+pub use risc0_zkp::core::hash::sha;
 
 #[cfg(target_os = "zkvm")]
 use core::arch::asm;

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -600,6 +600,8 @@ mod docker {
 
     #[test]
     fn verify_in_guest() {
+        let composite_receipt_sha256 = generate_receipt(ProverOpts::fast());
+        exec_verify(&composite_receipt_sha256);
         let composite_receipt = generate_receipt(ProverOpts::composite());
         exec_verify(&composite_receipt);
         let succinct_receipt = get_prover_server(&ProverOpts::succinct())

--- a/risc0/zkvm/src/sha.rs
+++ b/risc0/zkvm/src/sha.rs
@@ -51,15 +51,9 @@ pub use risc0_zkp::core::{
     hash::sha::{Block, Sha256, BLOCK_BYTES, BLOCK_WORDS, SHA256_INIT, WORD_SIZE},
 };
 
-// Pick the appropriate implementation of SHA-256 depending on whether we are
+// This Impl selects the approperiate implementation of SHA-256 depending on whether we are
 // in the zkVM guest. Users can simply `use risc0_zkvm::sha::Impl`.
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "zkvm")] {
-        pub use crate::guest::sha::Impl;
-    } else {
-        pub use risc0_zkp::core::hash::sha::cpu::Impl;
-    }
-}
+pub use risc0_zkp::core::hash::sha::Impl;
 
 /// Defines a collision resistant hash for the typed and structured data.
 pub trait Digestible {

--- a/risc0/zkvm/src/sha.rs
+++ b/risc0/zkvm/src/sha.rs
@@ -51,7 +51,7 @@ pub use risc0_zkp::core::{
     hash::sha::{Block, Sha256, BLOCK_BYTES, BLOCK_WORDS, SHA256_INIT, WORD_SIZE},
 };
 
-// This Impl selects the approperiate implementation of SHA-256 depending on whether we are
+// This Impl selects the appropriate implementation of SHA-256 depending on whether we are
 // in the zkVM guest. Users can simply `use risc0_zkvm::sha::Impl`.
 pub use risc0_zkp::core::hash::sha::Impl;
 


### PR DESCRIPTION
To implement the accerleation, I simply pushed this logic into the `risc0-zkp` crate and retained the `Impl` export in `risc0-zkvm`.
```
cfg_if::cfg_if! {
    if #[cfg(target_os = "zkvm")] {
        use crate::core::hash::sha::guest::Impl;
    } else {
        use crate::core::hash::sha::cpu::Impl;
    }
}
```