### PR TITLE
fix: pin cargo-binstall v1.6.9

### DIFF
--- a/rzup/rzup
+++ b/rzup/rzup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=0.1.0
+VERSION=0.1.1
 
 VERBOSE_MODE=1
 
@@ -71,7 +71,7 @@ check_rust_installed() {
 
 install_cargo_binstall() {
   if ! command -v cargo-binstall &>/dev/null; then
-    execute_with_feedback "cargo install --locked cargo-binstall --quiet" "Installing cargo-binstall"
+    execute_with_feedback "cargo install cargo-binstall --version '=1.6.9' --locked --quiet" "Installing cargo-binstall"
   else
     echo "cargo-binstall already installed, skipping step"
   fi


### PR DESCRIPTION
title says it all, cargo-binstall 1.7+ requires rustc 1.79. bumped rzup to version `0.1.1`. 
