### PR TITLE
Add @devel and @demos teams to codeowners for examples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,15 +3,16 @@
 # Note: Order is important; the last matching pattern takes the most
 # precedence.
 
+# Platform team is requires approval for all PRs
 *                                      @risc0/platform
 
+# Specific paths requiring teams and/or individual approval
 /bonsai/                               @risc0/bonsai
+/examples/                             @risc0/devrel @risc0/demos
+/groth16_proof/groth16/                @flaub @nategraf @tzerrell
 /rzup/                                 @risc0/platform @hmrtn
+/SECURITY.md                           @kevinnassery
 /web/                                  @risc0/platform @nahoc
 /website/                              @risc0/devrel @pdg744
-/examples/                             @risc0/devrel @risc0/demos
-
-/groth16_proof/groth16/                @flaub @nategraf @tzerrell
-/SECURITY.md                           @kevinnassery
 control_id.rs                          @flaub @nategraf @tzerrell
 recursion_zkr.zip                      @flaub @nategraf @tzerrell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,8 @@
 # Note: Order is important; the last matching pattern takes the most
 # precedence.
 
-# Platform team is requires approval for all PRs
 *                                      @risc0/platform
 
-# Specific paths requiring teams and/or individual approval
 /bonsai/                               @risc0/bonsai
 /examples/                             @risc0/devrel @risc0/demos @risc0/platform
 /rzup/                                 @risc0/platform @hmrtn

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 /website/                              @risc0/devrel @pdg744
 /examples/                             @risc0/devrel @risc0/demos
 
-
 /groth16_proof/groth16/                @flaub @nategraf @tzerrell
 /SECURITY.md                           @kevinnassery
 control_id.rs                          @flaub @nategraf @tzerrell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 
 # Specific paths requiring teams and/or individual approval
 /bonsai/                               @risc0/bonsai
-/examples/                             @risc0/devrel @risc0/demos
+/examples/                             @risc0/devrel @risc0/demos @risc0/platform
 /groth16_proof/groth16/                @flaub @nategraf @tzerrell
 /rzup/                                 @risc0/platform @hmrtn
 /SECURITY.md                           @kevinnassery

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,10 +9,12 @@
 # Specific paths requiring teams and/or individual approval
 /bonsai/                               @risc0/bonsai
 /examples/                             @risc0/devrel @risc0/demos @risc0/platform
-/groth16_proof/groth16/                @flaub @nategraf @tzerrell
 /rzup/                                 @risc0/platform @hmrtn
-/SECURITY.md                           @kevinnassery
 /web/                                  @risc0/platform @nahoc
 /website/                              @risc0/devrel @pdg744
+
+# These are sensitive files
+/groth16_proof/groth16/                @flaub @nategraf @tzerrell
+/SECURITY.md                           @kevinnassery
 control_id.rs                          @flaub @nategraf @tzerrell
 recursion_zkr.zip                      @flaub @nategraf @tzerrell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,8 @@
 /rzup/                                 @risc0/platform @hmrtn
 /web/                                  @risc0/platform @nahoc
 /website/                              @risc0/devrel @pdg744
+/examples/                             @risc0/devrel @risc0/demos
+
 
 /groth16_proof/groth16/                @flaub @nategraf @tzerrell
 /SECURITY.md                           @kevinnassery


### PR DESCRIPTION
https://github.com/orgs/risc0/teams - looking there this seems like the best fit for at least one of us to approve, mostly this is to ensure that those teams are notified of changes as examples are mission critical to @risc0/devrel and likely impact or even suggest breaking changes to @risc0/demos .

Ont thing though - we should not block merges - so maybe we want to add `@risc0/platform` or even `@risc0/dev` to ensure changes can be made without waiting on us.

Closes https://github.com/risc0/devrel/issues/99 .