### PR TITLE
backport 1.2: fix panic when using embedded allocator and add more details to OOM message (#2761)

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -272,7 +272,7 @@ mod test {
         build("../../risc0/zkvm/methods/guest/Cargo.toml");
         compare_image_id(
             "risc0_zkvm_methods_guest/hello_commit",
-            "0016cbf034e382f463f14ddfdb0055b8dbfdbff4cb4f00cbdc9d5c2f9daab06d",
+            "0d56868db9a567cb6840fe597349811a14703eb8a3717f440374f9b7a23a3f0c",
         );
     }
 }

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -848,6 +848,7 @@ name = "risc0-zkvm-methods-heap"
 version = "0.1.0"
 dependencies = [
  "risc0-zkvm",
+ "risc0-zkvm-platform",
 ]
 
 [[package]]

--- a/risc0/zkvm/methods/heap/Cargo.toml
+++ b/risc0/zkvm/methods/heap/Cargo.toml
@@ -11,6 +11,7 @@ risc0-zkvm = { path = "../..", default-features = false, features = [
   "heap-embedded-alloc",
   "std",
 ] }
+risc0-zkvm-platform = { path = "../../platform", default-features = false, features = ["sys-getenv"] }
 
 [profile.release]
 lto = true

--- a/risc0/zkvm/methods/heap/src/bin/heap.rs
+++ b/risc0/zkvm/methods/heap/src/bin/heap.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/methods/heap/src/bin/heap.rs
+++ b/risc0/zkvm/methods/heap/src/bin/heap.rs
@@ -15,6 +15,14 @@
 use risc0_zkvm::guest::env;
 
 fn main() {
+    let x: u32 = if std::env::var("ALL_FORKS") == Ok(String::from("1")) {
+        1
+    } else {
+        0
+    };
+
+    risc0_zkvm::guest::env::commit(&x);
+
     let iterations: u32 = env::read();
     for _ in 0..iterations {
         env::log("alloc");

--- a/risc0/zkvm/platform/src/heap/bump.rs
+++ b/risc0/zkvm/platform/src/heap/bump.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,7 +85,10 @@ pub(crate) unsafe fn alloc_aligned(bytes: usize, align: usize) -> *mut u8 {
 
     // Check to make sure heap doesn't collide with SYSTEM memory.
     if GUEST_MAX_MEM < heap_pos {
-        const MSG: &[u8] = "Out of memory!".as_bytes();
+        const MSG: &[u8] = "Out of memory! You have been using the default bump allocator which \
+            does not reclaim memory. Enable the `heap-embedded-alloc` feature to \
+            reclaim memory. This will result in extra cycle cost."
+            .as_bytes();
         unsafe { sys_panic(MSG.as_ptr(), MSG.len()) };
     }
 

--- a/risc0/zkvm/platform/src/syscall.rs
+++ b/risc0/zkvm/platform/src/syscall.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkvm/platform/src/syscall.rs
+++ b/risc0/zkvm/platform/src/syscall.rs
@@ -755,7 +755,8 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
 ))]
 #[no_mangle]
 pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u8 {
-    unimplemented!("sys_alloc_aligned called when the bump allocator is disabled");
+    use core::alloc::GlobalAlloc;
+    crate::heap::embedded::HEAP.alloc(core::alloc::Layout::from_size_align(bytes, align).unwrap())
 }
 
 /// # Safety

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -1176,6 +1176,7 @@ fn heap_alloc() {
     let env = ExecutorEnv::builder()
         .write(&6_u32)
         .unwrap()
+        .env_var("ALL_FORKS", "testing")
         .build()
         .unwrap();
     let session = ExecutorImpl::from_elf(env, HEAP_ELF)


### PR DESCRIPTION
This fixes a panic that happens when calling items in std when the embedded allocator is enabled. Our std implementation calls into `sys_alloc_aligned` so we should not panic when this is called. Fix this by calling the embedded allocator's alloc function.