### PR TITLE
ZKVM-897: fix: 1.2 mermaid diagrams

### DIFF
--- a/website/api_versioned_docs/version-1.2/getting-started.md
+++ b/website/api_versioned_docs/version-1.2/getting-started.md
@@ -1,3 +1,5 @@
+import GettingStartedMermaid from "@site/src/components/Mermaid/getting-started.mermaid";
+
 # Getting Started
 
 To harness the power of ZK, you'll need to:
@@ -6,46 +8,7 @@ To harness the power of ZK, you'll need to:
 2. [Generate proofs for your zkVM application][bonsai-quickstart].
 3. [Integrate your proofs into on-chain applications][bonsai-on-eth].
 
-```mermaid
-flowchart TD
-    %% Level 0
-    getting_started["Getting Started
-    To use the zkVM and/or Bonsai for blockchain applications, users will need to:
-    1. Build a zkVM app.
-    2. Generate proofs for their zkVM app.
-    3. Integrate proofs into blockchain applications."]
-
-
-
-    zkvm_app["1. zkVM Application Development"]
-        zkvm_quickstart["zkVM Quickstart"]
-    proof_generation["2. Generating proofs for your zkVM application"]
-
-    chain_integration["3. Blockchain Integration"]
-        getting_proofs_on_chain["Post proofs on-chain"]
-        onchain_verifier["Call our on-chain verifier"]
-
-
-    dev_mode["Dev Mode
-    - Skips proving enabling fast prototyping"]
-    local_proving["Local Proving
-    - Made possible by open-source tech
-    - Important for privacy applications"]
-    remote_proving["Remote Proving
-    - Bonsai is a scalable proving service, <br/>ready to generate proofs as needed."]
-
-
-
-    getting_started --> zkvm_app
-        zkvm_app --> zkvm_quickstart
-    getting_started --> proof_generation
-            proof_generation --> dev_mode
-            proof_generation --> local_proving
-            proof_generation --> remote_proving
-    getting_started --> chain_integration
-        chain_integration --> getting_proofs_on_chain
-        chain_integration --> onchain_verifier
-```
+<GettingStartedMermaid />
 
 [bonsai-on-eth]: ./blockchain-integration/bonsai-on-eth.md
 [bonsai-quickstart]: ./generating-proofs/proving-options.md

--- a/website/api_versioned_docs/version-1.2/recursion.md
+++ b/website/api_versioned_docs/version-1.2/recursion.md
@@ -1,3 +1,5 @@
+import RecursionMermaid from "@site/src/components/Mermaid/recursion.mermaid";
+
 # Recursive Proving
 
 RISC Zero's zkVM uses recursive proving in order to achieve unbounded computation size, constant proof size, proof aggregation, and proof composition.
@@ -16,91 +18,7 @@ The rest of this page describes low-level details that are not necessary for use
 
 The end-to-end process for proof generation is shown in the following diagram.
 
-```mermaid
-flowchart TB
-
-execute(".execute()")
---> Session
-
-subgraph Session["<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Session.html'>Session</a>"]
-direction TB
-s1("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Segment.html'>Segment</a>")
-s2("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Segment.html'>Segment</a>")
-s3("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Segment.html'>Segment</a>")
-s4("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Segment.html'>Segment</a>")
-s5("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Segment.html'>Segment</a>")
-s6("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Segment.html'>Segment</a>")
-end
-
-  s1-->ps1(".prove_segment()")
-  s2-->ps2(".prove_segment()")
-  s3-->ps3(".prove_segment()")
-  s4-->ps4(".prove_segment()")
-  s5-->ps5(".prove_segment()")
-  s6-->ps6(".prove_segment()")
-
-subgraph CompositeReceipt["<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.CompositeReceipt.html'>CompositeReceipt</a>"]
-direction TB
-c1("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SegmentReceipt.html'>SegmentReceipt</a>")
-c2("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SegmentReceipt.html'>SegmentReceipt</a>")
-c3("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SegmentReceipt.html'>SegmentReceipt</a>")
-c4("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SegmentReceipt.html'>SegmentReceipt</a>")
-c5("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SegmentReceipt.html'>SegmentReceipt</a>")
-c6("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SegmentReceipt.html'>SegmentReceipt</a>")
-end
-
-ps1-->c1
-ps2-->c2
-ps3-->c3
-ps4-->c4
-ps5-->c5
-ps6-->c6
-
-
-c1-->l1(".lift()")
-c2-->l2(".lift()")
-c3-->l3(".lift()")
-c4-->l4(".lift()")
-c5-->l5(".lift()")
-c6-->l6(".lift()")
-
-l1-->suc1("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-l2-->suc2("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-l3-->suc3("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-l4-->suc4("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-l5-->suc5("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-l6-->suc6("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-
-
-suc1-->j1(".join()")
-suc2-->j1
-suc3-->j2(".join()")
-suc4-->j2
-suc5-->j3(".join()")
-suc6-->j3
-
-j1-->suc11("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-j2-->suc12("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-j3-->suc13("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-
-suc11-->j11(".join()")
-suc12-->j11
-
-j11-->suc21("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-
-suc21-->j21(".join()")
-suc13-->j21
-
-j21-->suc31("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-
-suc31-->id(".identity_p254()")
-
-id-->suc41("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html'>SuccinctReceipt</a>")
-
-suc41-->compress(".compress()")
-
-compress-->groth16("<a target="_blank" href='https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Groth16Receipt.html'>Groth16Receipt</a>")
-```
+<RecursionMermaid />
 
 To summarize the diagram:
 


### PR DESCRIPTION
Seems like 2 mermaid diagrams didn't get migrated for 1.2