### PR TITLE
Fix replacement string in the guest's zkvm dependency in case of no-std

### DIFF
--- a/risc0/cargo-risczero/src/commands/new.rs
+++ b/risc0/cargo-risczero/src/commands/new.rs
@@ -183,6 +183,10 @@ risc0_zkvm::guest::entry!(main);\n";
                 Regex::new(r"\{\{ *no_std_preamble *\}\}")?,
                 no_std_preamble.to_string(),
             ));
+            template_variables.push((
+                Regex::new(r"\{\{ *risc0_feature_std *\}\}")?,
+                "".to_string(),
+            ));
         }
         self.gen_template(dest_dir, template_variables)?;
 


### PR DESCRIPTION
Currently `cargo-risczero --nostd` doesn't replace the "risc0_feature_std" placeholder, leading to the following snippet in `guest/Cargo.toml`, which doesn't compile.

```toml
[dependencies]
risc0-zkvm = { version = "1.0.1", default-features = false{{ risc0_feature_std }} }
```