### PR TITLE
rzup: add support for cross-device toolchain copying

### DIFF
--- a/rzup/src/toolchain.rs
+++ b/rzup/src/toolchain.rs
@@ -260,7 +260,7 @@ impl Toolchain {
                 ));
 
                 // Move subdir contents to toolchain dir
-                self.move_toolchain(&subdir, &toolchain_dir)?;
+                Toolchain::move_toolchain(&subdir, &toolchain_dir)?;
             }
         }
 
@@ -419,7 +419,7 @@ impl Toolchain {
                 self.prepare_git_repo(source_url, tag, &build_dir)?;
 
                 let build_output = self.build_toolchain(&build_dir)?;
-                self.move_toolchain(&build_output.toolchain_dir, &final_toolchain_dir)?;
+                Toolchain::move_toolchain(&build_output.toolchain_dir, &final_toolchain_dir)?;
                 self.copy_tools(&build_output.toolchain_dir, &final_toolchain_dir)?;
                 self.link(&final_toolchain_dir)?;
             }
@@ -515,14 +515,26 @@ impl Toolchain {
         }
     }
 
-    fn move_toolchain(&self, src: &Path, dst: &Path) -> Result<()> {
+    fn move_toolchain(src: &Path, dst: &Path) -> Result<()> {
         fs::create_dir_all(dst)?;
         for entry in fs::read_dir(src)? {
             let entry = entry?;
-            let entry_path = entry.path();
-            let file_name = entry.file_name();
-            fs::rename(entry_path, dst.join(file_name))?;
+            let src_path = entry.path();
+            let dst_path = dst.join(entry.file_name());
+            if src_path.is_dir() {
+                // recursively copy dir
+                fs::create_dir_all(&dst_path)?;
+                Toolchain::move_toolchain(&src_path, &dst_path)?;
+            } else {
+                fs::copy(&src_path, &dst_path)?;
+                let metadata = src_path.metadata()?;
+                let permissions = metadata.permissions();
+                fs::set_permissions(&dst_path, permissions)?;
+            }
         }
+        // clean up
+        fs::remove_dir_all(src)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
this resolves the `Invalid cross-device link (os error 18)` issue when extracting and moving toolchains by adding support for cross-device copying (rather than move) in `move_toolchain`. See [slack](https://risc0.slack.com/archives/C03J8034W10/p1732098080189069) for more context. 