### PR TITLE
chore: update metal dependency from 0.29 to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ repository = "https://github.com/risc0/risc0/"
 [workspace.dependencies]
 bonsai-sdk = { version = "1.3.0-alpha.1", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
-metal = "0.29"
+metal = "0.30"
 risc0-bigint2 = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/bigint2" }
 risc0-binfmt = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/binfmt" }
 risc0-build = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/build" }


### PR DESCRIPTION
## Description
Update metal dependency from 0.29 to 0.30

## Changes
- Update metal dependency to the latest stable version 0.30
- This update includes performance improvements and bug fixes from the latest metal release

## Testing
- [ ] Cargo check passes
- [ ] All tests pass
- [ ] No breaking changes introduced

## Related Issues
N/A

## Additional Notes
The metal 0.30 release is stable and brings important improvements for Apple Metal API integration.