### PR TITLE
backport 1.1: Enable env variable to configure Bonsai poll time and reduce default (#2198)

### DIFF
--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -87,13 +87,18 @@ impl Prover for BonsaiProver {
         )?;
         tracing::debug!("Bonsai proving SessionID: {}", session.uuid);
 
+        // TODO(#1759): Improve upon this polling solution.
+        let polling_interval = if let Ok(ms) = std::env::var("BONSAI_POLL_INTERVAL_MS") {
+            Duration::from_millis(ms.parse().context("invalid bonsai poll interval")?)
+        } else {
+            Duration::from_secs(1)
+        };
         let succinct_prove_info = loop {
             // The session has already been started in the executor. Poll bonsai to check if
             // the proof request succeeded.
             let res = session.status(&client)?;
             if res.status == "RUNNING" {
-                // TODO(#1759): Improve upon this polling solution.
-                std::thread::sleep(Duration::from_secs(5));
+                std::thread::sleep(polling_interval);
                 continue;
             }
             if res.status == "SUCCEEDED" {
@@ -152,8 +157,7 @@ impl Prover for BonsaiProver {
             let res = snark_session.status(&client)?;
             match res.status.as_str() {
                 "RUNNING" => {
-                    // TODO(#1759): Improve upon this polling solution.
-                    std::thread::sleep(Duration::from_secs(5));
+                    std::thread::sleep(polling_interval);
                     continue;
                 }
                 "SUCCEEDED" => {


### PR DESCRIPTION
Tested on low-latency proof workflows, and cuts those e2e snark times using this prove API by ~5s (as expected).

As for what the default is, just going with the upper limit of what @mothran suggested Bonsai can handle.

Keeping the TODO and #1759 open given this is still a very naive solution and could be improved. Before we are able to consider adding a WS API for this, we could do some of the following:
- [ ] Add a backoff function to the stark polling by default, to minimize server requests for long proofs
	- Possibly also having each configurable 	
- [ ] Separate the Snark and Stark polling intervals, have them both be configurable
- [ ] Add an initial delay for Starks or Snarks for the minimum duration we estimate

But I decided to keep it as simple as possible because it is unclear the direction of this in the long term.