### PR TITLE
Plumb ReceiptClaim through SessionInfo and client-server

### DIFF
--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -607,6 +607,10 @@ impl Client {
                                         .exit_code
                                         .ok_or(malformed_err())?
                                         .try_into()?,
+                                    receipt_claim: pb::core::ReceiptClaim::decode(
+                                        session.receipt_claim.ok_or(malformed_err())?.as_bytes()?,
+                                    )?
+                                    .try_into()?,
                                 }),
                                 None => Err(malformed_err()),
                             }

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -41,7 +41,7 @@ use lazy_regex::regex_captures;
 use prost::Message;
 use semver::Version;
 
-use crate::{get_version, ExitCode, Journal};
+use crate::{get_version, ExitCode, Journal, ReceiptClaim};
 
 mod pb {
     pub(crate) mod api {
@@ -356,6 +356,10 @@ pub struct SessionInfo {
 
     /// The [ExitCode] of the session.
     pub exit_code: ExitCode,
+
+    /// The [ReceiptClaim] associated with the executed session. This receipt claim is what will be
+    /// proven if this session is passed to the Prover.
+    pub receipt_claim: ReceiptClaim,
 }
 
 impl SessionInfo {

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -353,6 +353,7 @@ impl Server {
                 Ok(Box::new(NullSegmentRef))
             })?;
 
+            let receipt_claim = session.claim()?;
             Ok(pb::api::ServerReply {
                 kind: Some(pb::api::server_reply::Kind::Ok(pb::api::ClientCallback {
                     kind: Some(pb::api::client_callback::Kind::SessionDone(
@@ -361,6 +362,15 @@ impl Server {
                                 segments: session.segments.len().try_into()?,
                                 journal: session.journal.unwrap_or_default().bytes,
                                 exit_code: Some(session.exit_code.into()),
+                                receipt_claim: Some(pb::api::Asset::from_bytes(
+                                    &pb::api::AssetRequest {
+                                        kind: Some(pb::api::asset_request::Kind::Inline(())),
+                                    },
+                                    pb::core::ReceiptClaim::from(receipt_claim)
+                                        .encode_to_vec()
+                                        .into(),
+                                    "session_info.claim",
+                                )?),
                             }),
                         },
                     )),

--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -66,10 +66,12 @@ impl Executor for LocalProver {
             });
             Ok(Box::new(NullSegmentRef))
         })?;
+        let receipt_claim = session.claim()?;
         Ok(SessionInfo {
             segments,
             journal: session.journal.unwrap_or_default(),
             exit_code: session.exit_code,
+            receipt_claim,
         })
     }
 }

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -206,6 +206,7 @@ message SessionInfo {
   uint32 segments = 1;
   bytes journal = 2;
   base.ExitCode exit_code = 3;
+  Asset receipt_claim = 4;
 }
 
 message SegmentInfo {

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -315,10 +315,8 @@ pub struct ExecutorEnv {
     #[prost(message, optional, tag = "1")]
     pub binary: ::core::option::Option<Asset>,
     #[prost(map = "string, string", tag = "2")]
-    pub env_vars: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub env_vars:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(string, repeated, tag = "3")]
     pub slice_ios: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(uint32, repeated, tag = "4")]

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -315,8 +315,10 @@ pub struct ExecutorEnv {
     #[prost(message, optional, tag = "1")]
     pub binary: ::core::option::Option<Asset>,
     #[prost(map = "string, string", tag = "2")]
-    pub env_vars:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub env_vars: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     #[prost(string, repeated, tag = "3")]
     pub slice_ios: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(uint32, repeated, tag = "4")]
@@ -383,6 +385,8 @@ pub struct SessionInfo {
     pub journal: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "3")]
     pub exit_code: ::core::option::Option<super::base::ExitCode>,
+    #[prost(message, optional, tag = "4")]
+    pub receipt_claim: ::core::option::Option<Asset>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
This PR plumbs the `session.claim()` through to the `SessionInfo` such that it is available from executions carried out with the `Executor` trait. Motivation for this PR is that I am writing some tests of composition and want to be able to run the executor and convert the result into a fake receipt. This is possible with `ExecutorImpl`, but not with `Executor` right now.

More context on https://github.com/risc0/risc0/issues/2267#issuecomment-2347372529

Closes #2267