### PR TITLE
`rzup`: Add `list` command for listing installed and available toolchains and extensions

### DIFF
--- a/rzup/src/cli.rs
+++ b/rzup/src/cli.rs
@@ -17,6 +17,7 @@ pub mod default;
 pub mod extension;
 pub mod help;
 pub mod install;
+pub mod list;
 pub mod self_;
 pub mod show;
 pub mod toolchain;

--- a/rzup/src/cli/help.rs
+++ b/rzup/src/cli/help.rs
@@ -26,6 +26,9 @@ pub static SHOW_HELP: &str = r"Discussion:
     If there are multiple toolchains installed then all installed
     toolchains are listed as well.";
 
+pub static LIST_HELP: &str = r"Discussion:
+    Lists available toolchains and extensions.";
+
 pub static UPDATE_HELP: &str = r"Discussion:
     With no toolchain or extension specified, the `update` command
     updates each of the installed toolchains from the release channels.

--- a/rzup/src/cli/list.rs
+++ b/rzup/src/cli/list.rs
@@ -12,30 +12,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
-use crate::utils::{find_installed_extensions, find_installed_toolchains};
+use crate::utils::{
+    find_installed_extensions, find_installed_toolchains, list_cargo_risczero_versions,
+    list_cpp_toolchain_versions, list_rust_toolchain_versions,
+};
 
-pub fn handler(all: bool) -> Result<()> {
+pub async fn handler(all: bool) -> Result<()> {
     match all {
-        true => {
-            // not implemented
-            Err(anyhow!("Not implemented"))
-        }
-        false => {
-            eprintln!("Installed Extensions");
-            let extensions = find_installed_extensions()?;
-            for extension in extensions {
-                eprintln!("  {}", extension.file_name().unwrap().to_string_lossy());
-            }
-
-            eprintln!("\nInstalled Toolchains");
-            let toolchains = find_installed_toolchains()?;
-            for toolchain in toolchains {
-                eprintln!("  {}", toolchain);
-            }
-
-            Ok(())
-        }
+        true => list_all().await,
+        false => list_installed(),
     }
+}
+
+fn list_installed() -> Result<()> {
+    eprintln!("Installed Extensions");
+    let extensions = find_installed_extensions()?;
+    for extension in extensions {
+        eprintln!("  {}", extension.file_name().unwrap().to_string_lossy());
+    }
+
+    eprintln!("\nInstalled Toolchains");
+    let toolchains = find_installed_toolchains()?;
+    for toolchain in toolchains {
+        eprintln!("  {}", toolchain);
+    }
+
+    Ok(())
+}
+
+async fn list_all() -> Result<()> {
+    eprintln!("Available versions for `cargo-risczero`");
+    let versions = list_cargo_risczero_versions().await?;
+    for version in versions {
+        eprintln!("  {}", version);
+    }
+
+    eprintln!("\nAvailable versions for `rust-toolchain`");
+    let versions = list_rust_toolchain_versions().await?;
+    for version in versions {
+        eprintln!("  {}", version);
+    }
+
+    eprintln!("\nAvailable versions for `cpp-toolchain`");
+    let versions = list_cpp_toolchain_versions().await?;
+    for version in versions {
+        eprintln!("  {}", version);
+    }
+
+    Ok(())
 }

--- a/rzup/src/cli/list.rs
+++ b/rzup/src/cli/list.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{anyhow, Result};
+
+use crate::utils::{find_installed_extensions, find_installed_toolchains};
+
+pub fn handler(all: bool) -> Result<()> {
+    match all {
+        true => {
+            // not implemented
+            Err(anyhow!("Not implemented"))
+        }
+        false => {
+            eprintln!("Installed Extensions");
+            let extensions = find_installed_extensions()?;
+            for extension in extensions {
+                eprintln!("  {}", extension.file_name().unwrap().to_string_lossy());
+            }
+
+            eprintln!("\nInstalled Toolchains");
+            let toolchains = find_installed_toolchains()?;
+            for toolchain in toolchains {
+                eprintln!("  {}", toolchain);
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/rzup/src/main.rs
+++ b/rzup/src/main.rs
@@ -157,7 +157,7 @@ async fn run() -> Result<()> {
 
     match subcmd {
         RzupSubcmd::Show { subcmd } => cli::show::handler(subcmd),
-        RzupSubcmd::List { all } => cli::list::handler(all),
+        RzupSubcmd::List { all } => cli::list::handler(all).await,
         RzupSubcmd::Install {
             name,
             version,

--- a/rzup/src/main.rs
+++ b/rzup/src/main.rs
@@ -60,6 +60,14 @@ enum RzupSubcmd {
         #[command(subcommand)]
         subcmd: Option<cli::show::ShowSubcmd>,
     },
+    /// List available toolchains and extensions.
+    #[command(after_help = cli::help::LIST_HELP)]
+    List {
+        /// List all available toolchains and extensions, including those not
+        /// installed
+        #[arg(short, long)]
+        all: bool,
+    },
     /// Install toolchains or extensions
     #[command(after_help = cli::help::INSTALL_HELP)]
     Install {
@@ -149,6 +157,7 @@ async fn run() -> Result<()> {
 
     match subcmd {
         RzupSubcmd::Show { subcmd } => cli::show::handler(subcmd),
+        RzupSubcmd::List { all } => cli::list::handler(all),
         RzupSubcmd::Install {
             name,
             version,

--- a/rzup/src/utils.rs
+++ b/rzup/src/utils.rs
@@ -359,6 +359,36 @@ async fn check_cpp_toolchain_updates() -> Result<UpdateInfo, RzupError> {
     })
 }
 
+/// Gets a list of all available versions for the `cargo-risczero` extension.
+pub async fn list_cargo_risczero_versions() -> Result<Vec<String>, RzupError> {
+    let release_infos = Extension::CargoRiscZero.list_release_infos().await?;
+    let release_tags = release_infos
+        .iter()
+        .map(|info| info.tag_name.clone())
+        .collect();
+    Ok(release_tags)
+}
+
+/// Gets a list of all available versions for the `rust` toolchain.
+pub async fn list_rust_toolchain_versions() -> Result<Vec<String>, RzupError> {
+    let release_infos = Toolchain::Rust.list_release_infos().await?;
+    let release_tags = release_infos
+        .iter()
+        .map(|info| info.tag_name.clone())
+        .collect();
+    Ok(release_tags)
+}
+
+/// Gets a list of all available versions for the `cpp` toolchain.
+pub async fn list_cpp_toolchain_versions() -> Result<Vec<String>, RzupError> {
+    let release_infos = Toolchain::Cpp.list_release_infos().await?;
+    let release_tags = release_infos
+        .iter()
+        .map(|info| info.tag_name.clone())
+        .collect();
+    Ok(release_tags)
+}
+
 /// Checks for updates for the active toolchains and extensions and returns a list of update information.
 pub async fn get_updatable_active() -> Result<Vec<UpdateInfo>, RzupError> {
     let mut updates = Vec::new();


### PR DESCRIPTION
This PR proposes to add a `list` command to `rzup` for listing installed and available toolchains and extensions.

Closes #2316.