### PR TITLE
Add editor config for nvim and CoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .devcontainer/
 .DS_Store
 .idea/
-.vim/
 bazel-*
 ceremony/
 dist/

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,19 @@
+{
+  "rust-analyzer.linkedProjects": [
+    "Cargo.toml",
+    "benchmarks/Cargo.toml",
+    "examples/Cargo.toml",
+    "risc0/zkvm/methods/guest/Cargo.toml",
+    "risc0/zkvm/methods/std/Cargo.toml",
+    "tools/crates-validator/Cargo.toml"
+  ],
+  "rust-analyzer.check.extraEnv": {
+    "RISC0_SKIP_BUILD": "1",
+    "RISC0_SKIP_BUILD_KERNELS": "1",
+    "CARGO_TARGET_DIR": "target/analyzer"
+  },
+  "rust-analyzer.server.extraEnv": {
+    "CC": "clang",
+    "CXX": "clang++"
+  },
+}


### PR DESCRIPTION
Here is the repo-specific editor config I use for Neovim[^1] with the CoC LSP[^2] integration. This is the editor I use, and I've just been maintaining these configs locally, but @nuke-web3 and I were discussing this and I figured I'd open a PR to see if we want to include it for others.

Note the simmilarities between this and [.vscode/settings.json](https://github.com/risc0/risc0/blob/main/.vscode/settings.json). CoC is intended to be very similar to the VS Code plugin system and this uses the `rust-analyzer` plugin.

[^1]: https://neovim.io/
[^2]: https://github.com/neoclide/coc.nvim