### PR TITLE
backport 1.2: ec bigint2 handles zero/infinity point, add tzerrell as code owner (#2572)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 
 /bonsai/                               @risc0/bonsai
 /examples/                             @risc0/devrel @risc0/demos @risc0/platform
+/risc0/bigint2/                        @risc0/platform @tzerrell
 /rzup/                                 @risc0/platform @hmrtn
 /web/                                  @risc0/platform @nahoc
 /website/                              @risc0/platform @risc0/devrel @pdg744

--- a/risc0/bigint2/methods/guest/src/bin/ec_add.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_add.rs
@@ -13,43 +13,21 @@
 // limitations under the License.
 
 use risc0_bigint2::ec::{AffinePoint, Secp256k1Curve};
-#[allow(unused)]
 use risc0_zkvm::guest::env;
 
-fn main() {
-    let lhs = AffinePoint::new_unchecked(
-        [
-            0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
-            0x79be667e,
-        ],
-        [
-            0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465,
-            0x483ada77,
-        ],
-    );
-    let rhs = AffinePoint::new_unchecked(
-        [
-            0xac04dc3f, 0x9465e6a4, 0xf46d2dad, 0x5d5ac4b6, 0xad2c0db6, 0xa7c06f71, 0xe335abc9,
-            0x0f66dc33,
-        ],
-        [
-            0xd3f64d1c, 0x50650be0, 0x2a8577b0, 0xb701323c, 0x95565b00, 0x6dddd83d, 0x398fcd2c,
-            0x83641fc5,
-        ],
-    );
-    let expected = AffinePoint::new_unchecked(
-        [
-            0x3db079e0, 0xd4ad0ff5, 0xdd0da7e2, 0x4faad0a4, 0x85894785, 0x280d6b36, 0xe8ab292d,
-            0xa901b0db,
-        ],
-        [
-            0x47298a9d, 0x01d0e60e, 0xa6b063b3, 0x716bc5e0, 0x61e7ae64, 0xaf6f04dc, 0x834f1a61,
-            0x3f27e7e1,
-        ],
-    );
+fn input_point() -> AffinePoint<8, Secp256k1Curve> {
+    let point: Option<[[u32; 8]; 2]> = env::read();
+    point
+        .map(|[x, y]| AffinePoint::new_unchecked(x, y))
+        .unwrap_or(AffinePoint::IDENTITY)
+}
 
-    let mut result = AffinePoint::<8, Secp256k1Curve>::new_unchecked([0u32; 8], [0u32; 8]);
+fn main() {
+    let lhs = input_point();
+    let rhs = input_point();
+
+    let mut result = AffinePoint::<8, Secp256k1Curve>::IDENTITY;
     lhs.add(&rhs, &mut result);
 
-    assert_eq!(result, expected);
+    env::commit(&result.as_u32s());
 }

--- a/risc0/bigint2/methods/guest/src/bin/ec_double.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_double.rs
@@ -13,35 +13,20 @@
 // limitations under the License.
 
 use risc0_bigint2::ec::{AffinePoint, Secp256k1Curve};
-#[allow(unused)]
 use risc0_zkvm::guest::env;
 
+fn input_point() -> AffinePoint<8, Secp256k1Curve> {
+    let point: Option<[[u32; 8]; 2]> = env::read();
+    point
+        .map(|[x, y]| AffinePoint::new_unchecked(x, y))
+        .unwrap_or(AffinePoint::IDENTITY)
+}
+
 fn main() {
-    const POINT_G: [[u32; 8]; 2] = [
-        [
-            0x16F81798, 0x59F2815B, 0x2DCE28D9, 0x029BFCDB, 0xCE870B07, 0x55A06295, 0xF9DCBBAC,
-            0x79BE667E,
-        ],
-        [
-            0xFB10D4B8, 0x9C47D08F, 0xA6855419, 0xFD17B448, 0x0E1108A8, 0x5DA4FBFC, 0x26A3C465,
-            0x483ADA77,
-        ],
-    ];
-    const EXPECTED: [[u32; 8]; 2] = [
-        [
-            0x5C709EE5, 0xABAC09B9, 0x8CEF3CA7, 0x5C778E4B, 0x95C07CD8, 0x3045406E, 0x41ED7D6D,
-            0xC6047F94,
-        ],
-        [
-            0x50CFE52A, 0x236431A9, 0x3266D0E1, 0xF7F63265, 0x466CEAEE, 0xA3C58419, 0xA63DC339,
-            0x1AE168FE,
-        ],
-    ];
+    let point = input_point();
 
-    let in_pt = AffinePoint::<8, Secp256k1Curve>::new_unchecked(POINT_G[0], POINT_G[1]);
-    let expected_pt = AffinePoint::new_unchecked(EXPECTED[0], EXPECTED[1]);
+    let mut result = AffinePoint::<8, Secp256k1Curve>::IDENTITY;
+    point.double(&mut result);
 
-    let mut result = AffinePoint::new_unchecked([0u32; 8], [0u32; 8]);
-    in_pt.double(&mut result);
-    assert_eq!(result, expected_pt);
+    env::commit(&result.as_u32s());
 }

--- a/risc0/bigint2/methods/guest/src/bin/ec_mul.rs
+++ b/risc0/bigint2/methods/guest/src/bin/ec_mul.rs
@@ -61,7 +61,7 @@ fn main() {
         ],
     );
 
-    let mut result = AffinePoint::<8, TestSecp256k1Curve>::new_unchecked([0u32; 8], [0u32; 8]);
+    let mut result = AffinePoint::<8, TestSecp256k1Curve>::IDENTITY;
     point.mul(&scalar, &mut result);
     assert_eq!(result, expected);
 }

--- a/risc0/bigint2/src/ec/secp256k1.rs
+++ b/risc0/bigint2/src/ec/secp256k1.rs
@@ -1,0 +1,36 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{Curve, WeierstrassCurve, EC_256_WIDTH_WORDS};
+
+/// The secp256k1 curve's prime as u32 digits, least significant digit first
+pub(crate) const SECP256K1_PRIME: [u32; EC_256_WIDTH_WORDS] = [
+    0xFFFFFC2F, 0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+];
+const SECP256K1_CURVE: &WeierstrassCurve<EC_256_WIDTH_WORDS> =
+    &WeierstrassCurve::<EC_256_WIDTH_WORDS>::new(
+        SECP256K1_PRIME,
+        [0u32; EC_256_WIDTH_WORDS],
+        [7, 0, 0, 0, 0, 0, 0, 0],
+    );
+
+/// An implementation of [Curve] for secp256k1.
+///
+/// This type should be used as a generic for [AffinePoint].
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Secp256k1Curve {}
+
+impl Curve<EC_256_WIDTH_WORDS> for Secp256k1Curve {
+    const CURVE: &'static WeierstrassCurve<EC_256_WIDTH_WORDS> = SECP256K1_CURVE;
+}

--- a/risc0/bigint2/src/ec/tests.rs
+++ b/risc0/bigint2/src/ec/tests.rs
@@ -19,9 +19,48 @@ use risc0_zkvm::{
 use std::time::Instant;
 use test_log::test;
 
+use crate::ec::secp256k1::SECP256K1_PRIME;
+
 #[test]
-fn ec_add() {
-    let env = ExecutorEnv::builder().build().unwrap();
+fn ec_add_basic() {
+    let lhs: Option<[[u32; 8]; 2]> = Some([
+        [
+            0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
+            0x79be667e,
+        ],
+        [
+            0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465,
+            0x483ada77,
+        ],
+    ]);
+
+    let rhs: Option<[[u32; 8]; 2]> = Some([
+        [
+            0xac04dc3f, 0x9465e6a4, 0xf46d2dad, 0x5d5ac4b6, 0xad2c0db6, 0xa7c06f71, 0xe335abc9,
+            0x0f66dc33,
+        ],
+        [
+            0xd3f64d1c, 0x50650be0, 0x2a8577b0, 0xb701323c, 0x95565b00, 0x6dddd83d, 0x398fcd2c,
+            0x83641fc5,
+        ],
+    ]);
+
+    let expected = [
+        [
+            0x3db079e0, 0xd4ad0ff5, 0xdd0da7e2, 0x4faad0a4, 0x85894785, 0x280d6b36, 0xe8ab292d,
+            0xa901b0db,
+        ],
+        [
+            0x47298a9d, 0x01d0e60e, 0xa6b063b3, 0x716bc5e0, 0x61e7ae64, 0xaf6f04dc, 0x834f1a61,
+            0x3f27e7e1,
+        ],
+    ];
+
+    let env = ExecutorEnv::builder()
+        .write(&(lhs, rhs))
+        .unwrap()
+        .build()
+        .unwrap();
     let now = Instant::now();
     let session = ExecutorImpl::from_elf(env, EC_ADD_ELF)
         .unwrap()
@@ -34,13 +73,47 @@ fn ec_add() {
         .prove_session(&VerifierContext::default(), &session)
         .unwrap();
     let elapsed = now.elapsed();
+    assert_eq!(
+        prove_info
+            .receipt
+            .journal
+            .decode::<Option<[[u32; 8]; 2]>>()
+            .unwrap(),
+        Some(expected)
+    );
     tracing::info!("Runtime: {}", elapsed.as_millis());
     tracing::info!("User cycles: {}", prove_info.stats.user_cycles);
 }
 
 #[test]
-fn ec_double() {
-    let env = ExecutorEnv::builder().build().unwrap();
+fn ec_double_basic() {
+    let point: Option<[[u32; 8]; 2]> = Some([
+        [
+            0x16F81798, 0x59F2815B, 0x2DCE28D9, 0x029BFCDB, 0xCE870B07, 0x55A06295, 0xF9DCBBAC,
+            0x79BE667E,
+        ],
+        [
+            0xFB10D4B8, 0x9C47D08F, 0xA6855419, 0xFD17B448, 0x0E1108A8, 0x5DA4FBFC, 0x26A3C465,
+            0x483ADA77,
+        ],
+    ]);
+
+    let expected: [[u32; 8]; 2] = [
+        [
+            0x5C709EE5, 0xABAC09B9, 0x8CEF3CA7, 0x5C778E4B, 0x95C07CD8, 0x3045406E, 0x41ED7D6D,
+            0xC6047F94,
+        ],
+        [
+            0x50CFE52A, 0x236431A9, 0x3266D0E1, 0xF7F63265, 0x466CEAEE, 0xA3C58419, 0xA63DC339,
+            0x1AE168FE,
+        ],
+    ];
+
+    let env = ExecutorEnv::builder()
+        .write(&point)
+        .unwrap()
+        .build()
+        .unwrap();
     let now = Instant::now();
     let session = ExecutorImpl::from_elf(env, EC_DOUBLE_ELF)
         .unwrap()
@@ -53,6 +126,14 @@ fn ec_double() {
         .prove_session(&VerifierContext::default(), &session)
         .unwrap();
     let elapsed = now.elapsed();
+    assert_eq!(
+        prove_info
+            .receipt
+            .journal
+            .decode::<Option<[[u32; 8]; 2]>>()
+            .unwrap(),
+        Some(expected)
+    );
     tracing::info!("Runtime: {}", elapsed.as_millis());
     tracing::info!("User cycles: {}", prove_info.stats.user_cycles);
 }
@@ -74,4 +155,184 @@ fn ec_mul() {
     let elapsed = now.elapsed();
     tracing::info!("Runtime: {}", elapsed.as_millis());
     tracing::info!("User cycles: {}", prove_info.stats.user_cycles);
+}
+
+#[test]
+fn ec_add_point_plus_identity() {
+    let point: Option<[[u32; 8]; 2]> = Some([
+        [
+            0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
+            0x79be667e,
+        ],
+        [
+            0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465,
+            0x483ada77,
+        ],
+    ]);
+    let identity: Option<[[u32; 8]; 2]> = None;
+
+    let env = ExecutorEnv::builder()
+        .write(&(point, identity))
+        .unwrap()
+        .build()
+        .unwrap();
+    let session = ExecutorImpl::from_elf(env, EC_ADD_ELF)
+        .unwrap()
+        .run()
+        .unwrap();
+    let prover = get_prover_server(&ProverOpts::fast()).unwrap();
+    let prove_info = prover
+        .prove_session(&VerifierContext::default(), &session)
+        .unwrap();
+    assert_eq!(
+        prove_info
+            .receipt
+            .journal
+            .decode::<Option<[[u32; 8]; 2]>>()
+            .unwrap(),
+        point
+    );
+}
+
+#[test]
+fn ec_add_identity_plus_point() {
+    let point: Option<[[u32; 8]; 2]> = Some([
+        [
+            0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
+            0x79be667e,
+        ],
+        [
+            0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465,
+            0x483ada77,
+        ],
+    ]);
+    let identity: Option<[[u32; 8]; 2]> = None;
+
+    let env = ExecutorEnv::builder()
+        .write(&(identity, point))
+        .unwrap()
+        .build()
+        .unwrap();
+    let session = ExecutorImpl::from_elf(env, EC_ADD_ELF)
+        .unwrap()
+        .run()
+        .unwrap();
+    let prover = get_prover_server(&ProverOpts::fast()).unwrap();
+    let prove_info = prover
+        .prove_session(&VerifierContext::default(), &session)
+        .unwrap();
+    assert_eq!(
+        prove_info
+            .receipt
+            .journal
+            .decode::<Option<[[u32; 8]; 2]>>()
+            .unwrap(),
+        point
+    );
+}
+
+#[test]
+fn ec_add_point_plus_negative() {
+    let point: Option<[[u32; 8]; 2]> = Some([
+        [
+            0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
+            0x79be667e,
+        ],
+        [
+            0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465,
+            0x483ada77,
+        ],
+    ]);
+    let x = point.unwrap()[0];
+    let neg_y = {
+        let mut y = point.unwrap()[1];
+        for i in 0..8 {
+            // Ignoring carries for this test case.
+            y[i] = SECP256K1_PRIME[i] - y[i];
+        }
+        y
+    };
+    let neg_point: Option<[[u32; 8]; 2]> = Some([x, neg_y]);
+
+    let env = ExecutorEnv::builder()
+        .write(&(point, neg_point))
+        .unwrap()
+        .build()
+        .unwrap();
+    let session = ExecutorImpl::from_elf(env, EC_ADD_ELF)
+        .unwrap()
+        .run()
+        .unwrap();
+    let prover = get_prover_server(&ProverOpts::fast()).unwrap();
+    let prove_info = prover
+        .prove_session(&VerifierContext::default(), &session)
+        .unwrap();
+    assert_eq!(
+        prove_info
+            .receipt
+            .journal
+            .decode::<Option<[[u32; 8]; 2]>>()
+            .unwrap(),
+        None
+    );
+}
+
+#[test]
+fn ec_double_identity() {
+    let identity: Option<[[u32; 8]; 2]> = None;
+
+    let env = ExecutorEnv::builder()
+        .write(&identity)
+        .unwrap()
+        .build()
+        .unwrap();
+    let session = ExecutorImpl::from_elf(env, EC_DOUBLE_ELF)
+        .unwrap()
+        .run()
+        .unwrap();
+    let prover = get_prover_server(&ProverOpts::fast()).unwrap();
+    let prove_info = prover
+        .prove_session(&VerifierContext::default(), &session)
+        .unwrap();
+    assert_eq!(
+        prove_info
+            .receipt
+            .journal
+            .decode::<Option<[[u32; 8]; 2]>>()
+            .unwrap(),
+        None
+    );
+}
+
+#[test]
+fn ec_double_point_with_zero_y() {
+    let point_with_zero_y: Option<[[u32; 8]; 2]> = Some([
+        [
+            0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac,
+            0x79be667e,
+        ],
+        [0; 8], // y = 0
+    ]);
+
+    let env = ExecutorEnv::builder()
+        .write(&point_with_zero_y)
+        .unwrap()
+        .build()
+        .unwrap();
+    let session = ExecutorImpl::from_elf(env, EC_DOUBLE_ELF)
+        .unwrap()
+        .run()
+        .unwrap();
+    let prover = get_prover_server(&ProverOpts::fast()).unwrap();
+    let prove_info = prover
+        .prove_session(&VerifierContext::default(), &session)
+        .unwrap();
+    assert_eq!(
+        prove_info
+            .receipt
+            .journal
+            .decode::<Option<[[u32; 8]; 2]>>()
+            .unwrap(),
+        None
+    );
 }


### PR DESCRIPTION
Tried refactoring to make code cleaner by having the AffinePoint type be an enum, and was ~1-2% slower, so kept as is.

Also tried changing how the buffer initializations happen within `mul`, this was fastest. Perf overall with these extra checks seems to be about 5% slower tested with one signature verify in k256

---------