### PR TITLE
Better unstable marking for bigint2

### DIFF
--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -33,15 +33,12 @@ const SECP256K1_CURVE: &WeierstrassCurve<EC_256_WIDTH_WORDS> =
         [7, 0, 0, 0, 0, 0, 0, 0],
     );
 
-#[stability::unstable]
 pub const EC_256_WIDTH_WORDS: usize = 256 / 32;
 
-#[stability::unstable]
 pub trait Curve<const WIDTH: usize> {
     const CURVE: &'static WeierstrassCurve<WIDTH>;
 }
 
-#[stability::unstable]
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Secp256k1Curve {}
 
@@ -52,7 +49,6 @@ impl Curve<EC_256_WIDTH_WORDS> for Secp256k1Curve {
 /// An elliptic curve over a prime field
 ///
 /// The curve is given in short Weierstrass form y^2 = x^3 + ax + b. It supports a maximum `WIDTH` of its prime (and hence all coefficients and coordinates) given as number of 32-bit words (so the maximum bitwidth will be `32 * WIDTH`)
-#[stability::unstable]
 #[derive(Debug, Eq, PartialEq)]
 pub struct WeierstrassCurve<const WIDTH: usize> {
     // buffer[0] is the prime, buffer[1] is a, buffer[2] is b
@@ -80,13 +76,11 @@ impl<const WIDTH: usize> WeierstrassCurve<WIDTH> {
 }
 impl WeierstrassCurve<EC_256_WIDTH_WORDS> {
     /// The secp256k1 curve configuration.
-    #[stability::unstable]
     pub const fn secp256k1() -> &'static WeierstrassCurve<EC_256_WIDTH_WORDS> {
         SECP256K1_CURVE
     }
 }
 
-#[stability::unstable]
 #[derive(Clone, Debug, Eq, PartialEq, Copy)]
 pub struct AffinePoint<const WIDTH: usize, C> {
     buffer: [[u32; WIDTH]; 2],
@@ -96,7 +90,6 @@ pub struct AffinePoint<const WIDTH: usize, C> {
 impl<const WIDTH: usize, C> AffinePoint<WIDTH, C> {
     /// Constructs an affine point from x and y coordinates, without checking that it is on
     /// a specific curve.
-    #[stability::unstable]
     pub fn new_unchecked(x: [u32; WIDTH], y: [u32; WIDTH]) -> AffinePoint<WIDTH, C> {
         AffinePoint {
             buffer: [x, y],
@@ -108,14 +101,12 @@ impl<const WIDTH: usize, C> AffinePoint<WIDTH, C> {
     /// Little-endian, x coordinate before y coordinate
     /// TODO: Where to doc this next bit
     /// The result is returned as a [[u32; WIDTH]; 2], and the FFI with the guest expects a [u32; WIDTH * 2]. Per https://doc.rust-lang.org/reference/type-layout.html#array-layout they will be laid out the same in memory and this is acceptable.
-    #[stability::unstable]
     pub fn as_u32s(&self) -> &[[u32; WIDTH]; 2] {
         &self.buffer
     }
 }
 
 impl<const WIDTH: usize, C: Curve<WIDTH>> AffinePoint<WIDTH, C> {
-    #[stability::unstable]
     pub fn mul(&self, scalar: &[u32; WIDTH], result: &mut AffinePoint<WIDTH, C>) {
         // This assumes `pt` is actually on the curve
         // This assumption isn't checked here, so other code must ensure it's met

--- a/risc0/bigint2/src/lib.rs
+++ b/risc0/bigint2/src/lib.rs
@@ -19,7 +19,7 @@ pub mod ffi;
 #[cfg(feature = "unstable")]
 pub mod rsa;
 
-#[allow(dead_code)]  // Used by the unstable functions
+#[allow(dead_code)] // Used by the unstable functions
 pub(crate) const WORD_SIZE: usize = 4;
 
 /// Trait for converting values to a u32 array to be used for bigint2 acceleration.

--- a/risc0/bigint2/src/lib.rs
+++ b/risc0/bigint2/src/lib.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "unstable")]
 pub mod ec;
+#[cfg(feature = "unstable")]
 pub mod ffi;
+#[cfg(feature = "unstable")]
 pub mod rsa;
 
+#[allow(dead_code)]  // Used by the unstable functions
 pub(crate) const WORD_SIZE: usize = 4;
 
 /// Trait for converting values to a u32 array to be used for bigint2 acceleration.

--- a/risc0/bigint2/src/rsa/mod.rs
+++ b/risc0/bigint2/src/rsa/mod.rs
@@ -20,16 +20,13 @@ use include_bytes_aligned::include_bytes_aligned;
 use crate::ffi::sys_bigint2_3;
 use crate::WORD_SIZE;
 
-#[stability::unstable]
 pub const RSA_3072_WIDTH_WORDS: usize = 3072 / 32;
-#[stability::unstable]
 pub const RSA_3072_WIDTH_BYTES: usize = RSA_3072_WIDTH_WORDS * WORD_SIZE;
 
 const BLOB: &[u8] = include_bytes_aligned!(4, "modpow_65537.blob");
 
 type RsaArray = [u32; RSA_3072_WIDTH_WORDS];
 
-#[stability::unstable]
 pub fn modpow_65537(base: &RsaArray, modulus: &RsaArray, result: &mut [u32; RSA_3072_WIDTH_WORDS]) {
     unsafe {
         sys_bigint2_3(


### PR DESCRIPTION
Clean up how we mark bigint2 unstable. Includes the FFI module.