### PR TITLE
Fix concurrent access to TcpSocket for redis mode of r0vm

### DIFF
--- a/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
@@ -239,7 +239,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
                 self.pager.undo();
                 let used_cycles = self.insn_cycles + self.pager.cycles + RESERVED_CYCLES;
                 let po2_padding = (1 << segment_po2) - used_cycles;
-                tracing::info!(
+                tracing::debug!(
                     "split: {} + {} + {RESERVED_CYCLES} = {used_cycles}, padding: {po2_padding}, pending: {:?}",
                     self.insn_cycles,
                     self.pager.cycles,

--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -631,9 +631,9 @@ impl Client {
                             // tracing::trace!("tx: {msg:?}");
                             conn.send(msg)?;
                         }
-                        pb::api::client_callback::Kind::SegmentDone(segment) => {
-                            let reply: pb::api::GenericReply = segment
-                                .segment
+                        pb::api::client_callback::Kind::SegmentDone(segment_done) => {
+                            let reply: pb::api::GenericReply = segment_done
+                                .segment // some segment info
                                 .map_or_else(
                                     || Err(malformed_err()),
                                     |segment| {

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -119,10 +119,10 @@ impl ConnectionWrapper {
         self.inner.close()
     }
 
-    #[cfg(feature = "prove")]
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self::new(self.inner.try_clone()?))
-    }
+    // #[cfg(feature = "prove")]
+    // fn clone(&self) -> Result<Self> {
+    //     Ok(Self::new(self.inner.clone()))
+    // }
 }
 
 /// Connects a zkVM client and server

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -118,11 +118,6 @@ impl ConnectionWrapper {
     fn close(&mut self) -> Result<i32> {
         self.inner.close()
     }
-
-    // #[cfg(feature = "prove")]
-    // fn clone(&self) -> Result<Self> {
-    //     Ok(Self::new(self.inner.clone()))
-    // }
 }
 
 /// Connects a zkVM client and server

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -922,7 +922,6 @@ fn execute_redis(
         }
 
         if let Err(err) = inner(params.url, &receiver, opts, conn) {
-            tracing::error!("Hit error: {err:?}");
             *redis_err_clone.lock().unwrap() = Some(err);
         }
     });
@@ -932,7 +931,6 @@ fn execute_redis(
         if let Err(send_err) = sender.send((segment_key, segment)) {
             let mut redis_err_opt = redis_err.lock().unwrap();
             let redis_err_inner = redis_err_opt.take();
-            tracing::info!("triggered send err: {redis_err_inner:?}");
             return Err(match redis_err_inner {
                 Some(redis_thread_err) => anyhow::anyhow!(redis_thread_err),
                 None => send_err.into(),


### PR DESCRIPTION
This PR moves the ConnectionWrapper behind a Arc-Mutex for the r0vm server mode when doing executions to lock send/recv operations on the TCP socket to prevent protobuf corruptions when running with `redis` mode for AssestRequest's

TODO:

- [ ] Errors from within the redis thread now trigger a `sending on a closed channel` and skip the .join() thus hidding errors from inside the redis thread. 