### PR TITLE
Fix broken link in docs: Prepend "www" to ensure accessibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = ["tools/crates-validator"]
 version = "1.0.0-rc.5"
 edition = "2021"
 license = "Apache-2.0"
-homepage = "https://risczero.com/"
+homepage = "https://www.risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <a href="https://risczero.com"><img src="website/static/img/logo.png" height="100"></a>
+  <a href="https://www.risczero.com/"><img src="website/static/img/logo.png" height="100"></a>
 </p>
 
-<h1 align="center"><a href="https://risczero.com">RISC Zero</a></h1>
+<h1 align="center"><a href="https://www.risczero.com/">RISC Zero</a></h1>
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][licence-badge]][licence-url]

--- a/website/api/generating-proofs/local-proving.md
+++ b/website/api/generating-proofs/local-proving.md
@@ -14,6 +14,6 @@ The primary reason to consider using local proof generation for your application
 _With local proof generation, you can generate proofs about your private data, while your private data never leaves your machine._
 
 [Bonsai]: ./remote-proving.md
-[open-source]: https://risczero.com/news/open-source
+[open-source]: https://www.risczero.com/news/open-source
 [zkVM]: ../zkvm/zkvm_overview.md
 [feature flags]: https://github.com/risc0/risc0#feature-flags

--- a/website/api/introduction.md
+++ b/website/api/introduction.md
@@ -23,4 +23,4 @@ program!
 Check out our [Getting Started][docs-getting-started] page.
 
 [docs-getting-started]: ./getting-started.md
-[external-risc-zero]: https://risczero.com
+[external-risc-zero]: https://www.risczero.com

--- a/website/api/use-cases.md
+++ b/website/api/use-cases.md
@@ -47,17 +47,17 @@ In addition to being far easier to build on, we're also delivering on
 **Ready to start building?** <br/>
 Check out our [Getting Started] page.
 
-[Bonsai Pay]: https://risczero.com/news/bonsai-pay
+[Bonsai Pay]: https://www.risczero.com/news/bonsai-pay
 [chess]: https://github.com/risc0/risc0/tree/main/examples/chess
-[continuations]: https://risczero.com/news/continuations
+[continuations]: https://www.risczero.com/news/continuations
 [crate-validation]: https://reports.risczero.com/crates-validation
 [ecdsa]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
 [Getting Started]: ./getting-started.md
 [JSON]: https://github.com/risc0/risc0/tree/main/examples/json
 [optimism]: https://www.theblock.co/post/240929/optimism-zk-proof-proposals?utm_source=twitter&utm_medium=social
 [performance]: ./zkvm/benchmarks.md
-[waldo]: https://risczero.com/news/waldo
-[Zeth]: https://risczero.com/news/zeth-release
+[waldo]: https://www.risczero.com/news/waldo
+[Zeth]: https://www.risczero.com/news/zeth-release
 [zk-coprocessors-tweet]: https://twitter.com/RiscZero/status/1677316664772132864
-[zkpoex]: https://risczero.com/news/zkpoex
+[zkpoex]: https://www.risczero.com/news/zkpoex
 [zkVM]: ./zkvm/zkvm_overview.md

--- a/website/api/zkvm/examples.md
+++ b/website/api/zkvm/examples.md
@@ -58,5 +58,5 @@ cargo run --release
 [example-zkevm]: https://github.com/risc0/risc0/tree/main/examples/zkevm-demo
 [examples-dir]: https://github.com/risc0/risc0/tree/main/examples
 [install]: ./install.md
-[waldo-blog]: https://risczero.com/news/waldo
-[zkpoex]: https://risczero.com/news/zkpoex
+[waldo-blog]: https://www.risczero.com/news/waldo
+[zkpoex]: https://www.risczero.com/news/zkpoex

--- a/website/api/zkvm/zkvm_overview.md
+++ b/website/api/zkvm/zkvm_overview.md
@@ -94,5 +94,5 @@ Check out our [Bonsai on Eth] page.
 [use cases]: ../use-cases
 [verify]: /terminology#verify
 [waldo]: https://www.risczero.com/news/waldo
-[zeth]: https://risczero.com/news/zeth-release
+[zeth]: https://www.risczero.com/news/zeth-release
 [zkVM]: /terminology#zero-knowledge-virtual-machine-zkvm

--- a/website/api_versioned_docs/version-0.18/bonsai/bonsai-on-eth.md
+++ b/website/api_versioned_docs/version-0.18/bonsai/bonsai-on-eth.md
@@ -20,7 +20,7 @@ Our Bonsai-ETH Relay acts as a middle-man between your app contract and the Bons
 The [Bonsai Foundry Template] is the best place to get started building Bonsai applications for Ethereum.
 You may also want to check out our [Bonsai Quick Start](quickstart.md) page.
 
-[verified proofs]: https://risczero.com/news/on-chain-verification
+[verified proofs]: https://www.risczero.com/news/on-chain-verification
 [zk coprocessor]: https://twitter.com/RiscZero/status/1677316664772132864
 [Bonsai Foundry Template]: https://github.com/risc0/bonsai-foundry-template
 [smart contract]: https://github.com/risc0/bonsai-foundry-template/tree/main/contracts

--- a/website/api_versioned_docs/version-0.18/introduction.md
+++ b/website/api_versioned_docs/version-0.18/introduction.md
@@ -37,7 +37,7 @@ Key among these use cases are:
 
 To enable ZK builders to thrive, we're working on two core products: the [zkVM] and [Bonsai].
 
-[startup]: https://risczero.com/news/series-a
+[startup]: https://www.risczero.com/news/series-a
 [zk coprocessors]: https://twitter.com/RiscZero/status/1677316664772132864
 [our work with Optimism]: https://www.theblock.co/post/240929/optimism-zk-proof-proposals?utm_source=twitter&utm_medium=social
 [RISC Zero]: https://risczero.com
@@ -72,9 +72,9 @@ These applications include:
 
 [April 2022]: https://www.risczero.com/news/announce
 [JSON]: https://github.com/risc0/risc0/tree/release-0.18/examples/json
-[Where's Waldo]: https://risczero.com/news/waldo
+[Where's Waldo]: https://www.risczero.com/news/waldo
 [ZK Checkmate]: https://github.com/risc0/risc0/tree/release-0.18/examples/chess
-[ZK Proof of Exploit]: https://risczero.com/news/zkpoex
+[ZK Proof of Exploit]: https://www.risczero.com/news/zkpoex
 [ECDSA signature verification]: https://github.com/risc0/risc0/tree/release-0.18/examples/ecdsa
 
 These examples are all made possible by **leveraging a mature software ecosystem**: over 70% of the [top 1000 Rust crates] work out-of-the-box in the zkVM.
@@ -87,7 +87,7 @@ Given the ease of development and the performance, the zkVM is the clear choice 
 
 [top 1000 Rust crates]: https://reports.risczero.com/crates-validation
 [performance]: https://dev.risczero.com/zkvm/benchmarks
-[continuations]: https://risczero.com/news/continuations
+[continuations]: https://www.risczero.com/news/continuations
 
 ## Connect with us
 

--- a/website/api_versioned_docs/version-0.18/zkvm/zkvm_overview.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/zkvm_overview.md
@@ -24,7 +24,7 @@ Our demos show how to:
 [prove mate-in-one]: https://github.com/risc0/risc0/tree/release-0.18/examples/chess#zk-checkmate
 [proofs about private data]: https://github.com/risc0/risc0/tree/release-0.18/examples/json#json-example
 [prove you can find Waldo]: https://www.risczero.com/news/waldo
-[prove correct construction of Ethereum blocks]: https://risczero.com/news/zeth-release
+[prove correct construction of Ethereum blocks]: https://www.risczero.com/news/zeth-release
 
 On any other proving platform, building any of these projects requires starting from the ground up.
 By letting developers use the primitives they need, the RISC Zero zkVM makes verifiable software development a practical reality for projects of all scales.
@@ -80,7 +80,7 @@ _Looking for information about blockchain integration?_ <br/>
 Check out [Bonsai].
 
 _Curious about Zeth?_<br/>
-Read the [article](https://risczero.com/news/zeth-release).
+Read the [article](https://www.risczero.com/news/zeth-release).
 
 [cargo]: https://doc.rust-lang.org/cargo/index.html
 [imageID]: /terminology#image-id

--- a/website/api_versioned_docs/version-0.19/introduction.md
+++ b/website/api_versioned_docs/version-0.19/introduction.md
@@ -37,7 +37,7 @@ Key among these use cases are:
 
 To enable ZK builders to thrive, we're working on two core products: the [zkVM] and [Bonsai].
 
-[startup]: https://risczero.com/news/series-a
+[startup]: https://www.risczero.com/news/series-a
 [zk coprocessors]: https://twitter.com/RiscZero/status/1677316664772132864
 [our work with Optimism]: https://www.theblock.co/post/240929/optimism-zk-proof-proposals?utm_source=twitter&utm_medium=social
 [RISC Zero]: https://risczero.com
@@ -72,9 +72,9 @@ These applications include:
 
 [April 2022]: https://www.risczero.com/news/announce
 [JSON]: https://github.com/risc0/risc0/tree/release-0.19/examples/json
-[Where's Waldo]: https://risczero.com/news/waldo
+[Where's Waldo]: https://www.risczero.com/news/waldo
 [ZK Checkmate]: https://github.com/risc0/risc0/tree/release-0.19/examples/chess
-[ZK Proof of Exploit]: https://risczero.com/news/zkpoex
+[ZK Proof of Exploit]: https://www.risczero.com/news/zkpoex
 [ECDSA signature verification]: https://github.com/risc0/risc0/tree/release-0.19/examples/ecdsa
 
 These examples are all made possible by **leveraging a mature software ecosystem**: over 70% of the [top 1000 Rust crates] work out-of-the-box in the zkVM.
@@ -87,7 +87,7 @@ Given the ease of development and the performance, the zkVM is the clear choice 
 
 [top 1000 Rust crates]: https://reports.risczero.com/crates-validation
 [performance]: https://dev.risczero.com/zkvm/benchmarks
-[continuations]: https://risczero.com/news/continuations
+[continuations]: https://www.risczero.com/news/continuations
 
 ## Connect with us
 

--- a/website/api_versioned_docs/version-0.19/zkvm/examples.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/examples.md
@@ -11,8 +11,8 @@
 [Hello World]: https://github.com/risc0/risc0/tree/release-0.19/examples/hello-world
 [JSON]: https://github.com/risc0/risc0/tree/release-0.19/examples/json
 [Where's Waldo]: https://github.com/risc0/risc0/tree/release-0.19/examples/waldo
-[Where's Waldo blog]: https://risczero.com/news/waldo
+[Where's Waldo blog]: https://www.risczero.com/news/waldo
 [ZK Checkmate]: https://github.com/risc0/risc0/tree/release-0.19/examples/chess
-[ZK Proof of Exploit]: https://risczero.com/news/zkpoex
+[ZK Proof of Exploit]: https://www.risczero.com/news/zkpoex
 [ECDSA signature verification]: https://github.com/risc0/risc0/tree/release-0.19/examples/ecdsa
 [zkEVM]: https://github.com/risc0/risc0/tree/release-0.19/examples/zkevm-demo

--- a/website/api_versioned_docs/version-0.19/zkvm/zkvm_overview.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/zkvm_overview.md
@@ -24,7 +24,7 @@ Our demos show how to:
 [prove mate-in-one]: https://github.com/risc0/risc0/tree/release-0.19/examples/chess#zk-checkmate
 [proofs about private data]: https://github.com/risc0/risc0/tree/release-0.19/examples/json#json-example
 [prove you can find Waldo]: https://www.risczero.com/news/waldo
-[prove correct construction of Ethereum blocks]: https://risczero.com/news/zeth-release
+[prove correct construction of Ethereum blocks]: https://www.risczero.com/news/zeth-release
 
 On any other proving platform, building any of these projects requires starting from the ground up.
 By letting developers use the primitives they need, the RISC Zero zkVM makes verifiable software development a practical reality for projects of all scales.
@@ -89,7 +89,7 @@ _Looking for information about blockchain integration?_ <br/>
 Check out [Bonsai].
 
 _Curious about Zeth?_<br/>
-Read the [article](https://risczero.com/news/zeth-release).
+Read the [article](https://www.risczero.com/news/zeth-release).
 
 [cargo]: https://doc.rust-lang.org/cargo/index.html
 [continuations]: https://www.risczero.com/news/continuations

--- a/website/api_versioned_docs/version-0.20/introduction.md
+++ b/website/api_versioned_docs/version-0.20/introduction.md
@@ -125,7 +125,7 @@ list][mailing-list] to get our latest announcements.
 
 [Bonsai]: ./bonsai/bonsai-overview.md
 [chess]: https://github.com/risc0/risc0/tree/release-0.20/examples/chess
-[continuations]: https://risczero.com/news/continuations
+[continuations]: https://www.risczero.com/news/continuations
 [crate-validation]: https://reports.risczero.com/crates-validation
 [discord]: https://discord.gg/risczero
 [ecdsa]: https://github.com/risc0/risc0/tree/release-0.20/examples/ecdsa
@@ -138,10 +138,10 @@ list][mailing-list] to get our latest announcements.
 [risc0-repo]: https://github.com/risc0/risc0
 [risc0-zkvm]: https://docs.rs/risc0-zkvm
 [rust-libraries]: https://github.com/risc0/risc0#rust-libraries
-[startup]: https://risczero.com/news/series-a
+[startup]: https://www.risczero.com/news/series-a
 [twitter]: https://twitter.com/risczero
-[waldo]: https://risczero.com/news/waldo
+[waldo]: https://www.risczero.com/news/waldo
 [YouTube]: https://www.youtube.com/@risczero
 [zk coprocessors]: https://twitter.com/RiscZero/status/1677316664772132864
-[zkpoex]: https://risczero.com/news/zkpoex
+[zkpoex]: https://www.risczero.com/news/zkpoex
 [zkVM]: ./zkvm/zkvm_overview.md

--- a/website/api_versioned_docs/version-0.20/zkvm/examples.md
+++ b/website/api_versioned_docs/version-0.20/zkvm/examples.md
@@ -58,5 +58,5 @@ cargo run --release
 [example-zkevm]: https://github.com/risc0/risc0/tree/release-0.20/examples/zkevm-demo
 [examples-dir]: https://github.com/risc0/risc0/tree/release-0.20/examples
 [install]: ./install.md
-[waldo-blog]: https://risczero.com/news/waldo
-[zkpoex]: https://risczero.com/news/zkpoex
+[waldo-blog]: https://www.risczero.com/news/waldo
+[zkpoex]: https://www.risczero.com/news/zkpoex

--- a/website/api_versioned_docs/version-0.20/zkvm/zkvm_overview.md
+++ b/website/api_versioned_docs/version-0.20/zkvm/zkvm_overview.md
@@ -126,5 +126,5 @@ Read the [article][zeth].
 [session]: /terminology#session
 [verify]: /terminology#verify
 [waldo]: https://www.risczero.com/news/waldo
-[zeth]: https://risczero.com/news/zeth-release
+[zeth]: https://www.risczero.com/news/zeth-release
 [zkVM]: /terminology#zero-knowledge-virtual-machine-zkvm

--- a/website/api_versioned_docs/version-0.21/generating-proofs/local-proving.md
+++ b/website/api_versioned_docs/version-0.21/generating-proofs/local-proving.md
@@ -14,6 +14,6 @@ The primary reason to consider using local proof generation for your application
 _With local proof generation, you can generate proofs about your private data, while your private data never leaves your machine._
 
 [Bonsai]: ./remote-proving.md
-[open-source]: https://risczero.com/news/open-source
+[open-source]: https://www.risczero.com/news/open-source
 [zkVM]: ../zkvm/zkvm_overview.md
 [feature flags]: https://github.com/risc0/risc0#feature-flags

--- a/website/api_versioned_docs/version-0.21/use-cases.md
+++ b/website/api_versioned_docs/version-0.21/use-cases.md
@@ -47,17 +47,17 @@ In addition to being far easier to build on, we're also delivering on
 **Ready to start building?** <br/>
 Check out our [Getting Started] page.
 
-[Bonsai Pay]: https://risczero.com/news/bonsai-pay
+[Bonsai Pay]: https://www.risczero.com/news/bonsai-pay
 [chess]: https://github.com/risc0/risc0/tree/release-0.21/examples/chess
-[continuations]: https://risczero.com/news/continuations
+[continuations]: https://www.risczero.com/news/continuations
 [crate-validation]: https://reports.risczero.com/crates-validation
 [ecdsa]: https://github.com/risc0/risc0/tree/release-0.21/examples/ecdsa
 [Getting Started]: ./getting-started.md
 [JSON]: https://github.com/risc0/risc0/tree/release-0.21/examples/json
 [optimism]: https://www.theblock.co/post/240929/optimism-zk-proof-proposals?utm_source=twitter&utm_medium=social
 [performance]: ./zkvm/benchmarks.md
-[waldo]: https://risczero.com/news/waldo
-[Zeth]: https://risczero.com/news/zeth-release
+[waldo]: https://www.risczero.com/news/waldo
+[Zeth]: https://www.risczero.com/news/zeth-release
 [zk-coprocessors-tweet]: https://twitter.com/RiscZero/status/1677316664772132864
-[zkpoex]: https://risczero.com/news/zkpoex
+[zkpoex]: https://www.risczero.com/news/zkpoex
 [zkVM]: ./zkvm/zkvm_overview.md

--- a/website/api_versioned_docs/version-0.21/zkvm/examples.md
+++ b/website/api_versioned_docs/version-0.21/zkvm/examples.md
@@ -58,5 +58,5 @@ cargo run --release
 [example-zkevm]: https://github.com/risc0/risc0/tree/release-0.21/examples/zkevm-demo
 [examples-dir]: https://github.com/risc0/risc0/tree/release-0.21/examples
 [install]: ./install.md
-[waldo-blog]: https://risczero.com/news/waldo
-[zkpoex]: https://risczero.com/news/zkpoex
+[waldo-blog]: https://www.risczero.com/news/waldo
+[zkpoex]: https://www.risczero.com/news/zkpoex

--- a/website/api_versioned_docs/version-0.21/zkvm/zkvm_overview.md
+++ b/website/api_versioned_docs/version-0.21/zkvm/zkvm_overview.md
@@ -97,5 +97,5 @@ Check out our [Bonsai on Eth] page.
 [use cases]: ../use-cases
 [verify]: /terminology#verify
 [waldo]: https://www.risczero.com/news/waldo
-[zeth]: https://risczero.com/news/zeth-release
+[zeth]: https://www.risczero.com/news/zeth-release
 [zkVM]: /terminology#zero-knowledge-virtual-machine-zkvm

--- a/website/docs/education.md
+++ b/website/docs/education.md
@@ -22,7 +22,7 @@ Or find us on [Discord] and ask us there!
 _Looking for documentation?_<br/>
 Check out the [dev docs].
 
-[blog]: https://risczero.com/blog
+[blog]: https://www.risczero.com/blog
 [conference talks and podcast appearances]: https://www.youtube.com/playlist?list=PLcPzhUaCxlCgCvzkkaBWzVuHdBRsTNxj1
 [Dev Docs]: ./zkvm
 [Discord]: https://discord.gg/risczero

--- a/website/docs/proof-system/proof-system.md
+++ b/website/docs/proof-system/proof-system.md
@@ -76,8 +76,8 @@ In addition to the links in the sidebar, we recommend the following resources:
 [guest]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest
 [ImageID]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.SystemState.html
 [journal]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html#structfield.journal
-[news]: https://risczero.com/news
-[open-source]: https://risczero.com/news/open-source
+[news]: https://www.risczero.com/news
+[open-source]: https://www.risczero.com/news/open-source
 [proof composition]: ../terminology#composition
 [quickstart]: /api/zkvm/quickstart
 [Receipt]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -305,7 +305,7 @@ RISC Zero's zkVM implements the RISC-V instruction set architecture and uses a [
 [recursion program]: #recursion-program
 [RISC-V]: #risc-v
 [RISC-V Circuit]: #risc-v-circuit
-[RISC Zero's ZKP Whitepaper]: https://risczero.com/proof-system-in-detail.pdf
+[RISC Zero's ZKP Whitepaper]: https://www.risczero.com/proof-system-in-detail.pdf
 [Rust crate for zkVM guest]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/guest
 [seal]: #seal
 [Segment]: #segment

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -124,7 +124,7 @@ export default async function createConfigAsync() {
           logo: {
             alt: "RISC Zero Logo",
             src: "img/logo.png",
-            href: "https://risczero.com/",
+            href: "https://www.risczero.com/",
           },
           items: [
             {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -11,7 +11,7 @@ export default {
     {
       type: "link",
       label: "Articles",
-      href: "https://risczero.com/blog",
+      href: "https://www.risczero.com/blog",
     },
     "studyclub",
     {


### PR DESCRIPTION
## Description:

This pull request addresses a broken link "https://risczero.com" in the documentation that was causing a connection error.

## Changes made:

Prepended "www" to the URL in the documentation, making it https://www.risczero.com. This temporary fix ensures users can access the intended resource.

## Considerations:

This is a temporary solution. To permanently resolve the issue:
Consider configuring the web server to handle connections for both "https://risczero.com" and "https://www.risczero.com", directing them to the appropriate website content.