### PR TITLE
ZKVM-1003: Make sure we only call anyhow! macro in error paths.

### DIFF
--- a/risc0/binfmt/src/elf.rs
+++ b/risc0/binfmt/src/elf.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,9 @@ impl Program {
         if entry >= max_mem || entry % WORD_SIZE as u32 != 0 {
             bail!("Invalid entrypoint");
         }
-        let segments = elf.segments().ok_or(anyhow!("Missing segment table"))?;
+        let segments = elf
+            .segments()
+            .ok_or_else(|| anyhow!("Missing segment table"))?;
         if segments.len() > 256 {
             bail!("Too many program headers");
         }

--- a/risc0/binfmt/src/image.rs
+++ b/risc0/binfmt/src/image.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ impl PageTableInfo {
             let num_pages = remain / page_size;
             remain = num_pages
                 .checked_mul(DIGEST_BYTES as u32)
-                .ok_or(anyhow!("Invalid page_size specified"))?;
+                .ok_or_else(|| anyhow!("Invalid page_size specified"))?;
             layers.push(remain);
             page_table_size += remain;
         }

--- a/risc0/binfmt/src/image2.rs
+++ b/risc0/binfmt/src/image2.rs
@@ -180,7 +180,7 @@ impl MemoryImage2 {
         self.expand_if_zero(digest_idx);
         self.digests
             .get(&digest_idx)
-            .ok_or(anyhow!("Unavailable digest: {digest_idx}"))
+            .ok_or_else(|| anyhow!("Unavailable digest: {digest_idx}"))
     }
 
     /// Set a digest

--- a/risc0/cargo-risczero/src/commands/guest.rs
+++ b/risc0/cargo-risczero/src/commands/guest.rs
@@ -173,7 +173,7 @@ impl GuestCommand {
             child
                 .stdout
                 .take()
-                .ok_or(anyhow!("failed to read from cmd stdout"))?,
+                .ok_or_else(|| anyhow!("failed to read from cmd stdout"))?,
         );
         let mut tests: Vec<String> = Vec::new();
         for message in Message::parse_stream(reader) {

--- a/risc0/circuit/rv32im-v2/src/prove/witgen/preflight.rs
+++ b/risc0/circuit/rv32im-v2/src/prove/witgen/preflight.rs
@@ -509,7 +509,7 @@ impl<'a> Risc0Context for Preflight<'a> {
         let word = if addr >= MERKLE_TREE_START_ADDR {
             self.page_memory
                 .get(&addr)
-                .ok_or(anyhow!("Invalid load from page memory"))?
+                .ok_or_else(|| anyhow!("Invalid load from page memory"))?
         } else {
             self.pager.load(addr)?
         };
@@ -532,7 +532,7 @@ impl<'a> Risc0Context for Preflight<'a> {
         let prev_word = if addr >= MEMORY_END_ADDR {
             self.page_memory
                 .insert(&addr, word)
-                .ok_or(anyhow!("Invalid store to page memory"))?
+                .ok_or_else(|| anyhow!("Invalid store to page memory"))?
         } else {
             let prev_word = self.pager.load(addr)?;
             self.pager.store(addr, word)?;

--- a/risc0/circuit/rv32im/src/prove/emu/bibc.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/bibc.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ impl Op {
         let bits = stream.read_u64::<LittleEndian>()?;
         let opcode = FromPrimitive::from_u32((bits & 0x0F) as u32);
         Ok(Self {
-            code: opcode.ok_or(anyhow!("Invalid BigInt2 bytecode"))?,
+            code: opcode.ok_or_else(|| anyhow!("Invalid BigInt2 bytecode"))?,
             result_type: ((bits >> 4) & 0x0FFF) as usize,
             a: ((bits >> 16) & 0x00FFFFFF) as usize,
             b: ((bits >> 40) & 0x00FFFFFF) as usize,
@@ -206,7 +206,9 @@ impl Program {
                 }
                 OpCode::Inv => {
                     let (lhs, rhs) = operands(op, op_index, &regs);
-                    let value = lhs.modinv(rhs).ok_or(anyhow!("Can't divide by zero"))?;
+                    let value = lhs
+                        .modinv(rhs)
+                        .ok_or_else(|| anyhow!("Can't divide by zero"))?;
                     regs[op_index] = value.clone();
                 }
             }

--- a/risc0/circuit/rv32im/src/prove/emu/preflight/bigint2.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/preflight/bigint2.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,9 +69,9 @@ impl Instruction {
     pub fn decode(insn: u32) -> Result<Self> {
         Ok(Self {
             mem_op: MemoryOp::from_u32(insn >> 28 & 0x0f)
-                .ok_or(anyhow!("Invalid mem_op in bigint2 program"))?,
+                .ok_or_else(|| anyhow!("Invalid mem_op in bigint2 program"))?,
             poly_op: PolyOp::from_u32(insn >> 24 & 0x0f)
-                .ok_or(anyhow!("Invalid poly_op in bigint2 program"))?,
+                .ok_or_else(|| anyhow!("Invalid poly_op in bigint2 program"))?,
             coeff: (insn >> 21 & 0x07) as i32 - 4,
             reg: insn >> 16 & 0x1f,
             offset: insn & 0xffff,

--- a/risc0/circuit/rv32im/src/prove/emu/preflight/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/preflight/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -583,7 +583,7 @@ impl Preflight {
         let syscall = self
             .syscalls
             .pop_front()
-            .ok_or(anyhow!("Missing syscall record"))?;
+            .ok_or_else(|| anyhow!("Missing syscall record"))?;
         let (a0, a1) = syscall.regs;
 
         let stray_words = into_guest_len % IO_CHUNK_WORDS;
@@ -828,7 +828,7 @@ impl Preflight {
                 let addr = addr + i;
                 let word = witness
                     .get(&addr)
-                    .ok_or(anyhow!("Missing bigint2 witness: {addr:?}"))?;
+                    .ok_or_else(|| anyhow!("Missing bigint2 witness: {addr:?}"))?;
                 for (j, byte) in word.to_le_bytes().iter().enumerate() {
                     ret[i * WORD_SIZE + j] = (*byte) as u32;
                 }

--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -816,7 +816,7 @@ impl Client {
         let slice_io = table
             .inner
             .get(name)
-            .ok_or(anyhow!("Unknown I/O channel name: {name}"))?;
+            .ok_or_else(|| anyhow!("Unknown I/O channel name: {name}"))?;
         let result = slice_io.borrow_mut().handle_io(name, from_guest)?;
         Ok(result)
     }

--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -227,7 +227,7 @@ fn get_server_version<P: AsRef<Path>>(server_path: P) -> Result<Version> {
         .output()?;
     let cmd_output = String::from_utf8(output.stdout)?;
     let (_, version_str) = regex_captures!(r".* (.*)\n$", &cmd_output)
-        .ok_or(anyhow!("failed to parse server version number"))?;
+        .ok_or_else(|| anyhow!("failed to parse server version number"))?;
     Version::parse(version_str).map_err(|e| anyhow!(e))
 }
 
@@ -343,7 +343,7 @@ fn malformed_err() -> anyhow::Error {
 
 impl pb::api::Asset {
     fn as_bytes(&self) -> Result<Bytes> {
-        let bytes = match self.kind.as_ref().ok_or(malformed_err())? {
+        let bytes = match self.kind.as_ref().ok_or_else(malformed_err)? {
             pb::api::asset::Kind::Inline(bytes) => bytes.clone(),
             pb::api::asset::Kind::Path(path) => std::fs::read(path)?,
             pb::api::asset::Kind::Redis(_) => bail!("as_bytes not supported for redis"),

--- a/risc0/zkvm/src/host/client/posix_io.rs
+++ b/risc0/zkvm/src/host/client/posix_io.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,14 +86,14 @@ impl<'a> PosixIo<'a> {
     pub fn get_reader(&self, fd: u32) -> Result<SharedRead<'a>> {
         self.read_fds
             .get(&fd)
-            .ok_or(anyhow!("Bad read file descriptor {fd}"))
+            .ok_or_else(|| anyhow!("Bad read file descriptor {fd}"))
             .cloned()
     }
 
     pub fn get_writer(&self, fd: u32) -> Result<SharedWrite<'a>> {
         self.write_fds
             .get(&fd)
-            .ok_or(anyhow!("Bad write file descriptor {fd}"))
+            .ok_or_else(|| anyhow!("Bad write file descriptor {fd}"))
             .cloned()
     }
 }

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ impl Prover for BonsaiProver {
                 // Download the receipt, containing the output
                 let receipt_url = res
                     .receipt_url
-                    .ok_or(anyhow!("API error, missing receipt on completed session"))?;
+                    .ok_or_else(|| anyhow!("API error, missing receipt on completed session"))?;
 
                 let stats = res
                     .stats

--- a/risc0/zkvm/src/host/recursion/prove/mod.rs
+++ b/risc0/zkvm/src/host/recursion/prove/mod.rs
@@ -171,18 +171,14 @@ where
         .as_value_mut()
         .context("conditional receipt output is pruned")?
         .as_mut()
-        .ok_or(anyhow!(
-            "conditional receipt has empty output and no assumptions"
-        ))?
+        .ok_or_else(|| anyhow!("conditional receipt has empty output and no assumptions"))?
         .assumptions
         .as_value_mut()
         .context("conditional receipt assumptions are pruned")?
         .0
         .drain(..1)
         .next()
-        .ok_or(anyhow!(
-            "cannot resolve assumption from receipt with no assumptions"
-        ))?;
+        .ok_or_else(|| anyhow!("cannot resolve assumption from receipt with no assumptions"))?;
 
     let opts = ProverOpts::succinct();
     let mut prover = Prover::new_resolve(conditional, assumption, opts.clone())?;
@@ -541,7 +537,7 @@ impl Prover {
             .as_value()
             .context("cannot resolve conditional receipt with pruned output")?
             .as_ref()
-            .ok_or(anyhow!("cannot resolve conditional receipt with no output"))?
+            .ok_or_else(|| anyhow!("cannot resolve conditional receipt with no output"))?
             .clone();
 
         // Unwrap the MaybePruned assumptions list and resolve the corroborated assumption,
@@ -553,9 +549,7 @@ impl Prover {
         let head: Assumption = assumptions
             .0
             .first()
-            .ok_or(anyhow!(
-                "cannot resolve conditional receipt with no assumptions"
-            ))?
+            .ok_or_else(|| anyhow!("cannot resolve conditional receipt with no assumptions"))?
             .as_value()
             .context("cannot resolve conditional receipt with pruned head assumption")?
             .clone();

--- a/risc0/zkvm/src/host/recursion/prove/zkr.rs
+++ b/risc0/zkvm/src/host/recursion/prove/zkr.rs
@@ -35,7 +35,7 @@ fn get_zkr(name: &str, hashfn: &str) -> Result<(Program, Digest)> {
             .iter()
             .copied()
             .find_map(|(n, id)| (n == name).then_some(id))
-            .ok_or(anyhow!("failed to find {name} in the list of control IDs"))?,
+            .ok_or_else(|| anyhow!("failed to find {name} in the list of control IDs"))?,
     ))
 }
 

--- a/risc0/zkvm/src/host/server/exec/syscall/pipe.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall/pipe.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ impl Syscall for SysPipe {
         (to_guest[0], to_guest[1]) = posix_io
             .borrow_mut()
             .alloc_pipe(pipe)
-            .ok_or(anyhow!("Could not allocate pipe"))?;
+            .ok_or_else(|| anyhow!("Could not allocate pipe"))?;
         Ok((0, 0))
     }
 }

--- a/risc0/zkvm/src/host/server/prove/dev_mode.rs
+++ b/risc0/zkvm/src/host/server/prove/dev_mode.rs
@@ -88,9 +88,9 @@ impl ProverServer for DevModeProver {
             .map(|assumption_receipt| match assumption_receipt {
                 AssumptionReceipt::Proven(receipt) => Ok(receipt),
                 AssumptionReceipt::Unresolved(assumption) => {
-                    let claim = keccak_assumptions.get(&assumption).ok_or(anyhow!(
-                        "no receipt available for unresolved assumption: {assumption:#?}"
-                    ))?;
+                    let claim = keccak_assumptions.get(&assumption).ok_or_else(|| {
+                        anyhow!("no receipt available for unresolved assumption: {assumption:#?}")
+                    })?;
                     Ok(InnerAssumptionReceipt::Fake(FakeReceipt {
                         claim: MaybePruned::Pruned(*claim),
                     }))

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -130,9 +130,9 @@ pub trait ProverServer: private::Sealed {
                     }))
                 },
             )?
-            .ok_or(anyhow!(
-                "malformed composite receipt has no continuation segment receipts"
-            ))?;
+            .ok_or_else(|| {
+                anyhow!("malformed composite receipt has no continuation segment receipts")
+            })?;
 
         // Compress assumptions and resolve them to get the final succinct receipt.
         receipt.assumption_receipts.iter().try_fold(

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -96,7 +96,7 @@ impl ProverServer for ProverImpl {
         // Merge the output, including journal digest and assumptions, into the last segment.
         segments
             .last_mut()
-            .ok_or(anyhow!("session is empty"))?
+            .ok_or_else(|| anyhow!("session is empty"))?
             .claim
             .output
             .merge_with(
@@ -113,9 +113,7 @@ impl ProverServer for ProverImpl {
 
         let verifier_parameters = ctx
             .composite_verifier_parameters()
-            .ok_or(anyhow!(
-                "composite receipt verifier parameters missing from context"
-            ))?
+            .ok_or_else(|| anyhow!("composite receipt verifier parameters missing from context"))?
             .digest();
 
         let mut zkr_receipts = HashMap::new();
@@ -149,9 +147,9 @@ impl ProverServer for ProverImpl {
             .map(|assumption_receipt| match assumption_receipt {
                 AssumptionReceipt::Proven(receipt) => Ok(receipt),
                 AssumptionReceipt::Unresolved(assumption) => {
-                    let receipt = zkr_receipts.get(&assumption).ok_or(anyhow!(
-                        "no receipt available for unresolved assumption: {assumption:#?}"
-                    ))?;
+                    let receipt = zkr_receipts.get(&assumption).ok_or_else(|| {
+                        anyhow!("no receipt available for unresolved assumption: {assumption:#?}")
+                    })?;
                     Ok(InnerAssumptionReceipt::Succinct(receipt.clone()))
                 }
             })
@@ -237,9 +235,7 @@ impl ProverServer for ProverImpl {
         let verifier_parameters = ctx
             .segment_verifier_parameters
             .as_ref()
-            .ok_or(anyhow!(
-                "segment receipt verifier parameters missing from context"
-            ))?
+            .ok_or_else(|| anyhow!("segment receipt verifier parameters missing from context"))?
             .digest();
         let receipt = SegmentReceipt {
             seal,


### PR DESCRIPTION
The anyhow macro is a bit expensive, so it makes sense to only call it in an error path.