### PR TITLE
Update cargo semver checks to 0.36

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -441,7 +441,7 @@ jobs:
         uses: risc0/cargo-install@9f6037ed331dcf7da101461a20656273fa72abf0
         with:
           crate: cargo-semver-checks
-          version: "0.31.0"
+          version: "0.36.0"
       - name: run cargo semverchecks on ${{ github.event.pull_request.base.sha }}
         run: |
           cargo semver-checks --default-features --baseline-rev ${{ github.event.pull_request.base.sha }} \


### PR DESCRIPTION
With https://github.com/risc0/risc0/pull/2584, the `semver-check` job started failing with an error realted to unsupported rustdoc version v32. I should have investigated further and found the root cause, but I did not. I've now found that the root cause is that `cargo-semver-checks` needs to be updated, with v0.33 adding support for rustdoc v32 JSON format. This PR updates to the latest release, 0.36, as follow-up to https://github.com/risc0/risc0/pull/2584.

https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.33.0
