### PR TITLE
ZKVM-1028: update hello-world tutorial doc 

### DIFF
--- a/website/api/zkvm/tutorials/hello-world.md
+++ b/website/api/zkvm/tutorials/hello-world.md
@@ -10,102 +10,177 @@ following the steps in this guide, you will learn how:
 
 ## Step 1: Create a New Project
 
-Firstly, visit the [installation][install] page for how to install all the
-necessary software. Next, using the `cargo-risczero` tool create a `hello-world`
-project from the command line. The `cargo-risczero` tool provides a
-`--guest-name` parameter which allows control over the name of the guest
-program:
+Firstly, visit the [installation][install] page for how to install the
+necessary software. 
 
-```bash
-cargo risczero new hello-world --guest-name hello_guest
-cd hello-world
+Once installed, clone the `risc0` monorepo and change into the `hello-world` example directory:
+
+```sh
+git clone https://github.com/risc0/risc0
+cd examples/hello-world
 ```
 
-In the project folder, `hello-world`, build and run the project using `cargo run --release`. Use this command any time you'd like to check your progress.
+Next, check the version of `cargo risczero` installed:
+
+```sh
+cargo risczero --version
+cargo-risczero $MAJOR.$MINOR.$PATCH # e.g. release-1.2
+```
+
+To match the example release version with your local installation, check out the corresponding branch of the example: 
+
+```sh
+git checkout release-$MAJOR.$MINOR # e.g. release-1.2
+```
+
+For example, if your local version is `cargo-risczero 1.2.0`, run:
+
+```sh
+git checkout release-1.2
+```
+
+Once on the correct release branch, run the example:
+
+```sh
+cargo run --release
+```
+
+Use this command any time you'd like to check your progress.
 
 ## Step 2 (Host): Share Private Data as Input with the Guest
 
-zkVM or a [prover] runs on the **[host]**. The host code is in
-`hello-world/host/src/main.rs`. The host creates an executor environment
-`ExecutorEnv` before constructing a prover. The host makes the value `input`
-available to the guest before execution. It does it by adding `input` to the
-executor environment, which is responsible for managing guest-readable memory.
-When the prover executes the program, it can access input:
+The zkVM (or a prover) runs on the host. The host code is located in `hello-world/src/main.rs` and `hello-world/src/lib.rs`. 
 
-```rust
-use risc0_zkvm::{default_prover, ExecutorEnv};
+The host creates an executor environment `ExecutorEnv` before constructing a prover. This executor environment is responsible for managing guest-readable memory. The host makes the value `input` available to the guest program before execution by adding `input` to the executor environment. 
 
-fn main() {
-    let input: u32 = 7;
-    let env = ExecutorEnv::builder().write(&input).unwrap().build().unwrap();
+When the prover executes the program, it can access input via the `.write()` method on `ExecutorEnv::builder()`:
+
+```rust ignore
+// hello-world/src/lib.rs
+use risc0_zkvm::{default_prover, ExecutorEnv, Receipt};
+
+pub fn multiply(a: u64, b: u64) -> (Receipt, u64) {
+    let env = ExecutorEnv::builder()
+        // Send a & b to the guest
+        .write(&a)
+        .unwrap()
+        .write(&b)
+        .unwrap()
+        .build()
+        .unwrap();
+    
+    ...
 }
 ```
 
 ## Step 3 (Guest): Read Input and Commit Output
 
-Now, let's look at the guest code located in `methods/guest/src/main.rs`. This
+The guest code is located in `methods/guest/src/main.rs`. This
 is the portion of the code that will be proven. In the code snippet below, the
-guest reads the `input` value from the host and then commits it to the [journal]
+guest reads the two `a` and `b` values from the host and commits them to the [journal]
 portion of the [receipt].
 
 ```rust ignore
+// hello-world/methods/guest/src/main.rs
 use risc0_zkvm::guest::env;
+risc0_zkvm::guest::entry!(main);
 
 fn main() {
-    // read the input
-    let input: u32 = env::read();
-
-    // do something with the input
-    // writing to the journal makes it public
-    env::commit(&input);
+    // Load the first number from the host
+    let a: u64 = env::read();
+    // Load the second number from the host
+    let b: u64 = env::read();
+    // Verify that neither of them are 1 (i.e. nontrivial factors)
+    if a == 1 || b == 1 {
+        panic!("Trivial factors")
+    }
+    // Compute the product while being careful with integer overflow
+    let product = a.checked_mul(b).expect("Integer overflow");
+    env::commit(&product);
 }
 ```
 
 The `env::commit` function commits public results to the [journal]. Once
-committed to the journal, anyone with the [receipt] can read this value.
-
-Notice, by committing any private information to the journal, we make this
-private data public. We want to avoid committing sensitive data to public
-journal.
+committed to the journal, anyone with the [receipt] can read this value. Notice, by committing any private information to the journal, we make this **private data public**. For this reason, be sure to avoid committing sensitive data to the public journal.
 
 ## Step 4 (Host): Generate a Receipt and Read Its Journal Contents
 
-Let's look at how the host generates a receipt and extracts the [journal]'s
-contents. We get a receipt, extract a journal from the receipt, and verify it.
-In a real-world scenario, we'd want to hand the [receipt] to someone else for
-verification, and the `prove` function does internal verification of the
-receipt. After we extract the journal from the receipt, let's print `Hello
-world` with the public output by adding this line to the host:
+Let's look at how the host generates a receipt and extracts the contents of the [journal].
+
+First, the [receipt] is generated, and afterwards the journal can be extracted:
 
 ```rust ignore
-println!("Hello, world! I generated a proof of guest execution! {} is a public output from journal", output);
-```
-
-```rust ignore
-use methods::{HELLO_GUEST_ELF, HELLO_GUEST_ID};
-use risc0_zkvm::{default_prover, ExecutorEnv};
+// hello-world/src/main.rs
+use hello_world::multiply;
+use hello_world_methods::MULTIPLY_ID;
 
 fn main() {
-    let input: u32 = 15 * u32::pow(2, 27) + 1;
-    let env = ExecutorEnv::builder().write(&input).unwrap().build().unwrap();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    // Pick two numbers
+    let (receipt, _) = multiply(17, 23);
+
+    // Verify receipt, panic if it's wrong
+    receipt.verify(MULTIPLY_ID).expect(
+        "Code you have proven should successfully verify; did you specify the correct image ID?",
+    );
+}
+```
+
+where the full `multiply` function is:
+
+```rust ignore
+// hello-world/src/lib.rs
+// Compute the product a*b inside the zkVM
+pub fn multiply(a: u64, b: u64) -> (Receipt, u64) {
+    let env = ExecutorEnv::builder()
+        // Send a & b to the guest
+        .write(&a)
+        .unwrap()
+        .write(&b)
+        .unwrap()
+        .build()
+        .unwrap();
 
     // Obtain the default prover.
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, HELLO_GUEST_ELF).unwrap().receipt;
+    let receipt = prover.prove(env, MULTIPLY_ELF).unwrap().receipt;
 
-    // Extract journal of receipt
-    let output: u32 = receipt.journal.decode().unwrap();
+    // Extract journal of receipt (i.e. output c, where c = a * b)
+    let c: u64 = receipt.journal.decode().expect(
+        "Journal output should deserialize into the same types (& order) that it was written",
+    );
 
-    // Print, notice, after committing to a journal, the private input became public
-    println!("Hello, world! I generated a proof of guest execution! {} is a public output from journal ", output);
+    // Report the product
+    println!("I know the factors of {}, and I can prove it!", c);
+
+    (receipt, c)
 }
 ```
 
-You should now be able to see your proof with `cargo run --release`. If your
-program printed the "Hello, world!" assertion and [receipt] verification was a
-success, congratulations! If not, we hope that troubleshooting will get you
+The contents of the journal are stored in the variable `c`. `prover.prove()` carries out proving of the guest program, and it also completes internal verification of the receipt.
+
+## Step 5: Run the Hello World Example
+
+To run this example locally, and see if proving completed successfully, run:
+
+```sh
+cargo run --release
+```
+
+If proving is successful, the line `"I know the factors of 391, and I can prove it!"` is printed. 
+
+To change the number that is factorized, head to `hello-world/src/main.rs` and change this line:
+
+```rust ignore
+let (receipt, _) = multiply(17, 23); // where 17 * 23 = 391
+```
+
+If something went wrong, we hope that troubleshooting will get you
 familiar with the system, and we'd love to chat with you on [Discord]. Or, if
 you believe you've found a bug or other problem in our code, please open an
 [issue] describing the problem.

--- a/website/api/zkvm/tutorials/hello-world.md
+++ b/website/api/zkvm/tutorials/hello-world.md
@@ -49,7 +49,7 @@ Use this command any time you'd like to check your progress.
 
 ## Step 2 (Host): Share Private Data as Input with the Guest
 
-The zkVM (or a prover) runs on the host. The host code is located in `hello-world/src/main.rs` and `hello-world/src/lib.rs`. 
+The zkVM (or a [prover]) runs on the [host]. The host code is located in `hello-world/src/main.rs` and `hello-world/src/lib.rs`. 
 
 The host creates an executor environment `ExecutorEnv` before constructing a prover. This executor environment is responsible for managing guest-readable memory. The host makes the value `input` available to the guest program before execution by adding `input` to the executor environment. 
 

--- a/website/api_versioned_docs/version-1.2/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/tutorials/hello-world.md
@@ -10,102 +10,177 @@ following the steps in this guide, you will learn how:
 
 ## Step 1: Create a New Project
 
-Firstly, visit the [installation][install] page for how to install all the
-necessary software. Next, using the `cargo-risczero` tool create a `hello-world`
-project from the command line. The `cargo-risczero` tool provides a
-`--guest-name` parameter which allows control over the name of the guest
-program:
+Firstly, visit the [installation][install] page for how to install the
+necessary software. 
 
-```bash
-cargo risczero new hello-world --guest-name hello_guest
-cd hello-world
+Once installed, clone the `risc0` monorepo and change into the `hello-world` example directory:
+
+```sh
+git clone https://github.com/risc0/risc0
+cd examples/hello-world
 ```
 
-In the project folder, `hello-world`, build and run the project using `cargo run --release`. Use this command any time you'd like to check your progress.
+Next, check the version of `cargo risczero` installed:
+
+```sh
+cargo risczero --version
+cargo-risczero $MAJOR.$MINOR.$PATCH # e.g. release-1.2
+```
+
+To match the example release version with your local installation, check out the corresponding branch of the example: 
+
+```sh
+git checkout release-$MAJOR.$MINOR # e.g. release-1.2
+```
+
+For example, if your local version is `cargo-risczero 1.2.0`, run:
+
+```sh
+git checkout release-1.2
+```
+
+Once on the correct release branch, run the example:
+
+```sh
+cargo run --release
+```
+
+Use this command any time you'd like to check your progress.
 
 ## Step 2 (Host): Share Private Data as Input with the Guest
 
-zkVM or a [prover] runs on the **[host]**. The host code is in
-`hello-world/host/src/main.rs`. The host creates an executor environment
-`ExecutorEnv` before constructing a prover. The host makes the value `input`
-available to the guest before execution. It does it by adding `input` to the
-executor environment, which is responsible for managing guest-readable memory.
-When the prover executes the program, it can access input:
+The zkVM (or a prover) runs on the host. The host code is located in `hello-world/src/main.rs` and `hello-world/src/lib.rs`. 
 
-```rust
-use risc0_zkvm::{default_prover, ExecutorEnv};
+The host creates an executor environment `ExecutorEnv` before constructing a prover. This executor environment is responsible for managing guest-readable memory. The host makes the value `input` available to the guest program before execution by adding `input` to the executor environment. 
 
-fn main() {
-    let input: u32 = 7;
-    let env = ExecutorEnv::builder().write(&input).unwrap().build().unwrap();
+When the prover executes the program, it can access input via the `.write()` method on `ExecutorEnv::builder()`:
+
+```rust ignore
+// hello-world/src/lib.rs
+use risc0_zkvm::{default_prover, ExecutorEnv, Receipt};
+
+pub fn multiply(a: u64, b: u64) -> (Receipt, u64) {
+    let env = ExecutorEnv::builder()
+        // Send a & b to the guest
+        .write(&a)
+        .unwrap()
+        .write(&b)
+        .unwrap()
+        .build()
+        .unwrap();
+    
+    ...
 }
 ```
 
 ## Step 3 (Guest): Read Input and Commit Output
 
-Now, let's look at the guest code located in `methods/guest/src/main.rs`. This
+The guest code is located in `methods/guest/src/main.rs`. This
 is the portion of the code that will be proven. In the code snippet below, the
-guest reads the `input` value from the host and then commits it to the [journal]
+guest reads the two `a` and `b` values from the host and commits them to the [journal]
 portion of the [receipt].
 
 ```rust ignore
+// hello-world/methods/guest/src/main.rs
 use risc0_zkvm::guest::env;
+risc0_zkvm::guest::entry!(main);
 
 fn main() {
-    // read the input
-    let input: u32 = env::read();
-
-    // do something with the input
-    // writing to the journal makes it public
-    env::commit(&input);
+    // Load the first number from the host
+    let a: u64 = env::read();
+    // Load the second number from the host
+    let b: u64 = env::read();
+    // Verify that neither of them are 1 (i.e. nontrivial factors)
+    if a == 1 || b == 1 {
+        panic!("Trivial factors")
+    }
+    // Compute the product while being careful with integer overflow
+    let product = a.checked_mul(b).expect("Integer overflow");
+    env::commit(&product);
 }
 ```
 
 The `env::commit` function commits public results to the [journal]. Once
-committed to the journal, anyone with the [receipt] can read this value.
-
-Notice, by committing any private information to the journal, we make this
-private data public. We want to avoid committing sensitive data to public
-journal.
+committed to the journal, anyone with the [receipt] can read this value. Notice, by committing any private information to the journal, we make this **private data public**. For this reason, be sure to avoid committing sensitive data to the public journal.
 
 ## Step 4 (Host): Generate a Receipt and Read Its Journal Contents
 
-Let's look at how the host generates a receipt and extracts the [journal]'s
-contents. We get a receipt, extract a journal from the receipt, and verify it.
-In a real-world scenario, we'd want to hand the [receipt] to someone else for
-verification, and the `prove` function does internal verification of the
-receipt. After we extract the journal from the receipt, let's print `Hello
-world` with the public output by adding this line to the host:
+Let's look at how the host generates a receipt and extracts the contents of the [journal].
+
+First, the [receipt] is generated, and afterwards the journal can be extracted:
 
 ```rust ignore
-println!("Hello, world! I generated a proof of guest execution! {} is a public output from journal", output);
-```
-
-```rust ignore
-use methods::{HELLO_GUEST_ELF, HELLO_GUEST_ID};
-use risc0_zkvm::{default_prover, ExecutorEnv};
+// hello-world/src/main.rs
+use hello_world::multiply;
+use hello_world_methods::MULTIPLY_ID;
 
 fn main() {
-    let input: u32 = 15 * u32::pow(2, 27) + 1;
-    let env = ExecutorEnv::builder().write(&input).unwrap().build().unwrap();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    // Pick two numbers
+    let (receipt, _) = multiply(17, 23);
+
+    // Verify receipt, panic if it's wrong
+    receipt.verify(MULTIPLY_ID).expect(
+        "Code you have proven should successfully verify; did you specify the correct image ID?",
+    );
+}
+```
+
+where the full `multiply` function is:
+
+```rust ignore
+// hello-world/src/lib.rs
+// Compute the product a*b inside the zkVM
+pub fn multiply(a: u64, b: u64) -> (Receipt, u64) {
+    let env = ExecutorEnv::builder()
+        // Send a & b to the guest
+        .write(&a)
+        .unwrap()
+        .write(&b)
+        .unwrap()
+        .build()
+        .unwrap();
 
     // Obtain the default prover.
     let prover = default_prover();
 
     // Produce a receipt by proving the specified ELF binary.
-    let receipt = prover.prove(env, HELLO_GUEST_ELF).unwrap().receipt;
+    let receipt = prover.prove(env, MULTIPLY_ELF).unwrap().receipt;
 
-    // Extract journal of receipt
-    let output: u32 = receipt.journal.decode().unwrap();
+    // Extract journal of receipt (i.e. output c, where c = a * b)
+    let c: u64 = receipt.journal.decode().expect(
+        "Journal output should deserialize into the same types (& order) that it was written",
+    );
 
-    // Print, notice, after committing to a journal, the private input became public
-    println!("Hello, world! I generated a proof of guest execution! {} is a public output from journal ", output);
+    // Report the product
+    println!("I know the factors of {}, and I can prove it!", c);
+
+    (receipt, c)
 }
 ```
 
-You should now be able to see your proof with `cargo run --release`. If your
-program printed the "Hello, world!" assertion and [receipt] verification was a
-success, congratulations! If not, we hope that troubleshooting will get you
+The contents of the journal are stored in the variable `c`. `prover.prove()` carries out proving of the guest program, and it also completes internal verification of the receipt.
+
+## Step 5: Run the Hello World Example
+
+To run this example locally, and see if proving completed successfully, run:
+
+```sh
+cargo run --release
+```
+
+If proving is successful, the line `"I know the factors of 391, and I can prove it!"` is printed. 
+
+To change the number that is factorized, head to `hello-world/src/main.rs` and change this line:
+
+```rust ignore
+let (receipt, _) = multiply(17, 23); // where 17 * 23 = 391
+```
+
+If something went wrong, we hope that troubleshooting will get you
 familiar with the system, and we'd love to chat with you on [Discord]. Or, if
 you believe you've found a bug or other problem in our code, please open an
 [issue] describing the problem.

--- a/website/api_versioned_docs/version-1.2/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/tutorials/hello-world.md
@@ -49,7 +49,7 @@ Use this command any time you'd like to check your progress.
 
 ## Step 2 (Host): Share Private Data as Input with the Guest
 
-The zkVM (or a prover) runs on the host. The host code is located in `hello-world/src/main.rs` and `hello-world/src/lib.rs`. 
+The zkVM (or a [prover]) runs on the [host]. The host code is located in `hello-world/src/main.rs` and `hello-world/src/lib.rs`. 
 
 The host creates an executor environment `ExecutorEnv` before constructing a prover. This executor environment is responsible for managing guest-readable memory. The host makes the value `input` available to the guest program before execution by adding `input` to the executor environment. 
 


### PR DESCRIPTION
As pointed out in the [Discord](https://discord.com/channels/953703904086994974/1334542837387231242), the hello world tutorial on the docs was not up to date. Specifically it pointed the reader to use `cargo risczero new` as oppose to checking out the correct `examples/hello-world` directory. It also had outdated code.

This PR updates the [hello world tutorial](https://dev.risczero.com/api/zkvm/tutorials/hello-world) by:

* by guiding the reader to the right example code
* walking through the current hello world example code 
* running the example locally 

CC @pdg744 