### PR TITLE
Added clear callout to risc0-ethereum repo on ethereum examples page

### DIFF
--- a/website/api/blockchain-integration/eth-examples.md
+++ b/website/api/blockchain-integration/eth-examples.md
@@ -1,5 +1,9 @@
 # Ethereum Examples
 
+:::tip
+The [risc0-ethereum][risc0-ethereum] repo is where you can find [blockchain examples][blockchain-examples], [verifier contracts][verifier-contracts] and [Steel][steel-src].
+:::
+
 While all of the [zkVM examples][zkvm-examples] can be run on Bonsai by [configuring Bonsai][remote-proving] as your remote prover, those examples do not interact with or are intended to interact with Ethereum or any other blockchain. The references below are examples of how Bonsai and the zkVM can be integrated with Ethereum.
 
 ### Foundry Template
@@ -18,14 +22,18 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
+[blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/main/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
 [governance-example]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance
 [Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
 [remote-proving]: ../generating-proofs/remote-proving.md
 [revm]: https://crates.io/crates/revm
+[risc0-ethereum]: https://github.com/risc0/risc0-ethereum
 [signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
+[steel-src]: https://github.com/risc0/risc0-ethereum/tree/main/steel
 [steel-blog]: https://www.risczero.com/blog/introducing-steel
 [steel-repo]: https://crates.io/crates/risc0-steel
+[verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/main/contracts
 [zeth-article]: https://www.risczero.com/news/zeth-release
 [zeth-repo]: https://github.com/risc0/zeth
 [zkvm-examples]: ../zkvm/examples.md

--- a/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
+++ b/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
@@ -22,18 +22,18 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
-[blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/main/examples
+[blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
 [governance-example]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance
 [Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
 [remote-proving]: ../generating-proofs/remote-proving.md
 [revm]: https://crates.io/crates/revm
-[risc0-ethereum]: https://github.com/risc0/risc0-ethereum
+[risc0-ethereum]: https://github.com/risc0/risc0-ethereum/tree/release-1.0
 [signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
-[steel-src]: https://github.com/risc0/risc0-ethereum/tree/main/steel
+[steel-src]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/steel
 [steel-blog]: https://www.risczero.com/blog/introducing-steel
 [steel-repo]: https://crates.io/crates/risc0-steel
-[verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/main/contracts
+[verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/contracts
 [zeth-article]: https://www.risczero.com/news/zeth-release
 [zeth-repo]: https://github.com/risc0/zeth
 [zkvm-examples]: /api/zkvm/examples

--- a/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
+++ b/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
@@ -1,5 +1,9 @@
 # Ethereum Examples
 
+:::tip
+The [risc0-ethereum][risc0-ethereum] repo is where you can find [blockchain examples][blockchain-examples], [verifier contracts][verifier-contracts] and [Steel][steel-src].
+:::
+
 While all of the [zkVM examples][zkvm-examples] can be run on Bonsai by [configuring Bonsai][remote-proving] as your remote prover, those examples do not interact with or are intended to interact with Ethereum or any other blockchain. The references below are examples of how Bonsai and the zkVM can be integrated with Ethereum.
 
 ### Foundry Template
@@ -18,14 +22,18 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
+[blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/main/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
 [governance-example]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance
 [Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
 [remote-proving]: ../generating-proofs/remote-proving.md
 [revm]: https://crates.io/crates/revm
+[risc0-ethereum]: https://github.com/risc0/risc0-ethereum
 [signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
+[steel-src]: https://github.com/risc0/risc0-ethereum/tree/main/steel
 [steel-blog]: https://www.risczero.com/blog/introducing-steel
 [steel-repo]: https://crates.io/crates/risc0-steel
+[verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/main/contracts
 [zeth-article]: https://www.risczero.com/news/zeth-release
 [zeth-repo]: https://github.com/risc0/zeth
 [zkvm-examples]: /api/zkvm/examples


### PR DESCRIPTION
Based on feedback from devs at hackathons, and after a discussion with Victor, we are missing a clear CTA for the `risc0-ethereum` repo. 

Whilst I'm working on cleaning up the examples (and this `eth-examples` page alongside it), I want to add a temporary callout that "fixes" this issue for now.

## Changes 

Added a tip on 'Ethereum Examples' page seen here:

<img width="998" alt="image" src="https://github.com/user-attachments/assets/ac732c91-c75b-4d0e-9554-ae52f063f57a">
