### PR TITLE
fix: enable `std` for `hex`

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -27,7 +27,7 @@ downloader = { version = "0.2", default-features = false, features = [
 flate2 = "1"
 fs2 = "0.4"
 fs_extra = "1.3.0"
-hex = { version = "0.4", default-features = false }
+hex = { version = "0.4" }
 regex = "1.10.6"
 reqwest = { version = "0.11", default-features = false, features = [
   "json",

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -27,7 +27,7 @@ downloader = { version = "0.2", default-features = false, features = [
 flate2 = "1"
 fs2 = "0.4"
 fs_extra = "1.3.0"
-hex = { version = "0.4" }
+hex = "0.4"
 regex = "1.10.6"
 reqwest = { version = "0.11", default-features = false, features = [
   "json",


### PR DESCRIPTION
This PR fixes building `cargo-risczero` without default features. This is currently causing CI failures in https://github.com/risc0/risc0-ethereum.

Using `?` to convert a `FromHexError` into an `anyhow:Error` requires the `std` feature of the the `hex` crate. This happens in the following line: 
https://github.com/risc0/risc0/blob/b57db72db8c79a6f6bc52ad581189d167ba7eeef/risc0/cargo-risczero/src/commands/verify.rs#L73

This currently leads to compilation failures when building `cargo-risczero` without default features, otherwise the correctly configured `hex` will be pulled in via some other dependencies.

Since `std` is the only feature enabled with `default` in hex, removing `default-features = false` seams preferable to explicitly adding the `std` feature.