### PR TITLE
backport: BONSAI: Added cycle limit + SNARK response refactor (#2310)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,6 @@ dependencies = [
  "httpmock",
  "maybe-async",
  "reqwest 0.12.5",
- "risc0-groth16",
  "risc0-zkvm",
  "serde",
  "temp-env",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -426,7 +426,6 @@ dependencies = [
  "duplicate",
  "maybe-async",
  "reqwest 0.12.5",
- "risc0-groth16",
  "serde",
  "thiserror",
 ]

--- a/bonsai/sdk/Cargo.toml
+++ b/bonsai/sdk/Cargo.toml
@@ -16,7 +16,6 @@ reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
   "stream",
 ] }
-risc0-groth16 = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["fs"], optional = true }
@@ -34,8 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.10", features = ["v4"] }
 
 [features]
-default = ["std"]
-std = ["risc0-groth16/std"]
+default = []
 non_blocking = ["dep:tokio"]
 
 [package.metadata.docs.rs]

--- a/bonsai/sdk/README.md
+++ b/bonsai/sdk/README.md
@@ -86,6 +86,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bonsai_sdk::blocking::Client;
+use risc0_zkvm::Receipt;
 
 fn run_stark2snark(session_id: String) -> Result<()> {
     let client = Client::from_env(risc0_zkvm::VERSION)?;
@@ -101,8 +102,8 @@ fn run_stark2snark(session_id: String) -> Result<()> {
                 continue;
             }
             "SUCCEEDED" => {
-                let snark_receipt = res.output;
-                eprintln!("Snark proof!: {snark_receipt:?}");
+                let receipt_buf = client.download(&res.output.unwrap())?;
+                let snark_receipt: Receipt = bincode::deserialize(&receipt_buf)?;
                 break;
             }
             _ => {

--- a/bonsai/sdk/src/lib.rs
+++ b/bonsai/sdk/src/lib.rs
@@ -105,6 +105,7 @@
 //!
 //! use anyhow::Result;
 //! use bonsai_sdk::blocking::Client;
+//! use risc0_zkvm::Receipt;
 //!
 //! fn run_stark2snark(session_id: String) -> Result<()> {
 //!     let client = Client::from_env(risc0_zkvm::VERSION)?;
@@ -120,8 +121,8 @@
 //!                 continue;
 //!             }
 //!             "SUCCEEDED" => {
-//!                 let snark_receipt = res.output;
-//!                 eprintln!("Snark proof!: {snark_receipt:?}");
+//!                 let receipt_buf = client.download(&res.output.unwrap())?;
+//!                 let snark_receipt: Receipt = bincode::deserialize(&receipt_buf)?;
 //!                 break;
 //!             }
 //!             _ => {
@@ -189,7 +190,6 @@ enum ImageExistsOpt {
 
 /// Collection of serialization object for the REST api
 pub mod responses {
-    use risc0_groth16::Seal;
     use serde::{Deserialize, Serialize};
 
     /// Response of a upload request
@@ -226,6 +226,8 @@ pub mod responses {
         pub assumptions: Vec<String>,
         /// Execute Only Mode
         pub execute_only: bool,
+        /// executor cycle limit
+        pub exec_cycle_limit: Option<u64>,
     }
 
     /// Session statistics metadata file
@@ -296,23 +298,6 @@ pub mod responses {
         pub session_id: String,
     }
 
-    /// Snark Receipt object
-    ///
-    /// All relevant data to verify both the snark proof an corresponding
-    /// imageId on chain.
-    #[derive(Debug, Deserialize, Serialize, PartialEq)]
-    pub struct SnarkReceipt {
-        /// SNARK Groth16 seal object encoded in big endian
-        pub snark: Seal,
-        /// Post State Digest
-        ///
-        /// Collected from the STARK proof via
-        /// `receipt.get_metadata().post.digest()`
-        pub post_state_digest: Vec<u8>,
-        /// Journal data from the risc-zkvm Receipt object
-        pub journal: Vec<u8>,
-    }
-
     /// Session Status response
     #[derive(Deserialize, Serialize)]
     pub struct SnarkStatusRes {
@@ -320,10 +305,10 @@ pub mod responses {
         ///
         /// values: `[ RUNNING | SUCCEEDED | FAILED | TIMED_OUT | ABORTED ]`
         pub status: String,
-        /// SNARK receipt output
+        /// SNARK receipt download URL
         ///
-        /// Generated snark receipt,
-        pub output: Option<SnarkReceipt>,
+        /// Url to download the snark (receipt `risc0::Receipt` bincode encoded)
+        pub output: Option<String>,
         /// Snark Error message
         ///
         /// If the SNARK status is not `RUNNING` or `SUCCEEDED`, this is the
@@ -769,17 +754,18 @@ bonsai_sdk::non_blocking::Client::from_env(risc0_zkvm::VERSION)
 
         // - /sessions
 
-        /// Create a new proof request Session
+        /// Create a new proof request Session with executor cycle limit
         ///
         /// Supply the image_id and input_id created from uploading those files in
         /// previous steps
         #[maybe_async_attr]
-        pub async fn create_session(
+        pub async fn create_session_with_limit(
             &self,
             img_id: String,
             input_id: String,
             assumptions: Vec<String>,
             execute_only: bool,
+            exec_cycle_limit: Option<u64>,
         ) -> Result<SessionId, SdkErr> {
             let url = format!("{}/sessions/create", self.url);
 
@@ -788,6 +774,7 @@ bonsai_sdk::non_blocking::Client::from_env(risc0_zkvm::VERSION)
                 input: input_id,
                 assumptions,
                 execute_only,
+                exec_cycle_limit,
             };
 
             let res = self.client.post(url).json(&req).send().await?;
@@ -800,6 +787,22 @@ bonsai_sdk::non_blocking::Client::from_env(risc0_zkvm::VERSION)
             let res: CreateSessRes = res.json().await?;
 
             Ok(SessionId::new(res.uuid))
+        }
+
+        /// Create a new proof request Session
+        ///
+        /// Supply the image_id and input_id created from uploading those files in
+        /// previous steps
+        #[maybe_async_attr]
+        pub async fn create_session(
+            &self,
+            img_id: String,
+            input_id: String,
+            assumptions: Vec<String>,
+            execute_only: bool,
+        ) -> Result<SessionId, SdkErr> {
+            self.create_session_with_limit(img_id, input_id, assumptions, execute_only, None)
+                .await
         }
 
         // Utilities
@@ -1198,6 +1201,7 @@ mod tests {
             input: Uuid::new_v4().to_string(),
             assumptions: vec![],
             execute_only: false,
+            exec_cycle_limit: None,
         };
         let response = CreateSessRes {
             uuid: Uuid::new_v4().to_string(),
@@ -1219,11 +1223,12 @@ mod tests {
         let client = Client::from_parts(server_url, TEST_KEY.to_string(), TEST_VERSION).unwrap();
 
         let res = client
-            .create_session(
+            .create_session_with_limit(
                 request.img,
                 request.input,
                 request.assumptions,
                 request.execute_only,
+                request.exec_cycle_limit,
             )
             .unwrap();
         assert_eq!(res.uuid, response.uuid);

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
  "duplicate",
  "maybe-async",
  "reqwest 0.12.5",
- "risc0-groth16",
  "serde",
  "thiserror",
 ]

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -19,8 +19,8 @@ use bonsai_sdk::blocking::Client;
 
 use super::Prover;
 use crate::{
-    compute_image_id, is_dev_mode, sha::Digestible, ExecutorEnv, Groth16Receipt, InnerReceipt,
-    ProveInfo, ProverOpts, Receipt, ReceiptKind, VerifierContext,
+    compute_image_id, is_dev_mode, ExecutorEnv, InnerReceipt, ProveInfo, ProverOpts, Receipt,
+    ReceiptKind, VerifierContext,
 };
 
 /// An implementation of a [Prover] that runs proof workloads via Bonsai.
@@ -78,7 +78,13 @@ impl Prover for BonsaiProver {
         // While this is the executor, we want to start a session on the bonsai prover.
         // By doing so, we can return a session ID so that the prover can use it to
         // retrieve the receipt.
-        let session = client.create_session(image_id_hex, input_id, receipts_ids, false)?;
+        let session = client.create_session_with_limit(
+            image_id_hex,
+            input_id,
+            receipts_ids,
+            false,
+            env.session_limit,
+        )?;
         tracing::debug!("Bonsai proving SessionID: {}", session.uuid);
 
         let succinct_prove_info = loop {
@@ -142,7 +148,7 @@ impl Prover for BonsaiProver {
 
         // Request that Bonsai compress further, to Groth16.
         let snark_session = client.create_snark(session.uuid)?;
-        let snark_receipt = loop {
+        let snark_receipt_url = loop {
             let res = snark_session.status(&client)?;
             match res.status.as_str() {
                 "RUNNING" => {
@@ -177,14 +183,8 @@ impl Prover for BonsaiProver {
         // the verifier parameters for this version of risc0-zkvm, which may be different than
         // Bonsai. By verifying the receipt though, we at least know the proving key used on Bonsai
         // matches the verifying key used here.
-        let groth16_receipt = Receipt::new(
-            InnerReceipt::Groth16(Groth16Receipt {
-                seal: snark_receipt.snark.to_vec(),
-                claim: succinct_prove_info.receipt.claim()?,
-                verifier_parameters: ctx.groth16_verifier_parameters.digest(),
-            }),
-            succinct_prove_info.receipt.journal.bytes,
-        );
+        let receipt_buf = client.download(&snark_receipt_url)?;
+        let groth16_receipt: Receipt = bincode::deserialize(&receipt_buf)?;
         groth16_receipt
             .verify_integrity_with_context(ctx)
             .context("failed to verify Groth16Receipt returned by Bonsai")?;


### PR DESCRIPTION
This PR adds configurable execution cycle limits to bonsai session creation and refactors how snarks are delivered back to customers.

This change includes a breaking change for the way SNARKs are handled, now the successful snark status will provide a receipt URL (in the `output` field) to download a `bincode` encoded `risc0_zkvm::Receipt` with the inner type of Groth16.

Additionally it adds the `create_session_with_limit` to opt into the new client defined executor limit (works with both exec-only and normal STARKs)