### PR TITLE
bump version to 1.3.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.9.0-alpha.2"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -4113,14 +4113,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2-methods"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "cc",
  "directories",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-tools"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "assert_cmd",
  "clap 4.5.20",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "critical-section",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 
 [[package]]
 name = "rlsf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,31 +30,31 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
-bonsai-sdk = { version = "0.9.0-alpha.1", default-features = false, path = "bonsai/sdk" }
+bonsai-sdk = { version = "1.3.0-alpha.1", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/bigint2" }
-risc0-binfmt = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-recursion = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/zkp" }
-risc0-zkvm = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "1.2.0-alpha.1", default-features = false, path = "risc0/zkvm/platform" }
+risc0-bigint2 = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/bigint2" }
+risc0-binfmt = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-recursion = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkp" }
+risc0-zkvm = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkvm/platform" }
 sppark = "0.1.8"
 
 [profile.bench]

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.9.0-alpha.2"
+version = "1.3.0-alpha.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "cc",
  "directories",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/bonsai/sdk/Cargo.toml
+++ b/bonsai/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bonsai-sdk"
 description = "Bonsai Software Development Kit"
-version = "0.9.0-alpha.2"
+version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.9.0-alpha.2"
+version = "1.3.0-alpha.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -4039,14 +4039,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2-methods"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "cc",
  "directories",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 
 [[package]]
 name = "rkyv"

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -750,7 +750,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -712,7 +712,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -689,7 +689,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -695,7 +695,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -760,7 +760,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -734,7 +734,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -689,7 +689,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -759,7 +759,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.9.0-alpha.2"
+version = "1.3.0-alpha.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -681,7 +681,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/examples/zkevm-demo/methods/guest/Cargo.lock
+++ b/examples/zkevm-demo/methods/guest/Cargo.lock
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "risc0-bigint2"
+description = "RISC Zero's Big Integer Accelerator"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -709,7 +709,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -689,7 +689,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -681,7 +681,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1072,7 +1072,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "borsh",
  "ciborium",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -726,7 +726,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "critical-section",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0-alpha.1"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "rzup"
+description = "utility to install the RISC Zero toolchain"
 version = "0.2.2"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
+
+[package.metadata.release]
+release = false
 
 [dependencies]
 anyhow = "1.0.93"


### PR DESCRIPTION
This PR bumps crate versions to `1.3.0-alpha.1`. In doing the 1.2.0-rc.1 release, I noticed that bonsai-sdk was not set to use the version identified in the workspace. This something that I forgot to backport from release-1.1. When I ran `cargo publish release -x` it warned me about a few missing descriptions and it was trying to publish `rzup`. This new behavior that I hadn't observed in the past but I've added descriptions to the missing crates and disabled `rzup` from being published.