### PR TITLE
skip cargo-binstall if installed

### DIFF
--- a/rzup/rzup
+++ b/rzup/rzup
@@ -70,7 +70,11 @@ check_rust_installed() {
 }
 
 install_cargo_binstall() {
-  execute_with_feedback "cargo install --locked cargo-binstall --quiet" "Installing cargo-binstall"
+  if ! command -v cargo-binstall &>/dev/null; then
+    execute_with_feedback "cargo install --locked cargo-binstall --quiet" "Installing cargo-binstall"
+  else
+    echo "cargo-binstall already installed, skipping step"
+  fi
 }
 
 binstall_cargo_risczero() {


### PR DESCRIPTION
Small update as a stop-gap until #1961, I keep wanting to use rzup, but given it reinstalls cargo-binstall even if just a new patch version to update, I have avoided it. I'd use this if this change was made :D 