### PR TITLE
update docs for new rzup install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ To install `rzup` run the following command and follow the instructions:
 curl -L https://risczero.com/install | bash
 ```
 
-Next we can install the RISC Zero toolchain by running `rzup install`:
+Next we can install the RISC Zero toolchain by running `rzup`:
 
 ```bash
-rzup install
+rzup
 ```
 
 You can verify the installation was successful by running:

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ To install `rzup` run the following command and follow the instructions:
 curl -L https://risczero.com/install | bash
 ```
 
-Next we can install the RISC Zero toolchain by running `rzup`:
+Next we can install the RISC Zero toolchain by running `rzup install`:
 
 ```bash
-rzup
+rzup install
 ```
 
 You can verify the installation was successful by running:

--- a/website/api/zkvm/quickstart.md
+++ b/website/api/zkvm/quickstart.md
@@ -27,7 +27,7 @@ curl -L https://risczero.com/install | bash
 Run `rzup` to install the RISC Zero toolchain and `cargo-risczero`.
 
 ```bash
-rzup
+rzup install
 ```
 
 > Note: To install a specific version instead of using the latest stable


### PR DESCRIPTION
There's still a mention of the old rzup command in the main readme of the project. I'll take care of this in a separate PR that updates the README of the project to point to the correct versions of the published crates.