### PR TITLE
Ignore bonsai prover import in zkvm

### DIFF
--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -119,6 +119,7 @@ pub use {
     },
 };
 
+#[cfg(not(target_os = "zkvm"))]
 #[cfg(feature = "bonsai")]
 pub use self::host::client::prove::bonsai::BonsaiProver;
 


### PR DESCRIPTION
Seems this is a breaking change from a previous release as it might have been possible to import risc0-zkvm with default features inside the zkvm?

This change just ignores in the zkvm, which seems to be the strategy for these exports