### PR TITLE
`bench` Trigger Fix

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -1,4 +1,4 @@
-name: Benchmark Check 
+name: Benchmark Check
 
 on:
   merge_group:


### PR DESCRIPTION
Benchmark jobs triggered by `bench` are not triggered even when specified paths are modified:
```
- .github/workflows/bench_pr.yml
- risc0/**
```