### PR TITLE
rzup fix `rzup toolchain build rust`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,7 +4333,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/rzup/src/config.toml
+++ b/rzup/src/config.toml
@@ -1,5 +1,3 @@
-changelog-seen = 2
-
 [build]
 target = ["riscv32im-risc0-zkvm-elf"]
 extended = true


### PR DESCRIPTION
This change fixes the `rzup toolchain build rust` command for newer versions of the rust toolchain that deprecate the `changelog-seen` property.