### PR TITLE
Including pager cycles in user_cycles

### DIFF
--- a/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
@@ -364,7 +364,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
 
         self.pc = self.pending.pc;
         self.insn_cycles += self.pending.cycles;
-        self.cycles.user += self.pending.cycles as u64;
+        self.cycles.user += self.pending.cycles as u64 + self.pager.get_pending_cycles() as u64;
 
         if let Some(kind) = self.pending.ecall.take() {
             self.ecall_metrics.0[kind].count += 1;

--- a/risc0/circuit/rv32im/src/prove/emu/pager.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/pager.rs
@@ -281,6 +281,18 @@ impl PagedMemory {
         };
         self.pending_actions.push(action);
     }
+
+    pub fn get_pending_cycles(&self) -> usize {
+        let mut pending_cycles = 0;
+        for action in self.pending_actions.iter() {
+            match action {
+                Action::PageRead(_, cycles) => pending_cycles += cycles,
+                Action::PageWrite(_, cycles, _) => pending_cycles += cycles,
+                Action::Store(_, _) => {}
+            }
+        }
+        pending_cycles
+    }
 }
 
 impl Page {


### PR DESCRIPTION
I have observed that in my project
user cycles: 6177246
total_cycles: 9699328
cycle efficiency: 63%
insn_cycles: 6177246
pager_cycles: 3405386

User cycles seems to count only the part of insn_cycles, not the part that contains pager_cycles.
I'm not sure if this is a Bug, or is it designed that way?