### PR TITLE
Update verifier contract docs to fix OP Sepolia chain ID

### DIFF
--- a/website/api_versioned_docs/version-1.1/blockchain-integration/contracts/verifier.md
+++ b/website/api_versioned_docs/version-1.1/blockchain-integration/contracts/verifier.md
@@ -168,7 +168,7 @@ You can find detailed information in the [version management design][version-man
 
 <br/>
 
-### Optimism Sepolia (11110)
+### Optimism Sepolia (11155420)
 
 | Contract                                   | Address                                                                  |
 | ------------------------------------------ | ------------------------------------------------------------------------ |


### PR DESCRIPTION
The chain ID for OP Sepolia is currently incorrect. This update fixes it.