### PR TITLE
[TEST - DO NOT LAND]: Dummy commit to trigger concurrent CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,7 +335,7 @@ jobs:
         working-directory: examples/profiling
       - run: sccache --show-stats
 
-  # test-crates:
+  # test-crates:#
   #   if: needs.changes.outputs.test-crates == 'true'
   #   needs: changes
   #   runs-on: [self-hosted, prod, Linux, cpu]


### PR DESCRIPTION
Dummy commit to trigger concurrent CI tests between `risc0` and `boundless-xyz` org runners.