### PR TITLE
rzup: documentation and building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,7 +4608,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rzup"
-version = "0.2.2"
+version = "0.2.3"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/rzup/README.md
+++ b/rzup/README.md
@@ -1,41 +1,98 @@
 # `rzup`
 
-Install, update, or revert to a specific RISC Zero version.
+Install, manage, and build RISC Zero tooling.
 
-## Install
+## Quick Start
+
+Install `rzup`:
 
 ```sh
 curl -L https://risczero.com/install | bash
 ```
 
+You may need to source your PATH for non-interactive shells (i.e. docker).
+
 ## Usage
 
-To install the latest RISC Zero release version:
+### Installation
 
+Install the default RISC Zero suite (`cargo-risczero`, `r0vm`, and toolchains).
 ```sh
 rzup install
 ```
 
-Optionally, you can specify which version of `cargo-risczero` to install with:
-
-```bash
-rzup install cargo-risczero $VERSION
-```
-
-Where the `$VERSION` is a [release tag](https://github.com/risc0/risc0/releases) (e.g `v1.1.1`).
-
-To enable verbose installation logs:
+Install a specific extension version:
 
 ```sh
-rzup --verbose install
+rzup extension install <EXTENSION> [VERSION]
+```
+`<EXTENSION>` is a supported extension (e.g. `cargo-risczero`).
+
+
+`[VERSION]` optionally specifies an extension [release tag](https://github.com/risc0/risc0/releases) (e.g., `v1.0.0`).
+
+Install a specific toolchain:
+
+```sh
+rzup toolchain install <TOOLCHAIN> [VERSION]
+```
+`<TOOLCHAIN>` is a supported toolchain (e.g. `rust`, `cpp`, etc.).
+
+`[VERSION]` optionally specifies a toolchain [release tag](https://github.com/risc0/rust/releases/tag/r0.1.81.0) (e.g., `r0.1.81.0`).
+### Updating
+
+To check for updates:
+
+```sh
+rzup check
 ```
 
-To view usage/help information:
+Update to latest release:
+
+```sh
+rzup update
+```
+
+See `update -h` for more options.
+
+### Build
+
+Build from source:
+
+```sh
+rzup extension build <EXTENSION> [TAG]
+rzup toolchain build <TOOLCHAIN> [TAG]
+```
+
+`[TAG]` optionally specifies a git tag/commit. Uses default branch if unspecified.
+Built artifacts are automatically installed.
+
+### Misc.
+
+Update `rzup`:
+
+```sh
+rzup self update
+```
+
+Show active installations:
+
+```sh
+rzup show
+```
+
+Enable verbose logging:
+
+```sh
+rzup --verbose <COMMAND>
+```
+
+Show help:
 
 ```sh
 rzup --help
 ```
 
 ***
+**Tip**: Most subcommands have a single-character shorthand. See `rzup -h`.
 
-**Tip**: Most flags have a single-character shorthand. See `rzup -h` for more information.

--- a/rzup/src/cli/extension.rs
+++ b/rzup/src/cli/extension.rs
@@ -46,6 +46,13 @@ pub enum ExtensionSubcmd {
         /// The version of the extension to use (e.g., v1.0.1)
         version: String,
     },
+    /// Build extension from source
+    Build {
+        /// The extension to build (e.g., cargo-risczero)
+        extension: Extension,
+        /// The git tag or commit of the extension to build
+        tag: Option<String>,
+    },
     /// Uninstall an installed extension
     Uninstall {
         /// The extension to uninstall (e.g., cargo-risczero)
@@ -72,6 +79,7 @@ pub async fn handler(subcmd: ExtensionSubcmd) -> Result<()> {
             extension.link(&extension_path)
         }
         ExtensionSubcmd::Uninstall { extension } => extension.unlink(),
+        ExtensionSubcmd::Build { extension, tag } => extension.build(tag.as_deref()),
     }
 }
 

--- a/rzup/src/cli/toolchain.rs
+++ b/rzup/src/cli/toolchain.rs
@@ -20,16 +20,17 @@ use clap::Subcommand;
 #[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    after_help = "Toolchain help"
+    after_help = cli::help::TOOLCHAIN_HELP
 )]
 pub enum ToolchainSubcmd {
     /// List installed toolchains
     List,
+    /// Install a specific toolchain
     #[command(after_help = cli::help::TOOLCHAIN_HELP, aliases = ["add"])]
     Install {
         /// Toolchain name (rust or cpp)
         toolchain: String,
-        /// Version tag of the toolchain to install
+        /// An optional version tag of the toolchain to install
         version: Option<String>,
         /// Force installation, removing existing installations and downloads
         #[arg(short, long)]
@@ -40,12 +41,12 @@ pub enum ToolchainSubcmd {
         /// Toolchain name (rust or cpp)
         toolchain: String,
     },
-    /// Build a toolchain
+    /// Build a toolchain from source
     Build {
         /// Toolchain name (rust or cpp)
         toolchain: String,
-        /// Version tag or commit hash of the toolchain to build
-        version: Option<String>,
+        /// An optional git tag or commit of the toolchain to build
+        tag: Option<String>,
     },
 }
 
@@ -70,9 +71,9 @@ pub async fn handler(subcmd: ToolchainSubcmd) -> Result<()> {
             let toolchain = toolchain.parse::<Toolchain>()?;
             toolchain.unlink(toolchain.to_str()) // TODO: More specific uninstall - by name
         }
-        ToolchainSubcmd::Build { toolchain, version } => {
+        ToolchainSubcmd::Build { toolchain, tag } => {
             let toolchain = toolchain.parse::<Toolchain>()?;
-            toolchain.build(version.as_deref())
+            toolchain.build(tag.as_deref())
         }
     }
 }

--- a/rzup/src/toolchain.rs
+++ b/rzup/src/toolchain.rs
@@ -385,19 +385,20 @@ impl Toolchain {
         Ok(())
     }
 
-    pub fn build(&self, version: Option<&str>) -> Result<()> {
+    pub fn build(&self, tag: Option<&str>) -> Result<()> {
         match self {
             Toolchain::Rust => {
                 let source_url = self.git_url();
-                let tag = version.unwrap_or("risc0");
+                let tag = tag.unwrap_or("risc0");
                 let root_dir = if let Ok(dir) = std::env::var("RISC0_BUILD_DIR") {
                     PathBuf::from(dir)
                 } else {
                     dirs::home_dir()
                         .context("Could not determine home dir. Set RISC0_BUILD_DIR env var!")?
-                        .join(".rzup")
+                        .join(".risc0")
+                        .join("build")
                 };
-                let build_dir = root_dir.join(format!("build-{}", self.to_str()));
+                let build_dir = root_dir.join(format!("{}-toolchain", self.to_str()));
                 let toolchains_root_dir = rzup_home()?.join("toolchains");
                 let target = Target::host_target().ok_or_else(|| {
                     RzupError::Other("Failed to determine the host target".to_string())


### PR DESCRIPTION
This bumps `rzup` to version 0.23 and adds missing documentation in the readme and CLI. 

The documentation addresses some of the ambiguous/undocumented usage patterns of `rzup`. 

Also included is an extension build handler to allow users to build and install a specific `cargo-risczero` and `r0vm` from source, just as you can with the toolchain. 

We may want to consider removing the redundant `install` patterns here: https://github.com/risc0/risc0/blob/775e8be3294a300b7eeff23474d207bfb571c42b/rzup/src/cli/install.rs#L34-L47 

i.e. `rzup install cargo-risczero/rust/cpp`, which is equivalent to the documented pattern: `rzup extension/toolchain install ...`.

Supporting both is somewhat confusing IMO. 