### PR TITLE
docs: Fix wording in hosting service description Update README.md

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -24,7 +24,7 @@ This command starts a local development server and opens up a browser window. Mo
 bun run build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `build` directory and can be served using any static content hosting service.
 
 ### Deployment
 


### PR DESCRIPTION
**Description:**  

While reviewing the documentation, I noticed a issue in the phrase "static contents hosting service."
The word "contents" is unnecessary and doesn't align with common terminology.

I've updated it to "static **content** hosting service" for clarity and correctness.  

This change enhances the consistency of the documentation.