### PR TITLE
Fix Typos and Grammar in Documentation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
   development only.
 * Add an optional embedded allocator to the zkVM guest. By default, the zkvm
   uses an allocator that does not deallocate heap memory. The embedded allocator
-  deallocates and is useful for long running guest programs.
+  deallocates and is useful for long-running guest programs.
 * Add experimental support for `sys_fork`. This syscall allows the zkVM to
   execute unconstrained code. The RISC-V code executed within this system call
   will not be encoded as a part of the trace execution. This can be used to

--- a/website/api_versioned_docs/version-0.19/zkvm/zkvm-overview.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/zkvm-overview.md
@@ -57,7 +57,7 @@ Options for generating proofs using GPU acceleration and skipping proof generati
 
 ## Micro Architecture
 
-The zkVM is a verifiable computer that works like a real embedded RISC-V micro-processor. This enables developers to more easily develop zk powerful applications.
+The zkVM is a verifiable computer that works like a real embedded RISC-V microprocessor. This enables developers to more easily develop zk powerful applications.
 
 ### Continuations for limitless computations
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -172,7 +172,7 @@ If data is loaded from the host to restrict guest program size, the most signifi
 Loading data into the guest costs instruction cycles, as does data processing.
 
 There are workarounds for data limitations if the data is only included to ensure that its integrity becomes part of the proof of computation.
-If the data can be processed externally and simply needs to be verifiably unchanged, consider processing data externally and sending the guest a Merkle proof or (if no processing is needed) generating a SHA of a large dataset.
+If the data can be processed externally and simply needs to be verifiably unchanged, consider processing data externally and sending the guest a Merkle proof or (if no processing is needed) generating an SHA of a large dataset.
 
 In the future, we plan to lift these processing limitations using continuations and recursion.
 

--- a/website/docs/proof-system/proof-system-sequence-diagram.md
+++ b/website/docs/proof-system/proof-system-sequence-diagram.md
@@ -110,7 +110,7 @@ For a more formal articulation of the protocol, refer to the [ZKP Whitepaper].
 
 ### Extended Auxiliary Execution Trace
 
-- Using the transcript-thus-far as an entropy-source, we choose some random extension field elements, using a SHA-2 CRNG.
+- Using the transcript-thus-far as an entropy-source, we choose some random extension field elements, using an SHA-2 CRNG.
 - Then, the Prover uses the randomness to generate the `auxiliary/accum columns`. The Prover computes the Low-Degree Extension of the auxiliary columns to form the Extended Auxiliary Execution Trace.
 - The Prover commits the Extended Auxiliary Execution Trace to a Merkle tree and sends the Merkle root to the Verifier.
 - Using the transcript-thus-far as an entropy-source, we choose a random `constraint mixing parameter` $\alpha$, using a SHA-2 CRNG.


### PR DESCRIPTION
This PR addresses several typos and grammar issues found in the project's documentation:  

- **CHANGELOG.md**: Corrected "long running" to "long-running" to align with proper hyphenation rules.  
- **zkvm-overview.md**: Updated "micro-processor" to "microprocessor" for consistency and correctness.  
- **faq.md**: Replaced "a SHA" with "an SHA" for proper article usage before a vowel sound.  
- **proof-system-sequence-diagram.md**: Replaced "a SHA" with "an SHA" for proper article usage before a vowel sound.  

These changes improve the clarity and professionalism of the documentation. Let me know if additional updates or refinements are needed.  
