### PR TITLE
Extend `testutil` loop to support dynamic iters

### DIFF
--- a/risc0/circuit/rv32im/src/prove/emu/preflight/tests.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/preflight/tests.rs
@@ -141,7 +141,7 @@ fn system_split() {
         assert_eq!(trace.pre.txns.len(), 9968);
         assert_eq!(trace.pre.extras.len(), 24);
         assert_eq!(trace.body.cycles.len(), 4386);
-        assert_eq!(trace.body.txns.len(), 5377);
+        assert_eq!(trace.body.txns.len(), 5380);
         assert_eq!(trace.body.extras.len(), 15);
         let page_reads: Vec<_> = trace
             .pre

--- a/risc0/circuit/rv32im/src/prove/emu/preflight/tests.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/preflight/tests.rs
@@ -141,7 +141,7 @@ fn system_split() {
         assert_eq!(trace.pre.txns.len(), 9968);
         assert_eq!(trace.pre.extras.len(), 24);
         assert_eq!(trace.body.cycles.len(), 4386);
-        assert_eq!(trace.body.txns.len(), 5380);
+        assert_eq!(trace.body.txns.len(), 5686);
         assert_eq!(trace.body.extras.len(), 15);
         let page_reads: Vec<_> = trace
             .pre


### PR DESCRIPTION
This is implemented by packing the iteration count as a `u32` directly inside the guest program's RISC-V instruction stream.