### PR TITLE
Put word joiners in "C++" in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ output of the code, not any of its inputs or any state during execution.
 The code runs in a special virtual machine, called a _zkVM_. The RISC Zero zkVM
 emulates a small [RISC-V] computer, allowing it to run arbitrary code in any
 language, so long as a compiler toolchain exists that targets RISC-V. Currently,
-SDK support exists for Rust, C, and C++.
+SDK support exists for Rust, C, and C⁠+⁠+.
 
 ## Protocol overview and terminology
 


### PR DESCRIPTION
Adds two U+2060 characters to prevent C++ from line breaking.