### PR TITLE
Add @tzerrell as codeowner on bigint2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 
 /bonsai/                               @risc0/bonsai
 /examples/                             @risc0/devrel @risc0/demos @risc0/platform
+/risc0/bigint2/                        @risc0/platform @tzerrell
 /rzup/                                 @risc0/platform @hmrtn
 /web/                                  @risc0/platform @nahoc
 /website/                              @risc0/platform @risc0/devrel @pdg744


### PR DESCRIPTION
Adding this PR would authorize me to CI as sufficient to approve PRs that touch bigint2 code