### PR TITLE
backport 1.2: client/server: make receipt claim optional in session info (#2562)

### DIFF
--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -405,7 +405,7 @@ pub struct SessionInfo {
 
     /// The [ReceiptClaim] associated with the executed session. This receipt claim is what will be
     /// proven if this session is passed to the Prover.
-    pub receipt_claim: ReceiptClaim,
+    pub receipt_claim: Option<ReceiptClaim>,
 }
 
 impl SessionInfo {

--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -71,7 +71,7 @@ impl Executor for LocalProver {
             segments,
             journal: session.journal.unwrap_or_default(),
             exit_code: session.exit_code,
-            receipt_claim,
+            receipt_claim: Some(receipt_claim),
         })
     }
 }


### PR DESCRIPTION
#2342 added receipt claims to session info to facilitate testing. This also forces all servers to return a receipt claim for execution. This results in 1.2.0-rc.1 client erroring on older servers. Allows older servers that do not send receipt claims to work with newer clients by making the receipt claim optional.