### PR TITLE
[WIP] Add and use wide join, and join+lift programs

### DIFF
--- a/risc0/circuit/keccak/src/lib.rs
+++ b/risc0/circuit/keccak/src/lib.rs
@@ -26,6 +26,7 @@ pub const KECCAK_DEFAULT_PO2: usize = 17;
 
 pub const KECCAK_PO2_RANGE: core::ops::Range<usize> = 14..18;
 
+// DO NOT MERGE: Deprecate this value.
 pub const RECURSION_PO2: usize = 18;
 
 pub type KeccakState = [u64; 25];

--- a/risc0/circuit/recursion/src/prove/program.rs
+++ b/risc0/circuit/recursion/src/prove/program.rs
@@ -56,6 +56,21 @@ impl Program {
         prog
     }
 
+    /// Create a [Program] from a stream of data encoded by Zirgen, returning None if the encoded
+    /// program does not fit in the given po2.
+    pub fn try_from_encoded(encoded: &[u32], po2: usize) -> Option<Self> {
+        assert_eq!(encoded.len() % RECURSION_CODE_SIZE, 0);
+        if encoded.len() > (RECURSION_CODE_SIZE * (1 << po2) - ZK_CYCLES) {
+            return None;
+        }
+        let prog = Self {
+            code: encoded.iter().copied().map(BabyBearElem::from).collect(),
+            code_size: RECURSION_CODE_SIZE,
+            po2,
+        };
+        Some(prog)
+    }
+
     /// Total number of rows in the code group for this program.
     pub fn code_rows(&self) -> usize {
         self.code.len() / self.code_size

--- a/risc0/zkvm/src/host/recursion/mod.rs
+++ b/risc0/zkvm/src/host/recursion/mod.rs
@@ -35,7 +35,9 @@ pub use risc0_circuit_recursion::control_id::{ALLOWED_CONTROL_IDS, ALLOWED_CONTR
 #[cfg(feature = "prove")]
 pub use self::prove::test_zkr;
 #[cfg(feature = "prove")]
-pub use self::prove::{identity_p254, join, lift, resolve, Prover, RECURSION_PO2};
+pub use self::prove::{
+    identity_p254, join, join_n, lift, lift_join_n, resolve, Prover, MAX_JOIN_WIDTH, RECURSION_PO2,
+};
 #[cfg(feature = "prove")]
 pub use risc0_circuit_recursion::prove::{
     poseidon254_hal_pair, poseidon2_hal_pair, sha256_hal_pair, Program,

--- a/risc0/zkvm/src/host/server/prove/dev_mode.rs
+++ b/risc0/zkvm/src/host/server/prove/dev_mode.rs
@@ -98,6 +98,17 @@ impl ProverServer for DevModeProver {
         unimplemented!("This is unsupported for dev mode.")
     }
 
+    fn join_n(
+        &self,
+        _receipts: &[SuccinctReceipt<ReceiptClaim>],
+    ) -> Result<SuccinctReceipt<ReceiptClaim>> {
+        unimplemented!("This is unsupported for dev mode.")
+    }
+
+    fn lift_join_n(&self, _receipts: &[SegmentReceipt]) -> Result<SuccinctReceipt<ReceiptClaim>> {
+        unimplemented!("This is unsupported for dev mode.")
+    }
+
     fn resolve(
         &self,
         _conditional: &SuccinctReceipt<ReceiptClaim>,

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -28,7 +28,7 @@ use risc0_zkp::hal::{CircuitHal, Hal};
 
 use self::{dev_mode::DevModeProver, prover_impl::ProverImpl};
 use crate::{
-    host::prove_info::ProveInfo,
+    host::{prove_info::ProveInfo, recursion::MAX_JOIN_WIDTH},
     is_dev_mode,
     receipt::{
         CompositeReceipt, Groth16Receipt, Groth16ReceiptVerifierParameters, InnerAssumptionReceipt,
@@ -76,6 +76,15 @@ pub trait ProverServer {
         b: &SuccinctReceipt<ReceiptClaim>,
     ) -> Result<SuccinctReceipt<ReceiptClaim>>;
 
+    /// Join a slice [SuccinctReceipt] into a [SuccinctReceipt]
+    fn join_n(
+        &self,
+        receipts: &[SuccinctReceipt<ReceiptClaim>],
+    ) -> Result<SuccinctReceipt<ReceiptClaim>>;
+
+    /// Lift and join a slice [SegmentReceipt] into a [SuccinctReceipt]
+    fn lift_join_n(&self, receipts: &[SegmentReceipt]) -> Result<SuccinctReceipt<ReceiptClaim>>;
+
     /// Resolve an assumption from a conditional [SuccinctReceipt] by providing a [SuccinctReceipt]
     /// proving the validity of the assumption.
     fn resolve(
@@ -105,15 +114,24 @@ pub trait ProverServer {
         // Compress all receipts in the top-level session into one succinct receipt for the session.
         let continuation_receipt = receipt
             .segments
-            .iter()
+            .chunks(MAX_JOIN_WIDTH)
+            .map(|segments| match segments {
+                &[ref segment] => self.lift(segment),
+                _ => self.lift_join_n(segments),
+            })
+            .collect::<Result<Vec<_>>>()?
+            .chunks(MAX_JOIN_WIDTH - 1)
             .try_fold(
                 None,
                 |left: Option<SuccinctReceipt<ReceiptClaim>>,
-                 right: &SegmentReceipt|
+                 right: &[SuccinctReceipt<ReceiptClaim>]|
                  -> Result<_> {
-                    Ok(Some(match left {
-                        Some(left) => self.join(&left, &self.lift(right)?)?,
-                        None => self.lift(right)?,
+                    Ok(Some(match (left, right) {
+                        (None, &[ref right]) => right.clone(),
+                        // NOTE: This case is slightly less efficient than it could be.
+                        (None, _) => self.join_n(right)?,
+                        (Some(left), &[ref right]) => self.join(&left, right)?,
+                        (Some(left), _) => self.join_n(&[&[left], right].concat())?,
                     }))
                 },
             )?


### PR DESCRIPTION
This is a WIP implementation of adding new recursion programs to optimize the recursive compression (i.e. join tree) phase of proving by taking advantage of higher po2s.

By using a higher po2, two variations on the existing recursion programs become possible.

1. A combined join+lift program, that take two or more rv32im receipts, and generates a single joined recursion receipt. This cuts out the lift step, which eliminates one recursive verify per segment.
2. Wider join programs that can take `n` receipts for a chunk of segments and return a single receipt. This also reduces the number of intermediate recursive verifications that need to occur.

In additional to reducing the total number recursive verifies in the compression process (join tree), larger po2s are expected to allow us to better utilize the large number of cores available on GPUs. In practice, although the concrete work is linear in the size of the trace, the throughput increases as the po2 grows, making the latency sublinear up to a point. This is added to the concrete reductions of work mentioned above.

In its current state, a PoC level implementation is implemented, but not tested. Testing is blocked on code generation of new recursion programs.
