### PR TITLE
Ensure blob is aligned

### DIFF
--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -15,9 +15,11 @@
 #[cfg(test)]
 mod tests;
 
+use include_bytes_aligned::include_bytes_aligned;
+
 use crate::ffi::sys_bigint2_2;
 
-const DOUBLE_BLOB: &[u8] = include_bytes!("double.blob");
+const DOUBLE_BLOB: &[u8] = include_bytes_aligned!(16, "double.blob");
 
 pub fn double(point: &[u32], result: &mut [u32]) {
     unsafe {

--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -19,7 +19,7 @@ use include_bytes_aligned::include_bytes_aligned;
 
 use crate::ffi::sys_bigint2_2;
 
-const DOUBLE_BLOB: &[u8] = include_bytes_aligned!(16, "double.blob");
+const DOUBLE_BLOB: &[u8] = include_bytes_aligned!(4, "double.blob");
 
 pub fn double(point: &[u32], result: &mut [u32]) {
     unsafe {

--- a/risc0/bigint2/src/rsa/mod.rs
+++ b/risc0/bigint2/src/rsa/mod.rs
@@ -24,7 +24,7 @@ const WORD_SIZE: usize = 4;
 pub const RSA_3072_WIDTH_WORDS: usize = 3072 / 32;
 pub const RSA_3072_WIDTH_BYTES: usize = RSA_3072_WIDTH_WORDS * WORD_SIZE;
 
-const BLOB: &[u8] = include_bytes_aligned!(16, "modpow_65537.blob");
+const BLOB: &[u8] = include_bytes_aligned!(4, "modpow_65537.blob");
 
 #[cfg(feature = "num-bigint-dig")]
 fn to_u32_digits(input: &BigUint) -> Vec<u32> {


### PR DESCRIPTION
It's possible for `include_bytes!` to land on an unaligned address, leading to `LoadAddressMisaligned` errors in some cases. This will prevent that.