### PR TITLE
removing outdated references to 100 bits

### DIFF
--- a/risc0/zkp/src/lib.rs
+++ b/risc0/zkp/src/lib.rs
@@ -46,7 +46,7 @@ pub const MIN_CYCLES: usize = 1 << MIN_CYCLES_PO2; // 8K
 pub const MAX_CYCLES_PO2: usize = 24;
 pub const MAX_CYCLES: usize = 1 << MAX_CYCLES_PO2; // 16M
 
-/// 50 FRI queries gives ~100 bits of conjectured security
+/// 50 FRI queries is sufficient to achieve our security target of 99 bits (conjectured security)
 pub const QUERIES: usize = 50;
 pub const ZK_CYCLES: usize = 1994; // TODO: Ideally we'd compute ZK_CYCLES programmatically
 pub const MIN_PO2: usize = core::log2_ceil(1 + ZK_CYCLES);

--- a/risc0/zkp/src/prove/soundness.rs
+++ b/risc0/zkp/src/prove/soundness.rs
@@ -89,7 +89,6 @@ pub fn conjectured_strict<H: Hal>(taps: &TapSet, coeffs_size: usize) -> f32 {
 }
 
 /// Compute the system security following the Toy Model conjecture of ethSTARK.
-/// [ethSTARK]: https://eprint.iacr.org/2021/582
 /// This conjecture states that:
 /// 1. any AIR is as secure as the "simplest AIR" (1 column and degree 1
 ///    constraint).

--- a/risc0/zkp/src/prove/soundness.rs
+++ b/risc0/zkp/src/prove/soundness.rs
@@ -14,14 +14,25 @@
 
 //! A soundness calculator for the RISC Zero STARK protocol that secures the
 //! RISC Zero zkVM. Soundness for STARK protocols can be analyzed under a
-//! number of different cryptographic assumptions. RISC Zero targets 100 bits
-//! of conjectured soundness, using the Toy Problem Conjecture. For
-//! completeness, we also include analysis in three other regimes:
+//! number of different cryptographic assumptions.
 //!
-//! - Conjectured soundness using Conjecture 8.4 from [Proximity Gaps] and
+//! 1. Conjectured soundness using the Toy Problem Conjecture from [ethSTARK]
+//! 2. Conjectured soundness using Conjecture 8.4 from [Proximity Gaps] and
 //!   Conjecture 2.3 from [DEEP-FRI]
-//! - Proven soundness in the list-decoding regime
-//! - Proven soundness in the unique-decoding regime
+//! 3. Proven soundness in the list-decoding regime
+//! 4. Proven soundness in the unique-decoding regime
+//!
+//! With default parameters, RISC Zero's zkVM targets 99 bits of conjectured soundness,
+//! using the Toy Problem Conjecture.
+//!
+//! This target assumes a SEGMENT_SIZE of 2^20 cycles.
+//! Increasing SEGMENT_SIZE to the maximum of 2^24 cycles reduces the result to 95 bits of conjectured soundness.
+//!
+//! Use the following command to run the calculator:
+//! RUST_LOG=risc0_zkp=info cargo run --release
+//!
+//! Running the calculator results in a terminal printout for scenarios (1) and (3) in the list above.
+//! The calculator also includes code for scenarios (2) and (4).
 
 use risc0_core::field::{baby_bear, ExtElem};
 
@@ -78,6 +89,7 @@ pub fn conjectured_strict<H: Hal>(taps: &TapSet, coeffs_size: usize) -> f32 {
 }
 
 /// Compute the system security following the Toy Model conjecture of ethSTARK.
+/// [ethSTARK]: https://eprint.iacr.org/2021/582
 /// This conjecture states that:
 /// 1. any AIR is as secure as the "simplest AIR" (1 column and degree 1
 ///    constraint).

--- a/risc0/zkp/src/prove/soundness.rs
+++ b/risc0/zkp/src/prove/soundness.rs
@@ -16,7 +16,7 @@
 //! RISC Zero zkVM. Soundness for STARK protocols can be analyzed under a
 //! number of different cryptographic assumptions.
 //!
-//! 1. Conjectured soundness using the Toy Problem Conjecture from [ethSTARK]
+//! 1. Conjectured soundness using the Toy Problem Conjecture from ethSTARK
 //! 2. Conjectured soundness using Conjecture 8.4 from [Proximity Gaps] and
 //!   Conjecture 2.3 from [DEEP-FRI]
 //! 3. Proven soundness in the list-decoding regime

--- a/website/docs/proof-system/stark-by-hand.md
+++ b/website/docs/proof-system/stark-by-hand.md
@@ -340,10 +340,10 @@ The Prover sends a vector of 1024 evaluations, which the Verifier interpolates t
 > The queries serve as a random challenge, testing the legitimacy of the Prover's commitments.
 > Loosely speaking, with a blow-up factor of $4$, a single query will catch a cheating Prover $\frac{3}{4}$ of the time.
 > In other words, a single query provides $2$ bits of security.
-> The RISC Zero zkVM uses $50$ queries and a blow-up factor of 4, which amounts to 100 bits of security.
+> The RISC Zero zkVM uses $50$ queries and a blow-up factor of 4, which amounts to ~100 bits of security.
 >
-> Note that the paragraph above is a substantial simplification of the full security analysis; the precise security level is not exactly 100 bits.
-> For a more thorough security analysis, see our [ZKP Whitepaper](https://www.risczero.com/proof-system-in-detail.pdf) and the [Summary on the FRI Low-Degree Test](https://eprint.iacr.org/2022/1216).
+> Note that the paragraph above is a substantial simplification of the full security analysis.
+> For a more thorough security analysis, see our [cryptographic security model] page and our [security calculator].
 
 The Prover has committed to $f_0$ on powers of $28$, $f_1$ on powers of $28^2$, $f_2$ on powers of $28^4$, and $f_3$ on powers of $28^8$.
 
@@ -429,4 +429,6 @@ Whew! Congratulations and thank you for making it this far!
 
 Got questions, feedback, or corrections? Find us on [Twitter](https://twitter.com/risczero) and [Discord](https://discord.gg/risczero).
 
+[cryptographic security model]: api/security-model
 [RISC-V]: https://en.wikipedia.org/wiki/RISC-V
+[security calculator]: https://github.com/risc0/risc0/blob/release-1.0/risc0/zkp/src/prove/soundness.rs


### PR DESCRIPTION
The new work from Block & Tiwari indicated that our security target was 100 bits. 

Our intended security target has been 99 bits for the last few months, but I noticed a few places where we are still referencing 100 bits. 

This PR removes the references to 100 bits, and makes some minor language modifications to clarify. 