### PR TITLE
Use borsh_derive dependency instead of feature

### DIFF
--- a/risc0/binfmt/Cargo.toml
+++ b/risc0/binfmt/Cargo.toml
@@ -14,7 +14,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-borsh = { version = "1.5", default-features = false, features = ["derive"] }
+borsh = { version = "1.5", default-features = false }
+borsh-derive = { version = "1.5", default-features = false }
 derive_more = { version = "1.0", default-features = false, features = [
   "add",
   "add_assign",

--- a/risc0/binfmt/src/exit_code.rs
+++ b/risc0/binfmt/src/exit_code.rs
@@ -14,7 +14,7 @@
 
 use core::fmt;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 /// Exit condition indicated by the zkVM at the end of the guest execution.

--- a/risc0/binfmt/src/sys_state.rs
+++ b/risc0/binfmt/src/sys_state.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 use alloc::{collections::VecDeque, vec::Vec};
 use core::fmt;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_zkp::core::{digest::Digest, hash::sha::Sha256};
 use serde::{Deserialize, Serialize};
 

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -14,7 +14,8 @@ harness = false
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
-borsh = { version = "1.5", default-features = false, features = ["derive"] }
+borsh = { version = "1.5", default-features = false }
+borsh-derive = { version = "1.5", default-features = false }
 bytemuck = { version = "1.12", features = ["derive"] }
 cfg-if = "1.0"
 cust = { version = "0.3", optional = true }

--- a/risc0/zkp/src/core/digest.rs
+++ b/risc0/zkp/src/core/digest.rs
@@ -18,7 +18,7 @@
 use alloc::{format, vec::Vec};
 use core::fmt::{Debug, Display, Formatter};
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use bytemuck::{Pod, PodCastError, Zeroable};
 use hex::{FromHex, FromHexError};
 use serde::{Deserialize, Serialize};

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -34,7 +34,8 @@ required-features = ["prove"]
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-borsh = { version = "1.5", default-features = false, features = ["derive"] }
+borsh = { version = "1.5", default-features = false }
+borsh-derive = { version = "1.5", default-features = false }
 bytemuck = { version = "1.13", features = ["extern_crate_alloc"] }
 getrandom = { version = "0.2", features = ["custom"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -24,7 +24,7 @@ use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
 use core::fmt::Debug;
 
 use anyhow::Result;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_core::field::baby_bear::BabyBear;
 use risc0_zkp::{
     core::{

--- a/risc0/zkvm/src/receipt/composite.rs
+++ b/risc0/zkvm/src/receipt/composite.rs
@@ -16,7 +16,7 @@ use alloc::{vec, vec::Vec};
 use core::fmt::Debug;
 
 use anyhow::Result;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_binfmt::{tagged_struct, Digestible, ExitCode};
 use risc0_circuit_recursion::CircuitImpl;
 use risc0_zkp::{

--- a/risc0/zkvm/src/receipt/groth16.rs
+++ b/risc0/zkvm/src/receipt/groth16.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use anyhow::Result;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_binfmt::{tagged_struct, Digestible};
 use risc0_circuit_recursion::control_id::{ALLOWED_CONTROL_ROOT, BN254_IDENTITY_CONTROL_ID};
 use risc0_groth16::{fr_from_hex_string, split_digest, Seal, Verifier, VerifyingKey};

--- a/risc0/zkvm/src/receipt/merkle.rs
+++ b/risc0/zkvm/src/receipt/merkle.rs
@@ -18,7 +18,7 @@
 use alloc::vec::Vec;
 
 use anyhow::{ensure, Result};
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_core::field::baby_bear::BabyBear;
 use risc0_zkp::core::{digest::Digest, hash::HashFn};
 use serde::{Deserialize, Serialize};

--- a/risc0/zkvm/src/receipt/segment.rs
+++ b/risc0/zkvm/src/receipt/segment.rs
@@ -16,7 +16,7 @@ use alloc::{collections::BTreeSet, string::String, vec::Vec};
 use core::fmt::Debug;
 
 use anyhow::Result;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_binfmt::{tagged_iter, tagged_struct, Digestible, ExitCode, SystemState};
 use risc0_circuit_rv32im::{
     layout::{SystemStateLayout, OUT_LAYOUT},

--- a/risc0/zkvm/src/receipt/succinct.rs
+++ b/risc0/zkvm/src/receipt/succinct.rs
@@ -21,7 +21,7 @@ use alloc::{
 use core::fmt::Debug;
 
 use anyhow::bail;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_binfmt::{read_sha_halfs, tagged_struct, Digestible};
 use risc0_circuit_recursion::{
     control_id::{ALLOWED_CONTROL_ROOT, MIN_LIFT_PO2, POSEIDON2_CONTROL_IDS, SHA256_CONTROL_IDS},

--- a/risc0/zkvm/src/receipt_claim.rs
+++ b/risc0/zkvm/src/receipt_claim.rs
@@ -23,7 +23,7 @@ use alloc::{collections::VecDeque, vec::Vec};
 use core::{fmt, ops::Deref};
 
 use anyhow::{anyhow, bail, ensure};
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use risc0_binfmt::{
     read_sha_halfs, tagged_list, tagged_list_cons, tagged_struct, write_sha_halfs, Digestible,
     ExitCode, InvalidExitCodeError,
@@ -266,13 +266,13 @@ impl Digestible for Unknown {
     }
 }
 
-impl BorshSerialize for Unknown {
+impl borsh::BorshSerialize for Unknown {
     fn serialize<W>(&self, _: &mut W) -> core::result::Result<(), borsh::io::Error> {
         unreachable!("unreachable")
     }
 }
 
-impl BorshDeserialize for Unknown {
+impl borsh::BorshDeserialize for Unknown {
     fn deserialize_reader<R>(_: &mut R) -> core::result::Result<Self, borsh::io::Error> {
         unreachable!("unreachable")
     }


### PR DESCRIPTION
Hey :wave: 

When using [indexmap](https://docs.rs/indexmap/latest/indexmap/) and borsh, we need to disable the borsh feature "derive" and use the borsh_derive crate directly. But as risc0 enables "derive", we do have a cyclic dependency. Cf Indexmap doc:

> borsh: Adds implementations for [BorshSerialize](https://docs.rs/borsh/1.5.3/x86_64-unknown-linux-gnu/borsh/ser/trait.BorshSerialize.html) and [BorshDeserialize](https://docs.rs/borsh/1.5.3/x86_64-unknown-linux-gnu/borsh/de/trait.BorshDeserialize.html) to [IndexMap](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html) and [IndexSet](https://docs.rs/indexmap/latest/indexmap/set/struct.IndexSet.html). Note: When this feature is enabled, you cannot enable the derive feature of [borsh](https://docs.rs/borsh/1.5.3/x86_64-unknown-linux-gnu/borsh/index.html) due to a cyclic dependency. Instead, add the borsh-derive crate as an explicit dependency in your Cargo.toml and import as e.g. use borsh_derive::{BorshSerialize, BorshDeserialize};.

