### PR TITLE
crates-validator: update db-dump to fix CSV desrialization

### DIFF
--- a/tools/crates-validator/Cargo.lock
+++ b/tools/crates-validator/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "db-dump"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ce908474957c3f12cd3cab5e6d87c2435b52930c9806f1ade8a2d7806cb974"
+checksum = "ab3b2733a3e32e7ad9fcc3a5697cb4769fb9331e705567623c1c57e93cb398e9"
 dependencies = [
  "chrono",
  "csv",

--- a/tools/crates-validator/Cargo.toml
+++ b/tools/crates-validator/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "main"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 colored = "2"
-db-dump = "0.7.0"
+db-dump = "0.7"
 handlebars = "4.3"
 indicatif = "0.17"
 reqwest = { version = "0.11", default-features = false, features = [


### PR DESCRIPTION
Previous version was set to 0.7.0. Update to the latest 0.7.4. This fixes the following error:
```
versions.csv: CSV deserialize error: record 1 (line: 2, byte: 142): unknown field `bin_names`
```