### PR TITLE
bump rzup to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4558,7 +4558,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rzup"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
new binaries will be released shortly after this is merged.