### PR TITLE
fix(examples/zkevm-demo): allow dead-code methods

### DIFF
--- a/examples/zkevm-demo/core/src/lib.rs
+++ b/examples/zkevm-demo/core/src/lib.rs
@@ -38,6 +38,7 @@ impl<T> ResTrack<T>
 where
     T: Clone,
 {
+    #[allow(dead_code)]
     #[cfg(not(target_os = "zkvm"))]
     pub fn reset(&mut self) {
         self.idx = 0;
@@ -49,6 +50,7 @@ where
         res
     }
 
+    #[allow(dead_code)]
     #[cfg(not(target_os = "zkvm"))]
     pub fn set(&mut self, elm: &T) {
         self.elms.push(elm.clone());


### PR DESCRIPTION
The below error was throw when run `cargo build` within `examples/zkevm-demo/methods/guest/`:

```
error: methods `reset` and `set` are never used
  --> risc0/examples/zkevm-demo/core/src/lib.rs:42:12
   |
37 | / impl<T> ResTrack<T>
38 | | where
39 | |     T: Clone,
   | |_____________- methods in this implementation
...
42 |       pub fn reset(&mut self) {
   |              ^^^^^
...
53 |       pub fn set(&mut self, elm: &T) {
   |              ^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`

error: could not compile `zkevm-core` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```
