### PR TITLE
backport: updating to 97 bits (#2293)

### DIFF
--- a/risc0/zkp/src/lib.rs
+++ b/risc0/zkp/src/lib.rs
@@ -46,7 +46,7 @@ pub const MIN_CYCLES: usize = 1 << MIN_CYCLES_PO2; // 8K
 pub const MAX_CYCLES_PO2: usize = 24;
 pub const MAX_CYCLES: usize = 1 << MAX_CYCLES_PO2; // 16M
 
-/// 50 FRI queries is sufficient to achieve our security target of 99 bits (conjectured security)
+/// 50 FRI queries is sufficient to achieve our security target of 97 bits (conjectured security)
 pub const QUERIES: usize = 50;
 pub const ZK_CYCLES: usize = 1994; // TODO: Ideally we'd compute ZK_CYCLES programmatically
 pub const MIN_PO2: usize = core::log2_ceil(1 + ZK_CYCLES);

--- a/risc0/zkp/src/prove/soundness.rs
+++ b/risc0/zkp/src/prove/soundness.rs
@@ -22,7 +22,7 @@
 //! 3. Proven soundness in the list-decoding regime
 //! 4. Proven soundness in the unique-decoding regime
 //!
-//! With default parameters, RISC Zero's zkVM targets 99 bits of conjectured soundness,
+//! RISC Zero's on-chain verifier contracts target 97 bits of conjectured soundness,
 //! using the Toy Problem Conjecture.
 //!
 //! This target assumes a SEGMENT_SIZE of 2^20 cycles.

--- a/website/api/security-model.md
+++ b/website/api/security-model.md
@@ -59,11 +59,11 @@ In analyzing the cryptographic security of our system, we consider two primary q
 
 The first question is about the **soundness** of the protocol, and the second question is whether the protocol is **zero-knowledge**.
 
-Soundness is often quantified in terms of "[bits]" — our system currently targets 98 bits of security.
+Soundness is often quantified in terms of "[bits]" — our [on-chain verifier contracts][Verifier Contract] target 97 bits of security.
 
 | Prover                | Cryptographic Assumptions                                                                                                                     | Bits of Security | Quantum Safe? |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------- |
-| RISC-V Prover         | - Random Oracle Model <br/> - Toy Problem Conjecture                                                                                          | 98               | Yes           |
+| RISC-V Prover         | - Random Oracle Model <br/> - Toy Problem Conjecture                                                                                          | 97               | Yes           |
 | Recursion Prover      | - Random Oracle Model <br/> - Toy Problem Conjecture                                                                                          | 99               | Yes           |
 | STARK-to-SNARK Prover | - Security of elliptic curve pairing over BN254. <br/> - Knowledge of Exponent assumption <br/> - Integrity of Groth16 Trusted Setup Ceremony | 99+              | No            |
 

--- a/website/api_versioned_docs/version-1.0/security-model.md
+++ b/website/api_versioned_docs/version-1.0/security-model.md
@@ -59,11 +59,11 @@ In analyzing the cryptographic security of our system, we consider two primary q
 
 The first question is about the **soundness** of the protocol, and the second question is whether the protocol is **zero-knowledge**.
 
-Soundness is often quantified in terms of "[bits]" — our system currently targets 98 bits of security.
+Soundness is often quantified in terms of "[bits]" — our [on-chain verifier contracts][Verifier Contract] target 97 bits of security.
 
 | Prover                | Cryptographic Assumptions                                                                                                                     | Bits of Security | Quantum Safe? |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------- |
-| RISC-V Prover         | - Random Oracle Model <br/> - Toy Problem Conjecture                                                                                          | 98               | Yes           |
+| RISC-V Prover         | - Random Oracle Model <br/> - Toy Problem Conjecture                                                                                          | 97               | Yes           |
 | Recursion Prover      | - Random Oracle Model <br/> - Toy Problem Conjecture                                                                                          | 99               | Yes           |
 | STARK-to-SNARK Prover | - Security of elliptic curve pairing over BN254. <br/> - Knowledge of Exponent assumption <br/> - Integrity of Groth16 Trusted Setup Ceremony | 99+              | No            |
 


### PR DESCRIPTION
This docs change is being backported because it touches source code. backporting this commit to the release branch will make these appear on docs rs when the crates are published.