### PR TITLE
Back-port: Include powers of two (po2) up to 21 in the default verifier parameters (#2276)

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "020f2130b1f86850c30034e4a7a1da8869a4a45ff6017e428ea213d5f89c3227",
+            "f6bde17c4a606b944762090fa67891cc2a8c325fd8652c8420016b2422438a59",
         );
     }
 }

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -40,7 +40,7 @@ risc0-binfmt = { workspace = true, default-features = false }
 risc0-build = { workspace = true }
 risc0-r0vm = { workspace = true, optional = true }
 risc0-zkp = { workspace = true }
-risc0-zkvm = { workspace = true }
+risc0-zkvm = { workspace = true, features = ["unstable"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3.9"

--- a/risc0/cargo-risczero/src/commands/datasheet/mod.rs
+++ b/risc0/cargo-risczero/src/commands/datasheet/mod.rs
@@ -24,7 +24,8 @@ use clap::ValueEnum;
 use risc0_zkp::MAX_CYCLES_PO2;
 use risc0_zkvm::{
     ApiClient, Asset, AssetRequest, ExecutorEnv, ExecutorEnvBuilder, ProveInfo, ProverOpts,
-    ReceiptClaim, SegmentInfo, SessionInfo, SuccinctReceipt, VerifierContext, RECURSION_PO2,
+    ReceiptClaim, ReceiptKind, SegmentInfo, SessionInfo, SuccinctReceipt, VerifierContext,
+    RECURSION_PO2,
 };
 use serde_with::{serde_as, DurationSeconds};
 use tabled::{settings::Style, Table, Tabled};
@@ -127,7 +128,7 @@ impl Datasheet {
             &client,
             &util::loop_env(0)?,
             LOOP_ELF,
-            &ProverOpts::succinct(),
+            &ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Succinct),
         )?);
 
         let mut data = Vec::new();
@@ -228,7 +229,7 @@ mod util {
         let binary = risc0_zkvm::Asset::Inline(elf.to_vec().into());
         let prove_info = client.prove(env, opts, binary)?;
 
-        let ctx = VerifierContext::default();
+        let ctx = VerifierContext::all_po2s();
         if opts.prove_guest_errors {
             prove_info.receipt.verify_integrity_with_context(&ctx)?;
         } else {
@@ -280,7 +281,7 @@ mod benches {
         let expected_cycles = 1u64 << po2;
         println!("rv32im ({hashfn}): {expected_cycles}");
 
-        let opts = ProverOpts::default().with_hashfn(hashfn.to_string());
+        let opts = ProverOpts::all_po2s().with_hashfn(hashfn.to_string());
         let env = util::loop_env(iters)?;
         let (info, duration) = try_time(|| util::prove(client, &env, LOOP_ELF, &opts))?;
 
@@ -303,7 +304,7 @@ mod benches {
     pub fn succinct(client: &ApiClient, iters: u32) -> Result<BenchmarkData> {
         println!("succinct: {iters}");
 
-        let opts = ProverOpts::succinct();
+        let opts = ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Succinct);
         let env = util::loop_env(iters)?;
         let (info, duration) = try_time(|| util::prove(client, &env, LOOP_ELF, &opts))?;
 
@@ -323,7 +324,7 @@ mod benches {
         println!("lift");
 
         let env = util::loop_env(0)?;
-        let opts = ProverOpts::default();
+        let opts = ProverOpts::all_po2s();
 
         let segment: Asset = {
             let mut segment_count = 0;
@@ -363,7 +364,7 @@ mod benches {
         // for instruction".
         let (po2, iters) = CYCLES_PO2_ITERS[1];
 
-        let opts = ProverOpts::default();
+        let opts = ProverOpts::all_po2s();
         let env = util::loop_env_builder(iters)
             .segment_limit_po2(po2 - 1)
             .build()?;
@@ -412,7 +413,7 @@ mod benches {
     pub fn identity_p254(client: &ApiClient) -> Result<BenchmarkData> {
         println!("identity_p254");
 
-        let opts = ProverOpts::succinct();
+        let opts = ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Succinct);
         let info = util::prove(client, &util::loop_env(0)?, LOOP_ELF, &opts)?;
 
         let InnerReceipt::Succinct(receipt) = info.receipt.inner else {

--- a/risc0/circuit/recursion/src/control_id.rs
+++ b/risc0/circuit/recursion/src/control_id.rs
@@ -15,6 +15,9 @@
 use risc0_zkp::core::digest::Digest;
 use risc0_zkp::digest;
 
+/// Smallest cycle limit, as a power of two (po2), supported as a lift program.
+pub const MIN_LIFT_PO2: usize = 14;
+
 /// Control IDs allowed in the default set of recursion programs. Includes control IDs for the base
 /// set of recursion programs, and each power-of-two of the rv32im circuit, using Poseidon2.
 pub const ALLOWED_CONTROL_IDS: &[Digest] = &[
@@ -27,8 +30,6 @@ pub const ALLOWED_CONTROL_IDS: &[Digest] = &[
     digest!("17d75c070f373f333bbbaf33a688bb74fc05670435cd5d6378d37b608448e300"), // rv32im po2=19
     digest!("f3cf1217485c403cea526b1e52e70835c31bdc6e3016ee12916f6c6561fc0977"), // rv32im po2=20
     digest!("4043ce1426811d4f0e6a9c27256d052513c95739e9b80c74f628f313c739b75c"), // rv32im po2=21
-    digest!("b4edfc3f2c49f10285bcdc7493eb81063959820a59569356fb73b62c1586e01f"), // rv32im po2=22
-    digest!("cc1bd6753bb8fd41d41bba14bb56e90ffa9ddf4f20f7727734d140675a9cc52b"), // rv32im po2=23
     digest!("0e51536ec08ac01e42de3d2a0b2a552d8ff2c75e4ef2b5285eed23582a13ef5d"), // recursion identity.zkr
     digest!("d7b56f6ef29d18203ac26960eb21160d60da6f1975124261fbe38d1364fa0e6b"), // recursion join.zkr
     digest!("1131f74f290f9d52f9aa2e7343b0445dff1765597a1e1849ed5f3f0afaba9f4e"), // recursion lift_14.zkr
@@ -39,15 +40,12 @@ pub const ALLOWED_CONTROL_IDS: &[Digest] = &[
     digest!("c607b103592326302802cf1ff1c6ee5dab7f112e85c6106b4085e55c46535f1d"), // recursion lift_19.zkr
     digest!("deca5917ab949d3769a17415d4b5753d0a49f818af600815ad92c85067322217"), // recursion lift_20.zkr
     digest!("cc4245191072ea38989b65721112584cd548385f0eda402d76c70e0e718e0f73"), // recursion lift_21.zkr
-    digest!("dd6cd51e766f484d625df405e74e11067283c1269dbdae21bc6a031b1daa952e"), // recursion lift_22.zkr
-    digest!("4726ab732cc10d26e233aa6c82a32001f2d83a1878e5da7531017b737054dc6d"), // recursion lift_23.zkr
-    digest!("8ea32467c6445926da67365554e3b64be92a5076d071ff0632f45b294787253f"), // recursion lift_24.zkr
     digest!("18386311e4b86b527f3d966de55df3271f7e52209c037b607a41a62c8b4c9f61"), // recursion resolve.zkr
 ];
 
 /// Root of the Merkle tree constructed from [ALLOWED_CONTROL_IDS], using Poseidon2.
 pub const ALLOWED_CONTROL_ROOT: Digest =
-    digest!("9a3767040e4cf554112afa68bc043274a8636a06565e1d5e2b7fa90fda941218");
+    digest!("8b6dcf11d463ac455361b41fb3ed053febb817491bdea00fdb340e45013b852e");
 
 /// Control ID for the identity recursion programs (ZKR), using Poseidon over the BN254 scalar field.
 pub const BN254_IDENTITY_CONTROL_ID: Digest =

--- a/risc0/circuit/rv32im/src/control_id.rs
+++ b/risc0/circuit/rv32im/src/control_id.rs
@@ -15,7 +15,7 @@
 use risc0_zkp::core::digest::Digest;
 use risc0_zkp::digest;
 
-const CONTROL_ID_ENTRIES: usize = risc0_zkp::MAX_CYCLES_PO2 - risc0_zkp::MIN_CYCLES_PO2;
+const CONTROL_ID_ENTRIES: usize = risc0_zkp::MAX_CYCLES_PO2 - risc0_zkp::MIN_CYCLES_PO2 + 1;
 
 pub type ControlIds = [Digest; CONTROL_ID_ENTRIES];
 
@@ -32,6 +32,7 @@ pub const SHA256_CONTROL_IDS: ControlIds = [
     digest!("0d85ecb4d16be50857cf50883e5b66e3f7185b2aeb5a7479cfad24ec61306b9b"), // rv32im po2=21
     digest!("a60d1c94faf9ca4be54d70518502139d260882d0d981d6199152b9e1468db984"), // rv32im po2=22
     digest!("5a10d231bc367d19130b29acb569eb7f3827b67e47a271f947e3e209945283f1"), // rv32im po2=23
+    digest!("da30893f75e7b069cb0004874a0bcb0f7b713aa30be88b3135eda6758bfd780b"), // rv32im po2=24
 ];
 
 /// Control IDs for each power-of-two of the rv32im circuit using Poseidon2.
@@ -47,6 +48,7 @@ pub const POSEIDON2_CONTROL_IDS: ControlIds = [
     digest!("4043ce1426811d4f0e6a9c27256d052513c95739e9b80c74f628f313c739b75c"), // rv32im po2=21
     digest!("b4edfc3f2c49f10285bcdc7493eb81063959820a59569356fb73b62c1586e01f"), // rv32im po2=22
     digest!("cc1bd6753bb8fd41d41bba14bb56e90ffa9ddf4f20f7727734d140675a9cc52b"), // rv32im po2=23
+    digest!("278eca2b9c62fe6936b6cf5c1b066b55d7620322f7c4331a21a5f92f851f6c6b"), // rv32im po2=24
 ];
 
 /// Control IDs for each power-of-two of the rv32im circuit using Blake2b.
@@ -62,4 +64,5 @@ pub const BLAKE2B_CONTROL_IDS: ControlIds = [
     digest!("87f1d53aa67abf141f10d14075de1c32b6ac818110bc1e5a90021ea9b8024c31"), // rv32im po2=21
     digest!("04d5432e6e4ce69dcf868b08418c1a30ef9e4d0cf350e889e1c2436095b06058"), // rv32im po2=22
     digest!("d0a94a254af9bfc8e457d5f84afe5150d680579cff65e37140720aa112e63b9f"), // rv32im po2=23
+    digest!("46b765782f325e05cf04188e530fa6f33c6a8c33050f3b929bd6eedb541eb5a0"), // rv32im po2=24
 ];

--- a/risc0/circuit/rv32im/src/prove/engine/loader.rs
+++ b/risc0/circuit/rv32im/src/prove/engine/loader.rs
@@ -374,7 +374,7 @@ impl Loader {
     pub fn compute_control_id_table<H: Hal<Elem = BabyBearElem>>(hal: &H) -> Vec<(String, Digest)> {
         // Make the digest for each level
         let mut table = Vec::new();
-        for po2 in MIN_CYCLES_PO2..MAX_CYCLES_PO2 {
+        for po2 in MIN_CYCLES_PO2..=MAX_CYCLES_PO2 {
             table.push((
                 format!("rv32im po2={po2}"),
                 Self::compute_control_id(hal, po2),

--- a/risc0/zkvm/examples/datasheet.rs
+++ b/risc0/zkvm/examples/datasheet.rs
@@ -23,7 +23,8 @@ use enum_iterator::Sequence;
 use human_repr::{HumanCount, HumanDuration};
 use risc0_zkp::{hal::tracker, MAX_CYCLES_PO2};
 use risc0_zkvm::{
-    get_prover_server, ExecutorEnv, ExecutorImpl, ProverOpts, VerifierContext, RECURSION_PO2,
+    get_prover_server, ExecutorEnv, ExecutorImpl, ProverOpts, ReceiptKind, VerifierContext,
+    RECURSION_PO2,
 };
 use risc0_zkvm_methods::{bench::BenchmarkSpec, BENCH_ELF};
 use serde::Serialize;
@@ -171,7 +172,7 @@ impl Datasheet {
 
     fn composite(&mut self, args: &Args) {
         for hashfn in ["sha-256", "poseidon2"] {
-            let opts = ProverOpts::default().with_hashfn(hashfn.to_string());
+            let opts = ProverOpts::all_po2s().with_hashfn(hashfn.to_string());
             let prover = get_prover_server(&opts).unwrap();
 
             for (iterations, expected) in ITERATIONS.iter().take(args.max_po2 - MIN_PO2 + 1) {
@@ -219,9 +220,9 @@ impl Datasheet {
     fn lift(&mut self) {
         println!("lift");
 
-        let opts = ProverOpts::default();
+        let opts = ProverOpts::all_po2s();
         let prover = get_prover_server(&opts).unwrap();
-        let ctx = VerifierContext::default();
+        let ctx = VerifierContext::all_po2s();
 
         let env = ExecutorEnv::builder()
             .write(&BenchmarkSpec::SimpleLoop { iters: 0 })
@@ -259,9 +260,9 @@ impl Datasheet {
     fn join(&mut self) {
         println!("join");
 
-        let opts = ProverOpts::default();
+        let opts = ProverOpts::all_po2s();
         let prover = get_prover_server(&opts).unwrap();
-        let ctx = VerifierContext::default();
+        let ctx = VerifierContext::all_po2s();
 
         let env = ExecutorEnv::builder()
             .write(&BenchmarkSpec::SimpleLoop { iters: 4 * 1024 })
@@ -303,7 +304,7 @@ impl Datasheet {
     fn succinct(&mut self) {
         println!("succinct");
 
-        let opts = ProverOpts::succinct();
+        let opts = ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Succinct);
         let prover = get_prover_server(&opts).unwrap();
 
         let env = ExecutorEnv::builder()
@@ -342,7 +343,7 @@ impl Datasheet {
     fn identity_p254(&mut self) {
         println!("identity_p254");
 
-        let opts = ProverOpts::succinct();
+        let opts = ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Succinct);
         let prover = get_prover_server(&opts).unwrap();
 
         let env = ExecutorEnv::builder()
@@ -380,7 +381,7 @@ impl Datasheet {
     fn stark2snark(&mut self) {
         println!("stark2snark");
 
-        let opts = ProverOpts::succinct();
+        let opts = ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Succinct);
         let prover = get_prover_server(&opts).unwrap();
 
         let env = ExecutorEnv::builder()
@@ -417,7 +418,7 @@ impl Datasheet {
     fn groth16(&mut self) {
         println!("groth16");
 
-        let opts = ProverOpts::groth16();
+        let opts = ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Groth16);
         let prover = get_prover_server(&opts).unwrap();
 
         let env = ExecutorEnv::builder()
@@ -452,7 +453,7 @@ impl Datasheet {
         {
             println!("warmup");
 
-            let opts = ProverOpts::succinct();
+            let opts = ProverOpts::all_po2s().with_receipt_kind(ReceiptKind::Succinct);
             let prover = get_prover_server(&opts).unwrap();
 
             let env = ExecutorEnv::builder()

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -227,6 +227,10 @@ impl TryFrom<pb::api::ProverOpts> for ProverOpts {
                 .into_iter()
                 .map(TryInto::try_into)
                 .collect::<Result<_>>()?,
+            max_segment_po2: opts
+                .max_segment_po2
+                .try_into()
+                .map_err(|_| malformed_err())?,
         })
     }
 }
@@ -238,6 +242,7 @@ impl From<ProverOpts> for pb::api::ProverOpts {
             prove_guest_errors: opts.prove_guest_errors,
             receipt_kind: opts.receipt_kind as i32,
             control_ids: opts.control_ids.into_iter().map(Into::into).collect(),
+            max_segment_po2: opts.max_segment_po2 as u64,
         }
     }
 }

--- a/risc0/zkvm/src/host/client/prove/mod.rs
+++ b/risc0/zkvm/src/host/client/prove/mod.rs
@@ -24,13 +24,12 @@ use risc0_build::risc0_data;
 use serde::{Deserialize, Serialize};
 
 use risc0_circuit_recursion::control_id::ALLOWED_CONTROL_IDS;
-use risc0_circuit_rv32im::control_id::SHA256_CONTROL_IDS;
 use risc0_zkp::core::digest::Digest;
 
 use self::{bonsai::BonsaiProver, external::ExternalProver};
 use crate::{
-    get_version, host::prove_info::ProveInfo, is_dev_mode, ExecutorEnv, Receipt, SessionInfo,
-    VerifierContext,
+    get_version, host::prove_info::ProveInfo, is_dev_mode, receipt::DEFAULT_MAX_PO2, ExecutorEnv,
+    Receipt, SessionInfo, VerifierContext,
 };
 
 /// A Prover can execute a given ELF binary and produce a
@@ -92,7 +91,12 @@ pub trait Prover {
         elf: &[u8],
         opts: &ProverOpts,
     ) -> Result<ProveInfo> {
-        self.prove_with_ctx(env, &VerifierContext::default(), elf, opts)
+        self.prove_with_ctx(
+            env,
+            &VerifierContext::from_max_po2(opts.max_segment_po2),
+            elf,
+            opts,
+        )
     }
 
     /// Prove zkVM execution of the specified ELF binary and using the specified [VerifierContext]
@@ -163,6 +167,8 @@ pub struct ProverOpts {
     /// programs that are allowed to run and is a key field in the
     /// [SuccinctReceiptVerifierParameters][crate::SuccinctReceiptVerifierParameters].
     pub control_ids: Vec<Digest>,
+    /// Maximum cycle count, as a power of two (po2) that these prover options support.
+    pub(crate) max_segment_po2: usize,
 }
 
 /// An enumeration of receipt kinds that can be requested to be generated.
@@ -196,11 +202,38 @@ impl Default for ProverOpts {
             prove_guest_errors: false,
             receipt_kind: ReceiptKind::Composite,
             control_ids: ALLOWED_CONTROL_IDS.to_vec(),
+            max_segment_po2: DEFAULT_MAX_PO2,
         }
     }
 }
 
 impl ProverOpts {
+    /// Construct a [ProverOpts] ready to prove segments with up to the given max cycle count as a
+    /// power of two (po2). All fields are equal to the default expect where they need to be
+    /// adjusted to support a larger po2.
+    ///
+    /// NOTE: If the po2 used to prove is greater than the targeted verifier supports,
+    /// [DEFAULT_MAX_PO2] by default, receipts will be rejected by the verifier.
+    #[stability::unstable]
+    pub fn from_max_po2(po2_max: usize) -> Self {
+        Self {
+            hashfn: "poseidon2".to_string(),
+            prove_guest_errors: false,
+            receipt_kind: ReceiptKind::Composite,
+            control_ids: crate::receipt::succinct::allowed_control_ids("poseidon2", po2_max)
+                .unwrap()
+                .collect(),
+            max_segment_po2: po2_max,
+        }
+    }
+
+    /// Construct a verifier context that will accept receipts with control any of the default
+    /// control ID associated with cycle counts of all supported powers of two (po2).
+    #[stability::unstable]
+    pub fn all_po2s() -> Self {
+        Self::from_max_po2(risc0_zkp::MAX_CYCLES_PO2)
+    }
+
     /// Choose the fastest prover options. Receipt will be linear in length of the execution,
     /// and does not support compression via recursion.
     pub fn fast() -> Self {
@@ -208,7 +241,8 @@ impl ProverOpts {
             hashfn: "sha-256".to_string(),
             prove_guest_errors: false,
             receipt_kind: ReceiptKind::Composite,
-            control_ids: SHA256_CONTROL_IDS.to_vec(),
+            control_ids: risc0_circuit_rv32im::control_ids("sha-256", DEFAULT_MAX_PO2).collect(),
+            max_segment_po2: DEFAULT_MAX_PO2,
         }
     }
 
@@ -220,6 +254,7 @@ impl ProverOpts {
             prove_guest_errors: false,
             receipt_kind: ReceiptKind::Composite,
             control_ids: ALLOWED_CONTROL_IDS.to_vec(),
+            max_segment_po2: DEFAULT_MAX_PO2,
         }
     }
 
@@ -231,6 +266,7 @@ impl ProverOpts {
             prove_guest_errors: false,
             receipt_kind: ReceiptKind::Succinct,
             control_ids: ALLOWED_CONTROL_IDS.to_vec(),
+            max_segment_po2: DEFAULT_MAX_PO2,
         }
     }
 
@@ -244,6 +280,7 @@ impl ProverOpts {
             prove_guest_errors: false,
             receipt_kind: ReceiptKind::Groth16,
             control_ids: ALLOWED_CONTROL_IDS.to_vec(),
+            max_segment_po2: DEFAULT_MAX_PO2,
         }
     }
 
@@ -275,6 +312,15 @@ impl ProverOpts {
     pub fn with_control_ids(self, control_ids: Vec<Digest>) -> Self {
         Self {
             control_ids,
+            ..self
+        }
+    }
+
+    /// Return [ProverOpts] with the max_segment_po2 set to the given value.
+    #[stability::unstable]
+    pub fn with_segment_po2_max(self, max_segment_po2: usize) -> Self {
+        Self {
+            max_segment_po2,
             ..self
         }
     }

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -172,6 +172,7 @@ message ProverOpts {
   bool prove_guest_errors = 2;
   ReceiptKind receipt_kind = 3;
   repeated base.Digest control_ids = 4;
+  uint64 max_segment_po2 = 5;
 }
 
 enum ReceiptKind {

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -331,6 +331,8 @@ pub struct ProverOpts {
     pub receipt_kind: i32,
     #[prost(message, repeated, tag = "4")]
     pub control_ids: ::prost::alloc::vec::Vec<super::base::Digest>,
+    #[prost(uint64, tag = "5")]
+    pub max_segment_po2: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -391,6 +391,6 @@ fn stable_root() {
 
     assert_eq!(
         ALLOWED_CONTROL_ROOT,
-        digest!("9a3767040e4cf554112afa68bc043274a8636a06565e1d5e2b7fa90fda941218")
+        digest!("8b6dcf11d463ac455361b41fb3ed053febb817491bdea00fdb340e45013b852e")
     );
 }

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use risc0_circuit_rv32im::prove::SegmentProver;
 
 use super::ProverServer;
@@ -165,6 +165,13 @@ impl ProverServer for ProverImpl {
     }
 
     fn prove_segment(&self, ctx: &VerifierContext, segment: &Segment) -> Result<SegmentReceipt> {
+        ensure!(
+            segment.po2() <= self.opts.max_segment_po2,
+            "segment po2 exceeds max on ProverOpts: {} > {}",
+            segment.po2(),
+            self.opts.max_segment_po2
+        );
+
         let seal = self.segment_prover.prove_segment(&segment.inner)?;
 
         let mut claim = decode_receipt_claim_from_seal(&seal)?;

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -144,7 +144,7 @@ pub use receipt::{
     AssumptionReceipt, CompositeReceipt, CompositeReceiptVerifierParameters, FakeReceipt,
     InnerAssumptionReceipt, InnerReceipt, Journal, Receipt, ReceiptMetadata, SegmentReceipt,
     SegmentReceiptVerifierParameters, SuccinctReceipt, SuccinctReceiptVerifierParameters,
-    VerifierContext,
+    VerifierContext, DEFAULT_MAX_PO2,
 };
 //#[cfg(any(not(target_os = "zkvm"), feature = "std"))]
 pub use receipt::{Groth16Receipt, Groth16ReceiptVerifierParameters};

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -652,6 +652,12 @@ impl From<InnerReceipt> for InnerAssumptionReceipt {
     }
 }
 
+/// Maximum segment size, as a power of two (po2) that the default verifier parameters will accept.
+///
+/// A default of 21 was selected to reach a target of 97 bits of security under our analysis. Using
+/// a po2 higher than 21 shows a degradation of 1 bit of security per po2, to 94 bits at po2 24.
+pub const DEFAULT_MAX_PO2: usize = 21;
+
 /// Context available to the verification process.
 #[non_exhaustive]
 pub struct VerifierContext {
@@ -686,6 +692,32 @@ impl VerifierContext {
             ("poseidon2".into(), Poseidon2HashSuite::new_suite()),
             ("sha-256".into(), Sha256HashSuite::new_suite()),
         ])
+    }
+
+    /// Construct a verifier context that will accept receipts with control any of the default
+    /// control ID associated with cycle counts as powers of two (po2) up to the given max
+    /// inclusive.
+    #[stability::unstable]
+    pub fn from_max_po2(po2_max: usize) -> Self {
+        Self {
+            suites: Self::default_hash_suites(),
+            segment_verifier_parameters: Some(SegmentReceiptVerifierParameters::from_max_po2(
+                po2_max,
+            )),
+            succinct_verifier_parameters: Some(SuccinctReceiptVerifierParameters::from_max_po2(
+                po2_max,
+            )),
+            groth16_verifier_parameters: Some(Groth16ReceiptVerifierParameters::from_max_po2(
+                po2_max,
+            )),
+        }
+    }
+
+    /// Construct a verifier context that will accept receipts with control any of the default
+    /// control ID associated with cycle counts of all supported powers of two (po2).
+    #[stability::unstable]
+    pub fn all_po2s() -> Self {
+        Self::from_max_po2(risc0_zkp::MAX_CYCLES_PO2)
     }
 
     /// Return [VerifierContext] with the given map of hash suites.

--- a/risc0/zkvm/src/receipt/composite.rs
+++ b/risc0/zkvm/src/receipt/composite.rs
@@ -240,6 +240,27 @@ pub struct CompositeReceiptVerifierParameters {
     pub groth16: MaybePruned<Groth16ReceiptVerifierParameters>,
 }
 
+impl CompositeReceiptVerifierParameters {
+    /// Construct verifier parameters that will accept receipts with control any of the default
+    /// control ID associated with cycle counts as powers of two (po2) up to the given max
+    /// inclusive.
+    #[stability::unstable]
+    pub fn from_max_po2(po2_max: usize) -> Self {
+        Self {
+            segment: MaybePruned::Value(SegmentReceiptVerifierParameters::from_max_po2(po2_max)),
+            succinct: MaybePruned::Value(SuccinctReceiptVerifierParameters::from_max_po2(po2_max)),
+            groth16: MaybePruned::Value(Groth16ReceiptVerifierParameters::from_max_po2(po2_max)),
+        }
+    }
+
+    /// Construct verifier parameters that will accept receipts with control any of the default
+    /// control ID associated with cycle counts of all supported powers of two (po2).
+    #[stability::unstable]
+    pub fn all_po2s() -> Self {
+        Self::from_max_po2(risc0_zkp::MAX_CYCLES_PO2)
+    }
+}
+
 impl Digestible for CompositeReceiptVerifierParameters {
     /// Hash the [Groth16ReceiptVerifierParameters] to get a digest of the struct.
     fn digest<S: Sha256>(&self) -> Digest {
@@ -280,7 +301,7 @@ mod tests {
     fn composite_receipt_verifier_parameters_is_stable() {
         assert_eq!(
             CompositeReceiptVerifierParameters::default().digest(),
-            digest!("9d30e0a248d01263aa8a61aff7f614a090c19f9e98c8832e2e9c1a43b12de1fd")
+            digest!("e676b5e35f46df092b82e64c17d1b9d96341c70c03e68cb6ebd0968e5529c193")
         );
     }
 }

--- a/risc0/zkvm/src/receipt/groth16.rs
+++ b/risc0/zkvm/src/receipt/groth16.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 
 // Make succinct receipt available through this `receipt` module.
 use crate::{
-    receipt::VerifierContext,
+    receipt::{succinct::allowed_control_root, VerifierContext},
     receipt_claim::{MaybePruned, Unknown},
     sha,
 };
@@ -128,6 +128,27 @@ pub struct Groth16ReceiptVerifierParameters {
     pub verifying_key: VerifyingKey,
 }
 
+impl Groth16ReceiptVerifierParameters {
+    /// Construct verifier parameters that will accept receipts with control any of the default
+    /// control ID associated with cycle counts as powers of two (po2) up to the given max
+    /// inclusive.
+    #[stability::unstable]
+    pub fn from_max_po2(po2_max: usize) -> Self {
+        Self {
+            control_root: allowed_control_root("poseidon2", po2_max).unwrap(),
+            bn254_control_id: BN254_IDENTITY_CONTROL_ID,
+            verifying_key: risc0_groth16::verifying_key(),
+        }
+    }
+
+    /// Construct verifier parameters that will accept receipts with control any of the default
+    /// control ID associated with cycle counts of all supported powers of two (po2).
+    #[stability::unstable]
+    pub fn all_po2s() -> Self {
+        Self::from_max_po2(risc0_zkp::MAX_CYCLES_PO2)
+    }
+}
+
 impl Digestible for Groth16ReceiptVerifierParameters {
     /// Hash the [Groth16ReceiptVerifierParameters] to get a digest of the struct.
     fn digest<S: Sha256>(&self) -> Digest {
@@ -168,7 +189,7 @@ mod tests {
     fn groth16_receipt_verifier_parameters_is_stable() {
         assert_eq!(
             Groth16ReceiptVerifierParameters::default().digest(),
-            digest!("4c630d87e830256effaae0f27082e2fee7ce4d7e06bcf56c4ec538c3d77aca98")
+            digest!("50bd1769093e74abda3711c315d84d78e3e282173f6304a33272d92abb590ef5")
         );
     }
 }

--- a/risc0/zkvm/src/receipt/merkle.rs
+++ b/risc0/zkvm/src/receipt/merkle.rs
@@ -23,7 +23,6 @@
 // change the circuit later, this is set to 8 which allows for enough control IDs to be encoded
 // that we are unlikely to need more.
 /// Depth of the Merkle tree to use for encoding the set of allowed control IDs.
-#[cfg(feature = "prove")]
 pub const ALLOWED_CODE_MERKLE_DEPTH: usize = 8;
 
 use alloc::vec::Vec;
@@ -37,7 +36,6 @@ use serde::{Deserialize, Serialize};
 /// Merkle tree implementation used in the recursion system to commit to a set of recursion
 /// programs, and to verify the inclusion of a given program in the set.
 #[non_exhaustive]
-#[cfg(feature = "prove")]
 pub struct MerkleGroup {
     /// Depth of the Merkle tree.
     pub depth: u32,
@@ -58,7 +56,6 @@ pub struct MerkleProof {
     pub digests: Vec<Digest>,
 }
 
-#[cfg(feature = "prove")]
 impl MerkleGroup {
     /// Create a new [MerkleGroup] from the given leaves.
     /// Will fail if too many leaves are given for the default depth.
@@ -100,6 +97,7 @@ impl MerkleGroup {
 
     /// Calculate and return a [MerkleProof] for the given leaf.
     /// Will return an error if the given leaf is not in the tree.
+    #[cfg(feature = "prove")]
     pub fn get_proof(
         &self,
         control_id: &Digest,
@@ -113,6 +111,7 @@ impl MerkleGroup {
 
     /// Calculate and return a [MerkleProof] for the given leaf.
     /// Will panic if the given index is out of the range of leaves.
+    #[cfg(feature = "prove")]
     pub fn get_proof_by_index(&self, index: u32, hashfn: &dyn HashFn<BabyBear>) -> MerkleProof {
         let mut digests: Vec<Digest> = Vec::with_capacity(self.depth as usize);
 

--- a/xtask/src/bootstrap.rs
+++ b/xtask/src/bootstrap.rs
@@ -26,10 +26,11 @@ use risc0_zkp::{
     },
     field::baby_bear::BabyBear,
     hal::cpu::CpuHal,
+    MIN_CYCLES_PO2,
 };
 use risc0_zkvm::{
     recursion::{MerkleGroup, Program},
-    Loader, RECURSION_PO2,
+    Loader, DEFAULT_MAX_PO2, RECURSION_PO2,
 };
 
 #[derive(Parser)]
@@ -37,6 +38,8 @@ pub struct Bootstrap;
 
 const CONTROL_ID_PATH_RV32IM: &str = "risc0/circuit/rv32im/src/control_id.rs";
 const CONTROL_ID_PATH_RECURSION: &str = "risc0/circuit/recursion/src/control_id.rs";
+
+const MIN_LIFT_PO2: usize = 14;
 
 impl Bootstrap {
     // Format a list of control IDs, including a description as comments.
@@ -96,18 +99,22 @@ impl Bootstrap {
             .status()
             .expect("failed to format {CONTROL_ID_PATH_RV32IM}");
 
-        control_id_poseidon2
+        // Return the control IDs that should be included in the allowed control IDs that are used
+        // by default in segment receipt verification, and in forming the control root.
+        control_id_poseidon2[..=DEFAULT_MAX_PO2 - MIN_CYCLES_PO2].to_vec()
     }
 
     fn generate_recursion_control_ids(poseidon2_rv32im_control_ids: Vec<(String, Digest)>) {
-        // Recursion programs (ZKRs) that are to be included in the allowed set.
+        // Recursion programs (ZKRs) that are to be included in the allowed set, used in the
+        // default verifier context.
         // NOTE: We use an allow list here, rather than including all ZKRs in the zip archive,
         // because there may be ZKRs included only for tests, or ones that are not part of the main
-        // set of allowed programs (e.g. accelerators).
+        // set of allowed programs (e.g. accelerators, and po2 22-24). Those programs can be
+        // enabled by using a custom VerifierContext.
         let allowed_zkr_names: HashSet<String> = ["join.zkr", "resolve.zkr", "identity.zkr"]
             .map(str::to_string)
             .into_iter()
-            .chain((14..=24).map(|i| format!("lift_{i}.zkr")))
+            .chain((MIN_LIFT_PO2..=DEFAULT_MAX_PO2).map(|i| format!("lift_{i}.zkr")))
             .collect();
 
         tracing::info!("unzipping recursion programs (zkrs)");
@@ -145,6 +152,7 @@ impl Bootstrap {
         tracing::info!("Computed bn254_identity_control_id: {bn254_identity_control_id}");
         let contents = format!(
             include_str!("templates/control_id_zkr.rs"),
+            MIN_LIFT_PO2,
             Self::format_control_ids(&allowed_control_ids),
             allowed_control_root,
             bn254_identity_control_id,

--- a/xtask/src/templates/control_id_rv32im.rs
+++ b/xtask/src/templates/control_id_rv32im.rs
@@ -15,7 +15,7 @@
 use risc0_zkp::core::digest::Digest;
 use risc0_zkp::digest;
 
-const CONTROL_ID_ENTRIES: usize = risc0_zkp::MAX_CYCLES_PO2 - risc0_zkp::MIN_CYCLES_PO2;
+const CONTROL_ID_ENTRIES: usize = risc0_zkp::MAX_CYCLES_PO2 - risc0_zkp::MIN_CYCLES_PO2 + 1;
 
 pub type ControlIds = [Digest; CONTROL_ID_ENTRIES];
 

--- a/xtask/src/templates/control_id_zkr.rs
+++ b/xtask/src/templates/control_id_zkr.rs
@@ -15,6 +15,9 @@
 use risc0_zkp::core::digest::Digest;
 use risc0_zkp::digest;
 
+/// Smallest cycle limit, as a power of two (po2), supported as a lift program.
+pub const MIN_LIFT_PO2: usize = {};
+
 /// Control IDs allowed in the default set of recursion programs. Includes control IDs for the base
 /// set of recursion programs, and each power-of-two of the rv32im circuit, using Poseidon2.
 pub const ALLOWED_CONTROL_IDS: &[Digest] = &[{}];


### PR DESCRIPTION
As part of our continual security analysis work, we've created a calculated for the "bits of security" given all the system parameters relevant to the soundness of the proof of knowledge property guaranteed to the verifier. With this, we find that the lookup argument may not achieve our targeted 97 bits of soundness under worse case assumptions grounded in the Schwartz-Zippel lemma. Under these assumptions, up to 3 bits of security are given up by including segment sizes up to power of two 24, relative to po2 21.

This PR implements the cautious approach of removing po2s above 21 from the default verifier parameters. Developers that wish to use po2 22, 23, or 24 may opt-in by using a non-default `VerifierContext`.

Additionally, this PR fixes a pair of off-by-one errors that had removed the rv32im control IDs for po2 24. Technically, this constitutes a breaking change in the `risc0-circuit-rv32im` crate since the public type `ControlIds` is not a fixed array of length n+1.

https://github.com/risc0/risc0/pull/2276/files#diff-ce2293a7cee10116f619bedf007ecfedd524505b764cfe5383785b7bd17dd7c4

Note: It is expected that the `risc0-ethereum` CI job will fail right now, because the control root is changed. It will pass again once we've merged this and https://github.com/risc0/risc0-ethereum/pull/205 to their respective `main`.

---------