### PR TITLE
Revising terminology entry for deterministic builds

### DIFF
--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -77,7 +77,7 @@ See also: [Code reference for control root]
 
 A compilation process is called "deterministic" (or "reproducible") if it reliably produces the same binary file, on a byte-by-byte level.
 
-In the context of RISC Zero application development, deterministic builds are necessary to ensure a clear linkage between the [guest program] and the resulting [ImageID].
+In the context of RISC Zero application development, deterministic builds are necessary to ensure a clear linkage between the source code for the [guest program] and the resulting [Image ID][ImageID].
 
 To access deterministic builds for your zkVM application, use [`cargo risczero build`]. Deterministic builds are made possible by running the `rustc` compiler inside a Docker container.
 

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -190,7 +190,7 @@ For a list of all supported recursion programs, see the documentation for the [z
 ### Reproducible Build
 A compilation process is called "reproducible" if it reliably produces the same binary file, on a byte-by-byte level.
 
-In the context of RISC Zero application development, reproducible builds allow for a clear linkage between the [guest program] and the resulting [ImageID].
+In the context of RISC Zero application development, reproducible builds are necessary to ensure a clear linkage between the [guest program] and the resulting [ImageID].
 
 To get reproducible builds for your zkVM application, use [`cargo risczero build`]. Reproducible builds are made possible by running the `cargo` compiler inside a Docker container.
 

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -190,7 +190,7 @@ For a list of all supported recursion programs, see the documentation for the [z
 ### Reproducible Build
 A compilation process is called "reproducible" if it reliably produces the same binary file, on a byte-by-byte level.
 
-In the context of RISC Zero application development, reproducible builds allow for a clear linkage between the [guest code] and the resulting [Image ID].
+In the context of RISC Zero application development, reproducible builds allow for a clear linkage between the [guest program] and the resulting [ImageID].
 
 To get reproducible builds for your zkVM application, use [`cargo risczero build`]. Reproducible builds are made possible by running the `cargo` compiler inside a Docker container.
 

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -79,7 +79,7 @@ A compilation process is called "deterministic" (or "reproducible") if it reliab
 
 In the context of RISC Zero application development, deterministic builds are necessary to ensure a clear linkage between the [guest program] and the resulting [ImageID].
 
-To access deterministic builds for your zkVM application, use [`cargo risczero build`]. Deterministic builds are made possible by running the `cargo` compiler inside a Docker container.
+To access deterministic builds for your zkVM application, use [`cargo risczero build`]. Deterministic builds are made possible by running the `rustc` compiler inside a Docker container.
 
 ### ELF Binary
 

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -73,13 +73,6 @@ The control root plays a key role in enforcing zkVM version control. Each [contr
 This design allows for updates to the [RISC-V circuit] without necessitating a new trusted setup for the [Groth16 circuit]. <br/>
 See also: [Code reference for control root]
 
-### Deterministic Builds
-
-Our [cargo risczero] tool offers a deterministic compilation from user-written Rust code to RISC-V binary.
-Compiled binary files are identified by their [imageID].
-
-Deterministic builds are made possible by running the `cargo` compiler inside a Docker container. Without deterministic builds, the zkVM only proves correct execution of a given binary file. With deterministic builds, users can prove correct execution of Rust code.
-
 ### ELF Binary
 
 The executable format for the [RISC-V] instruction set.
@@ -197,9 +190,9 @@ For a list of all supported recursion programs, see the documentation for the [z
 ### Reproducible Build
 A compilation process is called "reproducible" if it reliably produces the same binary file, on a byte-by-byte level.
 
-In the context of RISC Zero application development, reproducible builds allow for a clear linkage between the guest code and the resulting [Image ID].
+In the context of RISC Zero application development, reproducible builds allow for a clear linkage between the [guest code] and the resulting [Image ID].
 
-To get reproducible builds for your zkVM application, use [`cargo risczero build`](https://docs.rs/crate/cargo-risczero/latest).
+To get reproducible builds for your zkVM application, use [`cargo risczero build`]. Reproducible builds are made possible by running the `cargo` compiler inside a Docker container.
 
 ### RISC-V
 
@@ -266,6 +259,7 @@ RISC Zero's zkVM implements the RISC-V instruction set architecture and uses a [
 [assumption]: #assumption
 [assumptions]: #assumption
 [cargo risczero]: https://docs.rs/crate/cargo-risczero/latest
+[`cargo risczero build`]: https://docs.rs/crate/cargo-risczero/latest
 [circuit]: #circuit
 [clock cycles]: #clock-cycles
 [Code reference for control root]: https://github.com/risc0/risc0/blob/v0.21.0/risc0/circuit/recursion/src/control_id.rs#L16

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -73,7 +73,7 @@ The control root plays a key role in enforcing zkVM version control. Each [contr
 This design allows for updates to the [RISC-V circuit] without necessitating a new trusted setup for the [Groth16 circuit]. <br/>
 See also: [Code reference for control root]
 
-### Deterministic Build
+### Deterministic Builds
 A compilation process is called "deterministic" (or "reproducible") if it reliably produces the same binary file, on a byte-by-byte level.
 
 In the context of RISC Zero application development, deterministic builds are necessary to ensure a clear linkage between the [guest program] and the resulting [ImageID].

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -74,6 +74,7 @@ This design allows for updates to the [RISC-V circuit] without necessitating a n
 See also: [Code reference for control root]
 
 ### Deterministic Builds
+
 A compilation process is called "deterministic" (or "reproducible") if it reliably produces the same binary file, on a byte-by-byte level.
 
 In the context of RISC Zero application development, deterministic builds are necessary to ensure a clear linkage between the [guest program] and the resulting [ImageID].

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -194,6 +194,13 @@ The [recursion circuit] is capable of efficiently evaluating polynomial constrai
 
 For a list of all supported recursion programs, see the documentation for the [zkVM API Client].
 
+### Reproducible Build
+A compilation process is called "reproducible" if it reliably produces the same binary file, on a byte-by-byte level.
+
+In the context of RISC Zero application development, reproducible builds allow for a clear linkage between the guest code and the resulting [Image ID].
+
+To get reproducible builds for your zkVM application, use [`cargo risczero build`](https://docs.rs/crate/cargo-risczero/latest).
+
 ### RISC-V
 
 The 5th edition of UC Berkeley's reduced instruction set computer architecture.

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -73,6 +73,13 @@ The control root plays a key role in enforcing zkVM version control. Each [contr
 This design allows for updates to the [RISC-V circuit] without necessitating a new trusted setup for the [Groth16 circuit]. <br/>
 See also: [Code reference for control root]
 
+### Deterministic Build
+A compilation process is called "deterministic" (or "reproducible") if it reliably produces the same binary file, on a byte-by-byte level.
+
+In the context of RISC Zero application development, deterministic builds are necessary to ensure a clear linkage between the [guest program] and the resulting [ImageID].
+
+To access deterministic builds for your zkVM application, use [`cargo risczero build`]. Deterministic builds are made possible by running the `cargo` compiler inside a Docker container.
+
 ### ELF Binary
 
 The executable format for the [RISC-V] instruction set.
@@ -186,13 +193,6 @@ The recursion circuit is used to aggregate and compose [proofs].
 The [recursion circuit] is capable of efficiently evaluating polynomial constraints, and was specifically designed to verify STARK proofs. Programs written for this circuit are loaded into the [control columns]. Each recursion program is identified by a [Control ID].
 
 For a list of all supported recursion programs, see the documentation for the [zkVM API Client].
-
-### Reproducible Build
-A compilation process is called "reproducible" if it reliably produces the same binary file, on a byte-by-byte level.
-
-In the context of RISC Zero application development, reproducible builds are necessary to ensure a clear linkage between the [guest program] and the resulting [ImageID].
-
-To get reproducible builds for your zkVM application, use [`cargo risczero build`]. Reproducible builds are made possible by running the `cargo` compiler inside a Docker container.
 
 ### RISC-V
 


### PR DESCRIPTION
We have a couple of open tickets (#1084, #1658) related to improving our documentation around reproducible/deterministic builds. 

This PR makes some minimal revisions to the existing terminology entry in order to clarify the meaning/importance of deterministic builds and how to use them.

IMO, we should hold off on adding a dedicated page on this topic until we address the engineering question of how to integrate deterministic builds into the foundry template developer workflow (which currently does not include `cargo risczero`). See #2075 & https://github.com/risc0/risc0-ethereum/issues/141