### PR TITLE
backport: Allow static mut references in specific places (#2398)

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -250,7 +250,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "6c5cc751c36081f1c6b7e5d87539a0873332a693c2879cfdf649fb7ac87ace2d",
+            "06b7cb51873fe66d2b9e9ecabc635f0ab0edff07ea6adcc693aab8e2e4763829",
         );
     }
 }

--- a/risc0/zkvm/src/guest/env/mod.rs
+++ b/risc0/zkvm/src/guest/env/mod.rs
@@ -119,7 +119,9 @@ static mut MEMORY_IMAGE_ENTROPY: [u32; 4] = [0u32; 4];
 /// Initialize globals before program main
 pub(crate) fn init() {
     unsafe {
+        #[allow(static_mut_refs)]
         HASHER.set(Sha256::new()).unwrap();
+        #[allow(static_mut_refs)]
         syscall::sys_rand(
             MEMORY_IMAGE_ENTROPY.as_mut_ptr(),
             MEMORY_IMAGE_ENTROPY.len(),
@@ -130,8 +132,10 @@ pub(crate) fn init() {
 /// Finalize execution
 pub(crate) fn finalize(halt: bool, user_exit: u8) {
     unsafe {
+        #[allow(static_mut_refs)]
         let hasher = HASHER.take();
         let journal_digest: Digest = hasher.unwrap().finalize().as_slice().try_into().unwrap();
+        #[allow(static_mut_refs)]
         let output = Output {
             journal: MaybePruned::Pruned(journal_digest),
             assumptions: MaybePruned::Pruned(ASSUMPTIONS_DIGEST.digest()),
@@ -400,7 +404,10 @@ pub fn stderr() -> FdWriter<impl for<'a> Fn(&'a [u8])> {
 /// Return a writer for the JOURNAL.
 pub fn journal() -> FdWriter<impl for<'a> Fn(&'a [u8])> {
     FdWriter::new(fileno::JOURNAL, |bytes| {
-        unsafe { HASHER.get_mut().unwrap_unchecked().update(bytes) };
+        #[allow(static_mut_refs)]
+        unsafe {
+            HASHER.get_mut().unwrap_unchecked().update(bytes)
+        };
     })
 }
 

--- a/risc0/zkvm/src/guest/env/verify.rs
+++ b/risc0/zkvm/src/guest/env/verify.rs
@@ -53,6 +53,7 @@ pub fn verify(image_id: impl Into<Digest>, journal: &[impl Pod]) -> Result<(), I
         // Use the zero digest as the control root, which indicates that the assumption is a zkVM
         // assumption to be verified with the same control root as the current execution.
         sys_verify_integrity(claim_digest.as_ref(), Digest::ZERO.as_ref());
+        #[allow(static_mut_refs)]
         ASSUMPTIONS_DIGEST.add(
             Assumption {
                 claim: claim_digest,
@@ -96,6 +97,7 @@ pub fn verify_integrity(claim: &ReceiptClaim) -> Result<(), VerifyIntegrityError
         // Use the zero digest as the control root, which indicates that the assumption is a zkVM
         // assumption to be verified with the same control root as the current execution.
         sys_verify_integrity(claim_digest.as_ref(), Digest::ZERO.as_ref());
+        #[allow(static_mut_refs)]
         ASSUMPTIONS_DIGEST.add(
             Assumption {
                 claim: claim_digest,
@@ -164,6 +166,7 @@ impl std::error::Error for VerifyIntegrityError {}
 pub fn verify_assumption(claim: Digest, control_root: Digest) -> Result<(), Infallible> {
     unsafe {
         sys_verify_integrity(claim.as_ref(), control_root.as_ref());
+        #[allow(static_mut_refs)]
         ASSUMPTIONS_DIGEST.add(
             Assumption {
                 claim,


### PR DESCRIPTION
In recent nightly builds, there is a warning against making mutable references to mutable statics (see e.g. here:
https://github.com/risc0/risc0/actions/runs/11148604622/job/30985587956?pr=2371). We are doing so in certain `unsafe` blocks where we have confirmed that our usage is acceptable, so this PR adds ` #[allow(static_mut_refs)]` to those locations to suppress this warning.