### PR TITLE
add mention of steel to dev docs site

### DIFF
--- a/website/api/blockchain-integration/eth-examples.md
+++ b/website/api/blockchain-integration/eth-examples.md
@@ -6,6 +6,10 @@ While all of the [zkVM examples][zkvm-examples] can be run on Bonsai by [configu
 
 The [RISC Zero Foundry Template][foundry-template] provides a minimal application that can act as a template for developing your application.
 
+### STEEL
+
+[STEEL] is a library for [view call proofs], which enables users to easily integrate claims about Ethereum state into zkVM applications.
+
 ### Zeth
 
 [Zeth][zeth-repo] produces ZK validity proofs for Ethereum Virtual Machine blocks (EVM). This is accomplished by running [revm], a Rust implementation of the EVM in the zkVM. The end result is an open-source zkEVM with high code reuse and minute, not hour, proving times on Bonsai. For more info check out [Announcing Zeth: The first Type Zero zkEVM][zeth-article].
@@ -23,3 +27,5 @@ This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. T
 [Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
 [signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
 [foundry-template]: https://github.com/risc0/bonsai-foundry-template
+[STEEL]: https://crates.io/crates/risc0-steel
+[view call proofs]: https://www.risczero.com/blog/introducing-steel

--- a/website/api/blockchain-integration/eth-examples.md
+++ b/website/api/blockchain-integration/eth-examples.md
@@ -8,7 +8,7 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 ### Steel
 
-[Steel] is a library for [view call proofs], which enables users to easily integrate claims about Ethereum state into zkVM applications.
+[Steel][steel-repo] is a library for [view call proofs][steel-blog], which enables users to easily integrate claims about Ethereum state into zkVM applications.
 
 ### Zeth
 

--- a/website/api/blockchain-integration/eth-examples.md
+++ b/website/api/blockchain-integration/eth-examples.md
@@ -6,9 +6,9 @@ While all of the [zkVM examples][zkvm-examples] can be run on Bonsai by [configu
 
 The [RISC Zero Foundry Template][foundry-template] provides a minimal application that can act as a template for developing your application.
 
-### STEEL
+### Steel
 
-[STEEL] is a library for [view call proofs], which enables users to easily integrate claims about Ethereum state into zkVM applications.
+[Steel] is a library for [view call proofs], which enables users to easily integrate claims about Ethereum state into zkVM applications.
 
 ### Zeth
 
@@ -27,5 +27,5 @@ This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. T
 [Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
 [signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
 [foundry-template]: https://github.com/risc0/bonsai-foundry-template
-[STEEL]: https://crates.io/crates/risc0-steel
+[Steel]: https://crates.io/crates/risc0-steel
 [view call proofs]: https://www.risczero.com/blog/introducing-steel

--- a/website/api/blockchain-integration/eth-examples.md
+++ b/website/api/blockchain-integration/eth-examples.md
@@ -27,5 +27,5 @@ This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. T
 [Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
 [signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
 [foundry-template]: https://github.com/risc0/bonsai-foundry-template
-[Steel]: https://crates.io/crates/risc0-steel
-[view call proofs]: https://www.risczero.com/blog/introducing-steel
+[steel-repo]: https://crates.io/crates/risc0-steel
+[steel-blog]: https://www.risczero.com/blog/introducing-steel


### PR DESCRIPTION
The dev docs site doesn't mention Steel yet. This PR adds a brief section to the Ethereum Examples page, to improve findability of Steel. 

Questions worth thinking about:
- is the risc0-steel crate is the appropriate place to point users
- do we want to add mentions/paths to Steel elsewhere (mb in the sidebar?) 