### PR TITLE
fix: typos in documentation files

### DIFF
--- a/rzup/src/cli/help.rs
+++ b/rzup/src/cli/help.rs
@@ -17,7 +17,7 @@ pub static RZUP_HELP: &str = r"Discussion:
     release channels, enabling you to easily switch between different
     versions and keep them updated.
 
-    If you are new to RISC Zero, consider visitng our documentation
+    If you are new to RISC Zero, consider visiting our documentation
     to learn more.";
 
 pub static SHOW_HELP: &str = r"Discussion:

--- a/rzup/src/main.rs
+++ b/rzup/src/main.rs
@@ -122,7 +122,7 @@ fn init() -> Result<()> {
     // this is a rust revamp of rzup. Before this version, rzup was a bash
     // script. In order to facilitate compatibility within our tools, we touch a
     // file in a known location to indicate to the client that the rust
-    // impelemtnation of rzup is being utilized.
+    // implementation of rzup is being utilized.
     let new_rzup_indicator = utils::rzup_home()?.join(risc0_build::RUST_RZUP_INDICATOR);
     if !new_rzup_indicator.exists() {
         fs::create_dir_all(new_rzup_indicator.parent().unwrap())?;


### PR DESCRIPTION

Corrected "visitng" to "visiting".
Corrected "impelemtnation" to "implementation".


