### PR TITLE
refactor AffinePoint to be generic over the curve

### DIFF
--- a/risc0/bigint2/methods/guest/src/bin/ec_add.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_add.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve};
+use risc0_bigint2::ec::{AffinePoint, Secp256k1Curve};
 #[allow(unused)]
 use risc0_zkvm::guest::env;
 
@@ -48,10 +48,8 @@ fn main() {
         ],
     );
 
-    let curve = WeierstrassCurve::secp256k1();
-
-    let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
-    risc0_bigint2::ec::add(&lhs, &rhs, curve, &mut result);
+    let mut result = AffinePoint::<8, Secp256k1Curve>::new_unchecked([0u32; 8], [0u32; 8]);
+    lhs.add(&rhs, &mut result);
 
     assert_eq!(result, expected);
 }

--- a/risc0/bigint2/methods/guest/src/bin/ec_double.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_double.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve};
+use risc0_bigint2::ec::{AffinePoint, Secp256k1Curve};
 #[allow(unused)]
 use risc0_zkvm::guest::env;
 
@@ -38,12 +38,10 @@ fn main() {
         ],
     ];
 
-    let curve = WeierstrassCurve::secp256k1();
-
-    let in_pt = AffinePoint::new_unchecked(POINT_G[0], POINT_G[1]);
+    let in_pt = AffinePoint::<8, Secp256k1Curve>::new_unchecked(POINT_G[0], POINT_G[1]);
     let expected_pt = AffinePoint::new_unchecked(EXPECTED[0], EXPECTED[1]);
 
     let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
-    risc0_bigint2::ec::double(&in_pt, curve, &mut result);
+    in_pt.double(&mut result);
     assert_eq!(result, expected_pt);
 }

--- a/risc0/bigint2/methods/guest/src/bin/ec_mul.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_mul.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_bigint2::ec::{AffinePoint, WeierstrassCurve};
+use risc0_bigint2::ec::{AffinePoint, Curve, WeierstrassCurve};
 #[allow(unused)]
 use risc0_zkvm::guest::env;
 
@@ -27,6 +27,13 @@ const CURVE: &WeierstrassCurve<8> = &WeierstrassCurve::<8>::new(
     [0u32; 8],
     [7, 0, 0, 0, 0, 0, 0, 0],
 );
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum TestSecp256k1Curve {}
+
+impl Curve<8> for TestSecp256k1Curve {
+    const CURVE: &'static WeierstrassCurve<8> = CURVE;
+}
 
 fn main() {
     let scalar = [
@@ -54,7 +61,7 @@ fn main() {
         ],
     );
 
-    let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
-    risc0_bigint2::ec::mul(&scalar, &point, CURVE, &mut result);
+    let mut result = AffinePoint::<8, TestSecp256k1Curve>::new_unchecked([0u32; 8], [0u32; 8]);
+    point.mul(&scalar, &mut result);
     assert_eq!(result, expected);
 }

--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -23,13 +23,28 @@ const ADD_BLOB: &[u8] = include_bytes_aligned!(4, "add.blob");
 const DOUBLE_BLOB: &[u8] = include_bytes_aligned!(4, "double.blob");
 
 /// The secp256k1 curve's prime as u32 digits, least significant digit first
-const SECP256K1_PRIME: [u32; 8] = [
+const SECP256K1_PRIME: [u32; EC_256_WIDTH_WORDS] = [
     0xFFFFFC2F, 0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
 ];
-const SECP256K1_CURVE: &WeierstrassCurve<8> =
-    &WeierstrassCurve::<8>::new(SECP256K1_PRIME, [0u32; 8], [7, 0, 0, 0, 0, 0, 0, 0]);
+const SECP256K1_CURVE: &WeierstrassCurve<EC_256_WIDTH_WORDS> =
+    &WeierstrassCurve::<EC_256_WIDTH_WORDS>::new(
+        SECP256K1_PRIME,
+        [0u32; EC_256_WIDTH_WORDS],
+        [7, 0, 0, 0, 0, 0, 0, 0],
+    );
 
 pub const EC_256_WIDTH_WORDS: usize = 256 / 32;
+
+pub trait Curve<const WIDTH: usize> {
+    const CURVE: &'static WeierstrassCurve<WIDTH>;
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Secp256k1Curve {}
+
+impl Curve<EC_256_WIDTH_WORDS> for Secp256k1Curve {
+    const CURVE: &'static WeierstrassCurve<EC_256_WIDTH_WORDS> = SECP256K1_CURVE;
+}
 
 /// An elliptic curve over a prime field
 ///
@@ -59,23 +74,27 @@ impl<const WIDTH: usize> WeierstrassCurve<WIDTH> {
         &self.buffer
     }
 }
-impl WeierstrassCurve<8> {
+impl WeierstrassCurve<EC_256_WIDTH_WORDS> {
     /// The secp256k1 curve configuration.
-    pub const fn secp256k1() -> &'static WeierstrassCurve<8> {
+    pub const fn secp256k1() -> &'static WeierstrassCurve<EC_256_WIDTH_WORDS> {
         SECP256K1_CURVE
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AffinePoint<const WIDTH: usize> {
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub struct AffinePoint<const WIDTH: usize, C> {
     buffer: [[u32; WIDTH]; 2],
+    _marker: std::marker::PhantomData<C>,
 }
 
-impl<const WIDTH: usize> AffinePoint<WIDTH> {
+impl<const WIDTH: usize, C> AffinePoint<WIDTH, C> {
     /// Constructs an affine point from x and y coordinates, without checking that it is on
     /// a specific curve.
-    pub fn new_unchecked(x: [u32; WIDTH], y: [u32; WIDTH]) -> AffinePoint<WIDTH> {
-        AffinePoint { buffer: [x, y] }
+    pub fn new_unchecked(x: [u32; WIDTH], y: [u32; WIDTH]) -> AffinePoint<WIDTH, C> {
+        AffinePoint {
+            buffer: [x, y],
+            _marker: std::marker::PhantomData,
+        }
     }
     /// The point as concatenated u32s for x and y
     ///
@@ -87,76 +106,81 @@ impl<const WIDTH: usize> AffinePoint<WIDTH> {
     }
 }
 
-pub fn mul<const WIDTH: usize>(
-    scalar: &[u32; WIDTH],
-    point: &AffinePoint<WIDTH>,
-    curve: &'static WeierstrassCurve<WIDTH>,
-    result: &mut AffinePoint<WIDTH>,
-) {
-    // This assumes `pt` is actually on the curve
-    // This assumption isn't checked here, so other code must ensure it's met
-    // This algorithm doesn't work if `scalar` is a multiple of `pt`'s order
+impl<const WIDTH: usize, C: Curve<WIDTH>> AffinePoint<WIDTH, C> {
+    pub fn mul(&self, scalar: &[u32; WIDTH], result: &mut AffinePoint<WIDTH, C>) {
+        // This assumes `pt` is actually on the curve
+        // This assumption isn't checked here, so other code must ensure it's met
+        // This algorithm doesn't work if `scalar` is a multiple of `pt`'s order
 
-    let curve = curve.as_u32s();
+        let curve = C::CURVE.as_u32s();
 
-    // Initialize two values to alternate writes to avoid unnecessary copies.
-    let mut result_flip = false;
-    let mut result1 = [[0u32; WIDTH]; 2];
-    let mut result2 = [[0u32; WIDTH]; 2];
+        // Initialize two values to alternate writes to avoid unnecessary copies.
+        let mut result_flip = false;
+        let mut result1 = [[0u32; WIDTH]; 2];
+        let mut result2 = [[0u32; WIDTH]; 2];
 
-    // Note: the first value can be an uninitialized value.
-    let mut doubled_pt1 = point.buffer;
-    let mut doubled_pt2 = point.buffer;
+        // Note: the first value can be an uninitialized value.
+        let mut doubled_pt1 = self.buffer;
+        let mut doubled_pt2 = self.buffer;
 
-    let mut first_write = true;
-    for pos in 0..bits(scalar) {
-        // Alternate between the doubled value. Immutable reference is to the current value,
-        // mutable reference is to the other that can be written to.
-        // Note: This is not using a boolean flag because `pos%2` is less cycles.
-        let (current_doubled, next_doubled) = if pos % 2 == 0 {
-            (&doubled_pt2, &mut doubled_pt1)
-        } else {
-            (&doubled_pt1, &mut doubled_pt2)
-        };
-
-        if bit(scalar, pos) {
-            // Alternate buffers to write to and use as current value.
-            let (current_result, next_result) = if result_flip {
-                (&result2, &mut result1)
+        let mut first_write = true;
+        for pos in 0..bits(scalar) {
+            // Alternate between the doubled value. Immutable reference is to the current value,
+            // mutable reference is to the other that can be written to.
+            // Note: This is not using a boolean flag because `pos%2` is less cycles.
+            let (current_doubled, next_doubled) = if pos % 2 == 0 {
+                (&doubled_pt2, &mut doubled_pt1)
             } else {
-                (&result1, &mut result2)
+                (&doubled_pt1, &mut doubled_pt2)
             };
 
-            if first_write {
-                first_write = false;
-                *next_result = *current_doubled;
-            } else {
-                add_raw(current_result, current_doubled, curve, next_result);
+            if bit(scalar, pos) {
+                // Alternate buffers to write to and use as current value.
+                let (current_result, next_result) = if result_flip {
+                    (&result2, &mut result1)
+                } else {
+                    (&result1, &mut result2)
+                };
+
+                if first_write {
+                    first_write = false;
+                    *next_result = *current_doubled;
+                } else {
+                    add_raw(current_result, current_doubled, curve, next_result);
+                }
+                result_flip = !result_flip;
             }
-            result_flip = !result_flip;
+
+            double_raw(current_doubled, curve, next_doubled);
         }
 
-        double_raw(current_doubled, curve, next_doubled);
+        // Assert that some value was written to the result.
+        if first_write {
+            panic!("Multiplication by zero forbidden as affine coordinates can't represent the point at infinity");
+        }
+
+        // Return the result, based on which buffer was written to last.
+        let result_point = if result_flip { result2 } else { result1 };
+        result.buffer = result_point;
     }
 
-    // Assert that some value was written to the result.
-    if first_write {
-        panic!("Multiplication by zero forbidden as affine coordinates can't represent the point at infinity");
+    pub fn double(&self, result: &mut Self) {
+        let curve = C::CURVE;
+        double_raw(self.as_u32s(), curve.as_u32s(), &mut result.buffer);
     }
 
-    // Return the result, based on which buffer was written to last.
-    let result_point = if result_flip { result2 } else { result1 };
-    result.buffer = result_point;
+    pub fn add(&self, rhs: &AffinePoint<WIDTH, C>, result: &mut AffinePoint<WIDTH, C>) {
+        let curve = C::CURVE;
+        // TODO: Do we want to check for P + P, P - P? It isn't necessary for soundness -- it will fail
+        // an EQZ if you try -- but maybe a pretty error here would be good DevEx?
+        add_raw(
+            self.as_u32s(),
+            rhs.as_u32s(),
+            curve.as_u32s(),
+            &mut result.buffer,
+        );
+    }
 }
-
-pub fn double<const WIDTH: usize>(
-    point: &AffinePoint<WIDTH>,
-    curve: &'static WeierstrassCurve<WIDTH>,
-    result: &mut AffinePoint<WIDTH>,
-) {
-    double_raw(point.as_u32s(), curve.as_u32s(), &mut result.buffer);
-}
-
 fn double_raw<const WIDTH: usize>(
     point: &[[u32; WIDTH]; 2],
     curve: &[[u32; WIDTH]; 3],
@@ -173,22 +197,6 @@ fn double_raw<const WIDTH: usize>(
             result.as_mut_ptr() as *mut u32,
         );
     }
-}
-
-pub fn add<const WIDTH: usize>(
-    lhs: &AffinePoint<WIDTH>,
-    rhs: &AffinePoint<WIDTH>,
-    curve: &'static WeierstrassCurve<WIDTH>,
-    result: &mut AffinePoint<WIDTH>,
-) {
-    // TODO: Do we want to check for P + P, P - P? It isn't necessary for soundness -- it will fail
-    // an EQZ if you try -- but maybe a pretty error here would be good DevEx?
-    add_raw(
-        lhs.as_u32s(),
-        rhs.as_u32s(),
-        curve.as_u32s(),
-        &mut result.buffer,
-    );
 }
 
 fn add_raw<const WIDTH: usize>(


### PR DESCRIPTION
Context is that in the future we may way to check that a point is on the curve on construction, and this generic would ensure that you don't perform arithmetic on points on different curves, to make it harder to misuse.

This trades off having an extra generic for the `AffinePoint` type for removing the need to pass the curve as a parameter to the fn.

Changes are very much optional, if we decide we want this, I will go through to update the upstream patches to ensure compatibility.