### PR TITLE
[rzup] fix: docker compatibility and rzup cwd binstall

### DIFF
--- a/rzup/install
+++ b/rzup/install
@@ -4,8 +4,6 @@
 
 set -eo pipefail
 
-clear
-
 echo "💾 Installing rzup"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}

--- a/rzup/rzup
+++ b/rzup/rzup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=0.1.1
+VERSION=0.1.2
 
 VERBOSE_MODE=1
 
@@ -78,11 +78,20 @@ install_cargo_binstall() {
 }
 
 binstall_cargo_risczero() {
+  # create a temp dir and switch to it
+  local TEMP_DIR
+  TEMP_DIR=$(mktemp -d)
+  pushd "$TEMP_DIR" >/dev/null || exit
+
   if [ -n "$RISCZERO_VERSION" ]; then
-    execute_with_feedback "cargo binstall cargo-risczero@$RISCZERO_VERSION --no-confirm" "Installing cargo-risczero version $RISCZERO_VERSION"
+    execute_with_feedback "cargo binstall cargo-risczero@$RISCZERO_VERSION --no-confirm --force" "Installing cargo-risczero version $RISCZERO_VERSION"
   else
-    execute_with_feedback "cargo binstall cargo-risczero --no-confirm" "Installing the latest version of cargo-risczero"
+    execute_with_feedback "cargo binstall cargo-risczero --no-confirm --force" "Installing the latest version of cargo-risczero"
   fi
+
+  # return to the original directory and remove the temp dir
+  popd >/dev/null || exit
+  rm -rf "$TEMP_DIR"
 }
 
 install_risczero() {


### PR DESCRIPTION
This fixes both docker compatibility for the install script and running `rzup` within the `risc0` repo by: 
-  removing the `clear` command in the install script, added in PR #1813 
-  forcing the binstall installation with `--force` and changing the current working directory to a temporarily created one (then moving back and deleting it).

Moving to a temporary directory may not be necessary, but is an extra precaution to avoid other installation issues.  

bump version to `0.1.2`