### PR TITLE
remove redundant prime checks, inline is_less

### DIFF
--- a/risc0/bigint2/src/ec/mod.rs
+++ b/risc0/bigint2/src/ec/mod.rs
@@ -151,12 +151,12 @@ impl<const WIDTH: usize, C: Curve<WIDTH>> AffinePoint<WIDTH, C> {
                     first_write = false;
                     *next_result = *current_doubled;
                 } else {
-                    current_result.add(current_doubled, next_result);
+                    current_result.add_internal(current_doubled, next_result);
                 }
                 result_flip = !result_flip;
             }
 
-            current_doubled.double(next_doubled);
+            current_doubled.double_internal(next_doubled);
         }
 
         if first_write {
@@ -166,11 +166,29 @@ impl<const WIDTH: usize, C: Curve<WIDTH>> AffinePoint<WIDTH, C> {
             // Return the result, based on which buffer was written to last.
             *result = if result_flip { result2 } else { result1 };
         }
+
+        // Check that the final result is less than the curve's prime.
+        let prime = C::CURVE.buffer[0];
+        assert!(crate::is_less(&result.buffer[0], &prime));
+        assert!(crate::is_less(&result.buffer[1], &prime));
     }
 
     /// Elliptic curve doubling of the affine point.
     #[stability::unstable]
     pub fn double(&self, result: &mut Self) {
+        self.double_internal(result);
+
+        // An honest host will always return a result less than the curve's prime in each coordinate.
+        // A dishonest prover can sometimes return a result greater than the prime, so enforce that
+        // we're in the honest case.
+        let prime = C::CURVE.buffer[0];
+        assert!(crate::is_less(&result.buffer[0], &prime));
+        assert!(crate::is_less(&result.buffer[1], &prime));
+    }
+
+    /// [double] without checking the result is less than the curve's prime.
+    #[inline]
+    fn double_internal(&self, result: &mut Self) {
         let curve = C::CURVE;
         // If the point is zero, can short-circuit and return the identity point.
         if let Some(point) = self.as_u32s() {
@@ -190,6 +208,18 @@ impl<const WIDTH: usize, C: Curve<WIDTH>> AffinePoint<WIDTH, C> {
     /// Elliptic curve addition of the affine point.
     #[stability::unstable]
     pub fn add(&self, rhs: &AffinePoint<WIDTH, C>, result: &mut AffinePoint<WIDTH, C>) {
+        self.add_internal(rhs, result);
+
+        // An honest host will always return a result less than the curve's prime in each coordinate.
+        // A dishonest prover can sometimes return a result greater than the prime, so enforce that
+        // we're in the honest case.
+        let prime = C::CURVE.buffer[0];
+        assert!(crate::is_less(&result.buffer[0], &prime));
+        assert!(crate::is_less(&result.buffer[1], &prime));
+    }
+
+    #[inline]
+    fn add_internal(&self, rhs: &AffinePoint<WIDTH, C>, result: &mut AffinePoint<WIDTH, C>) {
         let curve = C::CURVE;
 
         // If the left or right value is zero, can return the other value.
@@ -243,12 +273,6 @@ fn double_raw<const WIDTH: usize>(
             result.as_mut_ptr() as *mut u32,
         );
     }
-    // An honest host will always return a result less than the curve's prime in each coordinate.
-    // A dishonest prover can sometimes return a result greater than the prime, so enforce that
-    // we're in the honest case.
-    let prime = curve[0];
-    assert!(crate::is_less(&result[0], &prime));
-    assert!(crate::is_less(&result[1], &prime));
 }
 
 /// Adds two points on the curve.
@@ -273,12 +297,6 @@ fn add_raw<const WIDTH: usize>(
             result.as_mut_ptr() as *mut u32,
         );
     }
-    // An honest host will always return a result less than the curve's prime in each coordinate.
-    // A dishonest prover can sometimes return a result greater than the prime, so enforce that
-    // we're in the honest case.
-    let prime = curve[0];
-    assert!(crate::is_less(&result[0], &prime));
-    assert!(crate::is_less(&result[1], &prime));
 }
 
 /// Checks if the bit at the position is set.

--- a/risc0/bigint2/src/lib.rs
+++ b/risc0/bigint2/src/lib.rs
@@ -33,6 +33,7 @@ pub trait ToBigInt2Buffer<const WIDTH: usize> {
 }
 
 #[cfg(feature = "unstable")]
+#[inline]
 // Checks if two u32 arrays representing big integers with little-endian digit order satisfy lhs < rhs
 fn is_less<const N: usize>(lhs: &[u32; N], rhs: &[u32; N]) -> bool {
     for i in (0..N).rev() {


### PR DESCRIPTION
Only checks the result is within prime once per public function call

inlines `is_less` as it was measured to be an optimization (context: https://github.com/risc0/risc0/pull/2609#discussion_r1870272857)