### PR TITLE
Improve install docs, add helpful error msg for no `rzup` artifact found

### DIFF
--- a/rzup/src/extension.rs
+++ b/rzup/src/extension.rs
@@ -106,7 +106,7 @@ impl Extension {
         let release_info = self.release_info(tag).await?;
         let Some(asset) = release_info.assets.get(&target) else {
             return Err(
-                RzupError::Other(format!("No asset found for target: {:?}", target)).into(),
+                RzupError::Other(format!("No asset found for target: {:?}\n📝 It's likely you need to manually install the toolchain following these instructions:\nhttps://dev.risczero.com/api/zkvm/install#manual-installation-and-installation-for-all-other-systems-eg-x86-64-macos-arm64-linux", target)).into(),
             );
         };
 

--- a/rzup/src/toolchain.rs
+++ b/rzup/src/toolchain.rs
@@ -132,7 +132,7 @@ impl Toolchain {
         let release_info = self.release_info(tag).await?;
         let Some(asset) = release_info.assets.get(&target) else {
             return Err(
-                RzupError::Other(format!("No asset found for target: {:?}", target)).into(),
+                RzupError::Other(format!("No asset found for target: {:?}\n📝 It's likely you need to manually install the toolchain following these instructions:\nhttps://dev.risczero.com/api/zkvm/install#manual-installation-and-installation-for-all-other-systems-eg-x86-64-macos-arm64-linux", target)).into(),
             );
         };
 

--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -6,9 +6,14 @@ These instructions guide you through installing or updating RISC Zero tools to b
 
 The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] installed, start by [installing Rust and rustup][install-rust]. Please follow the recommended Rust installation instructions using [rustup], as RISC Zero specifically depends on the [rustup] tool.
 
-## Installation for x86-64 Linux and arm64 macOS
+## Use the `rzup` installer
 
-`rzup` is the RISC Zero toolchain installer. We recommend using `rzup` to manage the installation of RISC Zero.
+:::warning
+Only compatible with x86-64 Linux and arm64 macOS
+All other architectures must [install manually](#manual-install)
+:::
+
+`rzup` is the RISC Zero toolchain installer and version manager, inspired by [rustup].
 
 1. Install `rzup` by running the following command:
    ```sh
@@ -21,32 +26,26 @@ The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] 
 
 Running `rzup` will install the latest version of the RISC Zero toolchain.
 
-For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
-
-See `rzup --help` for more options. You can find out more about `rzup` [here][rzup-repo].
-
-### Manual Installation and installation for all other systems (e.g. x86-64 macOS, arm64 Linux)
-
-For users who prefer manual installation or those who use systems such as x86-64 macOS, arm64 Linux, follow these steps:
-
-- Clone the repository with `git clone https://github.com/risc0/risc0.git`.
-- In the root of the repository, install `rzup` with `cargo install --path rzup`.
-- Build and install the rust toolchain with `rzup toolchain build rust`. This command may require utilities such as `cmake` and the `ninja` build system to be installed.
-- Build and install the `cargo-risczero` by first checking out the branch `release-*` where `*` is `[major release number].[minor release number]` of your desired zkVM version. For example, if you would like to install version 1.1.0, run `git checkout origin/release-1.1` and run `cargo install --path risc0/cargo-risczero`.
-
-For x86-64 linux and arm64 macOS, install the C++ toolchains by running:
-
-```sh
-rzup install cpp
-```
-
-## Update
+### Version Management
 
 To update your installation:
 
 1. Run `rzup update` to update the RISC Zero toolchain to the latest [release tag] version.
 
 After you update your installation, be sure to update your project's RISC Zero crates. To do this, you must update all RISC Zero dependencies in your project's host and guest `Cargo.toml` files. In most projects, this is done by updating the host and guest `risc0-zkvm` crate and the `risc0-build` build dependency. They should be updated to use the version number displayed by `cargo risczero --version`.
+
+For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
+
+See `rzup --help` for more options. You can find out more about `rzup` [here][rzup-repo].
+
+## Manual Install
+
+For users who prefer manual installation or those who use systems such as x86-64 macOS, arm64 Linux, follow these steps:
+
+1. Clone the repository with `git clone https://github.com/risc0/risc0.git`.
+2. In the root of the repository, install `rzup` with `cargo install --path rzup`.
+3. Build and install the rust toolchain with `rzup toolchain build rust`. This command may require utilities such as `cmake` and the `ninja` build system to be installed.
+4. Build and install the `cargo-risczero` by first checking out the branch `release-*` where `*` is `[major release number].[minor release number]` of your desired zkVM version. For example, if you would like to install version 1.1.0, run `git checkout origin/release-1.1` and run `cargo install --path risc0/cargo-risczero`.
 
 [cargo-risczero]: https://crates.io/crates/cargo-risczero
 [install-rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html

--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -6,7 +6,7 @@ These instructions guide you through installing or updating RISC Zero tools to b
 
 The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] installed, start by [installing Rust and rustup][install-rust]. Please follow the recommended Rust installation instructions using [rustup], as RISC Zero specifically depends on the [rustup] tool.
 
-## Use the `rzup` installer
+## Using `rzup`
 
 :::warning
 Only compatible with x86-64 Linux and arm64 macOS
@@ -24,19 +24,22 @@ All other architectures must [install manually](#manual-install)
    rzup install
    ```
 
-Running `rzup` will install the latest version of the RISC Zero toolchain.
+Running `rzup` will install the [latest version][release tag] of the RISC Zero toolchain.
+
+See `rzup --help` for more options. You can find out more about `rzup` [here][rzup-repo].
 
 ### Version Management
 
-To update your installation:
+:::info
+Your project's RISC Zero crates _must match_ the installed tooling best managed by [rzup](#use-the-rzup-installer).
+Be sure to match all `Cargo.toml` files with the version of the installation.
 
-1. Run `rzup update` to update the RISC Zero toolchain to the latest [release tag] version.
+Check your presently installed version number displayed by `cargo risczero --version`.
+:::
 
-After you update your installation, be sure to update your project's RISC Zero crates. To do this, you must update all RISC Zero dependencies in your project's host and guest `Cargo.toml` files. In most projects, this is done by updating the host and guest `risc0-zkvm` crate and the `risc0-build` build dependency. They should be updated to use the version number displayed by `cargo risczero --version`.
+Run `rzup update` to update the RISC Zero toolchain to the [latest version][release tag].
 
 For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
-
-See `rzup --help` for more options. You can find out more about `rzup` [here][rzup-repo].
 
 ## Manual Install
 

--- a/website/api_versioned_docs/version-1.1/blockchain-integration/contracts/verifier.md
+++ b/website/api_versioned_docs/version-1.1/blockchain-integration/contracts/verifier.md
@@ -215,7 +215,7 @@ You can find detailed information in the [version management design][version-man
 [estop-84532-etherscan]: https://sepolia.basescan.org/address/0xB369b4dd27FBfb59921d3A4a3D23AC2fc32FB908#code
 [estop-421614-etherscan]: https://sepolia.arbiscan.io/address/0x5E36f0D56741013d864d8FEb5950AB0E7Eff9Ab1#code
 [estop-11155111-etherscan]: https://sepolia.etherscan.io/address/0x7a028d6f0BD603Ad2a47e3a3B1E504C0D6234877#code
-[estop-src]: https://github.com/risc0/risc0-ethereum/blob/v1.1.0/contracts/src/RiscZeroVerifierEmergencyStop.sol
+[estop-src]: https://github.com/risc0/risc0-ethereum/blob/release-1.1/contracts/src/RiscZeroVerifierEmergencyStop.sol
 [EvenNumber.sol]: https://github.com/risc0/risc0-foundry-template/blob/main/contracts/EvenNumber.sol#L46-L52
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/struct.Groth16Receipt.html

--- a/website/api_versioned_docs/version-1.1/blockchain-integration/contracts/verifier.md
+++ b/website/api_versioned_docs/version-1.1/blockchain-integration/contracts/verifier.md
@@ -215,7 +215,7 @@ You can find detailed information in the [version management design][version-man
 [estop-84532-etherscan]: https://sepolia.basescan.org/address/0xB369b4dd27FBfb59921d3A4a3D23AC2fc32FB908#code
 [estop-421614-etherscan]: https://sepolia.arbiscan.io/address/0x5E36f0D56741013d864d8FEb5950AB0E7Eff9Ab1#code
 [estop-11155111-etherscan]: https://sepolia.etherscan.io/address/0x7a028d6f0BD603Ad2a47e3a3B1E504C0D6234877#code
-[estop-src]: https://github.com/risc0/risc0-ethereum/tree/v1.1.0-rc.3/contracts/src/groth16/RiscZeroVerifierEmergencyStop.sol
+[estop-src]: https://github.com/risc0/risc0-ethereum/blob/v1.1.0/contracts/src/RiscZeroVerifierEmergencyStop.sol
 [EvenNumber.sol]: https://github.com/risc0/risc0-foundry-template/blob/main/contracts/EvenNumber.sol#L46-L52
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/struct.Groth16Receipt.html

--- a/website/api_versioned_docs/version-1.1/zkvm/install.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/install.md
@@ -6,9 +6,14 @@ These instructions guide you through installing or updating RISC Zero tools to b
 
 The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] installed, start by [installing Rust and rustup][install-rust]. Please follow the recommended Rust installation instructions using [rustup], as RISC Zero specifically depends on the [rustup] tool.
 
-## Installation for x86-64 Linux and arm64 macOS
+## Using `rzup`
 
-`rzup` is the RISC Zero toolchain installer. We recommend using `rzup` to manage the installation of RISC Zero.
+:::warning
+Only compatible with x86-64 Linux and arm64 macOS
+All other architectures must [install manually](#manual-install)
+:::
+
+`rzup` is the RISC Zero toolchain installer and version manager, inspired by [rustup].
 
 1. Install `rzup` by running the following command:
    ```sh
@@ -19,38 +24,35 @@ The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] 
    rzup install
    ```
 
-Running `rzup` will install the latest version of the RISC Zero toolchain.
-
-For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
+Running `rzup` will install the [latest version][release tag] of the RISC Zero toolchain.
 
 See `rzup --help` for more options. You can find out more about `rzup` [here][rzup-repo].
 
-### Manual Installation and installation for all other systems (e.g. x86-64 macOS, arm64 Linux)
+### Version Management
+
+:::info
+Your project's RISC Zero crates _must match_ the installed tooling best managed by [rzup](#use-the-rzup-installer).
+Be sure to match all `Cargo.toml` files with the version of the installation.
+
+Check your presently installed version number displayed by `cargo risczero --version`.
+:::
+
+Run `rzup update` to update the RISC Zero toolchain to the [latest version][release tag].
+
+For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a [release tag] (e.g `v1.1.1`).
+
+## Manual Install
 
 For users who prefer manual installation or those who use systems such as x86-64 macOS, arm64 Linux, follow these steps:
 
-- Clone the repository with `git clone https://github.com/risc0/risc0.git`.
-- In the root of the repository, install `rzup` with `cargo install --path rzup`.
-- Build and install the rust toolchain with `rzup toolchain build rust`. This command may require utilities such as `cmake` and the `ninja` build system to be installed.
-- Build and install the `cargo-risczero` by first checking out the branch `release-*` where `*` is `[major release number].[minor release number]` of your desired zkVM version. For example, if you would like to install version 1.1.0, run `git checkout origin/release-1.1` and run `cargo install --path risc0/cargo-risczero`.
-
-For x86-64 linux and arm64 macOS, install the C++ toolchains by running:
-
-```sh
-rzup install cpp
-```
-
-## Update
-
-To update your installation:
-
-1. Run `rzup update` to update the RISC Zero toolchain to the latest [release tag] version.
-
-After you update your installation, be sure to update your project's RISC Zero crates. To do this, you must update all RISC Zero dependencies in your project's host and guest `Cargo.toml` files. In most projects, this is done by updating the host and guest `risc0-zkvm` crate and the `risc0-build` build dependency. They should be updated to use the version number displayed by `cargo risczero --version`.
+1. Clone the repository with `git clone https://github.com/risc0/risc0.git`.
+2. In the root of the repository, install `rzup` with `cargo install --path rzup`.
+3. Build and install the rust toolchain with `rzup toolchain build rust`. This command may require utilities such as `cmake` and the `ninja` build system to be installed.
+4. Build and install the `cargo-risczero` by first checking out the branch `release-*` where `*` is `[major release number].[minor release number]` of your desired zkVM version. For example, if you would like to install version 1.1.0, run `git checkout origin/release-1.1` and run `cargo install --path risc0/cargo-risczero`.
 
 [cargo-risczero]: https://crates.io/crates/cargo-risczero
 [install-rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 [release tag]: https://github.com/risc0/risc0/releases
 [Rust]: https://www.rust-lang.org
 [rustup]: https://rustup.rs
-[rzup-repo]: https://github.com/risc0/risc0/tree/release-1.1/rzup
+[rzup-repo]: https://github.com/risc0/risc0/tree/main/rzup

--- a/website/api_versioned_docs/version-1.1/zkvm/install.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/install.md
@@ -55,4 +55,4 @@ For users who prefer manual installation or those who use systems such as x86-64
 [release tag]: https://github.com/risc0/risc0/releases
 [Rust]: https://www.rust-lang.org
 [rustup]: https://rustup.rs
-[rzup-repo]: https://github.com/risc0/risc0/tree/main/rzup
+[rzup-repo]: https://github.com/risc0/risc0/tree/release-1.1/rzup

--- a/website/lychee.toml
+++ b/website/lychee.toml
@@ -6,6 +6,10 @@ max_redirects = 10
 max_retries = 3
 
 exclude = [
-  # rate limited
-  "https://epubs.siam.org/doi/10.1137/0108018",
+  # rate limited & forbidden 403
+  "siam.org",
+  "basescan.org",
+  "arbiscan.io",
+  "theblock.co",
+  "hackenproof.com",
 ]


### PR DESCRIPTION
Closes #2421

Also to clarify better what systems are supported and have a more clean end-to-end instruction workflow, I tweaked the install page for 1.1 and future versions.

> [!NOTE]
> does not resolve the bug in detecting the arch mentioned in #2421 
