### PR TITLE
enable unstable feature for cargo risczero test

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -37,7 +37,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 reqwest-middleware = "0.3"
 reqwest-retry = "0.6"
 risc0-binfmt = { workspace = true, default-features = false }
-risc0-build = { workspace = true, features = ["unstable"] }
+risc0-build = { workspace = true }
 risc0-r0vm = { workspace = true, optional = true }
 risc0-zkp = { workspace = true }
 risc0-zkvm = { workspace = true, features = ["unstable"] }
@@ -75,6 +75,7 @@ experimental = [
   "dep:risc0-build",
   "dep:zip",
   "risc0-zkvm/prove",
+  "risc0-build/unstable",
 ]
 metal = ["risc0-zkvm/metal"]
 r0vm = ["dep:risc0-r0vm"]

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -37,7 +37,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 reqwest-middleware = "0.3"
 reqwest-retry = "0.6"
 risc0-binfmt = { workspace = true, default-features = false }
-risc0-build = { workspace = true }
+risc0-build = { workspace = true, features = ["unstable"] }
 risc0-r0vm = { workspace = true, optional = true }
 risc0-zkp = { workspace = true }
 risc0-zkvm = { workspace = true, features = ["unstable"] }

--- a/risc0/cargo-risczero/build.rs
+++ b/risc0/cargo-risczero/build.rs
@@ -26,7 +26,7 @@ mod runtime {
         let out_dir = Path::new(&out_dir_env); // $ROOT/target/$profile/build/$crate/out
 
         let rust_runtime =
-            build_rust_runtime_with_features(&["getrandom", "sys-getenv", "sys-args"]);
+            build_rust_runtime_with_features(&["getrandom", "sys-getenv", "sys-args", "unstable"]);
         let f = fs::File::create(out_dir.join("cargo-risczero.zip")).unwrap();
         let mut zip = ZipWriter::new(f);
         let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);


### PR DESCRIPTION
Not adding additional semantics by handling an unstable feature flag, given this is already gated behind `experimental` feature flag.

Needed to be able to test new unstable syscalls