### PR TITLE
change visibility of groth16 proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,6 +4005,7 @@ dependencies = [
  "risc0-zkp",
  "serde",
  "serde_json",
+ "stability",
  "tempfile",
  "test-log",
  "tracing",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "risc0-zkp",
  "serde",
  "serde_json",
+ "stability",
  "tempfile",
  "tracing",
 ]

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4182,6 +4182,7 @@ dependencies = [
  "risc0-zkp",
  "serde",
  "serde_json",
+ "stability",
  "tempfile",
  "tracing",
 ]

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1125,6 +1125,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -739,6 +739,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -748,6 +748,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -1484,6 +1484,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/risc0/circuit/bigint/methods/guest/Cargo.lock
+++ b/risc0/circuit/bigint/methods/guest/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/risc0/groth16/Cargo.toml
+++ b/risc0/groth16/Cargo.toml
@@ -8,7 +8,6 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-stability = "0.2"
 anyhow = { version = "1.0", default-features = false }
 ark-bn254 = { version = "0.4" }
 ark-ec = { version = "0.4" }
@@ -26,6 +25,7 @@ serde = { version = "1.0", default-features = false, features = [
   "derive",
 ] }
 serde_json = { version = "1.0", optional = true }
+stability = "0.2"
 tempfile = { version = "3", optional = true }
 tracing = { version = "0.1", optional = true }
 

--- a/risc0/groth16/Cargo.toml
+++ b/risc0/groth16/Cargo.toml
@@ -8,6 +8,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+stability = "0.2"
 anyhow = { version = "1.0", default-features = false }
 ark-bn254 = { version = "0.4" }
 ark-ec = { version = "0.4" }

--- a/risc0/groth16/src/lib.rs
+++ b/risc0/groth16/src/lib.rs
@@ -112,6 +112,7 @@ pub(crate) fn fr_from_bytes(scalar: &[u8]) -> Result<Fr, Error> {
 }
 
 /// Deserialize an element over the G1 group from bytes in big-endian format
+#[stability::unstable]
 pub fn g1_from_bytes(elem: &[Vec<u8>]) -> Result<G1Affine, Error> {
     if elem.len() != 2 {
         return Err(anyhow!("Malformed G1 field element"));
@@ -127,6 +128,7 @@ pub fn g1_from_bytes(elem: &[Vec<u8>]) -> Result<G1Affine, Error> {
 }
 
 /// Deserialize an element over the G2 group from bytes in big-endian format
+#[stability::unstable]
 pub fn g2_from_bytes(elem: &[Vec<Vec<u8>>]) -> Result<G2Affine, Error> {
     if elem.len() != 2 || elem[0].len() != 2 || elem[1].len() != 2 {
         return Err(anyhow!("Malformed G2 field element"));

--- a/risc0/groth16/src/lib.rs
+++ b/risc0/groth16/src/lib.rs
@@ -111,8 +111,8 @@ pub(crate) fn fr_from_bytes(scalar: &[u8]) -> Result<Fr, Error> {
         .map_err(|err| anyhow!(err))
 }
 
-// Deserialize an element over the G1 group from bytes in big-endian format
-pub(crate) fn g1_from_bytes(elem: &[Vec<u8>]) -> Result<G1Affine, Error> {
+/// Deserialize an element over the G1 group from bytes in big-endian format
+pub fn g1_from_bytes(elem: &[Vec<u8>]) -> Result<G1Affine, Error> {
     if elem.len() != 2 {
         return Err(anyhow!("Malformed G1 field element"));
     }
@@ -126,8 +126,8 @@ pub(crate) fn g1_from_bytes(elem: &[Vec<u8>]) -> Result<G1Affine, Error> {
     G1Affine::deserialize_uncompressed(&*g1_affine).map_err(|err| anyhow!(err))
 }
 
-// Deserialize an element over the G2 group from bytes in big-endian format
-pub(crate) fn g2_from_bytes(elem: &[Vec<Vec<u8>>]) -> Result<G2Affine, Error> {
+/// Deserialize an element over the G2 group from bytes in big-endian format
+pub fn g2_from_bytes(elem: &[Vec<Vec<u8>>]) -> Result<G2Affine, Error> {
     if elem.len() != 2 || elem[0].len() != 2 || elem[1].len() != 2 {
         return Err(anyhow!("Malformed G2 field element"));
     }

--- a/risc0/groth16/src/verifier.rs
+++ b/risc0/groth16/src/verifier.rs
@@ -158,7 +158,7 @@ impl Verifier {
 
 /// Verifying key for Groth16 proofs.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Fr(#[serde(with = "serde_ark")] pub(crate) ark_bn254::Fr);
+pub struct Fr(#[serde(with = "serde_ark")] pub ark_bn254::Fr);
 
 impl Digestible for Fr {
     /// Compute a tagged hash of the [Fr] value.
@@ -178,7 +178,7 @@ impl Digestible for Fr {
 
 /// Verifying key for Groth16 proofs.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct VerifyingKey(#[serde(with = "serde_ark")] pub(crate) ark_groth16::VerifyingKey<Bn254>);
+pub struct VerifyingKey(#[serde(with = "serde_ark")] pub ark_groth16::VerifyingKey<Bn254>);
 
 /// Hash a point on G1 or G2 by hashing the concatenated big-endian representation of (x, y).
 fn hash_point<S: Sha256>(p: impl AffineRepr) -> Digest {

--- a/risc0/groth16/src/verifier.rs
+++ b/risc0/groth16/src/verifier.rs
@@ -160,6 +160,13 @@ impl Verifier {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Fr(#[serde(with = "serde_ark")] pub ark_bn254::Fr);
 
+impl Fr {
+    #[stability::unstable]
+    pub fn ark_fr(&self) -> ark_bn254::Fr {
+        self.0
+    }
+}
+
 impl Digestible for Fr {
     /// Compute a tagged hash of the [Fr] value.
     fn digest<S: Sha256>(&self) -> Digest {
@@ -189,6 +196,13 @@ fn hash_point<S: Sha256>(p: impl AffineRepr) -> Digest {
     x.serialize_uncompressed(&mut buffer).unwrap();
     buffer.reverse();
     *S::hash_bytes(&buffer)
+}
+
+impl VerifyingKey {
+    #[stability::unstable]
+    pub fn ark_verifying_key(&self) -> ark_groth16::VerifyingKey<Bn254> {
+        self.0.clone()
+    }
 }
 
 impl Digestible for VerifyingKey {

--- a/risc0/groth16/src/verifier.rs
+++ b/risc0/groth16/src/verifier.rs
@@ -158,7 +158,7 @@ impl Verifier {
 
 /// Verifying key for Groth16 proofs.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Fr(#[serde(with = "serde_ark")] pub ark_bn254::Fr);
+pub struct Fr(#[serde(with = "serde_ark")] pub(crate) ark_bn254::Fr);
 
 impl Fr {
     #[stability::unstable]
@@ -185,7 +185,7 @@ impl Digestible for Fr {
 
 /// Verifying key for Groth16 proofs.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct VerifyingKey(#[serde(with = "serde_ark")] pub ark_groth16::VerifyingKey<Bn254>);
+pub struct VerifyingKey(#[serde(with = "serde_ark")] pub(crate) ark_groth16::VerifyingKey<Bn254>);
 
 /// Hash a point on G1 or G2 by hashing the concatenated big-endian representation of (x, y).
 fn hash_point<S: Sha256>(p: impl AffineRepr) -> Digest {

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1142,6 +1142,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-zkp",
  "serde",
+ "stability",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR changes the visibility of some structures and functions of groth16.
It's helpful to extract the *real* groth16 proof from r0 proof receipt for those teams writing on-chain verifier themselves.