### PR TITLE
fixing broken anchors

### DIFF
--- a/website/api/blockchain-integration/contracts/verifier.md
+++ b/website/api/blockchain-integration/contracts/verifier.md
@@ -67,4 +67,4 @@ You can use the [deployed contracts for a released version][doc-released-contrac
 [term-journal]: /terminology#journal
 [term-receipt]: /terminology#receipt
 [term-verify]: /terminology#verify
-[term-zkvm-program]: /terminology#zkvm-program
+[term-zkvm-program]: ../../zkvm/

--- a/website/api_versioned_docs/version-0.18/bonsai/eth-examples.md
+++ b/website/api_versioned_docs/version-0.18/bonsai/eth-examples.md
@@ -11,7 +11,7 @@ While all of the [zkVM examples][zkvm-examples] can be run on Bonsai by [configu
 This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
 [zkvm-examples]: /api/zkvm/examples
-[remote-proving]: /api/zkvm/quickstart#remote-proving
+[remote-proving]: ../zkvm/quickstart#remote-proving
 [zeth-repo]: https://github.com/risc0/zeth
 [revm]: https://crates.io/crates/revm
 [zeth-article]: https://www.risczero.com/news/zeth-release

--- a/website/api_versioned_docs/version-0.19/bonsai/eth-examples.md
+++ b/website/api_versioned_docs/version-0.19/bonsai/eth-examples.md
@@ -11,7 +11,7 @@ While all of the [zkVM examples][zkvm-examples] can be run on Bonsai by [configu
 This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
 [zkvm-examples]: /api/zkvm/examples
-[remote-proving]: /api/zkvm/quickstart#remote-proving
+[remote-proving]: ./bonsai-overview.md
 [zeth-repo]: https://github.com/risc0/zeth
 [revm]: https://crates.io/crates/revm
 [zeth-article]: https://www.risczero.com/news/zeth-release

--- a/website/api_versioned_docs/version-0.20/bonsai/eth-examples.md
+++ b/website/api_versioned_docs/version-0.20/bonsai/eth-examples.md
@@ -15,7 +15,7 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
 [zkvm-examples]: /api/zkvm/examples
-[remote-proving]: /api/zkvm/quickstart#remote-proving
+[remote-proving]: ./bonsai-overview.md
 [zeth-repo]: https://github.com/risc0/zeth
 [revm]: https://crates.io/crates/revm
 [zeth-article]: https://www.risczero.com/news/zeth-release

--- a/website/api_versioned_docs/version-0.21/blockchain-integration/contracts/verifier.md
+++ b/website/api_versioned_docs/version-0.21/blockchain-integration/contracts/verifier.md
@@ -69,5 +69,5 @@ You can choose to use this contract or deploy your own.
 [term-receipt]: /terminology#receipt
 [term-verify]: /terminology#verify
 [term-image-id]: /terminology#image-id
-[term-zkvm-program]: /terminology#zkvm-program
+[term-zkvm-program]: ../../zkvm/
 [foundry-template]: https://github.com/risc0/bonsai-foundry-template

--- a/website/api_versioned_docs/version-1.0/blockchain-integration/contracts/verifier.md
+++ b/website/api_versioned_docs/version-1.0/blockchain-integration/contracts/verifier.md
@@ -93,4 +93,4 @@ Users seeking to pin to a specific version of zkVM can use the following table t
 [term-journal]: /terminology#journal
 [term-receipt]: /terminology#receipt
 [term-verify]: /terminology#verify
-[term-zkvm-program]: /terminology#zkvm-program
+[term-zkvm-program]: ../../zkvm/

--- a/website/docs/contributors-guide.md
+++ b/website/docs/contributors-guide.md
@@ -15,7 +15,7 @@ _This page describes guidelines for community contributions to this [website](ht
 - All changes to this website are managed through GitHub pull requests, so you'll need a [GitHub Account](https://github.com) to contribute.
 - You can suggest an edit directly via the `Edit this Page` button at the bottom of each page.
 - To create a new page, you can use the [GitHub browser interface](https://github.com/risc0/risc0/tree/main/website); the content is in `src/pages` and `docs`.
-  - Please read about [the navbar and sidebars](./contributors-guide.md#navbar-and-sidebars) and [categories of documentation](./contributors-guide.md#categories-of-documentation) before creating a new page.
+  - Please read about [the navbar and sidebars](./contributors-guide.md#navbar-and-sidebars) before creating a new page.
 - If you want to clone the repository and work locally, you may want to check out the [Docusaurus documentation](https://docusaurus.io/docs/installation).
   We like to use `bun run start` to run a local build, especially when we're working with changes that involve links or sidebars.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -4,7 +4,7 @@
 
 ## Contents
 
-- [FAQ](#faq)
+- [FAQ](#contents)
   - [Contents](#contents)
   - [ZK Basics](#zk-basics)
   - [Building on the zkVM](#building-on-the-zkvm)


### PR DESCRIPTION
Resolves 90% of #2020. 

The sole remaining broken anchor is on the `terminology` page -- there are links there pointing to the term `control columns`, but that term is currently not included in the terms list. Will address this on a future PR. 