### PR TITLE
bump version to 1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ permissions:
 env:
   RISC0_RUST_TOOLCHAIN_VERSION: r0.1.79.0-2
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
-  TAG: v1.1.0
-  VERSION: "1.1.0"
+  TAG: v1.1.1
+  VERSION: "1.1.1"
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 TBD
 
+## [v1.1.1 (2024-09-23)](https://github.com/risc0/risc0/releases/tag/v1.1.1)
+
+Support wider range of client/server use cases.
+
 ## [v1.1.0 (2024-09-09)](https://github.com/risc0/risc0/releases/tag/v1.1.0)
 
 ### 🔥 Performance Improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "directories",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-bigint"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "cust",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-tools"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "critical-section",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "rmp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,30 +29,30 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
-bonsai-sdk = { version = "1.1.0", default-features = false, path = "bonsai/sdk" }
+bonsai-sdk = { version = "1.1.1", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-binfmt = { version = "1.1.0", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "1.1.0", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "1.1.0", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-recursion = { version = "1.1.0", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.1.0", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "1.1.0", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "1.1.0", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "1.1.0", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.1.0", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "1.1.0", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.1.0", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.1.0", default-features = false, path = "risc0/zkp" }
-risc0-zkvm = { version = "1.1.0", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "1.1.0", default-features = false, path = "risc0/zkvm/platform" }
+risc0-binfmt = { version = "1.1.1", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "1.1.1", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "1.1.1", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-recursion = { version = "1.1.1", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "1.1.1", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "1.1.1", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "1.1.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "1.1.1", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "1.1.1", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "1.1.1", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "1.1.1", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "1.1.1", default-features = false, path = "risc0/zkp" }
+risc0-zkvm = { version = "1.1.1", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "1.1.1", default-features = false, path = "risc0/zkvm/platform" }
 sppark = "0.1.8"
 
 [profile.bench]

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "directories",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "cust",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "directories",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "cc",
  "cust",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "borsh",
  "ciborium",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.1.0"
+version = "1.1.1"
 
 [[package]]
 name = "rkyv"

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -741,7 +741,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -703,7 +703,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -686,7 +686,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -725,7 +725,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -750,7 +750,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/circuit/bigint/methods/guest/Cargo.lock
+++ b/risc0/circuit/bigint/methods/guest/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-bigint"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1063,7 +1063,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "borsh",
  "ciborium",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -703,7 +703,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "critical-section",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -993,7 +993,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/tools/smoke-test/Cargo.toml
+++ b/tools/smoke-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = "1.1.0"
+risc0-zkvm = "1.1.1"
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../risc0/zkvm" }
 methods = { path = "methods" }

--- a/tools/smoke-test/methods/Cargo.toml
+++ b/tools/smoke-test/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = "1.1.0"
+risc0-build = "1.1.1"
 # Use this only for testing locally before a release.
 # risc0-build = { path = "../../../risc0/build" }
 

--- a/tools/smoke-test/methods/guest/Cargo.toml
+++ b/tools/smoke-test/methods/guest/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.1.0", default-features = false }
+risc0-zkvm = { version = "1.1.1", default-features = false }
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false }


### PR DESCRIPTION
This PR bumps the version of zkvm to 1.1.1. I'll run `cargo release publish` after I see that the CI is running. Setting this in draft right now to prevent merging.