### PR TITLE
Show unstable risc0-zkvm features on docs.rs

### DIFF
--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -104,7 +104,7 @@ test-log = { version = "0.2", default-features = false, features = ["trace"] }
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 # NOTE: cuda and metal are excluded because their build scripts require external tools.
-features = ["client", "prove", "getrandom", "std"]
+features = ["client", "prove", "getrandom", "std", "unstable"]
 
 [features]
 client = [


### PR DESCRIPTION
I went looking for the new `env::read_frame` function and realized that unstable methods are not shown on `docs.rs`. Assuming we want to show them, here is a PR to do so.