### PR TITLE
fix(risc0-build): Fix null-builds under custom rustc flags

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -370,20 +370,19 @@ where
         .iter()
         .filter(|target| target.kind.iter().any(|kind| kind == "bin"))
         .map(|target| {
-            let elf_path = target_dir
-                .as_ref()
-                .join("riscv32im-risc0-zkvm-elf")
-                .join("docker")
-                .join(pkg.name.replace('-', "_"))
-                .join(&target.name)
-                .to_str()
-                .context("elf path contains invalid unicode")
-                .unwrap()
-                .to_string();
-            G::build(&target.name, &elf_path).expect(&format!(
-                "Failed to locate ELF for guest {} at {}",
-                &target.name, elf_path
-            ))
+            G::build(
+                &target.name,
+                target_dir
+                    .as_ref()
+                    .join("riscv32im-risc0-zkvm-elf")
+                    .join("docker")
+                    .join(pkg.name.replace('-', "_"))
+                    .join(&target.name)
+                    .to_str()
+                    .context("elf path contains invalid unicode")
+                    .unwrap(),
+            )
+            .unwrap()
         })
         .collect()
 }

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -711,6 +711,7 @@ fn do_embed_methods<G: GuestBuilder>(
 ) -> Vec<G> {
     let out_dir_env = env::var_os("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir_env); // $ROOT/target/$profile/build/$crate/out
+
     // Read the cargo metadata for info from `[package.metadata.risc0]`.
     let pkg = current_package();
     let guest_packages = guest_packages(&pkg);


### PR DESCRIPTION
This PR gives each guest its own target directory based on its host package and guest package names to fix build-caching when using non-uniform rustc flags for different guests under the same host package.