### PR TITLE
Update install.md

### DIFF
--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -44,7 +44,7 @@ For users who prefer manual installation, follow these steps:
    >
    > The version used must match the `risc0-zkvm` version from your guest and host.
 
-2. For x86-64 macOS, you must run `cargo risczero build-toolchain` instead of `cargo risczero install`.
+2. For x86-64 macOS or other OS, you must run `cargo risczero build-toolchain --version v2024-04-22.0` instead of `cargo risczero install`.
 
 ## Update
 


### PR DESCRIPTION
the command `cargo risczero build-toolchain` will install `cargo 1.70.0-dev (ec8a8a0ca 2023-04-25)`, which have a bug to compile method. see here: https://github.com/risc0/risc0/issues/1993#issuecomment-2267442649