### PR TITLE
[AUD-7] Fix heap-pointer overflow in sys_alloc_aligned

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "bb799ba590eb97503daee9e0389258b8d3c87e3ffb742f4c3748cfe1e4b18ee8",
+            "6f52b77974aeef81fa57bd91926cdaebc11a0288506a68dcb73444b563e702b4",
         );
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/heap_limits.rs
+++ b/risc0/zkvm/methods/guest/src/bin/heap_limits.rs
@@ -1,0 +1,67 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::{
+    alloc::{alloc, Layout},
+    string::String,
+};
+
+use risc0_zkvm::guest::env;
+
+risc0_zkvm::entry!(main);
+
+/// Show that we crash if we try to allocate too much memory instead of something else like re-use
+/// old addresses or some other potentially bad behavior.
+fn heap_overflow_via_alloc() {
+    let ptr = unsafe {
+        alloc(Layout::from_size_align(isize::MAX as usize, 1).unwrap())
+    };
+
+    // Use the pointer in some way to defeat optimizer
+    core::hint::black_box(ptr);
+
+    unreachable!("expected a crash in the memory allocator")
+}
+
+extern "C" {
+    fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u8;
+}
+
+/// Show that we crash if we try to allocate too much memory instead of something else like re-use
+/// old addresses or some other potentially bad behavior.
+fn heap_overflow_via_sys_alloc_aligned() {
+    for size in [10usize, usize::MAX] {
+        let ptr = unsafe {
+            sys_alloc_aligned(size, 1)
+        };
+
+        // Use the pointer in some way to defeat optimizer
+        core::hint::black_box(ptr);
+    }
+
+    unreachable!("expected a crash in the memory allocator")
+}
+
+fn main() {
+    match &env::read::<String>()[..] {
+        "heap_overflow_via_alloc" => heap_overflow_via_alloc(),
+        "heap_overflow_via_sys_alloc_aligned" => heap_overflow_via_sys_alloc_aligned(),
+        unknown => panic!("unknown test {unknown}"),
+    }
+}

--- a/risc0/zkvm/tests/heap.rs
+++ b/risc0/zkvm/tests/heap.rs
@@ -1,0 +1,48 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "prove")]
+
+use risc0_zkvm::{get_prover_server, ExecutorEnv, ProverOpts};
+use risc0_zkvm_methods::HEAP_LIMITS_ELF;
+
+fn test_it(name: &str) -> anyhow::Error {
+    let env = ExecutorEnv::builder()
+        .write(&name)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let prover = get_prover_server(&ProverOpts::fast()).unwrap();
+
+    prover.prove(env, HEAP_LIMITS_ELF).map(|_| ()).unwrap_err()
+}
+
+#[test]
+fn heap_overflow_via_alloc() {
+    let error = test_it("heap_overflow_via_alloc");
+    assert!(
+        error.to_string().contains("Guest panicked: Out of memory!"),
+        "{error}"
+    );
+}
+
+#[test]
+fn heap_overflow_via_sys_alloc_aligned() {
+    let error = test_it("heap_overflow_via_sys_alloc_aligned");
+    assert!(
+        error.to_string().contains("Guest panicked: Out of memory!"),
+        "{error}"
+    );
+}


### PR DESCRIPTION
If you did a big enough allocation in just the right way you could previously overflow the heap pointer in the bump allocator. This fixes this by checking for overflow.

I added two tests to show we properly crash in the allocator when you attempt to allocate too much memory.