### PR TITLE
Add conversions for compact receipt

### DIFF
--- a/risc0/groth16/src/docker.rs
+++ b/risc0/groth16/src/docker.rs
@@ -46,16 +46,20 @@ pub fn stark_to_snark(identity_p254_seal_bytes: &[u8]) -> Result<Seal> {
     std::fs::write(seal_path, seal_json)?;
 
     tracing::debug!("risc0-groth16-prover");
-    let status = Command::new("docker")
+    let output = Command::new("docker")
         .arg("run")
         .arg("--rm")
         .arg("-v")
         .arg(&format!("{}:/mnt", work_dir.to_string_lossy()))
         .arg("risczero/risc0-groth16-prover:v2024-04-03.2")
-        .stdout(Stdio::null())
-        .status()?;
-    if !status.success() {
-        bail!("docker returned failure exit code: {:?}", status.code());
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    if !output.status.success() {
+        bail!(
+            "docker returned failure exit code: {:?}",
+            output.status.code()
+        );
     }
 
     tracing::debug!("Parsing proof");

--- a/risc0/groth16/src/docker.rs
+++ b/risc0/groth16/src/docker.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{env::consts::ARCH, path::Path, process::Command};
+use std::{
+    env::consts::ARCH,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 use anyhow::{bail, Result};
 use tempfile::tempdir;
@@ -48,6 +52,7 @@ pub fn stark_to_snark(identity_p254_seal_bytes: &[u8]) -> Result<Seal> {
         .arg("-v")
         .arg(&format!("{}:/mnt", work_dir.to_string_lossy()))
         .arg("risczero/risc0-groth16-prover:v2024-04-03.2")
+        .stdout(Stdio::null())
         .status()?;
     if !status.success() {
         bail!("docker returned failure exit code: {:?}", status.code());

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -25,8 +25,8 @@ use crate::{
         segment::decode_receipt_claim_from_seal, CompositeReceipt, InnerReceipt, ReceiptMetadata,
         SegmentReceipt, SuccinctReceipt,
     },
-    Assumptions, ExitCode, Input, Journal, MaybePruned, Output, ProveInfo, ProverOpts, Receipt,
-    ReceiptClaim, ReceiptKind, SessionStats, TraceEvent,
+    Assumptions, CompactReceipt, ExitCode, Input, Journal, MaybePruned, Output, ProveInfo,
+    ProverOpts, Receipt, ReceiptClaim, ReceiptKind, SessionStats, TraceEvent,
 };
 
 mod ver {
@@ -35,6 +35,7 @@ mod ver {
     pub const RECEIPT: CompatVersion = CompatVersion { value: 1 };
     pub const SEGMENT_RECEIPT: CompatVersion = CompatVersion { value: 1 };
     pub const SUCCINCT_RECEIPT: CompatVersion = CompatVersion { value: 1 };
+    pub const COMPACT_RECEIPT: CompatVersion = CompatVersion { value: 1 };
 }
 
 impl TryFrom<AssetRequest> for pb::api::AssetRequest {
@@ -415,6 +416,32 @@ impl TryFrom<pb::core::SuccinctReceipt> for SuccinctReceipt {
     }
 }
 
+impl From<CompactReceipt> for pb::core::Groth16Receipt {
+    fn from(value: CompactReceipt) -> Self {
+        Self {
+            version: Some(ver::COMPACT_RECEIPT),
+            seal: value.seal,
+            claim: Some(value.claim.into()),
+        }
+    }
+}
+
+impl TryFrom<pb::core::Groth16Receipt> for CompactReceipt {
+    type Error = anyhow::Error;
+
+    fn try_from(value: pb::core::Groth16Receipt) -> Result<Self> {
+        let version = value.version.ok_or(malformed_err())?.value;
+        if version > ver::COMPACT_RECEIPT.value {
+            bail!("Incompatible CompactReceipt version: {version}");
+        }
+
+        Ok(Self {
+            seal: value.seal,
+            claim: value.claim.ok_or(malformed_err())?.try_into()?,
+        })
+    }
+}
+
 impl From<InnerReceipt> for pb::core::InnerReceipt {
     fn from(value: InnerReceipt) -> Self {
         Self {
@@ -430,7 +457,9 @@ impl From<InnerReceipt> for pb::core::InnerReceipt {
                         claim: Some(claim.into()),
                     })
                 }
-                InnerReceipt::Compact(_) => unimplemented!(),
+                InnerReceipt::Compact(inner) => {
+                    pb::core::inner_receipt::Kind::Groth16(inner.into())
+                }
             }),
         }
     }
@@ -442,7 +471,7 @@ impl TryFrom<pb::core::InnerReceipt> for InnerReceipt {
     fn try_from(value: pb::core::InnerReceipt) -> Result<Self> {
         Ok(match value.kind.ok_or(malformed_err())? {
             pb::core::inner_receipt::Kind::Composite(inner) => Self::Composite(inner.try_into()?),
-            pb::core::inner_receipt::Kind::Groth16(_) => unimplemented!(),
+            pb::core::inner_receipt::Kind::Groth16(inner) => Self::Compact(inner.try_into()?),
             pb::core::inner_receipt::Kind::Succinct(inner) => Self::Succinct(inner.try_into()?),
             pb::core::inner_receipt::Kind::Fake(inner) => Self::Fake {
                 claim: inner.claim.ok_or(malformed_err())?.try_into()?,

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -216,7 +216,7 @@ impl Prover for BonsaiProver {
                 );
                 Ok(receipt.clone())
             }
-            // NOTE: Bonsai always returns a SuccinctReceipt, and does not currenly support
+            // NOTE: Bonsai always returns a SuccinctReceipt, and does not currently support
             // compression of existing receipts uploaded by clients.
             (_, ReceiptKind::Succinct) => {
                 bail!("BonsaiProver does not support compression on existing receipts");

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -144,7 +144,7 @@ pub use {
 
 pub use receipt::{
     Assumption, CompositeReceipt, CompositeReceiptVerifierParameters, InnerReceipt, Journal,
-    Receipt, SegmentReceipt, SegmentReceiptVerifierParameters, SuccinctReceipt,
+    Receipt, ReceiptMetadata, SegmentReceipt, SegmentReceiptVerifierParameters, SuccinctReceipt,
     SuccinctReceiptVerifierParameters, VerifierContext,
 };
 //#[cfg(any(not(target_os = "zkvm"), feature = "std"))]

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -144,7 +144,7 @@ pub use {
 
 pub use receipt::{
     Assumption, CompositeReceipt, CompositeReceiptVerifierParameters, InnerReceipt, Journal,
-    Receipt, ReceiptMetadata, SegmentReceipt, SegmentReceiptVerifierParameters, SuccinctReceipt,
+    Receipt, SegmentReceipt, SegmentReceiptVerifierParameters, SuccinctReceipt,
     SuccinctReceiptVerifierParameters, VerifierContext,
 };
 //#[cfg(any(not(target_os = "zkvm"), feature = "std"))]

--- a/xtask/src/bootstrap_groth16.rs
+++ b/xtask/src/bootstrap_groth16.rs
@@ -161,7 +161,7 @@ fn bootstrap_test_receipt(risc0_ethereum_path: &Path) {
     let image_id = hex::encode(image_id.as_bytes());
     let journal = hex::encode(receipt.journal.bytes);
 
-    // NOTE: Selector value is the fist four bytes of the verifier param digest. It is added as part
+    // NOTE: Selector value is the first four bytes of the verifier param digest. It is added as part
     // of ABI encoding and used for routing to the correct verifier on-chain. We do not use the
     // full ABI encoding implementation here because its part of risc0-ethereum-contracts, which
     // would be a hassle to import.


### PR DESCRIPTION
- Add converions for compact receipts so that can be used with `r0vm`
- Make Groth16 docker prover silent, so that can be used with the risc0-ethereum `ffi`
- Fix few typos