### PR TITLE
update 1.2 and next bigint2 docs, use k256 tagged patch

### DIFF
--- a/benchmarks/methods/Cargo.toml
+++ b/benchmarks/methods/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 methods = ["guest"]
 
 [build-dependencies]
-risc0-build = { workspace = true }
+risc0-build = { workspace = true, features = ["unstable"] }

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.5.2"
-source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?tag=v0.5.2-risc0#8b30304277cfe553b51a78a0e693f48bbb059eb3"
+source = "git+https://github.com/risc0/RustCrypto-crypto-bigint?tag=v0.5.2-risczero.1#fa1b8007baf01c13c7cb3b5d7636fbefb0e58760"
 dependencies = [
  "generic-array",
  "getrandom",
@@ -680,6 +680,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "indexmap"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,13 +715,15 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.1-risc0#44b1fc2b317e76bb150636cf67d0fbdfcac39601"
+version = "0.13.3"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.3-risczero.1#ff5d67b095cfcc2569b7789f2079ed87ef2c7756"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "risc0-bigint2",
  "serdect",
  "sha2",
 ]
@@ -1029,6 +1037,16 @@ dependencies = [
  "risc0-zkvm",
  "sha3",
  "starknet-crypto",
+]
+
+[[package]]
+name = "risc0-bigint2"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c185a3bfaee681eed5bfac1440128184bf0b6544c345fb4d7bd4317c909fb"
+dependencies = [
+ "include_bytes_aligned",
+ "stability",
 ]
 
 [[package]]

--- a/benchmarks/methods/guest/Cargo.toml
+++ b/benchmarks/methods/guest/Cargo.toml
@@ -14,11 +14,12 @@ k256 = { version = "=0.13.3", features = [
   "expose-field",
   "std",
   "ecdsa",
-], default_features = false }
+], default-features = false }
 nalgebra = "0.32"
 risc0-benchmark-lib = { path = "../../shared", default-features = false }
 risc0-zkvm = { path = "../../../risc0/zkvm", default-features = false, features = [
   "std",
+  "unstable"
 ] }
 risc0-zkp = { path = "../../../risc0/zkp", default-features = false }
 sha3 = { version = "0.10", default-features = false }

--- a/benchmarks/methods/guest/Cargo.toml
+++ b/benchmarks/methods/guest/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 blake3 = { version = "1.4", default-features = false }
 ed25519-dalek = { version = "2.0.0-rc.3", default-features = false }
-k256 = { version = "=0.13.1", features = [
+k256 = { version = "=0.13.3", features = [
   "arithmetic",
   "serde",
   "expose-field",
@@ -25,9 +25,9 @@ sha3 = { version = "0.10", default-features = false }
 starknet-crypto = "0.6"
 
 [patch.crates-io]
-crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.2-risc0" }
+crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.2-risczero.1" }
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.0-risczero.1" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.1-risc0" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.1" }
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.6-risczero.0" }
 
 [profile.release]

--- a/examples/ecdsa/methods/guest/Cargo.lock
+++ b/examples/ecdsa/methods/guest/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.3"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?branch=austin/bigint2#c2750428558944954af5fe147b01a67711a65062"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256/v0.13.3-risczero.1#ff5d67b095cfcc2569b7789f2079ed87ef2c7756"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/methods/guest/Cargo.toml
+++ b/examples/ecdsa/methods/guest/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false, features = ["std", "unstable"] }
 hex-literal = "0.4"
-k256 = { version = "=0.13.3", features = ["arithmetic", "serde", "expose-field", "std", "ecdsa"], default_features = false }
+k256 = { version = "=0.13.3", features = ["arithmetic", "serde", "expose-field", "std", "ecdsa"], default-features = false }
 
 [patch.crates-io]
 # Placing these patch statement in the workspace Cargo.toml will add RISC Zero SHA-256 and bigint

--- a/website/api/zkvm/precompiles.md
+++ b/website/api/zkvm/precompiles.md
@@ -31,7 +31,7 @@ each fork's repository on GitHub.
 
 | Crate | Versions supported | Patch Statement Example |
 |-------|-------------------|------------------------|
-| [`ed25519-dalek`](https://github.com/risc0/ed25519-dalek/releases) | 4.1.2, 4.1.1, 4.1.0 | `ed25519-dalek = { git = "https://github.com/risc0/ed25519-dalek", tag = "curve25519-4.1.2-risczero.0" }` |
+| [`curve25519-dalek`](https://github.com/risc0/curve25519-dalek/releases) | 4.1.2, 4.1.1, 4.1.0 | `ed25519-dalek = { git = "https://github.com/risc0/ed25519-dalek", tag = "curve25519-4.1.2-risczero.0" }` |
 
 ### RSA
 
@@ -54,6 +54,9 @@ If using `tag = "sha2-v0.10.8-risczero.0"`, the dependency should be:
 ```toml
 [dependencies]
 sha2 = "=0.10.8"
+
+[patch.crates-io]
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ```
 
 In some situations, for example when a patch is used indirectly, you may

--- a/website/api/zkvm/precompiles.md
+++ b/website/api/zkvm/precompiles.md
@@ -69,7 +69,7 @@ cargo update -p sha2 --precise 0.10.8
 
 > Note: To ensure that the patch is being applied, search for the crate in the `Cargo.lock` file
 > of your guest to ensure that it references the fork repository. It is generally good practice to
-> commit the `Cargo.lock` file to git, to ensure versions don't get accidentally updated.
+> [commit the `Cargo.lock` file to git][commit-lockfile], to ensure versions don't get accidentally updated.
 
 When using cryptography indirectly, e.g. via the `cookie`, `oauth2`, or `revm`,
 crates it may be possible to enable acceleration support without code changes by
@@ -90,20 +90,24 @@ RustCrypto's secp256k1 ECDSA library. This fork starts from the base
 implementation, and changes the core operations to use the accelerated 256-bit
 elliptic curve instructions. E.g. [`lincomb`][lincomb].
 
+## Stability
+
+Certain versions of patches for some crates (e.g. `k256`, `rsa`) depend on more optimized
+precompiles that are still undergoing revision and review, and so users must opt-in to these
+features by setting the `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by
+the zkVM guest and by the `risc0-build` crate used to build the guest. These also require using
+versions `>1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
+working on stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will
+no longer be required.
+
+
 [^1]: This is similar to the cryptography support such as [AES-NI] or the [SHA
     extensions] for x86 processors. In both cases, the circuitry is extended to
     compute otherwise expensive operations in fewer instruction cycles.
 
-[^2]: Certain versions of patches for this crate depend on our more optimized precompiles that are
-    still undergoing revision and review, and so users must opt-in to these features by setting the
-    `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by the zkVM guest and by the
-    `risc0-build` crate used to build the guest. These also require using versions `>1.2.0` of
-    `risc0` crates. For users who need a stable, production-ready version we are working on
-    stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will no
-    longer be required.
-
 [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
 [cargo-patch]: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
+[commit-lockfile]: https://blog.rust-lang.org/2023/08/29/committing-lockfiles.html
 [curve25519-dalek]: https://github.com/risc0/curve25519-dalek/tree/risczero
 [discord-url]: https://discord.gg/risczero
 [ecdsa]: https://github.com/risc0/risc0/tree/release-1.2/examples/ecdsa

--- a/website/api/zkvm/precompiles.md
+++ b/website/api/zkvm/precompiles.md
@@ -104,6 +104,8 @@ no longer be required.
 [^1]: This is similar to the cryptography support such as [AES-NI] or the [SHA
     extensions] for x86 processors. In both cases, the circuitry is extended to
     compute otherwise expensive operations in fewer instruction cycles.
+[^2]: Some tagged releases of this crate may depend on updated precompiles.
+    See [Stability](#stability) for more details.
 
 [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
 [cargo-patch]: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section

--- a/website/api/zkvm/precompiles.md
+++ b/website/api/zkvm/precompiles.md
@@ -96,7 +96,7 @@ Certain versions of patches for some crates (e.g. `k256`, `rsa`) depend on more 
 precompiles that are still undergoing revision and review, and so users must opt-in to these
 features by setting the `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by
 the zkVM guest and by the `risc0-build` crate used to build the guest. These also require using
-versions `>1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
+versions `>=1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
 working on stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will
 no longer be required.
 

--- a/website/api/zkvm/precompiles.md
+++ b/website/api/zkvm/precompiles.md
@@ -12,51 +12,65 @@ with significantly less resources [^1].
 We have patched several popular cryptographic Rust crates to create
 "accelerated" versions that integrate our precompiles.
 
-These crates include:
+For the most up to date tags to use for the following crates, see the `/releases` in
+each fork's repository on GitHub.
 
-- [RustCrypto's `crypto-bigint` crate][RustCrypto-crypto-bigint]
-- [RustCrypto's `k256` crate][RustCrypto-elliptic-curves]
-- [RustCrypto's `sha2` crate][RustCrypto-hashes]
-- [RustCrypto's `RSA` crate][RustCrypto-RSA]
-- [Dalek Cryptography's curve25519-dalek crate][curve25519-dalek]
+### Hash Functions
 
-Each of these are forks of the original source code repository, with
-modifications to use RISC Zero cryptography extensions.
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`sha2`](https://github.com/risc0/RustCrypto-hashes/releases) | 0.10.8, 0.10.7, 0.10.6, 0.9.9 | `sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }` |
 
-### Using Accelerated Crates
+### ECDSA
 
-When using any of the crates listed above directly, specifying the dependency as
-a [git dependency][git-dep]. For example:
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`k256`](https://github.com/risc0/RustCrypto-elliptic-curves/releases) | 0.13.4, 0.13.3, 0.13.2, 0.13.1 | `k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.1" }` [^2] |
 
-```toml
-[dependencies.sha2]
-git = "https://github.com/risc0/RustCrypto-hashes"
-tag = "sha2-v0.10.6-risczero.0"
-```
+### EDDSA
 
-Make sure that your dependency gives the same version of the crate as listed in
-the patch tag. In this example, the dependency would be
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`ed25519-dalek`](https://github.com/risc0/ed25519-dalek/releases) | 4.1.2, 4.1.1, 4.1.0 | `ed25519-dalek = { git = "https://github.com/risc0/ed25519-dalek", tag = "curve25519-4.1.2-risczero.0" }` |
+
+### RSA
+
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`rsa`](https://github.com/risc0/RustCrypto-RSA/releases) | 0.9.6 | `rsa = { git = "https://github.com/risc0/RustCrypto-RSA", tag = "v0.9.6-risczero.0" }` [^2] |
+
+### Other Accelerated Crates
+
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`crypto-bigint`](https://github.com/risc0/RustCrypto-crypto-bigint/releases) | 0.5.5, 0.5.4, 0.5.3, 0.5.2 | `crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }` |
+
+Make sure that your dependency gives the same patch version of the crate as listed in
+the git tag of the patch. If you need other patch versions or crates than listed here, please reach
+out to us on [Discord][discord-url] or otherwise!
+
+If using `tag = "sha2-v0.10.8-risczero.0"`, the dependency should be:
+
 ```toml
 [dependencies]
-sha2 = "0.10.6"
+sha2 = "=0.10.8"
 ```
 
-In some situations, particularly for crates you've used before with patch
-version updates, you may need to regenerate your `lock` file. For example:
-```toml
-cargo update -p sha2 --precise 0.10.6
+In some situations, for example when a patch is used indirectly, you may
+need to update the version specifically to update your lockfile for your guest.
+For example:
+
+```sh
+cargo update -p sha2 --precise 0.10.8
 ```
+
+> Note: To ensure that the patch is being applied, search for the crate in the `Cargo.lock` file
+> of your guest to ensure that it references the fork repository. It is generally good practice to
+> commit the `Cargo.lock` file to git, to ensure versions don't get accidentally updated.
 
 When using cryptography indirectly, e.g. via the `cookie`, `oauth2`, or `revm`,
 crates it may be possible to enable acceleration support without code changes by
 applying a [Cargo patch][cargo-patch].
-
-Several of our precompiles are still undergoing revision and
-review, and so users must opt-in to these features by setting the `"unstable"`
-feature flag on the `risc0-zkvm` crate used by the zkVM guest and by the
-`risc0-build` crate used to build the guest. For users who need a stable,
-production-ready version we are working on stablizing these precompiles as soon
-as possible.
 
 An example of how to use these crates to accelerate ECDSA signature verification
 can be in the [ECDSA example][ecdsa]. Note the [use of the patched
@@ -77,14 +91,24 @@ elliptic curve instructions. E.g. [`lincomb`][lincomb].
     extensions] for x86 processors. In both cases, the circuitry is extended to
     compute otherwise expensive operations in fewer instruction cycles.
 
+[^2]: Certain versions of patches for this crate depend on our more optimized precompiles that are
+    still undergoing revision and review, and so users must opt-in to these features by setting the
+    `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by the zkVM guest and by the
+    `risc0-build` crate used to build the guest. These also require using versions `>1.2.0` of
+    `risc0` crates. For users who need a stable, production-ready version we are working on
+    stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will no
+    longer be required.
+
 [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
 [cargo-patch]: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
 [curve25519-dalek]: https://github.com/risc0/curve25519-dalek/tree/risczero
+[discord-url]: https://discord.gg/risczero
 [ecdsa]: https://github.com/risc0/risc0/tree/release-1.2/examples/ecdsa
 [ecdsa-patched]: https://github.com/risc0/risc0/blob/release-1.2/examples/ecdsa/methods/guest/Cargo.toml#L13-L18
+[feature-flag]: https://doc.rust-lang.org/cargo/reference/features.html#dependency-features
 [git-dep]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories
-[k256-diff]: https://github.com/risc0/RustCrypto-elliptic-curves/compare/k256/v0.13.1..k256/v0.13.1-risczero.1
-[lincomb]: TODO
+[k256-diff]: https://github.com/risc0/RustCrypto-elliptic-curves/compare/k256/v0.13.3..k256/v0.13.3-risczero.1
+[lincomb]: https://github.com/risc0/RustCrypto-elliptic-curves/blob/k256/v0.13.3-risczero.1/k256/src/arithmetic/mul.rs#L349-L377
 [RustCrypto-crypto-bigint]: https://github.com/risc0/RustCrypto-crypto-bigint/tree/risczero
 [RustCrypto-elliptic-curves]: https://github.com/risc0/RustCrypto-elliptic-curves/tree/risczero
 [RustCrypto-hashes]: https://github.com/risc0/RustCrypto-hashes/tree/risczero

--- a/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
@@ -31,7 +31,7 @@ each fork's repository on GitHub.
 
 | Crate | Versions supported | Patch Statement Example |
 |-------|-------------------|------------------------|
-| [`ed25519-dalek`](https://github.com/risc0/ed25519-dalek/releases) | 4.1.2, 4.1.1, 4.1.0 | `ed25519-dalek = { git = "https://github.com/risc0/ed25519-dalek", tag = "curve25519-4.1.2-risczero.0" }` |
+| [`curve25519-dalek`](https://github.com/risc0/curve25519-dalek/releases) | 4.1.2, 4.1.1, 4.1.0 | `ed25519-dalek = { git = "https://github.com/risc0/ed25519-dalek", tag = "curve25519-4.1.2-risczero.0" }` |
 
 ### RSA
 
@@ -54,6 +54,9 @@ If using `tag = "sha2-v0.10.8-risczero.0"`, the dependency should be:
 ```toml
 [dependencies]
 sha2 = "=0.10.8"
+
+[patch.crates-io]
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ```
 
 In some situations, for example when a patch is used indirectly, you may

--- a/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
@@ -69,7 +69,7 @@ cargo update -p sha2 --precise 0.10.8
 
 > Note: To ensure that the patch is being applied, search for the crate in the `Cargo.lock` file
 > of your guest to ensure that it references the fork repository. It is generally good practice to
-> commit the `Cargo.lock` file to git, to ensure versions don't get accidentally updated.
+> [commit the `Cargo.lock` file to git][commit-lockfile], to ensure versions don't get accidentally updated.
 
 When using cryptography indirectly, e.g. via the `cookie`, `oauth2`, or `revm`,
 crates it may be possible to enable acceleration support without code changes by
@@ -97,20 +97,24 @@ RustCrypto's secp256k1 ECDSA library. This fork starts from the base
 implementation, and changes the core operations to use the accelerated 256-bit
 elliptic curve instructions. E.g. [`lincomb`][lincomb].
 
+## Stability
+
+Certain versions of patches for some crates (e.g. `k256`, `rsa`) depend on more optimized
+precompiles that are still undergoing revision and review, and so users must opt-in to these
+features by setting the `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by
+the zkVM guest and by the `risc0-build` crate used to build the guest. These also require using
+versions `>1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
+working on stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will
+no longer be required.
+
+
 [^1]: This is similar to the cryptography support such as [AES-NI] or the [SHA
     extensions] for x86 processors. In both cases, the circuitry is extended to
     compute otherwise expensive operations in fewer instruction cycles.
 
-[^2]: Certain versions of patches for this crate depend on our more optimized precompiles that are
-    still undergoing revision and review, and so users must opt-in to these features by setting the
-    `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by the zkVM guest and by the
-    `risc0-build` crate used to build the guest. These also require using versions `>1.2.0` of
-    `risc0` crates. For users who need a stable, production-ready version we are working on
-    stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will no
-    longer be required.
-
 [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
 [cargo-patch]: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
+[commit-lockfile]: https://blog.rust-lang.org/2023/08/29/committing-lockfiles.html
 [curve25519-dalek]: https://github.com/risc0/curve25519-dalek/tree/risczero
 [discord-url]: https://discord.gg/risczero
 [ecdsa]: https://github.com/risc0/risc0/tree/release-1.2/examples/ecdsa

--- a/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
@@ -112,6 +112,9 @@ no longer be required.
     extensions] for x86 processors. In both cases, the circuitry is extended to
     compute otherwise expensive operations in fewer instruction cycles.
 
+[^2]: Some tagged releases of this crate may depend on updated precompiles.
+    See [Stability](#stability) for more details.
+
 [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
 [cargo-patch]: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
 [commit-lockfile]: https://blog.rust-lang.org/2023/08/29/committing-lockfiles.html

--- a/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
@@ -103,7 +103,7 @@ Certain versions of patches for some crates (e.g. `k256`, `rsa`) depend on more 
 precompiles that are still undergoing revision and review, and so users must opt-in to these
 features by setting the `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by
 the zkVM guest and by the `risc0-build` crate used to build the guest. These also require using
-versions `>1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
+versions `>=1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
 working on stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will
 no longer be required.
 

--- a/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
@@ -2,50 +2,71 @@
 
 RISC Zero's rv32im implementation includes a number of specialized extension
 circuits, including "precompiles" for cryptographic and algebraic functions: SHA-256,
-Keccak, RSA, elliptic curve, and modular multiplication operations.
+RSA, elliptic curve, and modular multiplication operations.
 By implementing these operations directly in the "hardware" of
 the zkVM, programs that use these precompiles execute faster and can be proven
 with significantly less resources [^1].
 
 ## Accelerated Crates
 
-Our precompiles are currently integrated in "accelerated"
-versions of popular cryptographic Rust crates.
+We have patched several popular cryptographic Rust crates to create
+"accelerated" versions that integrate our precompiles.
 
-These crates include:
+For the most up to date tags to use for the following crates, see the `/releases` in
+each fork's repository on GitHub.
 
-- [RustCrypto's `crypto-bigint` crate][RustCrypto-crypto-bigint]
-- [RustCrypto's `k256` crate][RustCrypto-elliptic-curves]
-- [RustCrypto's `sha2` crate][RustCrypto-hashes]
-- [RustCrypto's `RSA` crate][RustCrypto-RSA]
-- [Dalek Cryptography's curve25519-dalek crate][curve25519-dalek]
+### Hash Functions
 
-Each of these are forks of the original source code repository, with
-modifications to use RISC Zero cryptography extensions.
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`sha2`](https://github.com/risc0/RustCrypto-hashes/releases) | 0.10.8, 0.10.7, 0.10.6, 0.9.9 | `sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }` |
 
-### Using Accelerated Crates
+### ECDSA
 
-When using any of the crates listed above directly, specifying the dependency as
-a [git dependency][git-dep]. For example:
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`k256`](https://github.com/risc0/RustCrypto-elliptic-curves/releases) | 0.13.4, 0.13.3, 0.13.2, 0.13.1 | `k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.1" }` [^2] |
 
-```toml
-[dependencies.sha2]
-git = "https://github.com/risc0/RustCrypto-hashes"
-tag = "sha2-v0.10.6-risczero.0"
-```
+### EDDSA
 
-Make sure that your dependency gives the same version of the crate as listed in
-the patch tag. In this example, the dependency would be
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`ed25519-dalek`](https://github.com/risc0/ed25519-dalek/releases) | 4.1.2, 4.1.1, 4.1.0 | `ed25519-dalek = { git = "https://github.com/risc0/ed25519-dalek", tag = "curve25519-4.1.2-risczero.0" }` |
+
+### RSA
+
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`rsa`](https://github.com/risc0/RustCrypto-RSA/releases) | 0.9.6 | `rsa = { git = "https://github.com/risc0/RustCrypto-RSA", tag = "v0.9.6-risczero.0" }` [^2] |
+
+### Other Accelerated Crates
+
+| Crate | Versions supported | Patch Statement Example |
+|-------|-------------------|------------------------|
+| [`crypto-bigint`](https://github.com/risc0/RustCrypto-crypto-bigint/releases) | 0.5.5, 0.5.4, 0.5.3, 0.5.2 | `crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }` |
+
+Make sure that your dependency gives the same patch version of the crate as listed in
+the git tag of the patch. If you need other patch versions or crates than listed here, please reach
+out to us on [Discord][discord-url] or otherwise!
+
+If using `tag = "sha2-v0.10.8-risczero.0"`, the dependency should be:
+
 ```toml
 [dependencies]
-sha2 = "=0.10.6"
+sha2 = "=0.10.8"
 ```
 
 In some situations, for example when a patch is used indirectly, you may
-need to update the version specifically to update your lockfile. For example:
-```toml
-cargo update -p sha2 --precise 0.10.6
+need to update the version specifically to update your lockfile for your guest.
+For example:
+
+```sh
+cargo update -p sha2 --precise 0.10.8
 ```
+
+> Note: To ensure that the patch is being applied, search for the crate in the `Cargo.lock` file
+> of your guest to ensure that it references the fork repository. It is generally good practice to
+> commit the `Cargo.lock` file to git, to ensure versions don't get accidentally updated.
 
 When using cryptography indirectly, e.g. via the `cookie`, `oauth2`, or `revm`,
 crates it may be possible to enable acceleration support without code changes by
@@ -70,16 +91,24 @@ elliptic curve instructions. E.g. [`lincomb`][lincomb].
     extensions] for x86 processors. In both cases, the circuitry is extended to
     compute otherwise expensive operations in fewer instruction cycles.
 
+[^2]: Certain versions of patches for this crate depend on our more optimized precompiles that are
+    still undergoing revision and review, and so users must opt-in to these features by setting the
+    `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by the zkVM guest and by the
+    `risc0-build` crate used to build the guest. These also require using versions `>1.2.0` of
+    `risc0` crates. For users who need a stable, production-ready version we are working on
+    stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will no
+    longer be required.
+
 [AES-NI]: https://en.wikipedia.org/wiki/AES_instruction_set#x86_architecture_processors
-[bigint]: https://github.com/risc0/risc0/pull/466
 [cargo-patch]: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
 [curve25519-dalek]: https://github.com/risc0/curve25519-dalek/tree/risczero
+[discord-url]: https://discord.gg/risczero
 [ecdsa]: https://github.com/risc0/risc0/tree/release-1.2/examples/ecdsa
 [ecdsa-patched]: https://github.com/risc0/risc0/blob/release-1.2/examples/ecdsa/methods/guest/Cargo.toml#L13-L18
-[field-mul]: https://github.com/risc0/RustCrypto-elliptic-curves/compare/k256/v0.13.1..k256/v0.13.1-risczero.1#diff-ab10e01be1d99a874f90c9a6143bb1c64f37e04dcb220b5ab50b9273d99e0a0cR176-R179
+[feature-flag]: https://doc.rust-lang.org/cargo/reference/features.html#dependency-features
 [git-dep]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories
-[k256-diff]: https://github.com/risc0/RustCrypto-elliptic-curves/compare/k256/v0.13.1..k256/v0.13.1-risczero.1
-[lincomb]: TODO
+[k256-diff]: https://github.com/risc0/RustCrypto-elliptic-curves/compare/k256/v0.13.3..k256/v0.13.3-risczero.1
+[lincomb]: https://github.com/risc0/RustCrypto-elliptic-curves/blob/k256/v0.13.3-risczero.1/k256/src/arithmetic/mul.rs#L349-L377
 [RustCrypto-crypto-bigint]: https://github.com/risc0/RustCrypto-crypto-bigint/tree/risczero
 [RustCrypto-elliptic-curves]: https://github.com/risc0/RustCrypto-elliptic-curves/tree/risczero
 [RustCrypto-hashes]: https://github.com/risc0/RustCrypto-hashes/tree/risczero


### PR DESCRIPTION
Some additions I think might be helpful, notably:
- Update `k256` to use tagged release
- Puts acceleration in table with example usages of each
  - noting this could include https://github.com/risc0/ed25519-consensus/pull/1 if we decide to tag those changes (currently used in blobstream0)
- Documentation around the nuances of updating to patch (as there are many footguns)
- Updates old patch tags to use the consistent `-risczero.X` format

Pointing at #2639 

