### PR TITLE
ZKVM-1000: Fix bigint field tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,9 +245,9 @@ jobs:
       - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - name: build workspace
-        run: cargo test -F $FEATURE -F prove -F redis --workspace --timings --no-run --exclude doc-test
+        run: cargo test -F $FEATURE -F prove -F redis -F unstable --workspace --timings --no-run --exclude doc-test
       - name: test workspace
-        run: cargo test -F $FEATURE -F prove -F redis --workspace --timings --exclude doc-test
+        run: cargo test -F $FEATURE -F prove -F redis -F unstable --workspace --timings --exclude doc-test
       - uses: actions/upload-artifact@v4
         with:
           name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}
@@ -263,7 +263,6 @@ jobs:
       - name: test risc0-r0vm
         run: cargo test -p risc0-r0vm -F $FEATURE -F disable-dev-mode
       - run: cargo test -p cargo-risczero -F experimental
-      - run: cargo test -p risc0-bigint2 -F unstable
       - name: run fibonacci benchmark
         run: cargo run -F $FEATURE -- fibonacci
         working-directory: benchmarks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,6 +263,7 @@ jobs:
       - name: test risc0-r0vm
         run: cargo test -p risc0-r0vm -F $FEATURE -F disable-dev-mode
       - run: cargo test -p cargo-risczero -F experimental
+      - run: cargo test -p risc0-bigint2 -F unstable
       - name: run fibonacci benchmark
         run: cargo run -F $FEATURE -- fibonacci
         working-directory: benchmarks

--- a/risc0/bigint2/src/field/tests.rs
+++ b/risc0/bigint2/src/field/tests.rs
@@ -18,7 +18,7 @@ extern crate num_bigint_dig as num_bigint;
 use num_bigint::BigUint;
 
 use risc0_bigint2_methods::{
-    EXTFIELDADD_ELF, EXTFIELDMUL_ELF, EXTFIELDSUB_ELF, EXTFIELD_DEG4_MUL_ELF,
+    EXTFIELD_DEG2_ADD_ELF, EXTFIELD_DEG2_MUL_ELF, EXTFIELD_DEG2_SUB_ELF, EXTFIELD_DEG4_MUL_ELF,
     EXTFIELD_XXONE_MUL_ELF, MODADD_ELF, MODINV_ELF, MODMUL_ELF, MODSUB_ELF,
 };
 use risc0_zkvm::{
@@ -190,7 +190,7 @@ fn extfieldadd() {
         .build()
         .unwrap();
     let now = Instant::now();
-    let session = ExecutorImpl::from_elf(env, EXTFIELDADD_ELF)
+    let session = ExecutorImpl::from_elf(env, EXTFIELD_DEG2_ADD_ELF)
         .unwrap()
         .run()
         .unwrap();
@@ -232,7 +232,7 @@ fn extfieldsub() {
         .build()
         .unwrap();
     let now = Instant::now();
-    let session = ExecutorImpl::from_elf(env, EXTFIELDSUB_ELF)
+    let session = ExecutorImpl::from_elf(env, EXTFIELD_DEG2_SUB_ELF)
         .unwrap()
         .run()
         .unwrap();
@@ -280,7 +280,7 @@ fn extfieldmul() {
         .build()
         .unwrap();
     let now = Instant::now();
-    let session = ExecutorImpl::from_elf(env, EXTFIELDMUL_ELF)
+    let session = ExecutorImpl::from_elf(env, EXTFIELD_DEG2_MUL_ELF)
         .unwrap()
         .run()
         .unwrap();


### PR DESCRIPTION
The bigint field tests were broken (trying to import ELFs that didn't exist). This fixes the tests and also puts them into CI.