### PR TITLE
replaced use of risc0_zkvm::Bytes with Vec<u8> to fix running tests in examples/waldo/core

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -5822,6 +5822,7 @@ dependencies = [
 name = "waldo-core"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "divrem",
  "elsa",

--- a/examples/waldo/core/Cargo.toml
+++ b/examples/waldo/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
 bincode = "1.3"
 divrem = "1.0"
 elsa = "1.7"

--- a/examples/waldo/core/src/image.rs
+++ b/examples/waldo/core/src/image.rs
@@ -15,6 +15,9 @@
 use image::{DynamicImage, GrayImage, Rgb, RgbImage};
 use serde::{Deserialize, Serialize};
 
+#[cfg(not(target_os = "zkvm"))]
+use anyhow::Error;
+
 use crate::merkle::{MerkleTree, Node};
 
 /// Recommended default chunk size to use in the ImageMerkleTree and
@@ -127,9 +130,7 @@ impl<const N: u32> ImageMerkleTree<N> {
     }
 
     #[cfg(not(target_os = "zkvm"))]
-    pub fn vector_oracle_callback(
-        &self,
-    ) -> impl Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> + '_ {
+    pub fn vector_oracle_callback(&self) -> impl Fn(Vec<u8>) -> Result<Vec<u8>, Error> + '_ {
         self.0.vector_oracle_callback()
     }
 }

--- a/examples/waldo/core/src/image.rs
+++ b/examples/waldo/core/src/image.rs
@@ -129,7 +129,7 @@ impl<const N: u32> ImageMerkleTree<N> {
     #[cfg(not(target_os = "zkvm"))]
     pub fn vector_oracle_callback(
         &self,
-    ) -> impl Fn(risc0_zkvm::Bytes) -> risc0_zkvm::Result<risc0_zkvm::Bytes> + '_ {
+    ) -> impl Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> + '_ {
         self.0.vector_oracle_callback()
     }
 }

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -1097,6 +1097,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "waldo-core"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "divrem",
  "elsa",

--- a/examples/waldo/src/bin/prove.rs
+++ b/examples/waldo/src/bin/prove.rs
@@ -16,7 +16,7 @@ use std::{error::Error, fs, path::PathBuf};
 
 use clap::Parser;
 use image::{io::Reader as ImageReader, GenericImageView};
-use risc0_zkvm::{default_prover, ExecutorEnv};
+use risc0_zkvm::{default_prover, Bytes, ExecutorEnv};
 use waldo_core::{
     image::{ImageMask, ImageMerkleTree, IMAGE_CHUNK_SIZE},
     merkle::SYS_VECTOR_ORACLE,
@@ -117,7 +117,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // vector oracle data from the Merkle tree.
     let env = ExecutorEnv::builder()
         .write(&input)?
-        .io_callback(SYS_VECTOR_ORACLE, img_merkle_tree.vector_oracle_callback())
+        .io_callback(SYS_VECTOR_ORACLE, |input: Bytes| {
+            let callback = img_merkle_tree.vector_oracle_callback();
+            callback(input.to_vec()).map(Bytes::from)
+        })
         .build()
         .unwrap();
 


### PR DESCRIPTION
[related discord issue](https://discord.com/channels/953703904086994974/1294228671527387136)

Running `cargo test` in `examples/waldo/core` gives errors:

```rust
error[E0412]: cannot find type `Bytes` in crate `risc0_zkvm`
   --> waldo/core/src/image.rs:132:71
    |
132 |     ) -> impl Fn(risc0_zkvm::Bytes) -> risc0_zkvm::Result<risc0_zkvm::Bytes> + '_ {
    |                                                                       ^^^^^ not found in `risc0_zkvm
```

This is because [Bytes](https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.Bytes.html) is only available for feature flags `client` or `prove`.

Instead of adding a feature flag, this PR replaces the use of `risc0_zkvm::Bytes` with `Vec<u8>`.
