### PR TITLE
mark affine constructor unchecked, remove curve from type

### DIFF
--- a/risc0/bigint2/methods/guest/src/bin/ec_add.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_add.rs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve, SECP256K1_PRIME};
+use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve};
 #[allow(unused)]
 use risc0_zkvm::guest::env;
 
-const CURVE: WeierstrassCurve<8> =
-    WeierstrassCurve::<8>::new(SECP256K1_PRIME, [0u32; 8], [7, 0, 0, 0, 0, 0, 0, 0]);
-
 fn main() {
-    let lhs = AffinePoint::new(
+    let lhs = AffinePoint::new_unchecked(
         [
             0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
             0x79be667e,
@@ -29,9 +26,8 @@ fn main() {
             0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465,
             0x483ada77,
         ],
-        &CURVE,
     );
-    let rhs = AffinePoint::new(
+    let rhs = AffinePoint::new_unchecked(
         [
             0xac04dc3f, 0x9465e6a4, 0xf46d2dad, 0x5d5ac4b6, 0xad2c0db6, 0xa7c06f71, 0xe335abc9,
             0x0f66dc33,
@@ -40,9 +36,8 @@ fn main() {
             0xd3f64d1c, 0x50650be0, 0x2a8577b0, 0xb701323c, 0x95565b00, 0x6dddd83d, 0x398fcd2c,
             0x83641fc5,
         ],
-        &CURVE,
     );
-    let expected = AffinePoint::new(
+    let expected = AffinePoint::new_unchecked(
         [
             0x3db079e0, 0xd4ad0ff5, 0xdd0da7e2, 0x4faad0a4, 0x85894785, 0x280d6b36, 0xe8ab292d,
             0xa901b0db,
@@ -51,10 +46,12 @@ fn main() {
             0x47298a9d, 0x01d0e60e, 0xa6b063b3, 0x716bc5e0, 0x61e7ae64, 0xaf6f04dc, 0x834f1a61,
             0x3f27e7e1,
         ],
-        &CURVE,
     );
 
-    let result = risc0_bigint2::ec::add(&lhs, &rhs);
+    let curve = WeierstrassCurve::secp256k1();
+
+    let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+    risc0_bigint2::ec::add(&lhs, &rhs, curve, &mut result);
 
     assert_eq!(result, expected);
 }

--- a/risc0/bigint2/methods/guest/src/bin/ec_double.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_double.rs
@@ -40,8 +40,8 @@ fn main() {
 
     let curve = WeierstrassCurve::secp256k1();
 
-    let in_pt = AffinePoint::from_u32s(POINT_G);
-    let expected_pt = AffinePoint::from_u32s(EXPECTED);
+    let in_pt = AffinePoint::new_unchecked(POINT_G[0], POINT_G[1]);
+    let expected_pt = AffinePoint::new_unchecked(EXPECTED[0], EXPECTED[1]);
 
     let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
     risc0_bigint2::ec::double(&in_pt, curve, &mut result);

--- a/risc0/bigint2/methods/guest/src/bin/ec_double.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_double.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve, SECP256K1_PRIME};
+use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve};
 #[allow(unused)]
 use risc0_zkvm::guest::env;
-
-const CURVE: WeierstrassCurve<8> =
-    WeierstrassCurve::<8>::new(SECP256K1_PRIME, [0u32; 8], [7, 0, 0, 0, 0, 0, 0, 0]);
 
 fn main() {
     const POINT_G: [[u32; 8]; 2] = [
@@ -41,9 +38,12 @@ fn main() {
         ],
     ];
 
-    let in_pt = AffinePoint::from_u32s(POINT_G, &CURVE);
-    let expected_pt = AffinePoint::from_u32s(EXPECTED, &CURVE);
+    let curve = WeierstrassCurve::secp256k1();
 
-    let result = risc0_bigint2::ec::double(&in_pt);
+    let in_pt = AffinePoint::from_u32s(POINT_G);
+    let expected_pt = AffinePoint::from_u32s(EXPECTED);
+
+    let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+    risc0_bigint2::ec::double(&in_pt, curve, &mut result);
     assert_eq!(result, expected_pt);
 }

--- a/risc0/bigint2/methods/guest/src/bin/ec_mul.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_mul.rs
@@ -12,19 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve, SECP256K1_PRIME};
+use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve};
 #[allow(unused)]
 use risc0_zkvm::guest::env;
 
-const CURVE: WeierstrassCurve<8> =
-    WeierstrassCurve::<8>::new(SECP256K1_PRIME, [0u32; 8], [7, 0, 0, 0, 0, 0, 0, 0]);
+// NOTE: This is manually constructed, to ensure changes to the API do not limit the ability to
+//       define a custom curve.
+// This is the secp256k1 curve.
+const CURVE: &WeierstrassCurve<8> = &WeierstrassCurve::<8>::new(
+    [
+        0xFFFFFC2F, 0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+        0xFFFFFFFF,
+    ],
+    [0u32; 8],
+    [7, 0, 0, 0, 0, 0, 0, 0],
+);
 
 fn main() {
     let scalar = [
         0x409f9918, 0xd218afb5, 0x81d5a9ae, 0x1aabde69, 0xe5cd569f, 0x478b33e5, 0xd5ff94e4,
         0x232ad1e3,
     ];
-    let point = AffinePoint::new(
+    let point = AffinePoint::new_unchecked(
         [
             0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
             0x79be667e,
@@ -33,9 +42,8 @@ fn main() {
             0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465,
             0x483ada77,
         ],
-        &CURVE,
     );
-    let expected = AffinePoint::new(
+    let expected = AffinePoint::new_unchecked(
         [
             0xd430a92d, 0x5fdd93b4, 0x23c8434f, 0x1616b5ae, 0x2570e09c, 0x673f0dec, 0xb6bdef51,
             0x2985d840,
@@ -44,9 +52,9 @@ fn main() {
             0x34ab3c01, 0x0abd13e0, 0x8060d279, 0xa37beeeb, 0xb083593d, 0x4679f415, 0x6c4af2e8,
             0x1af7251d,
         ],
-        &CURVE,
     );
 
-    let result = risc0_bigint2::ec::mul(&scalar, &point);
+    let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
+    risc0_bigint2::ec::mul(&scalar, &point, CURVE, &mut result);
     assert_eq!(result, expected);
 }

--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -72,7 +72,8 @@ pub struct AffinePoint<const WIDTH: usize> {
 }
 
 impl<const WIDTH: usize> AffinePoint<WIDTH> {
-    /// Constructs an affine point, without checking that it is on a specific curve.
+    /// Constructs an affine point from x and y coordinates, without checking that it is on
+    /// a specific curve.
     pub fn new_unchecked(x: [u32; WIDTH], y: [u32; WIDTH]) -> AffinePoint<WIDTH> {
         AffinePoint { buffer: [x, y] }
     }
@@ -83,13 +84,6 @@ impl<const WIDTH: usize> AffinePoint<WIDTH> {
     /// The result is returned as a [[u32; WIDTH]; 2], and the FFI with the guest expects a [u32; WIDTH * 2]. Per https://doc.rust-lang.org/reference/type-layout.html#array-layout they will be laid out the same in memory and this is acceptable.
     pub fn as_u32s(&self) -> &[[u32; WIDTH]; 2] {
         &self.buffer
-    }
-
-    /// Read the point from concatenated u32s for x and y
-    ///
-    /// Input interpreted as little-endian with x coordinate before y coordinate
-    pub fn from_u32s(data: [[u32; WIDTH]; 2]) -> AffinePoint<WIDTH> {
-        AffinePoint { buffer: data }
     }
 }
 

--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -189,7 +189,6 @@ pub fn add<const WIDTH: usize>(
 ) {
     // TODO: Do we want to check for P + P, P - P? It isn't necessary for soundness -- it will fail
     // an EQZ if you try -- but maybe a pretty error here would be good DevEx?
-    // assert_eq!(lhs.curve, rhs.curve);
     add_raw(
         lhs.as_u32s(),
         rhs.as_u32s(),

--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -23,10 +23,11 @@ const ADD_BLOB: &[u8] = include_bytes_aligned!(4, "add.blob");
 const DOUBLE_BLOB: &[u8] = include_bytes_aligned!(4, "double.blob");
 
 /// The secp256k1 curve's prime as u32 digits, least significant digit first
-/// TODO: public?
-pub const SECP256K1_PRIME: [u32; 8] = [
+const SECP256K1_PRIME: [u32; 8] = [
     0xFFFFFC2F, 0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
 ];
+const SECP256K1_CURVE: &WeierstrassCurve<8> =
+    &WeierstrassCurve::<8>::new(SECP256K1_PRIME, [0u32; 8], [7, 0, 0, 0, 0, 0, 0, 0]);
 
 pub const EC_256_WIDTH_WORDS: usize = 256 / 32;
 
@@ -54,28 +55,26 @@ impl<const WIDTH: usize> WeierstrassCurve<WIDTH> {
     /// The curve as concatenated u32s
     ///
     /// Little-endian, prime then a then b
-    pub fn as_u32s(&self) -> &[[u32; WIDTH]; 3] {
+    fn as_u32s(&self) -> &[[u32; WIDTH]; 3] {
         &self.buffer
+    }
+}
+impl WeierstrassCurve<8> {
+    /// The secp256k1 curve configuration.
+    pub const fn secp256k1() -> &'static WeierstrassCurve<8> {
+        SECP256K1_CURVE
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AffinePoint<const WIDTH: usize> {
     buffer: [[u32; WIDTH]; 2],
-    /// curve containing this point
-    curve: &'static WeierstrassCurve<WIDTH>,
 }
 
 impl<const WIDTH: usize> AffinePoint<WIDTH> {
-    pub fn new(
-        x: [u32; WIDTH],
-        y: [u32; WIDTH],
-        curve: &'static WeierstrassCurve<WIDTH>,
-    ) -> AffinePoint<WIDTH> {
-        AffinePoint {
-            buffer: [x, y],
-            curve,
-        }
+    /// Constructs an affine point, without checking that it is on a specific curve.
+    pub fn new_unchecked(x: [u32; WIDTH], y: [u32; WIDTH]) -> AffinePoint<WIDTH> {
+        AffinePoint { buffer: [x, y] }
     }
     /// The point as concatenated u32s for x and y
     ///
@@ -89,26 +88,22 @@ impl<const WIDTH: usize> AffinePoint<WIDTH> {
     /// Read the point from concatenated u32s for x and y
     ///
     /// Input interpreted as little-endian with x coordinate before y coordinate
-    pub fn from_u32s(
-        data: [[u32; WIDTH]; 2],
-        curve: &'static WeierstrassCurve<WIDTH>,
-    ) -> AffinePoint<WIDTH> {
-        AffinePoint {
-            buffer: data,
-            curve,
-        }
+    pub fn from_u32s(data: [[u32; WIDTH]; 2]) -> AffinePoint<WIDTH> {
+        AffinePoint { buffer: data }
     }
 }
 
 pub fn mul<const WIDTH: usize>(
     scalar: &[u32; WIDTH],
     point: &AffinePoint<WIDTH>,
-) -> AffinePoint<WIDTH> {
+    curve: &'static WeierstrassCurve<WIDTH>,
+    result: &mut AffinePoint<WIDTH>,
+) {
     // This assumes `pt` is actually on the curve
     // This assumption isn't checked here, so other code must ensure it's met
     // This algorithm doesn't work if `scalar` is a multiple of `pt`'s order
 
-    let curve = point.curve.as_u32s();
+    let curve = curve.as_u32s();
 
     // Initialize two values to alternate writes to avoid unnecessary copies.
     let mut result_flip = false;
@@ -156,15 +151,16 @@ pub fn mul<const WIDTH: usize>(
     }
 
     // Return the result, based on which buffer was written to last.
-    let result_scalar = if result_flip { result2 } else { result1 };
-
-    AffinePoint::from_u32s(result_scalar, point.curve)
+    let result_point = if result_flip { result2 } else { result1 };
+    result.buffer = result_point;
 }
 
-pub fn double<const WIDTH: usize>(point: &AffinePoint<WIDTH>) -> AffinePoint<WIDTH> {
-    let mut buffer = [[0u32; WIDTH]; 2];
-    double_raw(point.as_u32s(), point.curve.as_u32s(), &mut buffer);
-    AffinePoint::from_u32s(buffer, point.curve)
+pub fn double<const WIDTH: usize>(
+    point: &AffinePoint<WIDTH>,
+    curve: &'static WeierstrassCurve<WIDTH>,
+    result: &mut AffinePoint<WIDTH>,
+) {
+    double_raw(point.as_u32s(), curve.as_u32s(), &mut result.buffer);
 }
 
 fn double_raw<const WIDTH: usize>(
@@ -188,18 +184,18 @@ fn double_raw<const WIDTH: usize>(
 pub fn add<const WIDTH: usize>(
     lhs: &AffinePoint<WIDTH>,
     rhs: &AffinePoint<WIDTH>,
-) -> AffinePoint<WIDTH> {
+    curve: &'static WeierstrassCurve<WIDTH>,
+    result: &mut AffinePoint<WIDTH>,
+) {
     // TODO: Do we want to check for P + P, P - P? It isn't necessary for soundness -- it will fail
     // an EQZ if you try -- but maybe a pretty error here would be good DevEx?
-    assert_eq!(lhs.curve, rhs.curve);
-    let mut buffer = [[0u32; WIDTH]; 2];
+    // assert_eq!(lhs.curve, rhs.curve);
     add_raw(
         lhs.as_u32s(),
         rhs.as_u32s(),
-        lhs.curve.as_u32s(),
-        &mut buffer,
+        curve.as_u32s(),
+        &mut result.buffer,
     );
-    AffinePoint::from_u32s(buffer, lhs.curve)
 }
 
 fn add_raw<const WIDTH: usize>(


### PR DESCRIPTION
- Affine constructor now `new_unchecked` to indicate that points not on a curve can be constructed
- Removed curve field from `AffinePoint`
  - Removed curve check on ec add
- Change exported secp curve type (now a const fn on the curve type)
- Changed API to have a mutable ref to the return, consistent with RSA APIs (cycle optimization for re-using buffers)