### PR TITLE
Fix benchmarks app

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,14 @@
 {
   "recommendations": [
-    "bazelbuild.vscode-bazel",
+    "biomejs.biome",
     "EditorConfig.EditorConfig",
-    "james-yu.latex-workshop",
     "kriegalex.vscode-cudacpp",
-    "rust-lang.rust-analyzer",
+    "llvm-vs-code-extensions.vscode-clangd",
     "ms-vscode.cpptools",
+    "rust-lang.rust-analyzer",
+    "serayuzgur.crates",
     "stkb.rewrap",
-    "twxs.cmake",
+    "tamasfe.even-better-toml",
     "valentjn.vscode-ltex"
   ]
 }

--- a/web/README.md
+++ b/web/README.md
@@ -3,11 +3,14 @@
 #### Before You Start
 
 - Install [Node](https://nodejs.org/en) (≥ v20.x.x)
+
 - Install [bun](https://bun.sh/) (≥ v1.0.33)
 
-> #### General
->
-> When making code changes, please have the [Biome VSCode extension](https://marketplace.visualstudio.com/items?itemName=biomejs.biome) installed.
+```sh
+curl -fsSL https://bun.sh/install | bash
+```
+
+- If you're using vscode: please have the [Biome VSCode extension](https://marketplace.visualstudio.com/items?itemName=biomejs.biome) installed.
 
 ## Apps 👾
 
@@ -16,3 +19,15 @@
 ## Packages 📦
 
 - [`shared`](./packages/shared) → shared code between apps
+
+## Testing
+
+```sh
+bun run test
+```
+
+## Development
+
+```sh
+bun run dev
+```

--- a/web/apps/benchmarks-and-reports/.env.example
+++ b/web/apps/benchmarks-and-reports/.env.example
@@ -1,1 +1,0 @@
-GITHUB_PAT=

--- a/web/apps/benchmarks-and-reports/README.md
+++ b/web/apps/benchmarks-and-reports/README.md
@@ -2,8 +2,11 @@
 
 ## Getting Started 🚀
 
-> [!IMPORTANT]
-> Create an `.env` file at the root of the project and fill its contents (see `.env.example`)
+We need to install `bun` with:
+
+```sh
+curl -fsSL https://bun.sh/install | bash
+```
 
 Then run:
 

--- a/web/apps/benchmarks-and-reports/next.config.js
+++ b/web/apps/benchmarks-and-reports/next.config.js
@@ -11,7 +11,6 @@ let config = {
   transpilePackages: ["@risc0/ui"],
   experimental: {
     caseSensitiveRoutes: true,
-    ppr: true,
   },
   images: {
     dangerouslyAllowSVG: false,

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/_actions/fetch-applications-benchmarks-commit-hash.ts
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/_actions/fetch-applications-benchmarks-commit-hash.ts
@@ -7,7 +7,6 @@ export async function fetchApplicationsBenchmarksCommitHash({ version }: { versi
     `https://raw.githubusercontent.com/risc0/ghpages/${version}/dev/benchmarks/COMMIT_HASH.txt`,
     {
       headers: {
-        Authorization: `token ${env.GITHUB_PAT}`,
         Accept: "application/vnd.github.v3.raw",
       },
       next: { revalidate: 900 },

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/_actions/fetch-applications-benchmarks.ts
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/_actions/fetch-applications-benchmarks.ts
@@ -5,7 +5,6 @@ import env from "~/env";
 export async function fetchApplicationsBenchmarks({ url, version }: { url: string; version: string }) {
   return fetch(`https://raw.githubusercontent.com/risc0/ghpages/${version}/dev/benchmarks/${url}`, {
     headers: {
-      Authorization: `token ${env.GITHUB_PAT}`,
       Accept: "application/vnd.github.v3.raw",
     },
     next: { revalidate: 900 },

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/_actions/fetch-datasheet-commit-hash.ts
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/_actions/fetch-datasheet-commit-hash.ts
@@ -10,7 +10,6 @@ export async function fetchDatasheetCommitHash({ version }: { version: string })
     `https://raw.githubusercontent.com/risc0/ghpages/${version}/dev/datasheet/COMMIT_HASH.txt`,
     {
       headers: {
-        Authorization: `token ${env.GITHUB_PAT}`,
         Accept: "application/vnd.github.v3.raw",
       },
     },

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/_actions/fetch-datasheet.ts
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/_actions/fetch-datasheet.ts
@@ -8,7 +8,6 @@ export async function fetchDatasheet({ version, url }: { version: string; url: s
 
   return fetch(`https://raw.githubusercontent.com/risc0/ghpages/${version}/dev/datasheet/${url}`, {
     headers: {
-      Authorization: `token ${env.GITHUB_PAT}`,
       Accept: "application/vnd.github.v3.raw",
     },
   })

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/benchmarks/_components/charts.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/benchmarks/_components/charts.tsx
@@ -143,7 +143,7 @@ export function Charts() {
       <FooterAscii text="Benchmarks" />
 
       <Script
-        src="https://reports.risczero.com/benchmarks"
+        src="https://risc0.github.io/ghpages/dev/bench/data.js"
         onReady={() => {
           setReady(true);
         }}

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/crates-validation/_actions/fetch-crates-validation-results.ts
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/crates-validation/_actions/fetch-crates-validation-results.ts
@@ -10,7 +10,6 @@ export async function fetchCratesValidationResults({
     `https://raw.githubusercontent.com/risc0/ghpages/main/dev/crate-validation/results/${hash}.json`,
     {
       headers: {
-        Authorization: `token ${env.GITHUB_PAT}`,
         Accept: "application/vnd.github.v3.raw",
       },
       next: { revalidate: 900 },

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/crates-validation/_actions/find-most-recent-hash.ts
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/crates-validation/_actions/find-most-recent-hash.ts
@@ -7,7 +7,6 @@ export async function findMostRecentHash() {
     "https://raw.githubusercontent.com/risc0/ghpages/main/dev/crate-validation/results/index.json",
     {
       headers: {
-        Authorization: `token ${env.GITHUB_PAT}`,
         Accept: "application/vnd.github.v3.raw",
       },
       next: { revalidate: 900 },

--- a/web/apps/benchmarks-and-reports/src/env.js
+++ b/web/apps/benchmarks-and-reports/src/env.js
@@ -9,7 +9,6 @@ const env = createEnv({
    * Specify server-side environment variables schema here.
    */
   server: {
-    GITHUB_PAT: z.string(),
     NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
   },
 
@@ -25,7 +24,6 @@ const env = createEnv({
    */
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
-    GITHUB_PAT: process.env.GITHUB_PAT,
   },
   /**
    * Makes it so that empty strings are treated as undefined.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,9 @@
 {
   "name": "web",
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "build": "turbo build",
     "check": "cd .. && bunx @biomejs/biome check --apply-unsafe web",
@@ -18,8 +21,8 @@
     "@tanstack/react-table": "8.16.0",
     "@types/chart.js": "2.9.41",
     "@types/jest": "29.5.12",
-    "@types/node": "20.12.11",
-    "@types/react": "18.3.1",
+    "@types/node": "20.12.12",
+    "@types/react": "18.3.2",
     "@types/react-dom": "18.3.0",
     "@vercel/analytics": "1.2.2",
     "@vercel/edge-config": "1.1.0",
@@ -27,14 +30,14 @@
     "chart.js": "2.9.4",
     "deepmerge": "4.3.1",
     "lucide-react": "0.378.0",
-    "next": "canary",
+    "next": "14.2.3",
     "next-themes": "0.3.0",
     "prism-react-renderer": "2.3.1",
     "react": "18.3.1",
     "react-chartjs-2": "2.11.2",
     "react-dom": "18.3.1",
     "react-rainbow-ascii": "1.0.3",
-    "sharp": "0.33.3",
+    "sharp": "0.33.4",
     "string-ts": "2.1.1",
     "turbo": "1.13.3",
     "typescript": "5.4.5",


### PR DESCRIPTION
* Remove need for GITHUB_PAT
* Pin `next` to latest stable version
* Drop experimental features requiring `canary`
* Restore benchmarks data URL