### PR TITLE
Update links on dev.risczero.com to datasheet and benchmarks

### DIFF
--- a/website/api/zkvm/benchmarks.md
+++ b/website/api/zkvm/benchmarks.md
@@ -56,7 +56,7 @@ the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
 appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles
-[datasheet]: https://dev.risczero.com/datasheet.pdf
+[datasheet]: https://benchmarks.risczero.com/main/datasheet
 [execution]: /terminology#execute
 [install]: ./install.md
 [prover]: /terminology#prover

--- a/website/api_versioned_docs/version-0.21/zkvm/benchmarks.md
+++ b/website/api_versioned_docs/version-0.21/zkvm/benchmarks.md
@@ -56,7 +56,7 @@ the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
 appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles
-[datasheet]: https://dev.risczero.com/datasheet.pdf
+[datasheet]: https://benchmarks.risczero.com/release-0.21/datasheet
 [execution]: /terminology#execute
 [install]: ./install.md
 [prover]: /terminology#prover

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -123,7 +123,7 @@ As a consequence, _functionally equivalent_ binaries, from the zkVM perspective,
 <summary>
 Q: Are performance benchmarks available?
 </summary>
-A: Yes. We have a <a href="https://dev.risczero.com/datasheet.pdf">datasheet</a> with performance benchmarks, and you can also generate your own benchmarks. More details are available on the <a href="https://dev.risczero.com/zkvm/benchmarks">benchmarks page</a>.
+A: Yes. We have a <a href="https://benchmarks.risczero.com/">benchmarks website</a>, and you can also generate your own benchmarks. More details are available on the <a href="https://dev.risczero.com/zkvm/benchmarks">benchmarks page</a>.
 </details>
 
 <a class="anchor" id="language-support"></a>


### PR DESCRIPTION
A minimal PR to update docs on dev.risczero.com to point to the new benchmarking website and datasheet(s).

Note that I linked to the root page from the FAQ, instead of the datasheet. Primary reason for this is that this page is not versioned, and there is no way to link to the "latest release" on the website.

Benchmarking page could also use an update to have new instructions, when we get a chance https://dev.risczero.com/api/zkvm/benchmarks
