### PR TITLE
bump version to 1.0.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ permissions:
 
 env:
   RISC0_TOOLCHAIN_VERSION: r0.1.79.0
-  TAG: v1.0.4
-  VERSION: "1.0.4"
+  TAG: v1.0.5
+  VERSION: "1.0.5"
 
 jobs:
   release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cc",
  "directories",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cc",
  "cust",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-tools"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "risc0-build",
  "risc0-zkvm",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.0.4"
+version = "1.0.5"
 
 [[package]]
 name = "rrs-lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
@@ -36,20 +36,20 @@ repository = "https://github.com/risc0/risc0/"
 [workspace.dependencies]
 bonsai-sdk = { version = "0.9.0", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
-risc0-binfmt = { version = "1.0.4", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "1.0.4", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "1.0.4", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-recursion = { version = "1.0.4", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.0.4", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "1.0.4", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "1.0.4", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "1.0.4", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.0.4", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "1.0.4", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.0.4", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.0.4", default-features = false, path = "risc0/zkp" }
-risc0-zkvm = { version = "1.0.4", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "1.0.4", default-features = false, path = "risc0/zkvm/platform" }
+risc0-binfmt = { version = "1.0.5", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "1.0.5", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "1.0.5", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-recursion = { version = "1.0.5", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "1.0.5", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "1.0.5", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "1.0.5", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "1.0.5", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "1.0.5", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "1.0.5", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "1.0.5", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "1.0.5", default-features = false, path = "risc0/zkp" }
+risc0-zkvm = { version = "1.0.5", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "1.0.5", default-features = false, path = "risc0/zkvm/platform" }
 
 [profile.bench]
 lto = true

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cc",
  "directories",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cc",
  "cust",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cc",
  "directories",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cc",
  "cust",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.0.4"
+version = "1.0.5"
 
 [[package]]
 name = "rkyv"

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -514,7 +514,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -478,7 +478,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -491,7 +491,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -513,7 +513,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -556,7 +556,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -536,7 +536,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -555,7 +555,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -470,7 +470,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/multi_test",
-            "7174b0745fbceca4927593d3991910f55089a8f09892a93745ff8e6ef27c77ed",
+            "8f6f825a604b7608be2cbebeef688ad786f62f09087143cae14ee48276f7250c",
         );
     }
 }

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -771,7 +771,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "risc0-build",
  "risc0-zkvm",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -470,7 +470,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "elf",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "risc0-build",
  "risc0-zkvm",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/tools/smoke-test/Cargo.toml
+++ b/tools/smoke-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = "=1.0.4"
+risc0-zkvm = "=1.0.5"
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../risc0/zkvm" }
 methods = { path = "methods" }

--- a/tools/smoke-test/methods/Cargo.toml
+++ b/tools/smoke-test/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = "=1.0.4"
+risc0-build = "=1.0.5"
 # Use this only for testing locally before a release.
 # risc0-build = { path = "../../../risc0/build" }
 

--- a/tools/smoke-test/methods/guest/Cargo.toml
+++ b/tools/smoke-test/methods/guest/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "=1.0.4", default-features = false }
+risc0-zkvm = { version = "=1.0.5", default-features = false }
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false }


### PR DESCRIPTION
Note: #2147 needs to be merged before this PR. This PR is based off of #2147 and the changes releated to toolchain will go away after #2147 is merged and this has been rebased. marking as a draft - will mark as ready once 2147 is merged, this has been rebased, CI passes and crates have been published

Update: #2147 has been merged, this has been rebased on the current `release-1.0` so waiting for CI to pass