### PR TITLE
docs: add r0 light/dark logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 <p align="center">
   <a href="https://risczero.com" target="_blank">
-    <img src="https://risczero.com/companies/risczero.svg" alt="RISC Zero Company Logo" width="142" height="126">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://risczero.com/companies/risczero_dark.svg">
+      <img src="https://risczero.com/companies/risczero.svg" alt="RISC Zero Company Logo" width="142" height="126">
+    </picture>
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 > When building applications or running examples, use the [latest release](https://github.com/risc0/risc0/releases) instead.
 
 <p align="center">
-  <a href="https://risczero.com" target="_blank"><img src="website/static/img/banner.png" height="100"></a>
+  <a href="https://risczero.com" target="_blank">
+    <img src="https://risczero.com/companies/risczero.svg" alt="RISC Zero Company Logo" width="142" height="126">
+  </a>
 </p>
 
 [![Crates.io][crates-badge]][crates-url]


### PR DESCRIPTION
Fixing a pet-peeve of mine in the readme. Adds the current light/dark logo, sourced from the static website assets (https://github.com/risc0/risc0-website/pull/18), to the readme. 