### PR TITLE
Client/Server: add plumbing for compress

### DIFF
--- a/risc0/r0vm/tests/external_prover.rs
+++ b/risc0/r0vm/tests/external_prover.rs
@@ -14,10 +14,10 @@
 
 use anyhow::Result;
 use assert_cmd::cargo::cargo_bin;
-use risc0_zkvm::{ExecutorEnv, ExternalProver, ProveInfo, Prover};
+use risc0_zkvm::{ExecutorEnv, ExternalProver, Prover, ProverOpts, Receipt};
 use risc0_zkvm_methods::{multi_test::MultiTestSpec, MULTI_TEST_ELF, MULTI_TEST_ID};
 
-fn prove_nothing() -> Result<ProveInfo> {
+fn prove_nothing() -> Result<Receipt> {
     let env = ExecutorEnv::builder()
         .write(&MultiTestSpec::DoNothing)
         .unwrap()
@@ -25,11 +25,13 @@ fn prove_nothing() -> Result<ProveInfo> {
         .unwrap();
     let r0vm_path = cargo_bin("r0vm");
     let prover = ExternalProver::new("r0vm", r0vm_path);
-    prover.prove(env, MULTI_TEST_ELF)
+    let receipt = prover.prove(env, MULTI_TEST_ELF)?.receipt;
+    prover.compress(&ProverOpts::succinct(), &receipt)
 }
 
 #[test_log::test]
 fn basic_proof() {
-    let receipt = prove_nothing().unwrap().receipt;
+    let receipt = prove_nothing().unwrap();
     receipt.verify(MULTI_TEST_ID).unwrap();
+    receipt.inner.succinct().unwrap();
 }

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -82,6 +82,14 @@ impl TryFrom<SegmentReceipt> for Asset {
     }
 }
 
+impl TryFrom<Receipt> for Asset {
+    type Error = anyhow::Error;
+
+    fn try_from(receipt: Receipt) -> Result<Self> {
+        Ok(Asset::Inline(bincode::serialize(&receipt)?.into()))
+    }
+}
+
 impl TryFrom<pb::api::Asset> for Asset {
     type Error = anyhow::Error;
 

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -82,6 +82,8 @@ impl RootMessage for pb::api::ResolveRequest {}
 impl RootMessage for pb::api::ResolveReply {}
 impl RootMessage for pb::api::IdentityP254Request {}
 impl RootMessage for pb::api::IdentityP254Reply {}
+impl RootMessage for pb::api::CompressRequest {}
+impl RootMessage for pb::api::CompressReply {}
 
 impl ConnectionWrapper {
     fn new(inner: Box<dyn Connection>) -> Self {

--- a/risc0/zkvm/src/host/client/prove/external.rs
+++ b/risc0/zkvm/src/host/client/prove/external.rs
@@ -149,7 +149,8 @@ impl Prover for ExternalProver {
             }
             (_, ReceiptKind::Compact) => {
                 // TODO(#1760) Support compression to compact receipt in client/server API.
-                bail!("ExternalProver does not support compression to CompactReceipt");
+                let client = ApiClient::new_sub_process(&self.r0vm_path)?;
+                client.compress(opts, receipt.clone().try_into()?, AssetRequest::Inline)
             }
         }
     }

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -14,6 +14,7 @@ message ServerRequest {
     JoinRequest join = 5;
     IdentityP254Request identity_p254 = 6;
     ResolveRequest resolve = 7;
+    CompressRequest compress = 8;
   }
 }
 
@@ -123,6 +124,23 @@ message IdentityP254Reply {
 }
 
 message IdentityP254Result {
+  Asset receipt = 1;
+}
+
+message CompressRequest {
+  ProverOpts opts = 1;
+  Asset receipt = 2;
+  AssetRequest receipt_out = 3;
+}
+
+message CompressReply {
+  oneof kind {
+    CompressResult ok = 1;
+    GenericError error = 2;
+  }
+}
+
+message CompressResult {
   Asset receipt = 1;
 }
 
@@ -296,6 +314,7 @@ service Server {
   rpc lift(LiftRequest) returns (LiftReply);
   rpc join(JoinRequest) returns (JoinReply);
   rpc resolve(ResolveRequest) returns (ResolveReply);
+  rpc compress(CompressRequest) returns (CompressReply);
 }
 
 service ExecuteCallback {

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -277,10 +277,8 @@ pub struct ExecutorEnv {
     #[prost(message, optional, tag = "1")]
     pub binary: ::core::option::Option<Asset>,
     #[prost(map = "string, string", tag = "2")]
-    pub env_vars: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub env_vars:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(string, repeated, tag = "3")]
     pub slice_ios: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(uint32, repeated, tag = "4")]

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -2,7 +2,7 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServerRequest {
-    #[prost(oneof = "server_request::Kind", tags = "1, 2, 3, 4, 5, 6, 7")]
+    #[prost(oneof = "server_request::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
     pub kind: ::core::option::Option<server_request::Kind>,
 }
 /// Nested message and enum types in `ServerRequest`.
@@ -24,6 +24,8 @@ pub mod server_request {
         IdentityP254(super::IdentityP254Request),
         #[prost(message, tag = "7")]
         Resolve(super::ResolveRequest),
+        #[prost(message, tag = "8")]
+        Compress(super::CompressRequest),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -238,12 +240,47 @@ pub struct IdentityP254Result {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CompressRequest {
+    #[prost(message, optional, tag = "1")]
+    pub opts: ::core::option::Option<ProverOpts>,
+    #[prost(message, optional, tag = "2")]
+    pub receipt: ::core::option::Option<Asset>,
+    #[prost(message, optional, tag = "3")]
+    pub receipt_out: ::core::option::Option<AssetRequest>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CompressReply {
+    #[prost(oneof = "compress_reply::Kind", tags = "1, 2")]
+    pub kind: ::core::option::Option<compress_reply::Kind>,
+}
+/// Nested message and enum types in `CompressReply`.
+pub mod compress_reply {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Kind {
+        #[prost(message, tag = "1")]
+        Ok(super::CompressResult),
+        #[prost(message, tag = "2")]
+        Error(super::GenericError),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CompressResult {
+    #[prost(message, optional, tag = "1")]
+    pub receipt: ::core::option::Option<Asset>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorEnv {
     #[prost(message, optional, tag = "1")]
     pub binary: ::core::option::Option<Asset>,
     #[prost(map = "string, string", tag = "2")]
-    pub env_vars:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub env_vars: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     #[prost(string, repeated, tag = "3")]
     pub slice_ios: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(uint32, repeated, tag = "4")]


### PR DESCRIPTION
This change completes the implementation of the `ExternalProver`'s `compress` function by implementing plumbing for the `compress` function in the client server architecture. The composite to succinct function has been removed from `ExternalProver` because a call to compress has the same effect without having to pass segment receipts between the client and server.

Closes: #1760