### PR TITLE
fix typos

### DIFF
--- a/examples/sha/src/main.rs
+++ b/examples/sha/src/main.rs
@@ -17,7 +17,7 @@ use risc0_zkvm::{default_prover, sha::Digest, ExecutorEnv, Receipt};
 use sha_methods::{HASH_ELF, HASH_ID, HASH_RUST_CRYPTO_ELF};
 
 /// Hash the given bytes, returning the digest and a [Receipt] that can
-/// be used to verify that the that the hash was computed correctly (i.e. that
+/// be used to verify that the hash was computed correctly (i.e. that
 /// the Prover knows a preimage for the given SHA-256 hash)
 ///
 /// Select which method to use with `use_rust_crypto`.

--- a/rzup/src/extension.rs
+++ b/rzup/src/extension.rs
@@ -182,7 +182,7 @@ impl Extension {
                 archive.unpack(&extension_dir)?;
                 let binary_path = extension_dir.join("cargo-risczero");
 
-                verbose_msg!("Setting extension permissons to 0o755");
+                verbose_msg!("Setting extension permissions to 0o755");
 
                 let mut perms = fs::metadata(&binary_path)?.permissions();
                 perms.set_mode(0o755);


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `verify that the that the hash` to `verify that the hash`
Corrected `permissons` to `permissions`

Please review the changes and let me know if any additional changes are needed.