### PR TITLE
feat(website): add sitemap

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -70,15 +70,15 @@ export default async function createConfigAsync() {
             customCss: require.resolve("./src/css/custom.css"),
           },
           sitemap: {
-            lastmod: 'date',
-            changefreq: 'weekly',
+            lastmod: "date",
+            changefreq: "weekly",
             priority: 0.5,
-            ignorePatterns: ['/tags/**'],
-            filename: 'sitemap.xml',
+            ignorePatterns: ["/tags/**"],
+            filename: "sitemap.xml",
             createSitemapItems: async (params) => {
-              const {defaultCreateSitemapItems, ...rest} = params;
+              const { defaultCreateSitemapItems, ...rest } = params;
               const items = await defaultCreateSitemapItems(rest);
-              return items.filter((item) => !item.url.includes('/page/'));
+              return items.filter((item) => !item.url.includes("/page/"));
             },
           },
         }),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -69,6 +69,18 @@ export default async function createConfigAsync() {
           theme: {
             customCss: require.resolve("./src/css/custom.css"),
           },
+          sitemap: {
+            lastmod: 'date',
+            changefreq: 'weekly',
+            priority: 0.5,
+            ignorePatterns: ['/tags/**'],
+            filename: 'sitemap.xml',
+            createSitemapItems: async (params) => {
+              const {defaultCreateSitemapItems, ...rest} = params;
+              const items = await defaultCreateSitemapItems(rest);
+              return items.filter((item) => !item.url.includes('/page/'));
+            },
+          },
         }),
       ],
     ],


### PR DESCRIPTION
EDIT: docusaurus seems to do this automatically, closing this PR
Add a `sitemap.xml` file to google

Example result
https://docs-website-git-nahoc-add-sitemap2-risczero.vercel.app/sitemap.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset
    xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
    xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
    xmlns:xhtml="http://www.w3.org/1999/xhtml"
    xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
    xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
    <url>
        <loc>https://dev.risczero.com/litepaper</loc>
        <lastmod>2024-07-23</lastmod>
        <changefreq>weekly</changefreq>
        <priority>0.5</priority>
    </url>
    <url>
        <loc>https://dev.risczero.com/search</loc>
        <changefreq>weekly</changefreq>
        <priority>0.5</priority>
    </url>
    <url>
        <loc>https://dev.risczero.com/api/0.18/</loc>
        <lastmod>2024-07-21</lastmod>
        <changefreq>weekly</changefreq>
        <priority>0.5</priority>
    </url>
    <url>
        <loc>https://dev.risczero.com/api/0.18/bonsai/</loc>
        <lastmod>2024-07-21</lastmod>
        <changefreq>weekly</changefreq>
        <priority>0.5</priority>
    </url>
    <url>
        <loc>https://dev.risczero.com/api/0.18/bonsai/blockchain-zkvm-guide</loc>
        <lastmod>2024-07-21</lastmod>
        <changefreq>weekly</changefreq>
        <priority>0.5</priority>
    </url>
    <url>
        <loc>https://dev.risczero.com/api/0.18/bonsai/bonsai-on-eth</loc>
        <lastmod>2024-07-21</lastmod>
        <changefreq>weekly</changefreq>
        <priority>0.5</priority>
    </url>
..........
</urlset>
```