### PR TITLE
Update copyright year from 2024 to 2025 in build.rs and lib.rs

### DIFF
--- a/external/substrate/build.rs
+++ b/external/substrate/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/external/substrate/src/lib.rs
+++ b/external/substrate/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

This pull request updates the copyright headers in two files to reflect the new year:

- **external/substrate/build.rs**: The copyright line was updated from 2024 to 2025.
- **external/substrate/src/lib.rs**: The copyright line was updated from 2024 to 2025.

These changes ensure that the project’s legal headers remain current.