### PR TITLE
ZKVM-978: Update paths in `cargo_local_patch.py`

### DIFF
--- a/.github/cargo_local_patch.py
+++ b/.github/cargo_local_patch.py
@@ -102,10 +102,10 @@ if __name__ == "__main__":
         "risc0-zkvm-platform": "risc0/risc0/zkvm/platform",
         "risc0-ethereum-contracts": "risc0-ethereum/contracts",
         "risc0-build-ethereum": "risc0-ethereum/build",
-        "risc0-forge-ffi": "risc0-ethereum/ffi",
-        "risc0-steel": "risc0-ethereum/steel",
-        "risc0-op-steel": "risc0-ethereum/op-steel",
-        "risc0-aggregation": "risc0-ethereum/aggregation",
+        "risc0-forge-ffi": "risc0-ethereum/crates/ffi",
+        "risc0-steel": "risc0-ethereum/crates/steel",
+        "risc0-op-steel": "risc0-ethereum/crates/op-steel",
+        "risc0-aggregation": "risc0-ethereum/crates/aggregation",
     }
 
     main(os.path.normpath(args.directory), dep_path_mapping)


### PR DESCRIPTION
After https://github.com/risc0/risc0-ethereum/pull/390 most of the `risc0-ethereum` packages are under the `crates` folder