### PR TITLE
Add missing env feature to clap

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 bincode = "1.3"
 bonsai-sdk = { workspace = true }
 cargo_metadata = { version = "0.18" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 const_format = "0.2"
 dirs = "5.0"
 downloader = { version = "0.2", default-features = false, features = [


### PR DESCRIPTION
With https://github.com/risc0/risc0/pull/2196 we introduced the `env` usage in `clap` without adding the relative `env` feature to it. This result in having issues when building `cargo-risczero`, specifically when building it with only some of its features e.g.,:

```bash
cargo build -p cargo-risczero --no-default-features --features "cuda"
```

or

```bash
cargo build -p cargo-risczero --no-default-features --features "metal"
```

returns:

```
error[E0599]: no method named `env` found for struct `Arg` in the current scope
  --> risc0/cargo-risczero/src/commands/datasheet/mod.rs:41:38
   |
41 |     #[arg(long, value_name = "PATH", env = "RISC0_SERVER_PATH")]
   |                                      ^^^ method not found in `Arg`
```