### PR TITLE
docs: set default to latest releas

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -70,7 +70,6 @@ export default async function createConfigAsync() {
             // Otherwise we risk losing the update on the next release.
             return `https://github.com/risc0/risc0/edit/main/website/api/${docPath}`;
           },
-          lastVersion: "1.0",
         },
       ],
       [


### PR DESCRIPTION
1.1.1 has been released so the docs can now be updated to point to the latest release.
This reverts commit a5a6946256a070790b5fe9899d4fbf09baff6868.