### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ permissions:
 env:
   RISC0_RUST_TOOLCHAIN_VERSION: r0.1.81.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
-  TAG: v1.1.0
-  VERSION: "1.1.0"
+  TAG: v1.2.0-rc.1
+  VERSION: "1.2.0-rc.1"
 
 jobs:
   release:


### PR DESCRIPTION
this was missed during the release process. This resulted in the failure of the publish workflow after it successfully uploaded artifacts. This fix should enable the workflow to finish all the way through the smoke test.