### PR TITLE
Use receipt `seal_size` method in more places

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -142,7 +142,7 @@ impl Job {
         metrics.total_duration = metrics.exec_duration + metrics.proof_duration;
         metrics.speed = self.size as f32 / metrics.total_duration.as_secs_f32();
         metrics.output_bytes = receipt.journal.bytes.len();
-        metrics.proof_bytes = receipt.inner.succinct().unwrap().get_seal_bytes().len();
+        metrics.proof_bytes = receipt.inner.succinct().unwrap().seal_size();
 
         let start = Instant::now();
         receipt.verify(self.image_id).unwrap();

--- a/risc0/r0vm/tests/standard_lib.rs
+++ b/risc0/r0vm/tests/standard_lib.rs
@@ -56,7 +56,7 @@ fn stdio_outputs_in_receipt() {
 
     let segments = &receipt.inner.composite().unwrap().segments;
     assert_eq!(segments.len(), 1);
-    assert!(!segments[0].get_seal_bytes().is_empty());
+    assert_ne!(segments[0].seal_size(), 0);
 
     receipt.verify(STANDARD_LIB_ID).unwrap();
 }

--- a/risc0/zkvm/examples/datasheet.rs
+++ b/risc0/zkvm/examples/datasheet.rs
@@ -193,15 +193,7 @@ impl Datasheet {
                 let ram = tracker().lock().unwrap().peak;
                 assert_eq!(info.stats.total_cycles, *expected);
                 let throughput = (info.stats.total_cycles as f32) / duration.as_secs_f32();
-                let seal = info
-                    .receipt
-                    .inner
-                    .composite()
-                    .unwrap()
-                    .segments
-                    .iter()
-                    .map(|x| x.get_seal_bytes().len())
-                    .sum();
+                let seal = info.receipt.inner.composite().unwrap().seal_size();
 
                 self.results.push(PerformanceData {
                     name: "rv32im".into(),
@@ -243,7 +235,7 @@ impl Datasheet {
         let ram = tracker().lock().unwrap().peak;
         let cycles = 1 << RECURSION_PO2;
         let throughput = (cycles as f32) / duration.as_secs_f32();
-        let seal = receipt.get_seal_bytes().len();
+        let seal = receipt.seal_size();
 
         self.results.push(PerformanceData {
             name: "lift".into(),
@@ -287,7 +279,7 @@ impl Datasheet {
         let ram = tracker().lock().unwrap().peak;
         let cycles = 1 << RECURSION_PO2;
         let throughput = (cycles as f32) / duration.as_secs_f32();
-        let seal = receipt.get_seal_bytes().len();
+        let seal = receipt.seal_size();
 
         self.results.push(PerformanceData {
             name: "join".into(),
@@ -320,13 +312,7 @@ impl Datasheet {
 
         let ram = tracker().lock().unwrap().peak;
         let throughput = (info.stats.total_cycles as f32) / duration.as_secs_f32();
-        let seal = info
-            .receipt
-            .inner
-            .succinct()
-            .unwrap()
-            .get_seal_bytes()
-            .len();
+        let seal = info.receipt.inner.succinct().unwrap().seal_size();
 
         self.results.push(PerformanceData {
             name: "succinct".into(),
@@ -363,7 +349,7 @@ impl Datasheet {
         let ram = tracker().lock().unwrap().peak;
         let cycles = 1 << RECURSION_PO2;
         let throughput = (cycles as f32) / duration.as_secs_f32();
-        let seal = receipt.get_seal_bytes().len();
+        let seal = receipt.seal_size();
 
         self.results.push(PerformanceData {
             name: "identity_p254".into(),
@@ -434,7 +420,7 @@ impl Datasheet {
 
         let ram = tracker().lock().unwrap().peak;
         let throughput = (info.stats.total_cycles as f32) / duration.as_secs_f32();
-        let seal = info.receipt.inner.groth16().unwrap().seal.len();
+        let seal = info.receipt.inner.groth16().unwrap().seal_size();
 
         self.results.push(PerformanceData {
             name: "groth16".into(),

--- a/risc0/zkvm/examples/fib.rs
+++ b/risc0/zkvm/examples/fib.rs
@@ -95,7 +95,7 @@ fn top(prover: Rc<dyn ProverServer>, iterations: u32, skip_prover: bool) -> Metr
             .unwrap()
             .segments
             .iter()
-            .fold(0, |acc, segment| acc + segment.get_seal_bytes().len())
+            .fold(0, |acc, segment| acc + segment.seal_size())
     };
 
     Metrics {


### PR DESCRIPTION
Various places would allocate a `Vec<u8>` just to check the length.