### PR TITLE
serde: serializer: implement collect_str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,6 +3856,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "cfg-if",
+ "chrono",
  "clap",
  "criterion",
  "crypto-bigint",

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -77,6 +77,7 @@ typetag = { version = "0.2", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"]}
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = "0.8"
 tracing-forest = "0.1"

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -76,8 +76,8 @@ tempfile = { version = "3", optional = true }
 typetag = { version = "0.2", optional = true }
 
 [dev-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
-chrono = { version = "0.4", default-features = false, features = ["serde"]}
 criterion = { version = "0.5", features = ["html_reports"] }
 rand = "0.8"
 tracing-forest = "0.1"

--- a/risc0/zkvm/src/serde/mod.rs
+++ b/risc0/zkvm/src/serde/mod.rs
@@ -48,9 +48,9 @@ pub use serializer::{to_vec, to_vec_with_capacity, Serializer, WordWrite};
 
 #[cfg(test)]
 mod tests {
-    use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
-
     use crate::serde::{from_slice, to_vec};
+    use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
+    use chrono::NaiveDate;
 
     #[test]
     fn test_vec_round_trip() {
@@ -74,6 +74,14 @@ mod tests {
         let input: (u32, u64) = (1, 2);
         let data = to_vec(&input).unwrap();
         let output: (u32, u64) = from_slice(data.as_slice()).unwrap();
+        assert_eq!(input, output);
+    }
+
+    #[test]
+    fn naive_date_round_trip() {
+        let input: NaiveDate = NaiveDate::parse_from_str("2015-09-05", "%Y-%m-%d").unwrap();
+        let date_vec = to_vec(&input).unwrap();
+        let output: NaiveDate = from_slice(date_vec.as_slice()).unwrap();
         assert_eq!(input, output);
     }
 }

--- a/risc0/zkvm/src/serde/serializer.rs
+++ b/risc0/zkvm/src/serde/serializer.rs
@@ -438,7 +438,6 @@ impl<'a, W: WordWrite> serde::ser::SerializeStructVariant for &'a mut Serializer
 mod tests {
     use alloc::string::String;
 
-    use chrono::NaiveDate;
     use serde::Serialize;
 
     use super::*;
@@ -507,11 +506,5 @@ mod tests {
             second: "abc".into(),
         };
         assert_eq!(expected, to_vec(&input).unwrap().as_slice());
-    }
-
-    #[test]
-    fn test_date() {
-        let date: NaiveDate = NaiveDate::parse_from_str("2015-09-05", "%Y-%m-%d").unwrap();
-        let _date_vec = to_vec(&date).unwrap();
     }
 }

--- a/risc0/zkvm/src/serde/serializer.rs
+++ b/risc0/zkvm/src/serde/serializer.rs
@@ -18,6 +18,8 @@ use risc0_zkvm_platform::WORD_SIZE;
 
 use super::err::{Error, Result};
 
+use crate::alloc::string::ToString;
+
 /// A writer for writing streams preferring word-based data.
 pub trait WordWrite {
     /// Write the given words to the stream.
@@ -120,11 +122,11 @@ impl<'a, W: WordWrite> serde::ser::Serializer for &'a mut Serializer<W> {
         false
     }
 
-    fn collect_str<T>(self, _: &T) -> Result<()>
+    fn collect_str<T>(self, value: &T) -> Result<()>
     where
-        T: core::fmt::Display + ?Sized,
+        T: ?Sized + core::fmt::Display,
     {
-        panic!("collect_str")
+        self.serialize_str(&value.to_string())
     }
 
     fn serialize_bool(self, v: bool) -> Result<()> {
@@ -436,6 +438,7 @@ impl<'a, W: WordWrite> serde::ser::SerializeStructVariant for &'a mut Serializer
 mod tests {
     use alloc::string::String;
 
+    use chrono::NaiveDate;
     use serde::Serialize;
 
     use super::*;
@@ -504,5 +507,11 @@ mod tests {
             second: "abc".into(),
         };
         assert_eq!(expected, to_vec(&input).unwrap().as_slice());
+    }
+
+    #[test]
+    fn test_date() {
+        let date: NaiveDate = NaiveDate::parse_from_str("2015-09-05", "%Y-%m-%d").unwrap();
+        let _date_vec = to_vec(&date).unwrap();
     }
 }


### PR DESCRIPTION
The panic in this function was causing chrono's `NaiveDate` to fail serialization. In other words, this prevented users from passing `NaiveDate` as an input for the guest.