### PR TITLE
Add `#[allow(unreachable_patterns)]` to fix warning from nightly builds

### DIFF
--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -729,6 +729,7 @@ impl TryFrom<pb::core::ReceiptClaim> for ReceiptClaim {
             input: match value.input {
                 None => MaybePruned::Value(None),
                 Some(x) => match MaybePruned::<Input>::try_from(x)? {
+                    #[allow(unreachable_patterns)]
                     MaybePruned::Value(input) => MaybePruned::Value(Some(input)),
                     MaybePruned::Pruned(digest) => MaybePruned::Pruned(digest),
                 },
@@ -956,6 +957,7 @@ impl From<MaybePruned<Unknown>> for pb::core::MaybePruned {
     fn from(value: MaybePruned<Unknown>) -> Self {
         Self {
             kind: Some(match value {
+                #[allow(unreachable_patterns)]
                 MaybePruned::Value(inner) => {
                     match inner { /* unreachable */ }
                 }


### PR DESCRIPTION
Today's rustc nightly adds a new warning. Add a few cfg's to fix the following warning generated by rustc:

```
error: unreachable pattern
   --> risc0/zkvm/src/host/api/convert.rs:732:21
    |
732 |                     MaybePruned::Value(input) => MaybePruned::Value(Some(input)),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `receipt_claim::Input` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
    = note: `-D unreachable-patterns` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`

error: unreachable pattern
   --> risc0/zkvm/src/host/api/convert.rs:959:17
    |
959 |                 MaybePruned::Value(inner) => {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `Unknown` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
```