### PR TITLE
Warn that the ceremony is incomplete

### DIFF
--- a/website/api/trusted-setup-ceremony.md
+++ b/website/api/trusted-setup-ceremony.md
@@ -1,5 +1,11 @@
 # Trusted Setup Security
 
+:::warning
+
+As of the writing of this note, our trusted setup ceremony has not been finalized. Without this finalization step, our ceremony is not complete and you will not be able to verify its security with the instructions below (because it is not yet secure while finalization is still pending).
+
+:::
+
 RISC Zero has run a trusted setup ceremony for our Groth16 prover/verifier. This ceremony secures our STARK Verify circuit so we can publish compact receipts for our general purpose zkVM to limited-memory environments like blockchains.
 
 You don't need to take our word for it that this is secure, though! This document will walk you through how to verify the security of our ceremony for yourself. This can also be used to aid in the detection of attacks related to our ceremony, e.g. it may help detect fraudulent actors publishing something they claim to be the RISC Zero STARK Verifier but which is actually malicious code.

--- a/website/api_versioned_docs/version-0.21/trusted-setup-ceremony.md
+++ b/website/api_versioned_docs/version-0.21/trusted-setup-ceremony.md
@@ -1,5 +1,11 @@
 # Trusted Setup Security
 
+:::warning
+
+As of the writing of this note, our trusted setup ceremony has not been finalized. Without this finalization step, our ceremony is not complete and you will not be able to verify its security with the instructions below (because it is not yet secure while finalization is still pending).
+
+:::
+
 RISC Zero has run a trusted setup ceremony for our Groth16 prover/verifier. This ceremony secures our STARK Verify circuit so we can publish compact receipts for our general purpose zkVM to limited-memory environments like blockchains.
 
 You don't need to take our word for it that this is secure, though! This document will walk you through how to verify the security of our ceremony for yourself. This can also be used to aid in the detection of attacks related to our ceremony, e.g. it may help detect fraudulent actors publishing something they claim to be the RISC Zero STARK Verifier but which is actually malicious code.


### PR DESCRIPTION
Our trusted setup ceremony is not finalized yet; add a warning so users know to expect that.