### PR TITLE
Pin Foundry version at nightly-4351742481c98adaa9ca3e8642e619aa986b3cee

### DIFF
--- a/.github/workflows/risc0-ethereum.yml
+++ b/.github/workflows/risc0-ethereum.yml
@@ -127,6 +127,8 @@ jobs:
           cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
         working-directory: risc0
       - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
+        with:
+          version: nightly-4351742481c98adaa9ca3e8642e619aa986b3cee
       # Apply local patch
       - name: Local patch on risc0-ethereum
         run: python ${{ env.RISC0_PATH }}/.github/cargo_local_patch.py  .

--- a/.github/workflows/risc0-ethereum.yml
+++ b/.github/workflows/risc0-ethereum.yml
@@ -127,8 +127,6 @@ jobs:
           cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
         working-directory: risc0
       - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
-        with:
-          version: nightly-cafc2606a2187a42b236df4aa65f4e8cdfcea970
       # Apply local patch
       - name: Local patch on risc0-ethereum
         run: python ${{ env.RISC0_PATH }}/.github/cargo_local_patch.py  .


### PR DESCRIPTION
The current version of `anvil` provided when using the foundry version `nightly-cafc2606a2187a42b236df4aa65f4e8cdfcea970` has a bug that affects some `risc0-ethereum` tests. This PR drops that version and uses nightly-4351742481c98adaa9ca3e8642e619aa986b3cee