### PR TITLE
CI: add rzup to `base` and revert "fix: rzup install --version <VERSION> (#2372)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
               - Cargo.toml
               - rust-toolchain.toml
               - Cargo.lock
+              - rzup/**
             browser:
               - *base
               - examples/browser-verify/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,7 +4333,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rzup"
-version = "0.2.2"
+version = "0.2.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/rzup/src/cli/install.rs
+++ b/rzup/src/cli/install.rs
@@ -26,37 +26,23 @@ pub struct InstallOpts {
 }
 
 pub async fn handler(opts: InstallOpts) -> Result<()> {
-    match (opts.name.as_deref(), opts.version.as_deref()) {
-        (None, None) => {
-            // Install latest versions of everything
-            Toolchain::Rust.install(None, opts.force).await?;
-            Toolchain::Cpp.install(None, opts.force).await?;
-            Extension::CargoRiscZero.install(None, opts.force).await?;
-        }
-        (None, Some(version)) => {
-            // Install cargo-risczero with specified version (e.g. rzup install v1.0.5), and default toolchains
-            Toolchain::Rust.install(None, opts.force).await?;
-            Toolchain::Cpp.install(None, opts.force).await?;
-            Extension::CargoRiscZero
-                .install(Some(version), opts.force)
-                .await?;
-        }
-        (Some(name), Some(version)) => {
-            if let Ok(toolchain) = name.parse::<Toolchain>() {
-                toolchain.install(Some(version), opts.force).await?
-            } else if let Ok(extension) = name.parse::<Extension>() {
-                extension.install(Some(version), opts.force).await?
-            } else {
-                return Err(anyhow!(
-                    "invalid value '{}' for '<install>...' \n\nFor more information try '--help'.",
-                    name
-                ));
-            }
-        }
-        (Some(name), None) => {
-            if let Ok(toolchain) = name.parse::<Toolchain>() {
-                toolchain.install(None, opts.force).await?;
-            }
+    if opts.name.is_none() {
+        // Install all default
+        Toolchain::Rust.install(None, opts.force).await?;
+        Toolchain::Cpp.install(None, opts.force).await?;
+        Extension::CargoRiscZero.install(None, opts.force).await?;
+    } else {
+        let name = opts.name.unwrap();
+        let version = opts.version.as_deref();
+        if let Ok(toolchain) = name.parse::<Toolchain>() {
+            toolchain.install(version, opts.force).await?
+        } else if let Ok(extension) = name.parse::<Extension>() {
+            extension.install(version, opts.force).await?
+        } else {
+            return Err(anyhow!(
+                "invalid value '{}' for '<install>...' \n\nFor more information try '--help'.",
+                name
+            ));
         }
     }
     Ok(())

--- a/rzup/src/main.rs
+++ b/rzup/src/main.rs
@@ -66,7 +66,6 @@ enum RzupSubcmd {
         /// Name of the toolchain or extension to install
         name: Option<String>,
         /// Version tag of the toolchain or extension to install
-        #[arg(short, long)]
         version: Option<String>,
         /// Force the installation, ignoring existing installations and downloads
         #[arg(short, long)]


### PR DESCRIPTION
#2372 broke CI due to improper configuration of the paths filters. For now, let's add rzup to the base path so we run many CI workloads when rzup changes and back out #2372 for now.