### PR TITLE
Fix generation of `ControlD.sol` in `bootstrap-groth16`

### DIFF
--- a/xtask/src/bootstrap_groth16.rs
+++ b/xtask/src/bootstrap_groth16.rs
@@ -130,7 +130,8 @@ fn bootstrap_control_id(risc0_ethereum_path: &Path) {
     // NOTE: The solidity verifier interprets it as a uint256 and expects the oppisite byte order.
     bn254_control_id.as_mut_bytes().reverse();
     let bn254_control_id = format!(
-        r#"// NOTE: This has opposite byte order to the value in the risc0 repository.\nbytes32 public constant BN254_CONTROL_ID = hex"{}";"#,
+        r#"// NOTE: This has opposite byte order to the value in the risc0 repository.{}bytes32 public constant BN254_CONTROL_ID = hex"{}";"#,
+        "\n",
         hex::encode(bn254_control_id)
     );
     let content = &format!("{SOL_HEADER}{LIB_HEADER}\n{control_root}\n{bn254_control_id}\n}}");


### PR DESCRIPTION
A mistake in https://github.com/risc0/risc0/pull/1841, the newline `\n` in the format string doesn't turn into a newline when using `r#"` string literals.