### PR TITLE
chore(reports): reorder datasheet columns

### DIFF
--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/_components/datasheet-table-columns.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/_components/datasheet-table-columns.tsx
@@ -20,6 +20,13 @@ export const datasheetTableColumns = [
     cell: (info) => <div className="truncate font-mono">{info.getValue() ?? "-"}</div>,
   }),
   {
+    accessorKey: "throughput",
+    header: ({ column }) => <TableColumnHeader column={column} title="Speed" />,
+    cell: ({ row }) => (
+      <div className="truncate font-mono">{formatHz(row.getValue("throughput") ?? row.getValue("speed")) ?? "-"}</div>
+    ),
+  },
+  {
     accessorKey: "total_cycles",
     header: ({ column }) => <TableColumnHeader column={column} title="Cycles" />,
     cell: ({ row }) => (
@@ -40,11 +47,4 @@ export const datasheetTableColumns = [
     header: ({ column }) => <TableColumnHeader column={column} title="Seal" />,
     cell: (info) => <div className="truncate font-mono">{formatBytes(info.getValue()) ?? "-"}</div>,
   }),
-  {
-    accessorKey: "throughput",
-    header: ({ column }) => <TableColumnHeader column={column} title="Speed" />,
-    cell: ({ row }) => (
-      <div className="truncate font-mono">{formatHz(row.getValue("throughput") ?? row.getValue("speed")) ?? "-"}</div>
-    ),
-  },
 ] as ColumnDef<DatasheetTableSchema, unknown>[];


### PR DESCRIPTION
From frank:
> I often need to look at the 'speed' column in the datasheet, I'd like the columns to be in this order:
> `Name, Hash Function, Speed, Cycles, Duration, RAM, Proof Size`

<img width="782" alt="image" src="https://github.com/user-attachments/assets/0ca5554d-388e-4908-9b63-2f3efbf33300">
