### PR TITLE
docs: fix invalid links

### DIFF
--- a/website/api/blockchain-integration/contracts/verifier.md
+++ b/website/api/blockchain-integration/contracts/verifier.md
@@ -60,9 +60,9 @@ You can use the [deployed contracts for a released version][doc-released-contrac
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.Groth16Receipt.html
 [IRiscZeroVerifier]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/IRiscZeroVerifier.sol
 [RiscZeroVerifierRouter.sol]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/RiscZeroVerifierRouter.sol
-[term-image-id]: /terminology#image-id
-[term-journal]: /terminology#journal
-[term-receipt]: /terminology#receipt
-[term-verify]: /terminology#verify
-[term-zkvm]: /terminology#zero-knowledge-virtual-machine-zkvm
+[term-image-id]: /website/docs/terminology.md#image-id
+[term-journal]: /website/docs/terminology.md#journal
+[term-receipt]: /website/docs/terminology.md#receipt
+[term-verify]: /website/docs/terminology.md#verify
+[term-zkvm]: /website/docs/terminology.md#zero-knowledge-virtual-machine-zkvm
 [VersionManagement]: https://github.com/risc0/risc0-ethereum/blob/main/contracts/version-management-design.md

--- a/website/api/recursion.md
+++ b/website/api/recursion.md
@@ -140,13 +140,13 @@ All of the recursion programs in the previous section output a [SuccinctReceipt]
 The final step in the recursion process is `compress()`, which outputs a [Groth16Receipt], which can be verified on-chain using the [RISC Zero Verifier Contract].
 
 [`Prover::prove_with_opts`]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[assumption]: /terminology#assumption
+[assumption]: /website/docs/terminology.md#assumption
 [composite, succinct or groth16 receipts]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/enum.ReceiptKind.html
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.Groth16Receipt.html
 [proof composition]: ./zkvm/composition.md
-[proof system]: /proof-system/proof-system-sequence-diagram
+[proof system]: /website/docs/proof-system/proof-system-sequence-diagram.md
 [Prover]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[receipt claim]: /terminology#receipt-claim
+[receipt claim]: /website/docs/terminology.md#receipt-claim
 [reports.risczero.com]: https://reports.risczero.com
 [RISC Zero Verifier Contract]: blockchain-integration/contracts/verifier.md
 [SuccinctReceipt]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.SuccinctReceipt.html

--- a/website/api/zkvm/benchmarks.md
+++ b/website/api/zkvm/benchmarks.md
@@ -53,9 +53,9 @@ were added per second) with separate statistics for [execution] and
 the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
 appropriate feature flag.
 
-[cycle count]: /terminology#clock-cycles
+[cycle count]: /website/docs/terminology.md#clock-cycles
 [datasheet]: https://benchmarks.risczero.com/main/datasheet
-[execution]: /terminology#execute
+[execution]: /website/docs/terminology.md#execute
 [install]: ./install.md
-[prover]: /terminology#prover
+[prover]: /website/docs/terminology.md#prover
 [risc0 repository]: https://github.com/risc0/risc0

--- a/website/api/zkvm/profiling.md
+++ b/website/api/zkvm/profiling.md
@@ -103,7 +103,7 @@ web interface.
     synchronous and is not subject to any deviations in behavior due to
     measurement overhead.
 
-[cycle count]: /terminology#clock-cycles
+[cycle count]: /website/docs/terminology.md#clock-cycles
 [example-profiling]: https://github.com/risc0/risc0/tree/main/examples/profiling
 [flamegraph]: https://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html
 [golang-install]: https://go.dev/doc/install

--- a/website/api/zkvm/quickstart.md
+++ b/website/api/zkvm/quickstart.md
@@ -117,14 +117,14 @@ proportional to the number of cycles and segments used.
 [Bonsai]: ../generating-proofs/remote-proving.md
 [dev-mode]: ../generating-proofs/dev-mode.md
 [feature flags]: https://github.com/risc0/risc0#feature-flags
-[guest]: /terminology#guest-program
+[guest]: /website/docs/terminology.md#guest-program
 [hello-world]: ./tutorials/hello-world.md
-[host]: /terminology#host-program
-[journal]: /terminology#journal
-[prover]: /terminology#prover
-[receipt]: /terminology#receipt
+[host]: /website/docs/terminology.md#host-program
+[journal]: /website/docs/terminology.md#journal
+[prover]: /website/docs/terminology.md#prover
+[receipt]: /website/docs/terminology.md#receipt
 [request access]: https://bonsai.xyz/apply
-[seal]: /terminology#seal
+[seal]: /website/docs/terminology.md#seal
 [tutorial-step-2]: tutorials/hello-world.md#step-2-host-share-private-data-as-input-with-the-guest
 [tutorial-step-3]: tutorials/hello-world.md#step-3-guest-read-input-and-commit-output
 [tutorial-step-4]: tutorials/hello-world.md#step-4-host-generate-a-receipt-and-read-its-journal-contents

--- a/website/api/zkvm/receipts.md
+++ b/website/api/zkvm/receipts.md
@@ -59,15 +59,15 @@ is:
 
 `let bytes = bincode::serialize(&receipt);`
 
-[execution]: /terminology#execution-trace
-[guest program]: /terminology#guest-program
-[Image ID]: /terminology#image-id
-[journal]: /terminology#journal
-[receipt]: /terminology#receipt
+[execution]: /website/docs/terminology.md#execution-trace
+[guest program]: /website/docs/terminology.md#guest-program
+[Image ID]: /website/docs/terminology.md#image-id
+[journal]: /website/docs/terminology.md#journal
+[receipt]: /website/docs/terminology.md#receipt
 [receipt.journal]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html#structfield.journal
 [receipt.verify()]: https://docs.rs/risc0-zkvm/*/risc0_zkvm/struct.Receipt.html#method.verify
-[seal]: /terminology#seal
+[seal]: /website/docs/terminology.md#seal
 [serde]: https://crates.io/crates/serde
-[validity proof]: /terminology#validity-proof
-[verify]: /terminology#verify
+[validity proof]: /website/docs/terminology.md#validity-proof
+[verify]: /website/docs/terminology.md#verify
 [zkvm]: ./zkvm-overview.md

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -18,7 +18,7 @@ The complexity of a [guest program]'s [execution] is measured in clock cycles as
 
 Generally, a single cycle corresponds to a single [RISC-V] operation. However, some operations require two cycles.
 
-See the [Optimization Guide](/api/zkvm/optimization) for more information about the zkVM cycles and performance.
+See the [Optimization Guide](/website/api/zkvm/optimization.md) for more information about the zkVM cycles and performance.
 
 ### Commit
 
@@ -257,7 +257,7 @@ RISC Zero's zkVM implements the RISC-V instruction set architecture and uses a [
 [`cargo risczero build`]: https://docs.rs/crate/cargo-risczero/latest
 [About SNARKs]: https://ethereum.org/en/developers/docs/scaling/zk-rollups/#validity-proofs
 [About STARKs]: ./reference-docs/about-starks.md
-[Arithmetic Circuits]: /reference-docs/about-arithmetic-circuits
+[Arithmetic Circuits]: /website/docs/reference-docs/about-arithmetic-circuits.md
 [assumptions]: #assumption
 [circuit]: #circuit
 [clock cycles]: #clock-cycles


### PR DESCRIPTION
Some links within the document are not working. In many cases, Incorrect path of 'terminology' caused the links to be invalid.

Fixed.
