### PR TITLE
Docs reference correct cli commands for versioned rzup install for v1.1+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,10 @@ rzup install
 Optionally, you can specify which version of `cargo-risczero` to install with:
 
 ```bash
-rzup install --version $VERSION
+rzup install cargo-risczero $VERSION
 ```
+
+Where the `$VERSION` is a [release tag](https://github.com/risc0/risc0/releases) (e.g `v1.1.1`).
 
 > NOTE: It is only important that you install `cargo-risczero` with a matching version of the `zkvm` crate when interacting with the proof system as a separate, pre-built process ([`ExternalProver`](https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.ExternalProver.html)), which is currently the default. If you are using the `prove` feature on the `risc0-zkvm` crate for the host, this will compile the proving system into the host binary.
 
@@ -60,19 +62,19 @@ cargo xtask gen-receipt
 Before submitting a PR, ensure the following:
 
 1. Fork the `risc0` repository and create a new branch there to do your work.
-1. Format with `cargo fmt --all`.
-1. Lint with:
-    ```
-    RISC0_SKIP_BUILD=1 cargo clippy
-    $(cd examples && RISC0_SKIP_BUILD=1 cargo clippy)
-    $(cd benchmarks && RISC0_SKIP_BUILD=1 cargo clippy)
-    ```
-1. Perform the license check with `python3 license-check.py`.
-1. Tests pass with:
-    ```
-    cargo test -F prove -F docker
-    $(cd examples && cargo test)
-    $(cd benchmarks && cargo test)
-    ```
-1. Commit any outdated `Cargo.lock` files.
-1. Open a PR against the `main` branch.
+2. Format with `cargo fmt --all`.
+3. Lint with:
+   ```
+   RISC0_SKIP_BUILD=1 cargo clippy
+   $(cd examples && RISC0_SKIP_BUILD=1 cargo clippy)
+   $(cd benchmarks && RISC0_SKIP_BUILD=1 cargo clippy)
+   ```
+4. Perform the license check with `python3 license-check.py`.
+5. Tests pass with:
+   ```
+   cargo test -F prove -F docker
+   $(cd examples && cargo test)
+   $(cd benchmarks && cargo test)
+   ```
+6. Commit any outdated `Cargo.lock` files.
+7. Open a PR against the `main` branch.

--- a/rzup/README.md
+++ b/rzup/README.md
@@ -16,15 +16,13 @@ To install the latest RISC Zero release version:
 rzup install
 ```
 
-To install a specific release version:
+Optionally, you can specify which version of `cargo-risczero` to install with:
 
-```sh
-rzup install --version <VERSION>
+```bash
+rzup install cargo-risczero $VERSION
 ```
 
-Where `VERSION` can be replaced with a specified RISC Zero release (e.g.,
-`1.0.0`). See our [releases](https://github.com/risc0/risc0/releases) for more
-information.
+Where the `$VERSION` is a [release tag](https://github.com/risc0/risc0/releases) (e.g `v1.1.1`).
 
 To enable verbose installation logs:
 

--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -53,4 +53,4 @@ After you update your installation, be sure to update your project's RISC Zero c
 [release tag]: https://github.com/risc0/risc0/releases
 [Rust]: https://www.rust-lang.org
 [rustup]: https://rustup.rs
-[rzup-repo]: https://github.com/risc0/risc0/tree/release-1.1/rzup
+[rzup-repo]: https://github.com/risc0/risc0/tree/main/rzup

--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -21,7 +21,7 @@ The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] 
 
 Running `rzup` will install the latest version of the RISC Zero toolchain.
 
-For a specific version, use `rzup install --version <version>`, where the `<version>` is a [release tag].
+For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
 
 See `rzup --help` for more options. You can find out more about `rzup` [here](https://github.com/risc0/risc0/tree/main/rzup).
 

--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -23,7 +23,7 @@ Running `rzup` will install the latest version of the RISC Zero toolchain.
 
 For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
 
-See `rzup --help` for more options. You can find out more about `rzup` [here](https://github.com/risc0/risc0/tree/main/rzup).
+See `rzup --help` for more options. You can find out more about `rzup` [here][rzup-repo].
 
 ### Manual Installation and installation for all other systems (e.g. x86-64 macOS, arm64 Linux)
 
@@ -53,3 +53,4 @@ After you update your installation, be sure to update your project's RISC Zero c
 [release tag]: https://github.com/risc0/risc0/releases
 [Rust]: https://www.rust-lang.org
 [rustup]: https://rustup.rs
+[rzup-repo]: https://github.com/risc0/risc0/tree/release-1.1/rzup

--- a/website/api/zkvm/quickstart.md
+++ b/website/api/zkvm/quickstart.md
@@ -30,12 +30,6 @@ Run `rzup` to install the RISC Zero toolchain and `cargo-risczero`.
 rzup install
 ```
 
-> Note: To install a specific version instead of using the latest stable
-> version, use `rzup --version <version>`, where the `<version>` is a [release
-> tag](https://github.com/risc0/risc0/releases).
->
-> The version used must match the `risc0-zkvm` version from your guest and host.
-
 ## 2. Create a New Project
 
 The `cargo-risczero` tool takes `--guest-name` parameter, a [guest] program that

--- a/website/api_versioned_docs/version-1.1/zkvm/install.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/install.md
@@ -21,9 +21,9 @@ The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] 
 
 Running `rzup` will install the latest version of the RISC Zero toolchain.
 
-For a specific version, use `rzup install --version <version>`, where the `<version>` is a [release tag].
+For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
 
-See `rzup --help` for more options. You can find out more about `rzup` [here](https://github.com/risc0/risc0/tree/release-1.1/rzup).
+See `rzup --help` for more options. You can find out more about `rzup` [here](https://github.com/risc0/risc0/tree/main/rzup).
 
 ### Manual Installation and installation for all other systems (e.g. x86-64 macOS, arm64 Linux)
 

--- a/website/api_versioned_docs/version-1.1/zkvm/install.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/install.md
@@ -23,7 +23,7 @@ Running `rzup` will install the latest version of the RISC Zero toolchain.
 
 For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
 
-See `rzup --help` for more options. You can find out more about `rzup` [here](https://github.com/risc0/risc0/tree/main/rzup).
+See `rzup --help` for more options. You can find out more about `rzup` [here][rzup-repo].
 
 ### Manual Installation and installation for all other systems (e.g. x86-64 macOS, arm64 Linux)
 
@@ -53,3 +53,4 @@ After you update your installation, be sure to update your project's RISC Zero c
 [release tag]: https://github.com/risc0/risc0/releases
 [Rust]: https://www.rust-lang.org
 [rustup]: https://rustup.rs
+[rzup-repo]: https://github.com/risc0/risc0/tree/release-1.1/rzup

--- a/website/api_versioned_docs/version-1.1/zkvm/quickstart.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/quickstart.md
@@ -30,12 +30,6 @@ Run `rzup` to install the RISC Zero toolchain and `cargo-risczero`.
 rzup install
 ```
 
-> Note: To install a specific version instead of using the latest stable
-> version, use `rzup --version <version>`, where the `<version>` is a [release
-> tag](https://github.com/risc0/risc0/releases).
->
-> The version used must match the `risc0-zkvm` version from your guest and host.
-
 ## 2. Create a New Project
 
 The `cargo-risczero` tool takes `--guest-name` parameter, a [guest] program that


### PR DESCRIPTION
docs lagged the present state-of-the-art for `rzup` to change the versions. This amends the few places it was wrong for the latest version of the tool.

Related to https://github.com/risc0/risc0/issues/2382 and https://github.com/risc0/risc0/pull/2372