### PR TITLE
BONSAI: Added cycle limit + SNARK response refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,6 @@ dependencies = [
  "httpmock",
  "maybe-async",
  "reqwest 0.12.5",
- "risc0-groth16",
  "risc0-zkvm",
  "serde",
  "temp-env",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -426,7 +426,6 @@ dependencies = [
  "duplicate",
  "maybe-async",
  "reqwest 0.12.5",
- "risc0-groth16",
  "serde",
  "thiserror",
 ]

--- a/bonsai/sdk/Cargo.toml
+++ b/bonsai/sdk/Cargo.toml
@@ -16,7 +16,6 @@ reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
   "stream",
 ] }
-risc0-groth16 = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["fs"], optional = true }
@@ -34,8 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.10", features = ["v4"] }
 
 [features]
-default = ["std"]
-std = ["risc0-groth16/std"]
+default = []
 non_blocking = ["dep:tokio"]
 
 [package.metadata.docs.rs]

--- a/bonsai/sdk/README.md
+++ b/bonsai/sdk/README.md
@@ -86,6 +86,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bonsai_sdk::blocking::Client;
+use risc0_zkvm::Receipt;
 
 fn run_stark2snark(session_id: String) -> Result<()> {
     let client = Client::from_env(risc0_zkvm::VERSION)?;
@@ -101,8 +102,8 @@ fn run_stark2snark(session_id: String) -> Result<()> {
                 continue;
             }
             "SUCCEEDED" => {
-                let snark_receipt = res.output;
-                eprintln!("Snark proof!: {snark_receipt:?}");
+                let receipt_buf = client.download(&res.output.unwrap())?;
+                let snark_receipt: Receipt = bincode::deserialize(&receipt_buf)?;
                 break;
             }
             _ => {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
  "duplicate",
  "maybe-async",
  "reqwest 0.12.5",
- "risc0-groth16",
  "serde",
  "thiserror",
 ]

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -93,7 +93,13 @@ impl Prover for BonsaiProver {
         // While this is the executor, we want to start a session on the bonsai prover.
         // By doing so, we can return a session ID so that the prover can use it to
         // retrieve the receipt.
-        let session = client.create_session(image_id_hex, input_id, receipts_ids, false)?;
+        let session = client.create_session_with_limit(
+            image_id_hex,
+            input_id,
+            receipts_ids,
+            false,
+            env.session_limit,
+        )?;
         tracing::debug!("Bonsai proving SessionID: {}", session.uuid);
 
         let succinct_prove_info = loop {

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -19,9 +19,8 @@ use bonsai_sdk::blocking::Client;
 
 use super::Prover;
 use crate::{
-    compute_image_id, is_dev_mode, sha::Digestible, AssumptionReceipt, ExecutorEnv, Groth16Receipt,
-    InnerAssumptionReceipt, InnerReceipt, ProveInfo, ProverOpts, Receipt, ReceiptKind,
-    VerifierContext,
+    compute_image_id, is_dev_mode, AssumptionReceipt, ExecutorEnv, InnerAssumptionReceipt,
+    InnerReceipt, ProveInfo, ProverOpts, Receipt, ReceiptKind, VerifierContext,
 };
 
 /// An implementation of a [Prover] that runs proof workloads via Bonsai.
@@ -163,7 +162,7 @@ impl Prover for BonsaiProver {
 
         // Request that Bonsai compress further, to Groth16.
         let snark_session = client.create_snark(session.uuid)?;
-        let snark_receipt = loop {
+        let snark_receipt_url = loop {
             let res = snark_session.status(&client)?;
             match res.status.as_str() {
                 "RUNNING" => {
@@ -198,14 +197,8 @@ impl Prover for BonsaiProver {
         // the verifier parameters for this version of risc0-zkvm, which may be different than
         // Bonsai. By verifying the receipt though, we at least know the proving key used on Bonsai
         // matches the verifying key used here.
-        let groth16_receipt = Receipt::new(
-            InnerReceipt::Groth16(Groth16Receipt {
-                seal: snark_receipt.snark.to_vec(),
-                claim: succinct_prove_info.receipt.claim()?,
-                verifier_parameters: ctx.groth16_verifier_parameters.digest(),
-            }),
-            succinct_prove_info.receipt.journal.bytes,
-        );
+        let receipt_buf = client.download(&snark_receipt_url)?;
+        let groth16_receipt: Receipt = bincode::deserialize(&receipt_buf)?;
         groth16_receipt
             .verify_integrity_with_context(ctx)
             .context("failed to verify Groth16Receipt returned by Bonsai")?;


### PR DESCRIPTION
This PR adds configurable execution cycle limits to bonsai session creation and refactors how snarks are delivered back to customers.

This does slightly break the API of how SNARKs work so it should be considered a API breaking change. But this release also moves a major version for the bonsai-sdk.