### PR TITLE
Add risc0-op-steel to patch list for risc0-ethereum CI job

### DIFF
--- a/.github/cargo_local_patch.py
+++ b/.github/cargo_local_patch.py
@@ -104,6 +104,7 @@ if __name__ == "__main__":
         "risc0-build-ethereum": "risc0-ethereum/build",
         "risc0-forge-ffi": "risc0-ethereum/ffi",
         "risc0-steel": "risc0-ethereum/steel",
+        "risc0-op-steel": "risc0-ethereum/op-steel",
         "risc0-aggregation": "risc0-ethereum/aggregation",
     }
 


### PR DESCRIPTION
Adds `risc0-op-steel` to the list of crates to patch as part of the `risc0-ethereum` CI job to fix the following failure.
https://github.com/risc0/risc0/actions/runs/12244354993/job/34155926307?pr=2635
