### PR TITLE
fix Typo in Extension Management Code

### DIFF
--- a/rzup/src/cli/extension.rs
+++ b/rzup/src/cli/extension.rs
@@ -68,14 +68,14 @@ pub async fn handler(subcmd: ExtensionSubcmd) -> Result<()> {
             Ok(())
         }
         ExtensionSubcmd::Use { extension, version } => {
-            let extension_path = parse_extenstion_version(extension, version)?;
+            let extension_path = parse_extension_version(extension, version)?;
             extension.link(&extension_path)
         }
         ExtensionSubcmd::Uninstall { extension } => extension.unlink(),
     }
 }
 
-fn parse_extenstion_version(extension: Extension, version: String) -> Result<PathBuf> {
+fn parse_extension_version(extension: Extension, version: String) -> Result<PathBuf> {
     let extensions = find_installed_extensions()?;
     let version_pattern = match extension {
         Extension::CargoRiscZero => {

--- a/rzup/src/extension.rs
+++ b/rzup/src/extension.rs
@@ -182,7 +182,7 @@ impl Extension {
                 archive.unpack(&extension_dir)?;
                 let binary_path = extension_dir.join("cargo-risczero");
 
-                verbose_msg!("Setting extension permissons to 0o755");
+                verbose_msg!("Setting extension permissions to 0o755");
 
                 let mut perms = fs::metadata(&binary_path)?.permissions();
                 perms.set_mode(0o755);


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `parse_extenstion_version` to `parse_extension_version`
Corrected `permissons` to `permissions`

Please review the changes and let me know if any additional changes are needed.

