### PR TITLE
ZKVM-919: Add bounds checks on raw baby bear field elements

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -251,7 +251,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "4bc080d39faad4687b2399b0039cb4d375965816fbc8ca53d230f606c8cb2855",
+            "cdc701d40387213c832a3f58970239df379efb5b1144abb525099d33c4fe5434",
         );
     }
 }

--- a/risc0/circuit/recursion/src/prove/exec.rs
+++ b/risc0/circuit/recursion/src/prove/exec.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -173,11 +173,15 @@ impl crate::Externs for MachineContext {
             for i in 0..count {
                 let poly: Vec<BabyBearElem> = (0..k)
                     .map(|j| {
-                        BabyBearElem::new_raw(if flip {
-                            arr[i * k + j]
-                        } else {
-                            arr[j * count + i]
-                        })
+                        // TODO: Figure out why we're sometimes
+                        // getting out-of-bounds field elements here and remove the modulo-P
+                        BabyBearElem::new_raw(
+                            if flip {
+                                arr[i * k + j]
+                            } else {
+                                arr[j * count + i]
+                            } % risc0_zkp::field::baby_bear::P,
+                        )
                     })
                     .collect();
                 self.cur_iop_body.push_back(poly);

--- a/risc0/core/src/field/goldilocks.rs
+++ b/risc0/core/src/field/goldilocks.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,10 +106,6 @@ impl field::Elem for Elem {
 
     fn is_valid(&self) -> bool {
         self.0 != Self::INVALID.0
-    }
-
-    fn is_reduced(&self) -> bool {
-        self.0 < P
     }
 }
 
@@ -406,15 +402,6 @@ impl field::Elem for ExtElem {
 
     fn is_valid(&self) -> bool {
         self.0 != Self::INVALID.0
-    }
-
-    fn is_reduced(&self) -> bool {
-        for comp in self.0 {
-            if !comp.is_reduced() {
-                return false;
-            }
-        }
-        true
     }
 }
 

--- a/risc0/core/src/field/mod.rs
+++ b/risc0/core/src/field/mod.rs
@@ -108,12 +108,6 @@ pub trait Elem: 'static
     /// methods, this may be called on an INVALID element.
     fn is_valid(&self) -> bool;
 
-    /// Returns true if this element is represented in reduced/normalized form.
-    /// Every element has exactly one reduced form. For a field of prime order
-    /// P, this typically means the underlying data is < P, and for an extension
-    /// field, this typically means every component is in reduced form.
-    fn is_reduced(&self) -> bool;
-
     /// Returns 0 if this element is INVALID, else the value of this
     /// element.  Unlike most methods, this may be called on an
     /// INVALID element.
@@ -128,12 +122,6 @@ pub trait Elem: 'static
     /// Returns this element, but checks to make sure it's valid.
     fn ensure_valid(&self) -> &Self {
         debug_assert!(self.is_valid());
-        self
-    }
-
-    /// Returns this element, but checks to make sure it's in reduced form.
-    fn ensure_reduced(&self) -> &Self {
-        assert!(self.is_reduced());
         self
     }
 

--- a/risc0/zkp/src/core/hash/poseidon2/mod.rs
+++ b/risc0/zkp/src/core/hash/poseidon2/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,9 +52,6 @@ impl HashFn<BabyBear> for Poseidon2HashFn {
             .map(|w| BabyBearElem::new_raw(*w))
             .collect();
         assert!(both.len() == DIGEST_WORDS * 2);
-        for elem in &both {
-            assert!(elem.is_reduced());
-        }
         to_digest(unpadded_hash(both.iter()))
     }
 

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ fn test_recursion_poseidon2() {
 }
 
 #[test]
-#[should_panic(expected = "assertion failed: elem.is_reduced()")]
+#[should_panic(expected = "Raw field element not within field bounds")]
 fn test_poseidon2_sanitized_inputs() {
     use risc0_zkp::core::{digest::Digest, hash::poseidon2::Poseidon2HashSuite};
 


### PR DESCRIPTION
Fixes risc0/sec-issues#1
