### PR TITLE
rzup install: run source on the profile

### DIFF
--- a/rzup/install
+++ b/rzup/install
@@ -102,6 +102,7 @@ main() {
           echo
           echo "export PATH=\"\$PATH:$RZUP_BIN_DIR\""
       } >> "$PROFILE"
+      source "$PROFILE"
   else
       info "rzup found in PATH"
   fi


### PR DESCRIPTION
Users are running into issues when installing rzup due to the profile not being sourced. This forces them to run the source command manually or start a new shell. Fix this by running `source $PROFILE` to add `rzup` to the path.