### PR TITLE
Add new function to Groth16Receipt

### DIFF
--- a/risc0/zkvm/src/receipt/groth16.rs
+++ b/risc0/zkvm/src/receipt/groth16.rs
@@ -57,6 +57,15 @@ impl<Claim> Groth16Receipt<Claim>
 where
     Claim: Digestible + Debug + Clone + Serialize,
 {
+    /// Create a [Groth16Receipt] from the given seal, claim, and verifier parameters digest.
+    pub fn new(seal: Vec<u8>, claim: MaybePruned<Claim>, verifier_parameters: Digest) -> Self {
+        Self {
+            seal,
+            claim,
+            verifier_parameters,
+        }
+    }
+
     /// Verify the integrity of this receipt, ensuring the claim is attested
     /// to by the seal.
     pub fn verify_integrity(&self) -> Result<(), VerificationError> {


### PR DESCRIPTION
This PR added a `Groth16Receipt::new` function, allowing users of the crate to construct the `Groth16Receipt` type if they have the constituent parts. This is being added to support users of the Bonsai REST API, as this API returns the parts of the receipt, from which the caller needs to construct the `Groth16Receipt` object.
