### PR TITLE
docs: update logging command in quickstart, RUST_LOG=info

### DIFF
--- a/website/api/zkvm/quickstart.md
+++ b/website/api/zkvm/quickstart.md
@@ -82,7 +82,7 @@ it will be significantly faster than running proofs locally. You can [request ac
 
 To gain insights into your application's performance, you can obtain executor
 statistics by setting the `RUST_LOG` environment variable to
-`"[executor]=info"`.
+`info`.
 
 Setting this filter will print statistics about the execution before proof
 generation, so you can understand how computationally expensive your application
@@ -90,7 +90,7 @@ is. Since the statistics concern only the executor phase, it is recommended to
 run your application in dev-mode to avoid the overhead of proof generation:
 
 ```bash
-RISC0_DEV_MODE=1 RUST_LOG="[executor]=info" cargo run --release
+RISC0_DEV_MODE=1 RUST_LOG=info cargo run --release
 ```
 
 The statistics include:

--- a/website/api_versioned_docs/version-1.1/zkvm/quickstart.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/quickstart.md
@@ -82,7 +82,7 @@ it will be significantly faster than running proofs locally. You can [request ac
 
 To gain insights into your application's performance, you can obtain executor
 statistics by setting the `RUST_LOG` environment variable to
-`"[executor]=info"`.
+`info`.
 
 Setting this filter will print statistics about the execution before proof
 generation, so you can understand how computationally expensive your application
@@ -90,7 +90,7 @@ is. Since the statistics concern only the executor phase, it is recommended to
 run your application in dev-mode to avoid the overhead of proof generation:
 
 ```bash
-RISC0_DEV_MODE=1 RUST_LOG="[executor]=info" cargo run --release
+RISC0_DEV_MODE=1 RUST_LOG=info cargo run --release
 ```
 
 The statistics include:


### PR DESCRIPTION
Following changes [here](https://github.com/risc0/risc0/pull/2211/files#diff-dfa2cecf624b63ad559bad93cf1fb6eb8b2997d28df91660baa26b1cf8c9d141R224)

changing quickstart docs page in api/ and 1.1/ from:

`RISC0_DEV_MODE=1 RUST_LOG="[executor]=info" cargo run --release` 

to

`RISC0_DEV_MODE=1 RUST_LOG=info cargo run --release`

originally notice by @denciu on discord ([thread](https://discord.com/channels/953703904086994974/1299348658508140574)).
