### PR TITLE
backport typo fixes for 1.0.2

### DIFF
--- a/risc0/zkp/src/layout.rs
+++ b/risc0/zkp/src/layout.rs
@@ -94,7 +94,7 @@ pub trait Buffer: Sized {
     /// The type of element stored in this buffer.
     type Elem: Debug;
 
-    /// A register in this buffer, convertable from an offset.
+    /// A register in this buffer, convertible from an offset.
     type Reg: From<usize>;
 
     /// Returns the component tree rooted at the given component.

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -101,7 +101,7 @@ impl fmt::Display for VerificationError {
             VerificationError::UnexpectedExitCode => write!(f, "unexpected exit_code"),
             VerificationError::InvalidHashSuite => write!(f, "invalid hash suite"),
             VerificationError::VerifierParametersMissing => {
-                write!(f, "verifier paramters were not found in verifier context for the given receipt type")
+                write!(f, "verifier parameters were not found in verifier context for the given receipt type")
             }
             VerificationError::VerifierParametersMismatch { expected, received } => {
                 write!(f, "receipt was produced for a version of the verifier with parameters digest {received}; expected {expected}")

--- a/risc0/zkvm/platform/src/rust_rt.rs
+++ b/risc0/zkvm/platform/src/rust_rt.rs
@@ -61,7 +61,7 @@ mod entrypoint {
     static STACK_TOP: u32 = crate::memory::STACK_TOP;
 
     // Entry point; sets up global pointer and stack pointer and passes
-    // to __start.  TODO: when asm_const is stablized, use that here
+    // to __start.  TODO: when asm_const is stabilized, use that here
     // instead of defining a symbol and dereferencing it.
     core::arch::global_asm!(
         r#"

--- a/risc0/zkvm/src/guest/memcpy.s
+++ b/risc0/zkvm/src/guest/memcpy.s
@@ -173,7 +173,7 @@
 // All other files which have no copyright comments are original works
 // produced specifically for use as part of this library, written either
 // by Rich Felker, the main author of the library, or by one or more
-// contibutors listed above. Details on authorship of individual files
+// contributors listed above. Details on authorship of individual files
 // can be found in the git version control history of the project. The
 // omission of copyright and license comments in each file is in the
 // interest of source tree size.

--- a/risc0/zkvm/src/guest/memset.s
+++ b/risc0/zkvm/src/guest/memset.s
@@ -173,7 +173,7 @@
 // All other files which have no copyright comments are original works
 // produced specifically for use as part of this library, written either
 // by Rich Felker, the main author of the library, or by one or more
-// contibutors listed above. Details on authorship of individual files
+// contributors listed above. Details on authorship of individual files
 // can be found in the git version control history of the project. The
 // omission of copyright and license comments in each file is in the
 // interest of source tree size.

--- a/risc0/zkvm/src/guest/mod.rs
+++ b/risc0/zkvm/src/guest/mod.rs
@@ -167,7 +167,7 @@ unsafe extern "C" fn __start() -> ! {
 static STACK_TOP: u32 = risc0_zkvm_platform::memory::STACK_TOP;
 
 // Entry point; sets up global pointer and stack pointer and passes
-// to zkvm_start.  TODO: when asm_const is stablized, use that here
+// to zkvm_start.  TODO: when asm_const is stabilized, use that here
 // instead of defining a symbol and dereferencing it.
 #[cfg(target_os = "zkvm")]
 core::arch::global_asm!(

--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -349,11 +349,30 @@ impl Client {
         result
     }
 
-    /// Prove the verification of a recursion receipt using the Poseidon254 hash function for FRI.
+    /// Compress a [Receipt], proving the same computation using a smaller representation.
     ///
-    /// The identity_p254 program is used as the last step in the prover pipeline before running the
-    /// Groth16 prover. In Groth16 over BN254, it is much more efficient to verify a STARK that was
-    /// produced with Poseidon over the BN254 base field compared to using Poseidon over BabyBear.
+    /// Proving will, by default, produce a [CompositeReceipt](crate::CompositeReceipt), which
+    /// may contain an arbitrary number of receipts assembled into segments and assumptions.
+    /// Together, these receipts collectively prove a top-level
+    /// [ReceiptClaim](crate::ReceiptClaim). This function can be used to compress all of the constituent
+    /// receipts of a [CompositeReceipt](crate::CompositeReceipt) into a single
+    /// [SuccinctReceipt](crate::SuccinctReceipt) or [Groth16Receipt](crate::Groth16Receipt) that proves the same top-level claim.
+    ///
+    /// Compression from [Groth16Receipt](crate::CompositeReceipt) to
+    /// [SuccinctReceipt](crate::SuccinctReceipt) is accomplished by iterative application of the
+    /// recursion programs including lift, join, and resolve.
+    ///
+    /// Compression from [SuccinctReceipt](crate::SuccinctReceipt) to
+    /// [Groth16Receipt](crate::Groth16Receipt) is accomplished by running a Groth16 recursive
+    /// verifier, refered to as the "STARK-to-SNARK" operation.
+    ///
+    /// NOTE: Compression to [Groth16Receipt](crate::Groth16Receipt) is currently only supported on
+    /// x86 hosts, and requires Docker to be installed. See issue
+    /// [#1749](https://github.com/risc0/risc0/issues/1749) for more information.
+    ///
+    /// If the receipt is already at least as compressed as the requested compression level (e.g.
+    /// it is already succinct or Groth16 and a succinct receipt is required) this function is a
+    /// no-op. As a result, it is idempotent.
     pub fn compress(
         &self,
         opts: &ProverOpts,

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -563,7 +563,7 @@ impl TryFrom<pb::core::InnerReceipt> for InnerReceipt {
 }
 
 // NOTE: InnerReceipt and InnerAssumptionReceipt are the same type in protobuf.
-// In Rust, they are distinct types becaue Rust needs to size everything on the
+// In Rust, they are distinct types because Rust needs to size everything on the
 // stack and e.g. SuccinctReceipt<ReceiptClaim> and SuccinctReceipt<Unknown>
 // have different sizes. Protobuf handles this without issue.
 impl From<InnerAssumptionReceipt> for pb::core::InnerReceipt {

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -110,7 +110,7 @@ pub trait Prover {
     /// Compress a [Receipt], proving the same computation using a smaller representation.
     ///
     /// Proving will, by default, produce a [CompositeReceipt](crate::CompositeReceipt), which
-    /// may contain an arbitrary number of receipts assembled into continuations and compositions.
+    /// may contain an arbitrary number of receipts assembled into segments and assumptions.
     /// Together, these receipts collectively prove a top-level
     /// [ReceiptClaim](crate::ReceiptClaim). This function can be used to compress all of the constituent
     /// receipts of a [CompositeReceipt](crate::CompositeReceipt) into a single
@@ -122,7 +122,7 @@ pub trait Prover {
     ///
     /// Compression from [SuccinctReceipt](crate::SuccinctReceipt) to
     /// [Groth16Receipt](crate::Groth16Receipt) is accomplished by running a Groth16 recursive
-    /// verifier, refered to as the "STARK-to-SNARK" operation.
+    /// verifier, referred to as the "STARK-to-SNARK" operation.
     ///
     /// NOTE: Compression to [Groth16Receipt](crate::Groth16Receipt) is currently only supported on
     /// x86 hosts, and requires Docker to be installed. See issue

--- a/risc0/zkvm/src/host/protos/core.proto
+++ b/risc0/zkvm/src/host/protos/core.proto
@@ -27,7 +27,7 @@ message ReceiptMetadata {
 }
 
 // NOTE: InnerReceipt and InnerAssumptionReceipt are the same type in protobuf.
-// In Rust, they are distinct types becaue Rust needs to size everything on the
+// In Rust, they are distinct types because Rust needs to size everything on the
 // stack and e.g. SuccinctReceipt<ReceiptClaim> and SuccinctReceipt<Unknown>
 // have different sizes. Protobuf handles this without issue.
 message InnerReceipt {

--- a/risc0/zkvm/src/host/protos/core.rs
+++ b/risc0/zkvm/src/host/protos/core.rs
@@ -36,7 +36,7 @@ pub struct ReceiptMetadata {
     pub verifier_parameters: ::core::option::Option<super::base::Digest>,
 }
 /// NOTE: InnerReceipt and InnerAssumptionReceipt are the same type in protobuf.
-/// In Rust, they are distinct types becaue Rust needs to size everything on the
+/// In Rust, they are distinct types because Rust needs to size everything on the
 /// stack and e.g. SuccinctReceipt<ReceiptClaim> and SuccinctReceipt<Unknown>
 /// have different sizes. Protobuf handles this without issue.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -316,7 +316,7 @@ fn test_recursion_identity_sha256() {
         hashfn: opts.hashfn,
         control_id: control_id_sha256,
         control_inclusion_proof: sha256_control_inclusion_proof,
-        // Use the claim from the inner receipt that verifiy will only pass if they match.
+        // Use the claim from the inner receipt that verify will only pass if they match.
         claim: default_receipt.claim,
         verifier_parameters: params.digest(),
     };

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -93,7 +93,7 @@ pub trait ProverServer {
     /// Compress a [CompositeReceipt] into a single [SuccinctReceipt].
     ///
     /// A [CompositeReceipt] may contain an arbitrary number of receipts assembled into
-    /// continuations and compositions. Together, these receipts collectively prove a top-level
+    /// segments and assumptions. Together, these receipts collectively prove a top-level
     /// [ReceiptClaim](crate::ReceiptClaim). This function compresses all of the constituent receipts of a
     /// [CompositeReceipt] into a single [SuccinctReceipt] that proves the same top-level claim. It
     /// accomplishes this by iterative application of the recursion programs including lift, join,

--- a/risc0/zkvm/src/host/server/session.rs
+++ b/risc0/zkvm/src/host/server/session.rs
@@ -110,7 +110,7 @@ impl Segment {
 
 /// A reference to a [Segment].
 ///
-/// This allows implementors to determine the best way to represent this in an
+/// This allows implementers to determine the best way to represent this in an
 /// pluggable manner. See the [SimpleSegmentRef] for a very basic
 /// implementation.
 pub trait SegmentRef: Send {

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -421,7 +421,7 @@ where
     }
 
     /// Prunes the claim, retaining its digest, and converts into a [FakeReceipt] with an unknown
-    /// claim type. Can be used to get receipts of a uniform type across heterogenous claims.
+    /// claim type. Can be used to get receipts of a uniform type across heterogeneous claims.
     pub fn into_unknown(self) -> FakeReceipt<Unknown> {
         FakeReceipt {
             claim: MaybePruned::Pruned(self.claim.digest()),
@@ -553,7 +553,7 @@ impl From<ReceiptClaim> for AssumptionReceipt {
     }
 }
 
-/// An enumeration of receipt types simmilar to [InnerReceipt], but for use in [AssumptionReceipt].
+/// An enumeration of receipt types similar to [InnerReceipt], but for use in [AssumptionReceipt].
 /// Instead of proving only RISC-V execution with [ReceiptClaim], this type can prove any claim
 /// implemented by one of its inner types.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -676,7 +676,7 @@ impl VerifierContext {
         }
     }
 
-    /// Return the mapping of hash suites used in the defaul [VerifierContext].
+    /// Return the mapping of hash suites used in the default [VerifierContext].
     pub fn default_hash_suites() -> BTreeMap<String, HashSuite<BabyBear>> {
         BTreeMap::from([
             ("blake2b".into(), Blake2bCpuHashSuite::new_suite()),

--- a/risc0/zkvm/src/receipt/composite.rs
+++ b/risc0/zkvm/src/receipt/composite.rs
@@ -123,7 +123,7 @@ impl CompositeReceipt {
         }
         for (assumption, receipt) in assumptions.into_iter().zip(self.assumption_receipts.iter()) {
             let assumption_ctx = match assumption.control_root {
-                // If the control root is all zeroes, we should use the same verifier paramters.
+                // If the control root is all zeroes, we should use the same verifier parameters.
                 Digest::ZERO => None,
                 // Otherwise, we should verify the assumption receipt using the guest-provided root.
                 control_root => Some(

--- a/risc0/zkvm/src/receipt/groth16.rs
+++ b/risc0/zkvm/src/receipt/groth16.rs
@@ -105,7 +105,7 @@ where
     }
 
     /// Prunes the claim, retaining its digest, and converts into a [Groth16Receipt] with an unknown
-    /// claim type. Can be used to get receipts of a uniform type across heterogenous claims.
+    /// claim type. Can be used to get receipts of a uniform type across heterogeneous claims.
     pub fn into_unknown(self) -> Groth16Receipt<Unknown> {
         Groth16Receipt {
             claim: MaybePruned::Pruned(self.claim.digest::<sha::Impl>()),

--- a/risc0/zkvm/src/receipt/succinct.rs
+++ b/risc0/zkvm/src/receipt/succinct.rs
@@ -194,7 +194,7 @@ where
     }
 
     /// Prunes the claim, retaining its digest, and converts into a [SuccinctReceipt] with an unknown
-    /// claim type. Can be used to get receipts of a uniform type across heterogenous claims.
+    /// claim type. Can be used to get receipts of a uniform type across heterogeneous claims.
     pub fn into_unknown(self) -> SuccinctReceipt<Unknown> {
         SuccinctReceipt {
             claim: MaybePruned::Pruned(self.claim.digest::<sha::Impl>()),

--- a/xtask/src/bootstrap.rs
+++ b/xtask/src/bootstrap.rs
@@ -140,7 +140,7 @@ impl Bootstrap {
             writeln!(&mut allowed_control_ids_str, r#"digest!("{digest}"),"#).unwrap();
         }
 
-        // Calculuate a Merkle root for the allowed control IDs and add it to the file.
+        // Calculate a Merkle root for the allowed control IDs and add it to the file.
         let merkle_group = MerkleGroup::new(allowed_control_ids).unwrap();
         let hash_suite = Poseidon2HashSuite::new_suite();
         let hashfn = hash_suite.hashfn.as_ref();


### PR DESCRIPTION
Use `codespell` tool to find typos and check them as well ask fix description for compress.

This is a squash of #1990, #2027, and #2048

---------