### PR TITLE
Typo fix extension.rs

### DIFF
--- a/rzup/src/extension.rs
+++ b/rzup/src/extension.rs
@@ -182,7 +182,7 @@ impl Extension {
                 archive.unpack(&extension_dir)?;
                 let binary_path = extension_dir.join("cargo-risczero");
 
-                verbose_msg!("Setting extension permissons to 0o755");
+                verbose_msg!("Setting extension permissions to 0o755");
 
                 let mut perms = fs::metadata(&binary_path)?.permissions();
                 perms.set_mode(0o755);


### PR DESCRIPTION
# Commit: Typo Fix in `extension.rs`



## Context and Purpose

This commit addresses a typo in a log message. The word "permissons" was corrected to "permissions" to enhance the clarity and professionalism of debug output.

### Code Context:
```rust
verbose_msg!("Setting extension permissions to 0o755");
