### PR TITLE
fix(web): better formatDuration method

### DIFF
--- a/web/packages/shared/utils/format-duration.spec.ts
+++ b/web/packages/shared/utils/format-duration.spec.ts
@@ -3,9 +3,9 @@ import { formatDuration } from './format-duration';
 describe('formatDuration', () => {
   it('should return undefined for null or undefined', () => {
     // @ts-expect-error -- tests
-    expect(formatDuration(null)).toBeUndefined();
+    expect(formatDuration(null)).toBe("");
     // @ts-expect-error -- tests
-    expect(formatDuration(undefined)).toBeUndefined();
+    expect(formatDuration(undefined)).toBe("");
   });
 
   it('should return nanoseconds correctly', () => {
@@ -25,11 +25,12 @@ describe('formatDuration', () => {
   });
 
   it('should return minutes correctly', () => {
-    expect(formatDuration(1000 * 1000 * 1000 * 60)).toBe('1.00m');
+    expect(formatDuration(1000 * 1000 * 1000 * 60)).toBe('1m 0s');
+    expect(formatDuration(1000 * 1000 * 1000 * 60 + 1000 * 1000 * 1000 * 80)).toBe('2m 20s');
   });
 
   it('should return hours correctly', () => {
-    expect(formatDuration(1000 * 1000 * 1000 * 60 * 60)).toBe('1.00h');
+    expect(formatDuration(1000 * 1000 * 1000 * 60 * 60)).toBe('1h 0m');
   });
 
   it('should return the correct value for non-exact durations', () => {

--- a/web/packages/shared/utils/format-duration.ts
+++ b/web/packages/shared/utils/format-duration.ts
@@ -3,9 +3,9 @@ import { isNil } from "./is-nil";
 const THRESHOLDS = [1000, 1000, 1000, 60, 60] as const;
 const UNITS = ["ns", "µs", "ms", "s", "m", "h"] as const;
 
-export function formatDuration(duration: number) {
+export function formatDuration(duration: number): string {
   if (isNil(duration)) {
-    return;
+    return "";
   }
 
   let unitIndex = 0;
@@ -18,5 +18,20 @@ export function formatDuration(duration: number) {
     unitIndex++;
   }
 
+  // Special handling for minutes to include remaining seconds
+  if (UNITS[unitIndex] === "m") {
+    const minutes = Math.floor(duration);
+    const seconds = (duration - minutes) * 60;
+    return `${minutes}m ${seconds.toFixed(0)}s`;
+  }
+
+  // Special handling for hours to include remaining minutes
+  if (UNITS[unitIndex] === "h") {
+    const hours = Math.floor(duration);
+    const minutes = (duration - hours) * 60;
+    return `${hours}h ${minutes.toFixed(0)}m`;
+  }
+
+  // Format the result to two decimal places and add the appropriate unit
   return `${duration.toFixed(2)}${UNITS[unitIndex]}`;
 }


### PR DESCRIPTION
stupid assumption on my part, now hours/minutes/seconds show properly 🫨 

before:

<img width="145" alt="image" src="https://github.com/user-attachments/assets/0ffb0b22-6234-47f5-a52b-64099ad1fc0f">

after:

<img width="130" alt="image" src="https://github.com/user-attachments/assets/f953753d-9620-4e15-aede-f54957e066f0">
