### PR TITLE
rzup: replace toolchain `reqwest` download with `downloader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,6 +2508,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,11 +3966,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.3.1",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3967,6 +3985,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -4564,6 +4583,7 @@ dependencies = [
  "cfg-if",
  "clap 4.5.20",
  "dirs",
+ "downloader",
  "flate2",
  "fs2",
  "lazy_static",
@@ -5241,6 +5261,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.89"
 cfg-if = "1.0.0"
 clap = { version = "4.5.20", features = ["derive"] }
 dirs = "5.0.1"
+downloader = "0.2.8"
 flate2 = "1.0.34"
 fs2 = "0.4.3"
 lazy_static = "1.5.0"

--- a/rzup/src/toolchain.rs
+++ b/rzup/src/toolchain.rs
@@ -188,7 +188,7 @@ impl Toolchain {
             let results = downloader.download(&[dl])?;
 
             if let Some(Err(e)) = results.first() {
-                return Err(anyhow::anyhow!("Download failed: {}", e));
+                return Err(RzupError::Other(format!("Failed to download asset: {:?}", e)).into());
             }
 
             Ok(())

--- a/rzup/src/toolchain.rs
+++ b/rzup/src/toolchain.rs
@@ -23,10 +23,11 @@ use crate::{
     verbose_msg,
 };
 use anyhow::{bail, Context, Result};
+use downloader::{Download, Downloader};
 use flate2::bufread::GzDecoder;
 use std::{
     fs,
-    io::{BufReader, Write},
+    io::BufReader,
     os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
     process::Command,
@@ -34,6 +35,7 @@ use std::{
 };
 use tar::Archive;
 use tempfile::tempdir;
+use tokio::task;
 use xz::bufread::XzDecoder;
 
 const CONFIG_TOML: &str = include_str!("config.toml");
@@ -115,10 +117,7 @@ impl Toolchain {
         toolchain_root_dir: &Path,
         force: bool,
     ) -> Result<PathBuf> {
-        let client = http_client()?;
-
         let temp_dir = tempdir()?;
-
         let temp_file_path = match self {
             Toolchain::Rust => temp_dir.path().join("tmp_r0_rust_toolchain.tar.gz"),
             Toolchain::Cpp => temp_dir.path().join("tmp_r0_cpp_toolchain.tar.xz"),
@@ -173,32 +172,30 @@ impl Toolchain {
             "Requesting toolchain download from {}",
             &asset.browser_download_url
         ));
-        let response = client.get(&asset.browser_download_url).send().await?;
-        if !response.status().is_success() {
-            return Err(RzupError::Other(format!(
-                "Failed to download asset: {:?}",
-                response.status()
-            ))
-            .into());
-        }
 
-        verbose_msg!(format!(
-            "Creating temporary path at {}",
-            &temp_file_path.display()
-        ));
+        let download_url = asset.browser_download_url.clone();
+        let temp_file_path_clone = temp_file_path.clone();
+        let temp_dir_path = temp_dir.path().to_path_buf();
 
-        let mut file = fs::File::create(&temp_file_path)?;
-        let content = response.bytes().await?;
+        task::spawn_blocking(move || -> Result<()> {
+            let mut downloader = Downloader::builder()
+                .download_folder(&temp_dir_path)
+                .parallel_requests(1)
+                .build()?;
 
-        verbose_msg!(format!(
-            "Writing contents to file {}",
-            temp_file_path.display()
-        ));
+            let dl = Download::new(&download_url).file_name(&temp_file_path_clone);
 
-        file.write_all(&content)?;
+            let results = downloader.download(&[dl])?;
 
-        let tarball = fs::File::open(temp_file_path)?;
+            if let Some(Err(e)) = results.first() {
+                return Err(anyhow::anyhow!("Download failed: {}", e));
+            }
 
+            Ok(())
+        })
+        .await??;
+
+        let tarball = fs::File::open(&temp_file_path)?;
         info_msg!(format!("Extracting {} toolchain...", self.to_str()));
 
         match self {
@@ -226,7 +223,7 @@ impl Toolchain {
                         if entry.file_type()?.is_file() {
                             let mut perms = entry.metadata()?.permissions();
                             verbose_msg!(format!(
-                                "Setting permissons for {} to 0o755",
+                                "Setting permissions for {} to 0o755",
                                 entry.file_name().to_string_lossy()
                             ));
                             perms.set_mode(0o755);


### PR DESCRIPTION
fixes #2446

This reduces memory usage for memory constrained devices, from >800MB to <70MB by using the `downloader` crate. Attached are two `top` logs over a 60s interval with a 1s sample rate. 

New: [rzup_downloader_memory_log.txt](https://github.com/user-attachments/files/17579890/rzup_downloader_memory_log.txt)
Current: [rzup_memory_log.txt](https://github.com/user-attachments/files/17579891/rzup_memory_log.txt)

We should also make this change for all `rzup` download handlers.