### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,6 @@ This project is licensed under the Apache2 license. See [LICENSE](LICENSE).
 [risc-v]: https://en.wikipedia.org/wiki/RISC-V
 [security-model]: https://dev.risczero.com/api/security-model
 [twitter-badge]: https://img.shields.io/twitter/follow/risczero
-[twitter-url]: https://twitter.com/risczero
+[twitter-url]: https://x.com/risczero
 [zk-proof]: https://en.wikipedia.org/wiki/Non-interactive_zero-knowledge_proof
 [zksummit10-talk]: https://www.youtube.com/watch?v=wkIBN2CGJdc

--- a/risc0/cargo-risczero/templates/rust-starter/README.md
+++ b/risc0/cargo-risczero/templates/rust-starter/README.md
@@ -106,6 +106,6 @@ We'd love to hear from you on [Discord][discord] or [Twitter][twitter].
 [risc0-zkvm]: https://docs.rs/risc0-zkvm
 [rust-toolchain]: rust-toolchain.toml
 [rustup]: https://rustup.rs
-[twitter]: https://twitter.com/risczero
+[twitter]: https://.com/risczero
 [zkhack-iii]: https://www.youtube.com/watch?v=Yg_BGqj_6lg&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=5
 [zkvm-overview]: https://dev.risczero.com/zkvm

--- a/website/api/trusted-setup-ceremony.md
+++ b/website/api/trusted-setup-ceremony.md
@@ -57,7 +57,7 @@ We used the open-source tools [p0tion] and [DefinitelySetup] to run our ceremony
 [audits-readme]: https://github.com/risc0/rz-security/blob/main/audits/README.md
 [DefinitelySetup]: https://github.com/privacy-scaling-explorations/DefinitelySetup
 [install-circom]: https://docs.circom.io/getting-started/installation
-[kobi-bad-ceremony-list]: https://twitter.com/kobigurk/status/1782502969453494530
+[kobi-bad-ceremony-list]: https://x.com/kobigurk/status/1782502969453494530
 [p0tion]: https://github.com/privacy-scaling-explorations/p0tion
 [p0tion-config]: https://github.com/risc0/risc0/blob/d4e427283027c28b38b8eda1562e8e0e68d1b0e2/compact_proof/groth16/p0tionConfig.json
 [powers-of-tau-hez-23]: https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_23.ptau

--- a/website/api_versioned_docs/version-0.18/introduction.md
+++ b/website/api_versioned_docs/version-0.18/introduction.md
@@ -76,7 +76,7 @@ If you want to report a bug or contribute to our code, you can do so on [GitHub]
 
 You're welcome to join [our Discord community](https://discord.gg/risczero) to discuss RISC Zero, ask questions, and see how other people use RISC Zero!
 
-Follow us on [Twitter](https://twitter.com/risczero) and [YouTube](https://www.youtube.com/@risczero) to get our latest announcements.
+Follow us on [Twitter](https://x.com/risczero) and [YouTube](https://www.youtube.com/@risczero) to get our latest announcements.
 
 [April 2022]: https://www.risczero.com/news/announce
 [Bonsai]: bonsai/bonsai-overview.md

--- a/website/api_versioned_docs/version-0.19/introduction.md
+++ b/website/api_versioned_docs/version-0.19/introduction.md
@@ -76,7 +76,7 @@ If you want to report a bug or contribute to our code, you can do so on [GitHub]
 
 You're welcome to join [our Discord community](https://discord.gg/risczero) to discuss RISC Zero, ask questions, and see how other people use RISC Zero!
 
-Follow us on [Twitter](https://twitter.com/risczero) and [YouTube](https://www.youtube.com/@risczero), and [sign up for our mailing list](https://fmree464va4.typeform.com/to/X3KJB85v) to get our latest announcements.
+Follow us on [Twitter](https://x.com/risczero) and [YouTube](https://www.youtube.com/@risczero), and [sign up for our mailing list](https://fmree464va4.typeform.com/to/X3KJB85v) to get our latest announcements.
 
 [April 2022]: https://www.risczero.com/news/announce
 [Bonsai]: bonsai/bonsai-overview.md

--- a/website/api_versioned_docs/version-0.20/introduction.md
+++ b/website/api_versioned_docs/version-0.20/introduction.md
@@ -137,7 +137,7 @@ list][mailing-list] to get our latest announcements.
 [risc0-zkvm]: https://docs.rs/risc0-zkvm
 [rust-libraries]: https://github.com/risc0/risc0#rust-libraries
 [startup]: https://risczero.com/news/series-a
-[twitter]: https://twitter.com/risczero
+[twitter]: https://x.com/risczero
 [waldo]: https://risczero.com/news/waldo
 [YouTube]: https://www.youtube.com/@risczero
 [zk coprocessors]: https://www.risczero.com/blog/a-guide-to-zk-coprocessors-for-scalability

--- a/website/api_versioned_docs/version-0.21/trusted-setup-ceremony.md
+++ b/website/api_versioned_docs/version-0.21/trusted-setup-ceremony.md
@@ -57,7 +57,7 @@ We used the open-source tools [p0tion] and [DefinitelySetup] to run our ceremony
 [audits-readme]: https://github.com/risc0/rz-security/blob/main/audits/README.md
 [DefinitelySetup]: https://github.com/privacy-scaling-explorations/DefinitelySetup
 [install-circom]: https://docs.circom.io/getting-started/installation
-[kobi-bad-ceremony-list]: https://twitter.com/kobigurk/status/1782502969453494530
+[kobi-bad-ceremony-list]: https://x.com/kobigurk/status/1782502969453494530
 [p0tion]: https://github.com/privacy-scaling-explorations/p0tion
 [p0tion-config]: https://github.com/risc0/risc0/blob/d4e427283027c28b38b8eda1562e8e0e68d1b0e2/compact_proof/groth16/p0tionConfig.json
 [powers-of-tau-hez-23]: https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_23.ptau

--- a/website/api_versioned_docs/version-1.0/trusted-setup-ceremony.md
+++ b/website/api_versioned_docs/version-1.0/trusted-setup-ceremony.md
@@ -57,7 +57,7 @@ We used the open-source tools [p0tion] and [DefinitelySetup] to run our ceremony
 [audits-readme]: https://github.com/risc0/rz-security/blob/main/audits/README.md
 [DefinitelySetup]: https://github.com/privacy-scaling-explorations/DefinitelySetup
 [install-circom]: https://docs.circom.io/getting-started/installation
-[kobi-bad-ceremony-list]: https://twitter.com/kobigurk/status/1782502969453494530
+[kobi-bad-ceremony-list]: https://x.com/kobigurk/status/1782502969453494530
 [p0tion]: https://github.com/privacy-scaling-explorations/p0tion
 [p0tion-config]: https://github.com/risc0/risc0/blob/d4e427283027c28b38b8eda1562e8e0e68d1b0e2/compact_proof/groth16/p0tionConfig.json
 [powers-of-tau-hez-23]: https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_23.ptau

--- a/website/api_versioned_docs/version-1.1/trusted-setup-ceremony.md
+++ b/website/api_versioned_docs/version-1.1/trusted-setup-ceremony.md
@@ -57,7 +57,7 @@ We used the open-source tools [p0tion] and [DefinitelySetup] to run our ceremony
 [audits-readme]: https://github.com/risc0/rz-security/blob/main/audits/README.md
 [DefinitelySetup]: https://github.com/privacy-scaling-explorations/DefinitelySetup
 [install-circom]: https://docs.circom.io/getting-started/installation
-[kobi-bad-ceremony-list]: https://twitter.com/kobigurk/status/1782502969453494530
+[kobi-bad-ceremony-list]: https://x.com/kobigurk/status/1782502969453494530
 [p0tion]: https://github.com/privacy-scaling-explorations/p0tion
 [p0tion-config]: https://github.com/risc0/risc0/blob/d4e427283027c28b38b8eda1562e8e0e68d1b0e2/compact_proof/groth16/p0tionConfig.json
 [powers-of-tau-hez-23]: https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_23.ptau

--- a/website/api_versioned_docs/version-1.2/trusted-setup-ceremony.md
+++ b/website/api_versioned_docs/version-1.2/trusted-setup-ceremony.md
@@ -57,7 +57,7 @@ We used the open-source tools [p0tion] and [DefinitelySetup] to run our ceremony
 [audits-readme]: https://github.com/risc0/rz-security/blob/main/audits/README.md
 [DefinitelySetup]: https://github.com/privacy-scaling-explorations/DefinitelySetup
 [install-circom]: https://docs.circom.io/getting-started/installation
-[kobi-bad-ceremony-list]: https://twitter.com/kobigurk/status/1782502969453494530
+[kobi-bad-ceremony-list]: https://x.com/kobigurk/status/1782502969453494530
 [p0tion]: https://github.com/privacy-scaling-explorations/p0tion
 [p0tion-config]: https://github.com/risc0/risc0/blob/d4e427283027c28b38b8eda1562e8e0e68d1b0e2/compact_proof/groth16/p0tionConfig.json
 [powers-of-tau-hez-23]: https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_23.ptau

--- a/website/docs/proof-system/stark-by-hand.md
+++ b/website/docs/proof-system/stark-by-hand.md
@@ -427,7 +427,7 @@ The key point here is that the FRI folding procedure can be checked _locally_: t
 
 Whew! Congratulations and thank you for making it this far!
 
-Got questions, feedback, or corrections? Find us on [Twitter](https://twitter.com/risczero) and [Discord](https://discord.gg/risczero).
+Got questions, feedback, or corrections? Find us on [Twitter](https://x.com/risczero) and [Discord](https://discord.gg/risczero).
 
 [cryptographic security model]: /api/security-model
 [RISC-V]: https://en.wikipedia.org/wiki/RISC-V

--- a/website/docs/reference-docs/about-fri.md
+++ b/website/docs/reference-docs/about-fri.md
@@ -40,7 +40,7 @@ The RISC Zero ZKP system uses the original FRI protocol.
 ### Explanatory References
 
 - RISC Zero Study Club [Slides](https://drive.google.com/file/d/1TuufbM8py2mGDkjMUg5FWZzw8VqNri4O/view?usp=share_link) & [Video Recording](https://www.youtube.com/watch?v=j35yz22OVGE)
-- [FRI Sequence Diagram](https://twitter.com/EllipticHector/status/1641842245337743367)
+- [FRI Sequence Diagram](https://x.com/EllipticHector/status/1641842245337743367)
 - [A summary on the FRI low degree test (Ulrich Haböck, Orbis Labs, 2022)](https://eprint.iacr.org/2022/1216.pdf) (PDF)
 - [Low Degree Testing](https://medium.com/starkware/low-degree-testing-f7614f5172db), part 3 of the STARK Math series
 - [Vitalik's FRI article](https://vitalik.eth.limo/general/2017/11/22/starks_part_2.html)

--- a/website/docs/reference-docs/about-plonk.md
+++ b/website/docs/reference-docs/about-plonk.md
@@ -29,7 +29,7 @@ For general references, we recommend the following:
 
 - [ZK Podcast episode](https://www.youtube.com/watch?v=n6_nicI4ckM\&t=2629s) with the authors of the PLONK paper
 - [Vitalik's PLONK intro](https://vitalik.eth.limo/general/2019/09/22/plonk.html)
-- [@0xtaetaehoho's PLONK Skilltree](https://twitter.com/0xtaetaehoho/status/1618979438913527814)
+- [@0xtaetaehoho's PLONK Skilltree](https://x.com/0xtaetaehoho/status/1618979438913527814)
 
 ### Moderately Technical
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -215,7 +215,7 @@ export default async function createConfigAsync() {
                 },
                 {
                   label: "Twitter",
-                  href: "https://twitter.com/risczero",
+                  href: "https://x.com/risczero",
                 },
                 {
                   label: "YouTube",


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.