### PR TITLE
Fix rate limiting failure on Nightly Jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       RUST_BACKTRACE: full
       RUST_LOG: info
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rustup
@@ -32,8 +33,6 @@ jobs:
 
       - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: cargo build --release
         working-directory: tools/crates-validator/


### PR DESCRIPTION
Fix some recent Nightly failures:
- https://github.com/risc0/risc0/actions/runs/10806714997/job/30008209491
- https://github.com/risc0/risc0/actions/runs/10715551052/job/29711233444
- https://github.com/risc0/risc0/actions/runs/10573349236/job/29292669555

```
Error: Rate limited by GitHub API. Please set a GitHub token in the GITHUB_TOKEN environment variable.
Error: Process completed with exit code 1.
```

`GITHUB_TOKEN` can now be used in all steps in workflow.