### PR TITLE
rust-toolchain: remove deprecated `changelog-seen`

### DIFF
--- a/risc0/cargo-risczero/src/commands/config.toml
+++ b/risc0/cargo-risczero/src/commands/config.toml
@@ -1,5 +1,3 @@
-changelog-seen = 2
-
 [build]
 target = ["riscv32im-risc0-zkvm-elf"]
 extended = true


### PR DESCRIPTION
This has been removed as of 1.79 and if left in this file, it will break the rust toolchain build for 1.79.