### PR TITLE
CI: template test: add no_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -445,6 +445,15 @@ jobs:
         shell: bash
       - run: cargo run --release --manifest-path ${{ runner.temp }}/template-test/Cargo.toml
       - run: ${{ runner.temp }}/template-test/target/release/host
+      - run: |
+          cargo risczero new \
+            --path $(pwd) \
+            --dest ${{ runner.temp }} \
+            --guest-name test_method \
+            --no-std \
+            template-test-no-std
+        shell: bash
+      - run: cargo run --release --manifest-path ${{ runner.temp }}/template-test-no-std/Cargo.toml
       - run: sccache --show-stats
 
   crates-validator:


### PR DESCRIPTION
We were running the template test only for templates with the `std` feature enabled and it turns out that `no_std` templates were broken. It has now been fixed. Add a test for `no_std` templates to ensure that regressions do not occur.