### PR TITLE
docs: Improve consistency in documentation phrasing

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -29,7 +29,7 @@ blockchains or not, RISC Zero offers the most flexible and mature
 ecosystem for developing applications that involve ZKPs.
 
 You can run the zkVM locally and your secrets will never leave your own machine,
-or you can upload your program & inputs to [Bonsai] for remote proving.
+or you can upload your programs & inputs to [Bonsai] for remote proving.
 
 ## Project Organization
 


### PR DESCRIPTION
### Description  
I noticed a small inconsistency in the phrasing of the documentation and made an adjustment to enhance clarity.  

The original text reads:  
> You can run the zkVM locally and your secrets will never leave your own machine,  
> or you can upload your program & inputs to [Bonsai] for remote proving.  

For consistency and accuracy, I updated **"program & inputs"** to **"programs & inputs"**, aligning it with the plural nature of "inputs." The corrected version is:  
> You can run the zkVM locally and your secrets will never leave your own machine,  
> or you can upload your programs & inputs to [Bonsai] for remote proving.  

This minor fix ensures better readability and uniformity in the documentation.