### PR TITLE
Updates to documentation from a review pass on May 23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -356,7 +356,7 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: macOS-nightly
-      - run: cargo +nightly doc -p risc0-zkvm -Fclient,prove,docker,getrandom,std --no-deps
+      - run: cargo +nightly doc -p risc0-zkvm -Fclient,prove,getrandom,std --no-deps
       - run: cargo +nightly doc -p risc0-zkp -Fprove,std --no-deps
       - run: cargo +nightly doc -p cargo-risczero -Fdocker,r0vm --no-deps
       - run: cargo +nightly doc -p risc0-binfmt -p risc0-core -p risc0-groth16 -p risc0-zkvm-platform --all-features  --no-deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,8 @@ jobs:
         working-directory: bonsai/sdk
       - run: cargo rdme -c
         working-directory: risc0/zkvm
+      - run: cargo rdme -c
+        working-directory: risc0/groth16
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/groth16_proof/README.md
+++ b/groth16_proof/README.md
@@ -7,6 +7,9 @@ This directory contains utilities for performing a "stark2snark" workflow. This
 is useful for transforming a RISC Zero STARK proof into a Groth16 SNARK proof
 which is suitable for publishing on-chain.
 
+> Recommended way to produce Groth16 receipts is to use the `Prover` trait in the `risc0-zkvm` crate.
+> See the crate documentation for more information.
+
 ## Quickstart
 
 To install the necessary dependencies, run:

--- a/risc0/binfmt/src/exit_code.rs
+++ b/risc0/binfmt/src/exit_code.rs
@@ -96,7 +96,7 @@ impl ExitCode {
 
 impl Eq for ExitCode {}
 
-/// Error returned when a (system, user) exit code pair is an invalid
+/// Error returned when a `(system, user)` exit code pair is an invalid
 /// representation.
 #[derive(Debug, Copy, Clone)]
 pub struct InvalidExitCodeError(pub u32, pub u32);

--- a/risc0/groth16/Cargo.toml
+++ b/risc0/groth16/Cargo.toml
@@ -38,7 +38,6 @@ all-features = true
 
 [features]
 default = ["std"]
-docker = ["prove"]
 prove = [
   "dep:num-traits",
   "dep:risc0-core",

--- a/risc0/groth16/README.md
+++ b/risc0/groth16/README.md
@@ -1,3 +1,5 @@
+<!-- cargo-rdme start -->
+
 # Groth16
 
 This library implements a verifier for the Groth16 protocol over the BN_254 elliptic curve.
@@ -23,6 +25,7 @@ use risc0_groth16::{ProofJson, PublicInputsJson, Verifier, VerifyingKeyJson};
 ```
 
 ## STARK to SNARK
+
 It also provides a utility function to call a prover (via Docker).
 After generating a RISC Zero STARK proof, it can be transformed into a SNARK using the `stark_to_snark` function.
 This function becomes available when the `prove` feature flag is enabled.
@@ -79,3 +82,6 @@ fn stark2snark() {
     receipt.verify(MULTI_TEST_ID).unwrap();
 }
 ```
+
+<!-- cargo-rdme end -->
+

--- a/risc0/groth16/README.md
+++ b/risc0/groth16/README.md
@@ -9,79 +9,35 @@ This library implements a verifier for the Groth16 protocol over the BN_254 elli
 ```rust
 use risc0_groth16::{ProofJson, PublicInputsJson, Verifier, VerifyingKeyJson};
 
-    const TEST_VERIFICATION_KEY: &str = include_str!("data/verification_key.json");
-    const TEST_PROOF: &str = include_str!("data/proof.json");
-    const TEST_PUBLIC_INPUTS: &str = include_str!("data/public.json");
+const TEST_VERIFICATION_KEY: &str = test_data!("verification_key.json");
+const TEST_PROOF: &str = test_data!("proof.json");
+const TEST_PUBLIC_INPUTS: &str = test_data!("public.json");
 
-    fn verify() {
-        let verifying_key: VerifyingKeyJson = serde_json::from_str(TEST_VERIFICATION_KEY).unwrap();
-        let proof: ProofJson = serde_json::from_str(TEST_PROOF).unwrap();
-        let public_inputs = PublicInputsJson {
-            values: serde_json::from_str(TEST_PUBLIC_INPUTS).unwrap(),
-        };
-        let verifier = Verifier::from_json(proof, public_inputs, verifying_key).unwrap();
-        verifier.verify().unwrap();
-    }
+fn verify() {
+    let verifying_key: VerifyingKeyJson = serde_json::from_str(TEST_VERIFICATION_KEY).unwrap();
+    let proof: ProofJson = serde_json::from_str(TEST_PROOF).unwrap();
+    let public_inputs = PublicInputsJson {
+        values: serde_json::from_str(TEST_PUBLIC_INPUTS).unwrap(),
+    };
+    let verifier = Verifier::from_json(proof, public_inputs, verifying_key).unwrap();
+    verifier.verify().unwrap();
+}
 ```
 
 ## STARK to SNARK
 
-It also provides a utility function to call a prover (via Docker).
-After generating a RISC Zero STARK proof, it can be transformed into a SNARK using the `stark_to_snark` function.
-This function becomes available when the `prove` feature flag is enabled.
+It also provides the [stark_to_snark][docker::stark_to_snark] function to run a prover Groth16
+recursion prover via Docker. After generating a RISC Zero STARK proof, this function can be
+used to transform it into a Groth16 proof. This function becomes available when the `prove`
+feature flag is enabled.
 
 > IMPORTANT: This feature requires an x86 architecture and Docker installed.
 > Additionally, specific [installation steps](https://github.com/risc0/risc0/tree/main/groth16_proof) must be followed to use this functionality.
 
-### Example
+The recommended way to get a Groth16 proof is to use the `Prover` trait in the [risc0-zkvm]
+crate. With `ProverOpts::groth16()` it will produce a Groth16 proof.
 
-```rust
-#[cfg(feature = "prove")]
-fn stark2snark() {
-    use risc0_groth16::docker::stark_to_snark;
-    use risc0_zkvm::{
-        get_prover_server, recursion::identity_p254, Groth16Receipt, ExecutorEnv, ExecutorImpl,
-        InnerReceipt, ProverOpts, Receipt, VerifierContext,
-    };
-    use risc0_zkvm_methods::{multi_test::MultiTestSpec, MULTI_TEST_ELF, MULTI_TEST_ID};
-
-    let env = ExecutorEnv::builder()
-        .write(&MultiTestSpec::BusyLoop { cycles: 0 })
-        .unwrap()
-        .build()
-        .unwrap();
-
-    tracing::info!("execute");
-
-    let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
-    let session = exec.run().unwrap();
-
-    tracing::info!("prove");
-    let opts = ProverOpts::default();
-    let ctx = VerifierContext::default();
-    let prover = get_prover_server(&opts).unwrap();
-    let receipt = prover.prove_session(&ctx, &session).unwrap().receipt;
-    let claim = receipt.claim().unwrap();
-    let composite_receipt = receipt.inner.composite().unwrap();
-    let succinct_receipt = prover.compress(composite_receipt).unwrap();
-    let journal = session.journal.unwrap().bytes;
-
-    tracing::info!("identity_p254");
-    let ident_receipt = identity_p254(&succinct_receipt).unwrap();
-    let seal_bytes = ident_receipt.get_seal_bytes();
-
-    tracing::info!("stark-to-snark");
-    let seal = stark_to_snark(&seal_bytes).unwrap().to_vec();
-
-    tracing::info!("Receipt");
-    let receipt = Receipt::new(
-        InnerReceipt::Groth16(Groth16Receipt { seal, claim }),
-        journal,
-    );
-
-    receipt.verify(MULTI_TEST_ID).unwrap();
-}
-```
+[risc0-zkvm]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/
 
 <!-- cargo-rdme end -->
 

--- a/risc0/groth16/src/lib.rs
+++ b/risc0/groth16/src/lib.rs
@@ -12,7 +12,88 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Groth16 prover and verifier integration for RISC Zero.
+//! # Groth16
+//!
+//! This library implements a verifier for the Groth16 protocol over the BN_254 elliptic curve.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use risc0_groth16::{ProofJson, PublicInputsJson, Verifier, VerifyingKeyJson};
+//!
+//!     const TEST_VERIFICATION_KEY: &str = include_str!("data/verification_key.json");
+//!     const TEST_PROOF: &str = include_str!("data/proof.json");
+//!     const TEST_PUBLIC_INPUTS: &str = include_str!("data/public.json");
+//!
+//!     fn verify() {
+//!         let verifying_key: VerifyingKeyJson = serde_json::from_str(TEST_VERIFICATION_KEY).unwrap();
+//!         let proof: ProofJson = serde_json::from_str(TEST_PROOF).unwrap();
+//!         let public_inputs = PublicInputsJson {
+//!             values: serde_json::from_str(TEST_PUBLIC_INPUTS).unwrap(),
+//!         };
+//!         let verifier = Verifier::from_json(proof, public_inputs, verifying_key).unwrap();
+//!         verifier.verify().unwrap();
+//!     }
+//! ```
+//!
+//! ## STARK to SNARK
+//!
+//! It also provides a utility function to call a prover (via Docker).
+//! After generating a RISC Zero STARK proof, it can be transformed into a SNARK using the `stark_to_snark` function.
+//! This function becomes available when the `prove` feature flag is enabled.
+//!
+//! > IMPORTANT: This feature requires an x86 architecture and Docker installed.
+//! > Additionally, specific [installation steps](https://github.com/risc0/risc0/tree/main/groth16_proof) must be followed to use this functionality.
+//!
+//! ### Example
+//!
+//! ```rust
+//! #[cfg(feature = "prove")]
+//! fn stark2snark() {
+//!     use risc0_groth16::docker::stark_to_snark;
+//!     use risc0_zkvm::{
+//!         get_prover_server, recursion::identity_p254, CompactReceipt, ExecutorEnv, ExecutorImpl,
+//!         InnerReceipt, ProverOpts, Receipt, VerifierContext,
+//!     };
+//!     use risc0_zkvm_methods::{multi_test::MultiTestSpec, MULTI_TEST_ELF, MULTI_TEST_ID};
+//!
+//!     let env = ExecutorEnv::builder()
+//!         .write(&MultiTestSpec::BusyLoop { cycles: 0 })
+//!         .unwrap()
+//!         .build()
+//!         .unwrap();
+//!
+//!     tracing::info!("execute");
+//!
+//!     let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
+//!     let session = exec.run().unwrap();
+//!
+//!     tracing::info!("prove");
+//!     let opts = ProverOpts::default();
+//!     let ctx = VerifierContext::default();
+//!     let prover = get_prover_server(&opts).unwrap();
+//!     let receipt = prover.prove_session(&ctx, &session).unwrap().receipt;
+//!     let claim = receipt.claim().unwrap();
+//!     let composite_receipt = receipt.inner.composite().unwrap();
+//!     let succinct_receipt = prover.compress(composite_receipt).unwrap();
+//!     let journal = session.journal.unwrap().bytes;
+//!
+//!     tracing::info!("identity_p254");
+//!     let ident_receipt = identity_p254(&succinct_receipt).unwrap();
+//!     let seal_bytes = ident_receipt.get_seal_bytes();
+//!
+//!     tracing::info!("stark-to-snark");
+//!     let seal = stark_to_snark(&seal_bytes).unwrap().to_vec();
+//!
+//!     tracing::info!("Receipt");
+//!     let receipt = Receipt::new(
+//!         InnerReceipt::Compact(CompactReceipt { seal, claim }),
+//!         journal,
+//!     );
+//!
+//!     receipt.verify(MULTI_TEST_ID).unwrap();
+//! }
+//! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]

--- a/risc0/groth16/src/lib.rs
+++ b/risc0/groth16/src/lib.rs
@@ -21,79 +21,41 @@
 //! ```rust
 //! use risc0_groth16::{ProofJson, PublicInputsJson, Verifier, VerifyingKeyJson};
 //!
-//!     const TEST_VERIFICATION_KEY: &str = include_str!("data/verification_key.json");
-//!     const TEST_PROOF: &str = include_str!("data/proof.json");
-//!     const TEST_PUBLIC_INPUTS: &str = include_str!("data/public.json");
+//! # macro_rules! test_data {
+//! #    ($s:expr) => {
+//! #        include_str!(concat!("../tests/data/", $s))
+//! #    };
+//! # }
+//! #
+//! const TEST_VERIFICATION_KEY: &str = test_data!("verification_key.json");
+//! const TEST_PROOF: &str = test_data!("proof.json");
+//! const TEST_PUBLIC_INPUTS: &str = test_data!("public.json");
 //!
-//!     fn verify() {
-//!         let verifying_key: VerifyingKeyJson = serde_json::from_str(TEST_VERIFICATION_KEY).unwrap();
-//!         let proof: ProofJson = serde_json::from_str(TEST_PROOF).unwrap();
-//!         let public_inputs = PublicInputsJson {
-//!             values: serde_json::from_str(TEST_PUBLIC_INPUTS).unwrap(),
-//!         };
-//!         let verifier = Verifier::from_json(proof, public_inputs, verifying_key).unwrap();
-//!         verifier.verify().unwrap();
-//!     }
+//! fn verify() {
+//!     let verifying_key: VerifyingKeyJson = serde_json::from_str(TEST_VERIFICATION_KEY).unwrap();
+//!     let proof: ProofJson = serde_json::from_str(TEST_PROOF).unwrap();
+//!     let public_inputs = PublicInputsJson {
+//!         values: serde_json::from_str(TEST_PUBLIC_INPUTS).unwrap(),
+//!     };
+//!     let verifier = Verifier::from_json(proof, public_inputs, verifying_key).unwrap();
+//!     verifier.verify().unwrap();
+//! }
 //! ```
 //!
 //! ## STARK to SNARK
 //!
-//! It also provides a utility function to call a prover (via Docker).
-//! After generating a RISC Zero STARK proof, it can be transformed into a SNARK using the `stark_to_snark` function.
-//! This function becomes available when the `prove` feature flag is enabled.
+//! It also provides the [stark_to_snark][docker::stark_to_snark] function to run a prover Groth16
+//! recursion prover via Docker. After generating a RISC Zero STARK proof, this function can be
+//! used to transform it into a Groth16 proof. This function becomes available when the `prove`
+//! feature flag is enabled.
 //!
 //! > IMPORTANT: This feature requires an x86 architecture and Docker installed.
 //! > Additionally, specific [installation steps](https://github.com/risc0/risc0/tree/main/groth16_proof) must be followed to use this functionality.
 //!
-//! ### Example
+//! The recommended way to get a Groth16 proof is to use the `Prover` trait in the [risc0-zkvm]
+//! crate. With `ProverOpts::groth16()` it will produce a Groth16 proof.
 //!
-//! ```rust
-//! #[cfg(feature = "prove")]
-//! fn stark2snark() {
-//!     use risc0_groth16::docker::stark_to_snark;
-//!     use risc0_zkvm::{
-//!         get_prover_server, recursion::identity_p254, CompactReceipt, ExecutorEnv, ExecutorImpl,
-//!         InnerReceipt, ProverOpts, Receipt, VerifierContext,
-//!     };
-//!     use risc0_zkvm_methods::{multi_test::MultiTestSpec, MULTI_TEST_ELF, MULTI_TEST_ID};
-//!
-//!     let env = ExecutorEnv::builder()
-//!         .write(&MultiTestSpec::BusyLoop { cycles: 0 })
-//!         .unwrap()
-//!         .build()
-//!         .unwrap();
-//!
-//!     tracing::info!("execute");
-//!
-//!     let mut exec = ExecutorImpl::from_elf(env, MULTI_TEST_ELF).unwrap();
-//!     let session = exec.run().unwrap();
-//!
-//!     tracing::info!("prove");
-//!     let opts = ProverOpts::default();
-//!     let ctx = VerifierContext::default();
-//!     let prover = get_prover_server(&opts).unwrap();
-//!     let receipt = prover.prove_session(&ctx, &session).unwrap().receipt;
-//!     let claim = receipt.claim().unwrap();
-//!     let composite_receipt = receipt.inner.composite().unwrap();
-//!     let succinct_receipt = prover.compress(composite_receipt).unwrap();
-//!     let journal = session.journal.unwrap().bytes;
-//!
-//!     tracing::info!("identity_p254");
-//!     let ident_receipt = identity_p254(&succinct_receipt).unwrap();
-//!     let seal_bytes = ident_receipt.get_seal_bytes();
-//!
-//!     tracing::info!("stark-to-snark");
-//!     let seal = stark_to_snark(&seal_bytes).unwrap().to_vec();
-//!
-//!     tracing::info!("Receipt");
-//!     let receipt = Receipt::new(
-//!         InnerReceipt::Compact(CompactReceipt { seal, claim }),
-//!         journal,
-//!     );
-//!
-//!     receipt.verify(MULTI_TEST_ID).unwrap();
-//! }
-//! ```
+//! [risc0-zkvm]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -101,7 +101,7 @@ test-log = { version = "0.2", default-features = false, features = ["trace"] }
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 # NOTE: cuda and metal are excluded because their build scripts require external tools.
-features = ["client", "prove", "docker", "getrandom", "std"]
+features = ["client", "prove", "getrandom", "std"]
 
 [features]
 client = [

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -132,8 +132,8 @@ disable-dev-mode = []
 # this flag measure cycles and segments. Without this flag, the rust build
 # system will generate binaries that not identical across all architectures.
 # While this is acceptable for most tests, the tests counting cycles and
-# segments will fail intermittently.
-docker = ["risc0-groth16/docker"]
+# segments will fail intermittently. It does not effect non-test code.
+docker = []
 # The zkVM exposes a getrandom implementation that panics by default. This will
 # expose a getrandom implementation that uses the `sys_random` ecall.
 getrandom = ["risc0-zkvm-platform/getrandom"]

--- a/risc0/zkvm/src/host/client/env.rs
+++ b/risc0/zkvm/src/host/client/env.rs
@@ -75,7 +75,7 @@ impl SegmentPath {
     }
 }
 
-/// The [crate::Executor] is configured from this object.
+/// The [Executor][crate::Executor] is configured from this object.
 ///
 /// The executor environment holds configuration details that inform how the
 /// guest environment is set up prior to guest program execution.

--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -20,7 +20,7 @@ use crate::{
     Receipt, SegmentInfo, SessionInfo, VerifierContext,
 };
 
-/// A [Prover] implementation that selects a [crate::ProverServer] by calling
+/// A [Prover] implementation that selects a [ProverServer][crate::ProverServer] by calling
 /// [get_prover_server].
 pub struct LocalProver {
     name: String,

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -129,7 +129,7 @@ pub trait Prover {
     /// [#1749](https://github.com/risc0/risc0/issues/1749) for more information.
     ///
     /// If the receipt is already at least as compressed as the requested compression level (e.g.
-    /// it is already succinct or groth16 and a succinct receipt is required) this function is a
+    /// it is already succinct or Groth16 and a succinct receipt is required) this function is a
     /// no-op. As a result, it is idempotent.
     fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt>;
 }
@@ -179,7 +179,7 @@ pub enum ReceiptKind {
     /// Request that a [Groth16Receipt][crate::Groth16Receipt] be generated.
     ///
     /// Groth16 receipts are proven using Groth16, are constant in size, and are the smallest
-    /// available receipt format. A groth16 receipt can be serialized to a few hundred bytes.
+    /// available receipt format. A Groth16 receipt can be serialized to a few hundred bytes.
     Groth16,
 }
 
@@ -235,7 +235,7 @@ impl ProverOpts {
     /// Choose the prover that generates Groth16 receipts which are constant size in the length of
     /// the execution and small enough to verify on blockchains, like Ethereum.
     ///
-    /// Only supported for x86_64 Linux
+    /// Only supported for x86_64 Linux with Docker installed.
     pub fn groth16() -> Self {
         Self {
             hashfn: "poseidon2".to_string(),

--- a/risc0/zkvm/src/host/mod.rs
+++ b/risc0/zkvm/src/host/mod.rs
@@ -19,6 +19,6 @@ pub(crate) mod client;
 #[cfg(any(feature = "client", feature = "prove"))]
 mod protos;
 pub(crate) mod prove_info;
-pub(crate) mod recursion;
+pub mod recursion;
 #[cfg(feature = "prove")]
 pub(crate) mod server;

--- a/risc0/zkvm/src/host/recursion/mod.rs
+++ b/risc0/zkvm/src/host/recursion/mod.rs
@@ -32,7 +32,7 @@ mod tests;
 // of SuccinctReceipt, but is logically part of the recursion system.
 #[cfg(feature = "prove")]
 pub use crate::receipt::merkle::{MerkleGroup, MerkleProof};
-pub use risc0_circuit_recursion::control_id::ALLOWED_CONTROL_ROOT;
+pub use risc0_circuit_recursion::control_id::{ALLOWED_CONTROL_IDS, ALLOWED_CONTROL_ROOT};
 
 #[cfg(test)]
 pub use self::prove::test_recursion_circuit;

--- a/risc0/zkvm/src/host/recursion/mod.rs
+++ b/risc0/zkvm/src/host/recursion/mod.rs
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This module implements the verifier for the recursion circuit.
+//! Prover implementation for the recursion VM.
 //!
-//! This module implements receipts that are generated from the recursion
-//! circuit as well as verification functions for each type of receipt.
+//! This module contains the recursion [Prover], and the recursion programs used with the zkVM. The
+//! recursion VM is a non-Turing-complete virtual machine (VM) optimized for algebraic constraint
+//! checking. In particular, it is well-tuned for verifying STARKs.
+//!
+//! The recursion VM runs "recursion programs", which define the functionality it will implement.
+//! As examples, the [lift], [join], and [resolve] programs are used to compress a collection of
+//! STARK receipts for a composition into a single succinct receipt.
 
 #[cfg(feature = "prove")]
 pub(crate) mod prove;

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -40,8 +40,8 @@ use crate::{
     Segment, Session, VerifierContext,
 };
 
-/// A ProverServer can execute a given ELF binary and produce a [ProveInfo] which contains a [crate::Receipt]
-/// that can be used to verify correct computation.
+/// A ProverServer can execute a given ELF binary and produce a [ProveInfo] which contains a
+/// [Receipt][crate::Receipt] that can be used to verify correct computation.
 pub trait ProverServer {
     /// Prove the specified ELF binary.
     fn prove(&self, env: ExecutorEnv<'_>, elf: &[u8]) -> Result<ProveInfo> {

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -54,7 +54,6 @@
 //! | client           | all except rv32im | std        | Enables the client API.                                                                                                                                      |
 //! | cuda             |                   | prove, std | Enables CUDA GPU acceleration for the prover. Requires CUDA toolkit to be installed.                                                                         |
 //! | disable-dev-mode | all except rv32im |            | Disables dev mode so that proving and verifying may not be faked. Used to prevent a misplaced `RISC0_DEV_MODE` from breaking security in production systems. |
-//! | docker           | all except rv32im |            | Enables features that require Docker. In particular, this enables Groth16 proving.                                                                           |
 //! | metal            | macos             | prove, std | Enables Metal GPU acceleration for the prover.                                                                                                               |
 //! | prove            | all except rv32im | std        | Enables the prover, incompatible within the zkvm guest.                                                                                                      |
 //! | std              | all               |            | Support for the Rust stdlib.                                                                                                                                 |

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -81,9 +81,7 @@ pub mod serde;
 pub mod sha;
 
 #[cfg(all(not(target_os = "zkvm"), feature = "prove"))]
-pub mod recursion {
-    pub use super::host::recursion::*;
-}
+pub use host::recursion;
 
 pub use anyhow::Result;
 #[cfg(not(target_os = "zkvm"))]

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -133,7 +133,7 @@ pub use {
 pub use {
     self::host::{
         prove_info::{ProveInfo, SessionStats},
-        recursion::ALLOWED_CONTROL_ROOT,
+        recursion::{ALLOWED_CONTROL_IDS, ALLOWED_CONTROL_ROOT},
     },
     risc0_binfmt::compute_image_id,
     risc0_circuit_rv32im::control_id::POSEIDON2_CONTROL_IDS,

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -47,13 +47,14 @@
 //! The following feature flags are supported.
 //!
 //! Note that in order to use `risc0-zkvm` in the guest, you must disable the
-//! "prove" feature by setting `default-features = false`.
+//! default features by setting `default-features = false`.
 //!
 //! | Feature          | Target(s)         | Implies    | Description                                                                                                                                                  |
 //! | ---------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 //! | client           | all except rv32im | std        | Enables the client API.                                                                                                                                      |
 //! | cuda             |                   | prove, std | Enables CUDA GPU acceleration for the prover. Requires CUDA toolkit to be installed.                                                                         |
 //! | disable-dev-mode | all except rv32im |            | Disables dev mode so that proving and verifying may not be faked. Used to prevent a misplaced `RISC0_DEV_MODE` from breaking security in production systems. |
+//! | docker           | all except rv32im |            | Enables features that require Docker. In particular, this enables Groth16 proving.                                                                           |
 //! | metal            | macos             | prove, std | Enables Metal GPU acceleration for the prover.                                                                                                               |
 //! | prove            | all except rv32im | std        | Enables the prover, incompatible within the zkvm guest.                                                                                                      |
 //! | std              | all               |            | Support for the Rust stdlib.                                                                                                                                 |
@@ -80,7 +81,6 @@ mod receipt_claim;
 pub mod serde;
 pub mod sha;
 
-/// Re-exports for recursion
 #[cfg(all(not(target_os = "zkvm"), feature = "prove"))]
 pub mod recursion {
     pub use super::host::recursion::*;

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -257,7 +257,11 @@ impl Receipt {
     }
 }
 
-/// A journal is a record of all public commitments for a given proof session.
+/// A record of the public commitments for a proven zkVM execution.
+///
+/// Public outputs, including commitments to important inputs, are written to the journal during
+/// zkVM execution. Along with an image ID, it constitutes the statement proven by a given
+/// [Receipt]
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct Journal {
     /// The raw bytes of the journal.
@@ -425,10 +429,12 @@ where
     }
 }
 
-/// Metadata providing context on the receipt, about the proving system, SDK versions, and other
-/// information to help with interoperability. It is not cryptographically bound to the receipt,
-/// and should not be used for security-relevant decisions, such as choosing whether or not to
-/// accept a receipt based on it's stated version.
+/// Metadata providing context on the receipt.
+///
+/// It contains information about the proving system, SDK versions, and other information to help
+/// with interoperability. It is not cryptographically bound to the receipt, and should not be used
+/// for security-relevant decisions, such as choosing whether or not to accept a receipt based on
+/// it's stated version.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct ReceiptMetadata {

--- a/risc0/zkvm/src/receipt/composite.rs
+++ b/risc0/zkvm/src/receipt/composite.rs
@@ -34,9 +34,9 @@ use crate::{
     sha, Assumption, InnerAssumptionReceipt, MaybePruned, Output, PrunedValueError, ReceiptClaim,
 };
 
-/// A receipt composed of one or more [SegmentReceipt] structs proving a single
-/// execution with continuations, and zero or more [Receipt](crate::Receipt) structs proving any
-/// assumptions.
+/// A receipt composed of one or more [SegmentReceipt] structs proving a single execution with
+/// continuations, and zero or more [InnerAssumptionReceipt](crate::InnerAssumptionReceipt) structs
+/// proving any assumptions.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[non_exhaustive]

--- a/risc0/zkvm/src/receipt/succinct.rs
+++ b/risc0/zkvm/src/receipt/succinct.rs
@@ -31,11 +31,13 @@ use crate::{
     sha,
 };
 
-/// A succinct receipt, produced via recursion, proving the execution of the zkVM with a STARK.
+/// A succinct receipt, produced via recursion, proving the execution of the zkVM with a [STARK].
 ///
-/// Using recursion, a [crate::CompositeReceipt] can be compressed to form a [SuccinctReceipt]. In this
-/// way, a constant sized proof can be generated for arbitrarily long computations, and with an
-/// arbitrary number of segments linked via composition.
+/// Using recursion, a [CompositeReceipt][crate::CompositeReceipt] can be compressed to form a
+/// [SuccinctReceipt]. In this way, a constant sized proof can be generated for arbitrarily long
+/// computations, and with an arbitrary number of segments linked via composition.
+///
+/// [STARK]: https://dev.risczero.com/terminology#stark
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[non_exhaustive]

--- a/risc0/zkvm/src/receipt_claim.rs
+++ b/risc0/zkvm/src/receipt_claim.rs
@@ -216,6 +216,7 @@ impl Digestible for Unknown {
 }
 
 /// Input field in the [ReceiptClaim], committing to a public value accessible to the guest.
+///
 /// NOTE: This type is currently uninhabited (i.e. it cannot be constructed), and only its digest
 /// is accessible. It may become inhabited in a future release.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -263,9 +264,11 @@ impl Digestible for Output {
     }
 }
 
-/// An [assumption] made in the course of proving program execution. Assumptions are generated when
-/// the guest makes a recursive verification call. Each assumption commits the statement, such that
-/// only a receipt proving that statement can be used to resolve and remove the assumption.
+/// An [assumption] made in the course of proving program execution.
+///
+/// Assumptions are generated when the guest makes a recursive verification call. Each assumption
+/// commits the statement, such that only a receipt proving that statement can be used to resolve
+/// and remove the assumption.
 ///
 /// [assumption]: https://dev.risczero.com/terminology#assumption
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -277,9 +280,10 @@ pub struct Assumption {
     /// Commitment to the set of [recursion programs] that can be used to resolve this assumption.
     ///
     /// Binding the set of recursion programs also binds the circuits, and creates an assumption
-    /// resolved by independent set of circuits (e.g. keccak or Groth16). Proofs of these external
-    /// claims are verified by a "lift" program implemented for the recursion VM which brings the
-    /// claim into the recursion system. This lift program is committed to in the control root.
+    /// resolved by independent set of circuits (e.g. keccak or Groth16 verify). Proofs of these
+    /// external claims are verified by a "lift" program implemented for the recursion VM which
+    /// brings the claim into the recursion system. This lift program is committed to in the
+    /// control root.
     ///
     /// A special value of all zeroes indicates "self-composition", where the control root used to
     /// verify this claim is also used to verify the assumption.


### PR DESCRIPTION
A number of smaller docs updates from a quick pass over the documentation.

Largest change is to include the `risc-groth16` README in the crate documentation, thus bringing it under test in CI, and to drop the verbose example of STARK to SNARK proving, which can now be accomplished through the main APIs.
