### PR TITLE
keccak: fix range check to include po2 = 18 add `no_mangle` to `risc0_keccak_update`

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -272,7 +272,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "dffae71728bc3678f7a98901041d58c0a85cdce856c9f15cd18589a9eba92f7e",
+            "e6b24269e7bed4d876b0f602a6b7fd039aa01f6256302ada628472b0d27ed7e6",
         );
     }
 }

--- a/risc0/circuit/keccak/src/lib.rs
+++ b/risc0/circuit/keccak/src/lib.rs
@@ -24,7 +24,9 @@ pub use self::control_id::{KECCAK_CONTROL_IDS, KECCAK_CONTROL_ROOT};
 
 pub const KECCAK_DEFAULT_PO2: usize = 17;
 
-pub const KECCAK_PO2_RANGE: core::ops::Range<usize> = 14..18;
+pub const KECCAK_MAX_PO2: usize = 18;
+
+pub const KECCAK_PO2_RANGE: core::ops::Range<usize> = 14..KECCAK_MAX_PO2 + 1;
 
 pub const RECURSION_PO2: usize = 18;
 

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -518,7 +518,7 @@ fn main() {
         }
         MultiTestSpec::KeccakUpdate => {
             let mut state = KeccakState::default();
-            env::keccak_update(&mut state);
+            env::risc0_keccak_update(&mut state);
             assert_eq!(state, KECCAK_UPDATE);
         }
         MultiTestSpec::KeccakUpdate2 => {
@@ -533,7 +533,7 @@ fn main() {
             }
             let mut state = test_input();
 
-            env::keccak_update(&mut state);
+            env::risc0_keccak_update(&mut state);
             assert_eq!(
                 state,
                 [
@@ -562,8 +562,8 @@ fn main() {
                     0xdbaf74e7812a697b,
                     0xe4458a47859ad246,
                     0xd5f9328619cd99f7
-                    ]
-                );
+                ]
+            );
         }
     }
 }

--- a/risc0/zkvm/src/guest/env/batcher.rs
+++ b/risc0/zkvm/src/guest/env/batcher.rs
@@ -59,8 +59,9 @@ impl Keccak2Batcher {
             let po2: u32 = po2.parse::<u32>().unwrap();
             if !KECCAK_PO2_RANGE.contains(&(po2 as usize)) {
                 panic!(
-                    "invalid keccak po2 {po2}. Expected range: {:?}",
-                    KECCAK_PO2_RANGE
+                    "invalid keccak po2 {po2}. Expected range: {} - {}",
+                    KECCAK_PO2_RANGE.start,
+                    KECCAK_PO2_RANGE.end - 1
                 );
             }
             po2

--- a/risc0/zkvm/src/guest/env/mod.rs
+++ b/risc0/zkvm/src/guest/env/mod.rs
@@ -500,6 +500,7 @@ pub fn read_buffered<T: DeserializeOwned>() -> Result<T, crate::serde::Error> {
 
 /// get an updated keccak state
 #[cfg(feature = "unstable")]
-pub fn keccak_update(state: &mut risc0_circuit_keccak::KeccakState) {
+#[no_mangle]
+pub fn risc0_keccak_update(state: &mut risc0_circuit_keccak::KeccakState) {
     unsafe { KECCAK2_BATCHER.get_mut().unwrap().update(state) }
 }


### PR DESCRIPTION
The `no_mangle` declaration will allow our patched `tiny-keccak` crate to drop its `risc0` dependency. `keccak_update` sounds too generic and could result in name collisions so I've renamed this to `risc0_keccak_update`.