### PR TITLE
[ZKVM-972] Purge `cargo risczero install` from "next" documentation

### DIFF
--- a/website/api/generating-proofs/local-proving.md
+++ b/website/api/generating-proofs/local-proving.md
@@ -59,8 +59,7 @@ source ~/.bashrc
 git clone https://github.com/risc0/risc0.git
 cd risc0
 # install the r0vm
-cargo install --force --path risc0/cargo-risczero
-cargo risczero install
+cargo run --bin rzup install
 # run a benchmark on your GPU!
 # NOTE: Building the GPU kernels may take a long time.
 RUSTFLAGS="-C target-cpu=native" cargo run -F cuda -r --example datasheet

--- a/website/api/zkvm/rust-crates-with-cpp.md
+++ b/website/api/zkvm/rust-crates-with-cpp.md
@@ -12,13 +12,13 @@ The C++ toolchain is installed alongside the Rust toolchain. [Here are the insta
 ## How to Build and Run These Crates
 
 RISC Zero has a GCC-based C++ toolchain to enable these crates to build and run
-on the RISC Zero zkVM. The toolchain can be installed by running `cargo risczero
-install`. This command will download the guest Rust toolchain as well as a C++
-toolchain that compiles C++ to riscv32im. After installing the toolchain, these
-crates can be built and run on the zkVM like any other Rust crate. Under the
-hood, the `risc0-build` crate will use the downloaded toolchain while building
-the guest crate. The C++ toolchain is typically used by the `build.rs` file of
-crates that use C++ code.
+on the RISC Zero zkVM. The toolchain can be installed by running `rzup install`.
+This command will download the guest Rust toolchain as well as a C++ toolchain
+that compiles C++ to riscv32im. After installing the toolchain, these crates can
+be built and run on the zkVM like any other Rust crate. Under the hood, the
+`risc0-build` crate will use the downloaded toolchain while building the guest
+crate. The C++ toolchain is typically used by the `build.rs` file of crates that
+use C++ code.
 
 ## Overriding the C++ toolchain
 


### PR DESCRIPTION
This command will be replaced by `rzup install` in the next release.