### PR TITLE
rzup: switch to static tls linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
+ "indexmap 2.7.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,6 +2447,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -4068,6 +4088,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4754,7 +4754,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.1+3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,6 +3369,7 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rzup"
 description = "utility to install the RISC Zero toolchain"
-version = "0.2.2"
+version = "0.2.3"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1.5.0"
 regex = "1.11.1"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
+  "http2",
   "native-tls",
   "native-tls-vendored",
   "native-tls-alpn"

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -22,7 +22,9 @@ lazy_static = "1.5.0"
 regex = "1.11.1"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
-  "default-tls",
+  "native-tls",
+  "native-tls-vendored",
+  "native-tls-alpn"
 ] }
 risc0-build = { path = "../risc0/build" }
 serde = { version = "1.0.215", features = ["derive"] }

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.5.0"
 regex = "1.11.1"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
-  "rustls-tls",
+  "default-tls",
 ] }
 risc0-build = { path = "../risc0/build" }
 serde = { version = "1.0.215", features = ["derive"] }


### PR DESCRIPTION
OpenSSL 1.1 is deprecated in favor of 3.0: https://github.com/actions/runner-images/issues/10817
`rzup` was being dynamically linked against OpenSSL 1.1 on our runners, causing compatibility issues on systems with different OpenSSL versions. 

This switches `reqwest` feature to use `native-tls-vendored` for static linking, rather than dynamically linked `rustls-tls`.


