### PR TITLE
Add compile time env vars to docker build

### DIFF
--- a/risc0/build/src/config.rs
+++ b/risc0/build/src/config.rs
@@ -24,6 +24,9 @@ pub struct DockerOptions {
     ///
     /// The current working directory is used if `None` is specified.
     pub root_dir: Option<PathBuf>,
+
+    /// Specify the environemnt variables for the docker build.
+    pub compile_time_env: Option<Vec<(String, String)>>,
 }
 
 /// Options defining how to embed a guest package in

--- a/risc0/zkvm/methods/build.rs
+++ b/risc0/zkvm/methods/build.rs
@@ -28,6 +28,7 @@ fn main() {
 
     let docker_opts = DockerOptions {
         root_dir: Some("../../..".into()),
+        compile_time_env: None,
     };
 
     let use_docker = if env::var("RISC0_USE_DOCKER").is_ok() {

--- a/risc0/zkvm/methods/guest/src/bin/hello_commit_env.rs
+++ b/risc0/zkvm/methods/guest/src/bin/hello_commit_env.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+#![no_main]
+
+use risc0_zkvm::guest::env;
+
+risc0_zkvm::entry!(main);
+
+// using option_env so test runs in the repo does not fail
+// env! macro can also be used
+// in this example code would look better with env!
+const COMMIT_STR: &str = match option_env!("COMMIT_STR") {
+    Some(s) => s,
+    None => "hello world",
+};
+
+const SHOULD_COMMIT: bool = match option_env!("SHOULD_COMMIT") {
+    Some(s) => {
+        matches!(s.as_bytes(), b"true")
+    }
+    None => false,
+};
+
+fn main() {
+    if SHOULD_COMMIT {
+        env::commit_slice(COMMIT_STR.as_bytes());
+    }
+}


### PR DESCRIPTION
Implemented passing of compile time environment variables to Docker builds.

Compile time env vars are very useful for guest code that's desired to be run for different environments or different modes. One example would be light clients for blockchains, which you'd like to support mainnet / testnet. Instead of adding an output stating which network the proof belongs to, (or a genesis hash) you can compile different elf files for different environments. And it'd be up to the verifier to know which method id to use.

We are looking to use this feature in [Citrea](https://github.com/chainwayxyz/citrea) and [risc0-to-bitvm2](https://github.com/chainwayxyz/risc0-to-bitvm2).

 There's a few points I need feedback on so I'm opening the PR as draft.
 
 - `DockerOptions::compile_time_env` is Option<Vec> but it can be implemented as Vec. (empty vec instead of None)
 - A lot of `build_guest_package_docker` calls were made with `GuestBuildOptions::default()` which has `use_docker` set to None. I expected `use_docker` to be some in my patch, however, I can change that behaviour if that's not what you desire.
 - `cargo risczero build` command needs to be updated so that a list of env. var. names can be passed. How should that be implemented? Expect a pair of key values or just keys?
 
 