### PR TITLE
Fix `send_recv_slice` for cases where `U != u8`

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "ec8e474ced27c291bf43348384a6fdd9facc955f1b26a9aac4f7186ef3c0f253",
+            "f8e993930660610c97d69ccca820a9a591fcf59adb88fec2e67a30e6a110202d",
         );
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -32,7 +32,7 @@ use risc0_zkvm::{
     sha::{Digest, Sha256},
     Assumption, ReceiptClaim,
 };
-use risc0_zkvm_methods::multi_test::{MultiTestSpec, SYS_MULTI_TEST};
+use risc0_zkvm_methods::multi_test::{MultiTestSpec, SYS_MULTI_TEST, SYS_MULTI_TEST_WORDS};
 use risc0_zkvm_platform::{
     fileno,
     memory::{self, SYSTEM},
@@ -145,6 +145,12 @@ fn main() {
                 input = bytemuck::cast_slice(host_data);
                 input_len = input.len();
             }
+        }
+        MultiTestSpec::SyscallWords => {
+            let input: &[u64] = &[0x0102030405060708];
+
+            let host_data = env::send_recv_slice::<u64, u32>(SYS_MULTI_TEST_WORDS, &input);
+            assert_eq!(host_data, &[0x05060708, 0x01020304]);
         }
         MultiTestSpec::DoRandom => {
             // Test random number generation in the zkvm

--- a/risc0/zkvm/methods/src/multi_test.rs
+++ b/risc0/zkvm/methods/src/multi_test.rs
@@ -47,6 +47,7 @@ pub enum MultiTestSpec {
     Syscall {
         count: u32,
     },
+    SyscallWords,
     DoRandom,
     SysInput(Digest),
     SysRead {
@@ -97,3 +98,4 @@ pub enum MultiTestSpec {
 }
 
 declare_syscall!(pub SYS_MULTI_TEST);
+declare_syscall!(pub SYS_MULTI_TEST_WORDS);

--- a/risc0/zkvm/src/guest/env.rs
+++ b/risc0/zkvm/src/guest/env.rs
@@ -322,11 +322,11 @@ pub fn verify_assumption(claim: Digest, control_root: Digest) -> Result<(), Infa
 ///
 /// On the host side, implement SliceIo to provide a handler for this call.
 pub fn send_recv_slice<T: Pod, U: Pod>(syscall_name: SyscallName, to_host: &[T]) -> &'static [U] {
-    let syscall::Return(nelem, _) = syscall(syscall_name, bytemuck::cast_slice(to_host), &mut []);
-    let nwords = align_up(core::mem::size_of::<T>() * nelem as usize, WORD_SIZE) / WORD_SIZE;
+    let syscall::Return(nbytes, _) = syscall(syscall_name, bytemuck::cast_slice(to_host), &mut []);
+    let nwords = align_up(nbytes as usize, WORD_SIZE) / WORD_SIZE;
     let from_host_buf = unsafe { core::slice::from_raw_parts_mut(sys_alloc_words(nwords), nwords) };
     syscall(syscall_name, &[], from_host_buf);
-    &bytemuck::cast_slice(from_host_buf)[..nelem as usize]
+    &bytemuck::cast_slice(from_host_buf)[..nbytes as usize / core::mem::size_of::<U>()]
 }
 
 /// Read private data from the STDIN of the zkVM and deserializes it.


### PR DESCRIPTION
The `send_recv_slice` function works by making a pair of syscalls. One to get
the size of the data and another to retrieve that amount of data. There
was a mistake in assuming that the first syscall returned the number of
elements to return. In fact, the first syscall returns the number of
bytes. The guest handler has been fixed to reflect this.
    
The calculation for buffer size in the subsequent syscall has been fixed
by removing the multiplication to calculate the size of the the host
buffer and by dividing by `sizeof::<U>` before returning to the guest.