### PR TITLE
Guest method required features

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -323,11 +323,21 @@ fn get_env_var(name: &str) -> String {
 }
 
 /// Returns all methods associated with the given guest crate.
-fn guest_methods<G: GuestBuilder>(pkg: &Package, target_dir: impl AsRef<Path>) -> Vec<G> {
+fn guest_methods<G: GuestBuilder>(
+    pkg: &Package,
+    target_dir: impl AsRef<Path>,
+    guest_features: &[String],
+) -> Vec<G> {
     let profile = if is_debug() { "debug" } else { "release" };
     pkg.targets
         .iter()
         .filter(|target| target.kind.iter().any(|kind| kind == "bin"))
+        .filter(|target| {
+            target
+                .required_features
+                .iter()
+                .all(|required_feature| guest_features.contains(required_feature))
+        })
         .map(|target| {
             G::build(
                 &target.name,
@@ -743,7 +753,7 @@ fn do_embed_methods<G: GuestBuilder>(
             guest_methods_docker(&guest_pkg, &guest_dir)
         } else {
             build_guest_package(&guest_pkg, &guest_dir, &guest_opts, None);
-            guest_methods(&guest_pkg, &guest_dir)
+            guest_methods(&guest_pkg, &guest_dir, &guest_opts.features)
         };
 
         for method in methods {

--- a/risc0/zkvm/methods/std/Cargo.toml
+++ b/risc0/zkvm/methods/std/Cargo.toml
@@ -32,3 +32,8 @@ release = false
 [features]
 test_feature1 = []
 test_feature2 = []
+test_feature3 = []
+
+[[bin]]
+name = "test_required_features"
+required-features = ["test_feature3"]

--- a/risc0/zkvm/methods/std/src/bin/test_required_features.rs
+++ b/risc0/zkvm/methods/std/src/bin/test_required_features.rs
@@ -1,0 +1,23 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[allow(unused_imports)]
+use std::compile_error;
+
+use risc0_zkvm as _;
+
+fn main() {
+    #[cfg(not(feature = "test_feature3"))]
+    compile_error!("Test feature was not found.");
+}


### PR DESCRIPTION
This PR allows guest methods binary targets to customize `required-features` and skip building such targets if not all required features were provided.

`test_required_features` binary target in `risc0-zkvm-methods-std` guest methods demonstrates the use of this PR:
1. in `Cargo.toml` the binary target customizes `test_feature3` as required without which it wouldn't compile;
2. `build.rs` script doesn't set `test_feature3` in `GuestOptions` which would exclude `test_required_features` target from build process;
3. tests succeed as expected.