### PR TITLE
docker builds: fix cpp toolchain support

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -154,7 +154,7 @@ fn create_dockerfile(
     .join(" ");
 
     let build = DockerFile::new()
-        .from_alias("build", "risczero/risc0-guest-builder:r0.1.79.0-2")
+        .from_alias("build", "risczero/risc0-guest-builder:r0.1.79.0-3")
         .workdir("/src")
         .copy(".", ".")
         .env(manifest_env)
@@ -162,6 +162,11 @@ fn create_dockerfile(
         .env(&[("CARGO_TARGET_DIR", "target")])
         // Fetching separately allows docker to cache the downloads, assuming the Cargo.lock
         // doesn't change.
+        .env(&[(
+            "CC",
+            "/root/.local/share/cargo-risczero/cpp/bin/riscv32-unknown-elf-gcc",
+        )])
+        .env(&[("CFLAGS_riscv32im_risc0_zkvm_elf", "-march=rv32im -nostdlib")])
         .run(&fetch_cmd)
         .run(&build_cmd);
 

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -160,13 +160,13 @@ fn create_dockerfile(
         .env(manifest_env)
         .env(rustflags_env)
         .env(&[("CARGO_TARGET_DIR", "target")])
-        // Fetching separately allows docker to cache the downloads, assuming the Cargo.lock
-        // doesn't change.
         .env(&[(
             "CC_riscv32im_risc0_zkvm_elf",
             "/root/.local/share/cargo-risczero/cpp/bin/riscv32-unknown-elf-gcc",
         )])
         .env(&[("CFLAGS_riscv32im_risc0_zkvm_elf", "-march=rv32im -nostdlib")])
+        // Fetching separately allows docker to cache the downloads, assuming the Cargo.lock
+        // doesn't change.
         .run(&fetch_cmd)
         .run(&build_cmd);
 

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -163,7 +163,7 @@ fn create_dockerfile(
         // Fetching separately allows docker to cache the downloads, assuming the Cargo.lock
         // doesn't change.
         .env(&[(
-            "CC",
+            "CC_riscv32im_risc0_zkvm_elf",
             "/root/.local/share/cargo-risczero/cpp/bin/riscv32-unknown-elf-gcc",
         )])
         .env(&[("CFLAGS_riscv32im_risc0_zkvm_elf", "-march=rv32im -nostdlib")])

--- a/risc0/cargo-risczero/docker/Dockerfile.release
+++ b/risc0/cargo-risczero/docker/Dockerfile.release
@@ -1,10 +1,10 @@
-# To build run: docker build -f Dockerfile.release --build-arg="RISC0_TOOLCHAIN_VERSION=r0.1.79.0-2" -t risczero/risc0-guest-builder:r0.1.79.0-2 .
+# To build run: docker build -f Dockerfile.release --build-arg="RISC0_TOOLCHAIN_VERSION=r0.1.79.0-2" -t risczero/risc0-guest-builder:r0.1.79.0-3 .
 FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
 
 ARG RISC0_TOOLCHAIN_VERSION=
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config
+RUN apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config build-essential
 RUN curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https://sh.rustup.rs' | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo install cargo-binstall

--- a/risc0/zkvm/methods/build.rs
+++ b/risc0/zkvm/methods/build.rs
@@ -40,7 +40,7 @@ fn main() {
         (
             "risc0-zkvm-methods-guest",
             GuestOptions {
-                use_docker,
+                use_docker: use_docker.clone(),
                 ..Default::default()
             },
         ),
@@ -48,6 +48,13 @@ fn main() {
             "risc0-zkvm-methods-std",
             GuestOptions {
                 features: vec!["test_feature1".to_string(), "test_feature2".to_string()],
+                ..Default::default()
+            },
+        ),
+        (
+            "risc0-zkvm-methods-cpp-crates",
+            GuestOptions {
+                use_docker,
                 ..Default::default()
             },
         ),


### PR DESCRIPTION
This change fixes errors that occur from building guests that use C code (such as c-kzg) using the docker reproducible build image. This change set adds the `CC` and `CFLAGS` to the appropriate location and uses a new docker image that includes the `build-essentials` package. 