### PR TITLE
Fix: env::read_buffered() is gated behind the 'std' feature

### DIFF
--- a/risc0/zkvm/methods/src/bench.rs
+++ b/risc0/zkvm/methods/src/bench.rs
@@ -42,6 +42,7 @@ pub enum BenchmarkSpec {
     },
     Read,
     ReadFramed,
+    #[cfg(feature = "std")]
     ReadBuffered,
     #[cfg(feature = "std")]
     Bincode,
@@ -97,6 +98,7 @@ impl BenchmarkSpec {
                 let claims: Vec<ReceiptClaim> = env::read_framed().unwrap();
                 memory_barrier(&claims);
             }
+            #[cfg(feature = "std")]
             BenchmarkSpec::ReadBuffered => {
                 let claims: Vec<ReceiptClaim> = env::read_buffered().unwrap();
                 memory_barrier(&claims);


### PR DESCRIPTION
This PR adds a fix to an error caused by running `cargo build` from `risc0/zkvm/methods` dir:

```
error[E0425]: cannot find function `read_buffered` in module `env`
   --> risc0/zkvm/methods/src/bench.rs:101:54
    |
101 |                 let claims: Vec<ReceiptClaim> = env::read_buffered().unwrap();
    |                                                      ^^^^^^^^^^^^^ not found in `env`
    |
note: found an item that was configured out
   --> /risc0/risc0/zkvm/src/guest/env/mod.rs:462:8
    |
462 | pub fn read_buffered<T: DeserializeOwned>() -> Result<T, crate::serde::Error> {
    |        ^^^^^^^^^^^^^
    = note: the item is gated behind the `std` feature

For more information about this error, try `rustc --explain E0425`.
```