### PR TITLE
Move `benchmarks` subdomain links to `reports.risczero.com`

### DIFF
--- a/risc0/cargo-risczero/README.md
+++ b/risc0/cargo-risczero/README.md
@@ -117,7 +117,7 @@ The `datasheet` command performs a benchmark to evaluate zkVM performance for
 the current machine's hardware, and then prints a table (along with optional
 `--json` output).
 
-See [our benchmarks](https://benchmarks.risczero.com/main/datasheet) for numbers
+See [our benchmarks](https://reports.risczero.com/main/datasheet) for numbers
 you can expect to see from this.
 
 Schema:

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ curl -fsSL https://bun.sh/install | bash
 
 ## Apps 👾
 
-- [`benchmarks-and-reports`](./apps/benchmarks-and-reports) → [LIVE PROD URL](https://benchmarks.risczero.com)
+- [`benchmarks-and-reports`](./apps/benchmarks-and-reports) → [LIVE PROD URL](https://reports.risczero.com)
 
 ## Packages 📦
 

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/page.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/page.tsx
@@ -37,7 +37,7 @@ export function generateMetadata({
     openGraph: {
       images: [
         {
-          url: `https://benchmarks.risczero.com/api/og?title=Applications%20Benchmark&description=${encodeURIComponent(
+          url: `https://reports.risczero.com/api/og?title=Applications%20Benchmark&description=${encodeURIComponent(
             APPLICATIONS_BENCHMARKS_DESCRIPTION,
           )}`,
         },

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/page.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   openGraph: {
     images: [
       {
-        url: `https://benchmarks.risczero.com/api/og?title=Datasheet&description=${encodeURIComponent(
+        url: `https://reports.risczero.com/api/og?title=Datasheet&description=${encodeURIComponent(
           DATASHEET_DESCRIPTION,
         )}`,
       },

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/benchmarks/page.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/benchmarks/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
   openGraph: {
     images: [
       {
-        url: `https://benchmarks.risczero.com/api/og?title=Benchmarks&description=${encodeURIComponent(
+        url: `https://reports.risczero.com/api/og?title=Benchmarks&description=${encodeURIComponent(
           BENCHMARKS_DESCRIPTION,
         )}`,
       },

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/crates-validation/page.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/crates-validation/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   openGraph: {
     images: [
       {
-        url: `https://benchmarks.risczero.com/api/og?title=Crates.io%20Validation&description=${encodeURIComponent(
+        url: `https://reports.risczero.com/api/og?title=Crates.io%20Validation&description=${encodeURIComponent(
           CRATES_VALIDATION_DESCRIPTION,
         )}`,
       },

--- a/web/apps/benchmarks-and-reports/src/app/layout.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/layout.tsx
@@ -15,12 +15,12 @@ export const metadata: Metadata = {
     default: "RISC Zero Benchmarks & Reports",
   },
   keywords: ["risczero", "zero knowledge proofs", "zkvm", "benchmarks", "zk", "reports", "risc0", "risc0.com"],
-  metadataBase: new URL("https://benchmarks.risczero.com"),
+  metadataBase: new URL("https://reports.risczero.com"),
   description: "Get to market fast with dramatically lower development costs on the first general purpose zkVM",
   openGraph: {
     images: [
       {
-        url: "https://benchmarks.risczero.com/api/og?title=RISC%20Zero%20Benchmarks%20%26%20Reports",
+        url: "https://reports.risczero.com/api/og?title=RISC%20Zero%20Benchmarks%20%26%20Reports",
       },
     ],
   },

--- a/web/apps/benchmarks-and-reports/src/app/sitemap.ts
+++ b/web/apps/benchmarks-and-reports/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { VERSIONS } from "~/versions";
 
-export const baseUrl = "https://benchmarks.risczero.com";
+export const baseUrl = "https://reports.risczero.com";
 
 // @TODO: add individual tabs for app benchmarks?
 export default async function sitemap() {

--- a/website/api/generating-proofs/local-proving.md
+++ b/website/api/generating-proofs/local-proving.md
@@ -75,7 +75,7 @@ No options need to be configured to take advantage of acceleration through the u
 [#1749]: https://github.com/risc0/risc0/issues/1749
 [Bonsai]: ./remote-proving.md
 [apple-metal]: https://developer.apple.com/metal/
-[datasheet]: https://benchmarks.risczero.com/main/datasheet
+[datasheet]: https://reports.risczero.com/main/datasheet
 [feature flags]: https://github.com/risc0/risc0#feature-flags
 [open-source]: https://risczero.com/news/open-source
 [segment-limit-docs]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.ExecutorEnvBuilder.html#method.segment_limit_po2

--- a/website/api/zkvm/benchmarks.md
+++ b/website/api/zkvm/benchmarks.md
@@ -54,7 +54,7 @@ the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
 appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles
-[datasheet]: https://benchmarks.risczero.com/main/datasheet
+[datasheet]: https://reports.risczero.com/main/datasheet
 [execution]: /terminology#execute
 [install]: ./install.md
 [prover]: /terminology#prover

--- a/website/api/zkvm/rust-resources.md
+++ b/website/api/zkvm/rust-resources.md
@@ -29,7 +29,7 @@ in our [Crate Validation Report][crate-validation].
 
 ![From Guest Code to Receipt][from-rust-to-receipt]
 
-[crate-validation]: https://benchmarks.risczero.com/crates-validation
+[crate-validation]: https://reports.risczero.com/crates-validation
 [from-rust-to-receipt]: /diagrams/from-rust-to-receipt.png
 [install-rust]: https://www.rust-lang.org/tools/install
 [risc0-zkvm]: https://docs.rs/risc0-zkvm

--- a/website/api_versioned_docs/version-0.21/zkvm/benchmarks.md
+++ b/website/api_versioned_docs/version-0.21/zkvm/benchmarks.md
@@ -53,7 +53,7 @@ the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
 appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles
-[datasheet]: https://benchmarks.risczero.com/release-0.21/datasheet
+[datasheet]: https://reports.risczero.com/release-0.21/datasheet
 [execution]: /terminology#execute
 [install]: ./install.md
 [prover]: /terminology#prover

--- a/website/api_versioned_docs/version-1.0/generating-proofs/local-proving.md
+++ b/website/api_versioned_docs/version-1.0/generating-proofs/local-proving.md
@@ -75,7 +75,7 @@ No options need to be configured to take advantage of acceleration through the u
 [#1749]: https://github.com/risc0/risc0/issues/1749
 [Bonsai]: ./remote-proving.md
 [apple-metal]: https://developer.apple.com/metal/
-[datasheet]: https://benchmarks.risczero.com/release-1.0/datasheet
+[datasheet]: https://reports.risczero.com/release-1.0/datasheet
 [feature flags]: https://github.com/risc0/risc0#feature-flags
 [open-source]: https://risczero.com/news/open-source
 [segment-limit-docs]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/struct.ExecutorEnvBuilder.html#method.segment_limit_po2

--- a/website/api_versioned_docs/version-1.0/zkvm/benchmarks.md
+++ b/website/api_versioned_docs/version-1.0/zkvm/benchmarks.md
@@ -54,7 +54,7 @@ the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
 appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles
-[datasheet]: https://benchmarks.risczero.com/release-1.0/datasheet
+[datasheet]: https://reports.risczero.com/release-1.0/datasheet
 [execution]: /terminology#execute
 [install]: ./install.md
 [prover]: /terminology#prover

--- a/website/api_versioned_docs/version-1.0/zkvm/rust-resources.md
+++ b/website/api_versioned_docs/version-1.0/zkvm/rust-resources.md
@@ -29,7 +29,7 @@ in our [Crate Validation Report][crate-validation].
 
 ![From Guest Code to Receipt][from-rust-to-receipt]
 
-[crate-validation]: https://benchmarks.risczero.com/crates-validation
+[crate-validation]: https://reports.risczero.com/crates-validation
 [from-rust-to-receipt]: /diagrams/from-rust-to-receipt.png
 [install-rust]: https://www.rust-lang.org/tools/install
 [risc0-zkvm]: https://docs.rs/risc0-zkvm

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -121,7 +121,7 @@ As a consequence, _functionally equivalent_ binaries, from the zkVM perspective,
 <summary>
 Q: Are performance benchmarks available?
 </summary>
-A: Yes. We have a <a href="https://benchmarks.risczero.com/">benchmarks website</a>, and you can also generate your own benchmarks. More details are available on the <a href="https://dev.risczero.com/zkvm/benchmarks">benchmarks page</a>.
+A: Yes. We have a <a href="https://reports.risczero.com/">benchmarks website</a>, and you can also generate your own benchmarks. More details are available on the <a href="https://dev.risczero.com/zkvm/benchmarks">benchmarks page</a>.
 </details>
 
 <a class="anchor" id="language-support"></a>


### PR DESCRIPTION
Just a fix of a nit on what is the "right" URL to use.

Closes https://linear.app/risczero/issue/WEBR0-23/update-all-links-to-use-reportsrisczerocom

Related to #2320 