### PR TITLE
Update pinned foundry version to latest nightly

### DIFF
--- a/.github/workflows/risc0-ethereum.yml
+++ b/.github/workflows/risc0-ethereum.yml
@@ -128,7 +128,7 @@ jobs:
         working-directory: risc0
       - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
         with:
-          version: nightly-4351742481c98adaa9ca3e8642e619aa986b3cee
+          version: nightly-5c69a9d9fd4e2ec07fc398ab5ef9d706c33890c2
       # Apply local patch
       - name: Local patch on risc0-ethereum
         run: python ${{ env.RISC0_PATH }}/.github/cargo_local_patch.py  .


### PR DESCRIPTION
This PR updates the pinned foundry version for the `risc0-ethereum` CI checks to the latest nightly version. This nightly includes a fix for https://github.com/foundry-rs/foundry/pull/9202 which was causing problems with the latest `alloy` release.