### PR TITLE
add hash to toolchain builds

### DIFF
--- a/risc0/cargo-risczero/src/commands/config.toml
+++ b/risc0/cargo-risczero/src/commands/config.toml
@@ -10,6 +10,7 @@ cargo-native-static = true
 [rust]
 lld = true
 llvm-tools = true
+omit-git-hash = false
 
 [llvm]
 download-ci-llvm = false


### PR DESCRIPTION
Setting this option allows rustc to display the build date and git hash, leading to improved transparency like so:
```
% ~/.risc0/rust/build/host/stage2/bin/rustc -vV          
rustc 1.78.0-dev (b6c404a66 2024-06-21)
binary: rustc
commit-hash: b6c404a66d9775d8362b4f22cef94529235549f6
commit-date: 2024-06-21
host: aarch64-apple-darwin
release: 1.78.0-dev
LLVM version: 18.1.2
```
closes: #2018 