### PR TITLE
ZKVM-1011: Add unstable feature flag to risc0-zkp Cargo.toml to address warning and allow usage of unstable feature

### DIFF
--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -71,3 +71,4 @@ prove = [
   "std",
 ]
 std = ["anyhow/std"]
+unstable = []


### PR DESCRIPTION
https://github.com/risc0/risc0/pull/2658 introduced some API surface under `#[stability::unstable]` but forgot to add the `unstable` flag. I saw warnings about this in the CI builds and so figured I should open this PR
