### PR TITLE
Add links to refactored governance example

### DIFF
--- a/website/api/blockchain-integration/eth-examples.md
+++ b/website/api/blockchain-integration/eth-examples.md
@@ -20,17 +20,17 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 ### DAO Governance Example
 
-This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
+This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard][governor-standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of ~77% is achieved with significant room for optimizations.
 
 [blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/main/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
-[governance-example]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance
-[Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
+[governance-example]: https://github.com/risc0/risc0-ethereum/tree/main/examples/governance
+[governor-standard]: https://docs.openzeppelin.com/contracts/5.x/api/governance
 [remote-proving]: ../generating-proofs/remote-proving.md
 [revm]: https://crates.io/crates/revm
 [risc0-ethereum]: https://github.com/risc0/risc0-ethereum
-[signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
-[steel-blog]: https://www.risczero.com/blog/introducing-steel
+[signature-aggregation]: https://github.com/risc0/risc0-ethereum/blob/main/examples/governance/methods/guest/src/bin/finalize_votes.rs
+[steel-blog]: https://www.risczero.com/blog/introducing-steel-1.0
 [steel-repo]: https://crates.io/crates/risc0-steel
 [steel-src]: https://github.com/risc0/risc0-ethereum/tree/main/steel
 [verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/main/contracts

--- a/website/api/generating-proofs/remote-proving.md
+++ b/website/api/generating-proofs/remote-proving.md
@@ -48,7 +48,7 @@ You can log the cycle count and other performance info for your zkVM Guest progr
 [external-bonsai-sdk]: https://crates.io/crates/bonsai-sdk
 [external-default-prover-fn]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/fn.default_prover.html
 [external-foundry-template]: https://github.com/risc0/risc0-foundry-template/blob/main/README.md
-[external-governance-showcase]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance#readme
+[external-governance-showcase]: https://github.com/risc0/risc0-ethereum/tree/main/examples/governance#readme
 [external-zeth]: https://www.risczero.com/blog/zeth-release
 [external-zkcoprocessor]: https://www.risczero.com/blog/a-guide-to-zk-coprocessors-for-scalability
 [term-cycles]: /terminology#clock-cycles

--- a/website/api/zkvm/optimization.md
+++ b/website/api/zkvm/optimization.md
@@ -528,7 +528,7 @@ below.
 [RISC-V operations]: https://marks.page/riscv
 [Sampling CPU profilers]: https://nikhilism.com/post/2018/sampling-profiler-internals-introduction
 [SHA extensions]: https://en.wikipedia.org/wiki/Intel_SHA_extensions
-[snippet-bonsai-governance]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs#L88-L90
+[snippet-bonsai-governance]: https://github.com/risc0/risc0-ethereum/blob/main/examples/governance/methods/guest/src/bin/finalize_votes.rs#L86-L87
 [snippet-password-checker]: https://github.com/risc0/risc0/blob/main/examples/password-checker/methods/guest/src/main.rs#L24
 [superscalar]: https://en.wikipedia.org/wiki/Superscalar_processor
 [waldo-merkle]: https://github.com/risc0/risc0/blob/main/examples/waldo/core/src/merkle.rs

--- a/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
+++ b/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
@@ -20,17 +20,17 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 ### DAO Governance Example
 
-This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
+This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard][governor-standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
 [blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
-[governance-example]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance
-[Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
+[governance-example]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/examples/governance
+[governor-standard]: https://docs.openzeppelin.com/contracts/5.x/api/governance
 [remote-proving]: ../generating-proofs/remote-proving.md
 [revm]: https://crates.io/crates/revm
 [risc0-ethereum]: https://github.com/risc0/risc0-ethereum/tree/release-1.0
-[signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
-[steel-blog]: https://www.risczero.com/blog/introducing-steel
+[signature-aggregation]: https://github.com/risc0/risc0-ethereum/blob/release-1.0/examples/governance/methods/guest/src/bin/finalize_votes.rs
+[steel-blog]: https://www.risczero.com/blog/introducing-steel-1.0
 [steel-repo]: https://crates.io/crates/risc0-steel
 [steel-src]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/steel
 [verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/contracts

--- a/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
+++ b/website/api_versioned_docs/version-1.0/blockchain-integration/eth-examples.md
@@ -20,7 +20,7 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 ### DAO Governance Example
 
-This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard][governor-standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
+This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard][governor-standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of ~77% is achieved with significant room for optimizations.
 
 [blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template

--- a/website/api_versioned_docs/version-1.0/generating-proofs/remote-proving.md
+++ b/website/api_versioned_docs/version-1.0/generating-proofs/remote-proving.md
@@ -47,7 +47,7 @@ You can log the cycle count and other performance info for your zkVM Guest progr
 [external-bonsai-sdk]: https://crates.io/crates/bonsai-sdk
 [external-cargo-risczero]: https://crates.io/crates/cargo-risczero
 [external-foundry-template]: https://github.com/risc0/risc0-foundry-template/blob/main/README.md
-[external-governance-showcase]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance#readme
+[external-governance-showcase]: https://github.com/risc0/risc0-ethereum/tree/release-1.0/examples/governance#readme
 [external-zeth]: https://www.risczero.com/news/zeth-release
 [external-zkcoprocessor]: https://www.risczero.com/news/a-guide-to-zk-coprocessors-for-scalability
 [term-cycles]: /terminology#clock-cycles

--- a/website/api_versioned_docs/version-1.0/zkvm/optimization.md
+++ b/website/api_versioned_docs/version-1.0/zkvm/optimization.md
@@ -528,7 +528,7 @@ below.
 [RISC-V operations]: https://marks.page/riscv
 [Sampling CPU profilers]: https://nikhilism.com/post/2018/sampling-profiler-internals-introduction
 [SHA extensions]: https://en.wikipedia.org/wiki/Intel_SHA_extensions
-[snippet-bonsai-governance]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs#L88-L90
+[snippet-bonsai-governance]: https://github.com/risc0/risc0-ethereum/blob/release-1.0/examples/governance/methods/guest/src/bin/finalize_votes.rs#L86-L87
 [snippet-password-checker]: https://github.com/risc0/risc0/blob/release-1.0/examples/password-checker/methods/guest/src/main.rs#L24
 [superscalar]: https://en.wikipedia.org/wiki/Superscalar_processor
 [waldo-merkle]: https://github.com/risc0/risc0/blob/release-1.0/examples/waldo/core/src/merkle.rs

--- a/website/api_versioned_docs/version-1.1/blockchain-integration/eth-examples.md
+++ b/website/api_versioned_docs/version-1.1/blockchain-integration/eth-examples.md
@@ -20,7 +20,7 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 ### DAO Governance Example
 
-This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard][governor-standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
+This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard][governor-standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of ~77% is achieved with significant room for optimizations.
 
 [blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/release-1.1/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template

--- a/website/api_versioned_docs/version-1.1/blockchain-integration/eth-examples.md
+++ b/website/api_versioned_docs/version-1.1/blockchain-integration/eth-examples.md
@@ -20,17 +20,17 @@ The [RISC Zero Foundry Template][foundry-template] provides a minimal applicatio
 
 ### DAO Governance Example
 
-This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
+This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. The protocol, based on the OpenZeppelin [Governor smart contract standard][governor-standard], batches signature verifications off-chain for a DAO governance vote. The end result is that in [\~160 lines of Rust][signature-aggregation], a gas savings of 66% is achieved with significant room for optimizations.
 
 [blockchain-examples]: https://github.com/risc0/risc0-ethereum/tree/release-1.1/examples
 [foundry-template]: https://github.com/risc0/risc0-foundry-template
-[governance-example]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance
-[Governor smart contract standard]: https://docs.openzeppelin.com/contracts/4.x/api/governance
+[governance-example]: https://github.com/risc0/risc0-ethereum/tree/release-1.1/examples/governance
+[governor-standard]: https://docs.openzeppelin.com/contracts/5.x/api/governance
 [remote-proving]: ../generating-proofs/remote-proving.md
 [revm]: https://crates.io/crates/revm
 [risc0-ethereum]: https://github.com/risc0/risc0-ethereum
-[signature-aggregation]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs
-[steel-blog]: https://www.risczero.com/blog/introducing-steel
+[signature-aggregation]: https://github.com/risc0/risc0-ethereum/blob/release-1.1/examples/governance/methods/guest/src/bin/finalize_votes.rs
+[steel-blog]: https://www.risczero.com/blog/introducing-steel-1.0
 [steel-repo]: https://crates.io/crates/risc0-steel
 [steel-src]: https://github.com/risc0/risc0-ethereum/tree/release-1.1/steel
 [verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/release-1.1/contracts

--- a/website/api_versioned_docs/version-1.1/generating-proofs/remote-proving.md
+++ b/website/api_versioned_docs/version-1.1/generating-proofs/remote-proving.md
@@ -48,7 +48,7 @@ You can log the cycle count and other performance info for your zkVM Guest progr
 [external-bonsai-sdk]: https://crates.io/crates/bonsai-sdk
 [external-default-prover-fn]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/fn.default_prover.html
 [external-foundry-template]: https://github.com/risc0/risc0-foundry-template/blob/main/README.md
-[external-governance-showcase]: https://github.com/risc0/risc0/tree/release-0.20/bonsai/examples/governance#readme
+[external-governance-showcase]: https://github.com/risc0/risc0-ethereum/tree/release-1.1/examples/governance#readme
 [external-zeth]: https://www.risczero.com/blog/zeth-release
 [external-zkcoprocessor]: https://www.risczero.com/blog/a-guide-to-zk-coprocessors-for-scalability
 [term-cycles]: /terminology#clock-cycles

--- a/website/api_versioned_docs/version-1.1/zkvm/optimization.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/optimization.md
@@ -528,7 +528,7 @@ below.
 [RISC-V operations]: https://marks.page/riscv
 [Sampling CPU profilers]: https://nikhilism.com/post/2018/sampling-profiler-internals-introduction
 [SHA extensions]: https://en.wikipedia.org/wiki/Intel_SHA_extensions
-[snippet-bonsai-governance]: https://github.com/risc0/risc0/blob/release-0.20/bonsai/examples/governance/methods/guest/src/bin/finalize_votes.rs#L88-L90
+[snippet-bonsai-governance]: https://github.com/risc0/risc0-ethereum/blob/release-1.1/examples/governance/methods/guest/src/bin/finalize_votes.rs#L86-L87
 [snippet-password-checker]: https://github.com/risc0/risc0/blob/release-1.1/examples/password-checker/methods/guest/src/main.rs#L24
 [superscalar]: https://en.wikipedia.org/wiki/Superscalar_processor
 [waldo-merkle]: https://github.com/risc0/risc0/blob/release-1.1/examples/waldo/core/src/merkle.rs

--- a/website/link-version-check.py
+++ b/website/link-version-check.py
@@ -13,9 +13,6 @@ EXTENSIONS = [
 EXCEPTIONS = [
     # allow refs to trusted setup ceremony assets
     "d4e427283027c28b38b8eda1562e8e0e68d1b0e2",
-    # allow references to the governance example from prior versions.
-    # Related issue https://github.com/risc0/risc0-ethereum/issues/1
-    "bonsai/examples/governance",
     # allow link to risc0-ethereum before versioning started to match with 1.0
     "github.com/risc0/risc0-ethereum/blob/release-0.7",
     "github.com/risc0/risc0-ethereum/blob/release-0.10",


### PR DESCRIPTION
After refactoring the governance example to work with 1.X, the docs still point to the old `release-2.0` version. This PR fixes these inconsistencies, and removes the now unnecessary CI rule for "bonsai governance".