### PR TITLE
ZKVM-1035: Improvements to guest profiling

### DIFF
--- a/risc0/circuit/rv32im/src/prove/emu/pager.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/pager.rs
@@ -55,7 +55,7 @@ pub struct PageFaults {
 }
 
 #[derive(Clone, Debug)]
-enum Action {
+pub enum Action {
     PageRead(u32, usize),
     PageWrite(u32, usize, bool),
     Store(WordAddr, u32),
@@ -214,8 +214,8 @@ impl PagedMemory {
         }
     }
 
-    pub fn commit_step(&mut self) {
-        self.pending_actions.clear();
+    pub fn commit_step(&mut self) -> Vec<Action> {
+        take(&mut self.pending_actions)
     }
 
     pub fn clear(&mut self) {

--- a/risc0/circuit/rv32im/src/trace.rs
+++ b/risc0/circuit/rv32im/src/trace.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,12 @@ pub enum TraceEvent {
         /// Data that's been written
         region: Vec<u8>,
     },
+
+    /// A page is read for the first time in a segment
+    PageIn { cycles: u64 },
+
+    /// A page has been written to for the first time in a segment
+    PageOut { cycles: u64 },
 }
 
 /// A callback used to collect [TraceEvent]s.
@@ -70,6 +76,8 @@ impl core::fmt::Debug for TraceEvent {
             Self::MemorySet { addr, region } => {
                 write!(f, "MemorySet(0x{addr:08X}, {region:#04X?})")
             }
+            Self::PageIn { cycles } => write!(f, "PageIn({cycles})"),
+            Self::PageOut { cycles } => write!(f, "PageOut({cycles})"),
         }
     }
 }

--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -17,6 +17,9 @@
 #![no_main]
 #![no_std]
 
+#[path = "multi_test/profiler.rs"]
+mod profiler;
+
 extern crate alloc;
 
 use alloc::{
@@ -77,18 +80,6 @@ const KECCAK_UPDATE: KeccakState = [
     0xEAF1FF7B5CECA249,
 ];
 
-#[inline(never)]
-#[no_mangle]
-fn profile_test_func1() {
-    profile_test_func2()
-}
-
-#[inline(always)]
-#[no_mangle]
-fn profile_test_func2() {
-    unsafe { asm!("nop") }
-}
-
 fn main() {
     let impl_select: MultiTestSpec = env::read();
     match impl_select {
@@ -131,7 +122,7 @@ fn main() {
         },
         MultiTestSpec::Profiler => {
             // Call an external function to make sure it's detected during profiling.
-            profile_test_func1()
+            profiler::profile_test_func1()
         }
         MultiTestSpec::Panic => {
             panic!("MultiTestSpec::Panic invoked");

--- a/risc0/zkvm/methods/guest/src/bin/multi_test/profiler.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test/profiler.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::arch::asm;
+
+#[inline(never)]
+#[no_mangle]
+pub fn profile_test_func1() {
+    // Two functions inlined one after the other to test we get the bounds correct.
+    profile_test_func2();
+    profile_test_func3();
+
+    profile_test_func4();
+
+    // Tail-call to non-inlined function can produce confusing jump
+    profile_test_func5();
+}
+
+#[inline(always)]
+#[no_mangle]
+fn profile_test_func2() {
+    unsafe { asm!("nop") }
+}
+
+#[inline(always)]
+#[no_mangle]
+fn profile_test_func3() {
+    unsafe { asm!("nop") }
+}
+
+/// This contains a jump in the middle that shouldn't be interpreted as a "call" by the profiler.
+#[inline(always)]
+#[no_mangle]
+fn profile_test_func4() {
+    unsafe { asm!("la a0, 1f", "jr a0", "1:", "nop") }
+}
+
+/// Inline the same function many times in different locations
+#[inline(never)]
+#[no_mangle]
+fn profile_test_func5() {
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+    profile_test_func3();
+}

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -161,6 +161,16 @@ impl From<TraceEvent> for pb::api::TraceEvent {
                     },
                 )),
             },
+            TraceEvent::PageIn { cycles } => Self {
+                kind: Some(pb::api::trace_event::Kind::PageIn(
+                    pb::api::trace_event::PageIn { cycles },
+                )),
+            },
+            TraceEvent::PageOut { cycles } => Self {
+                kind: Some(pb::api::trace_event::Kind::PageOut(
+                    pb::api::trace_event::PageOut { cycles },
+                )),
+            },
         }
     }
 }
@@ -182,6 +192,12 @@ impl TryFrom<pb::api::TraceEvent> for TraceEvent {
             pb::api::trace_event::Kind::MemorySet(event) => TraceEvent::MemorySet {
                 addr: event.addr,
                 region: event.region,
+            },
+            pb::api::trace_event::Kind::PageIn(event) => TraceEvent::PageIn {
+                cycles: event.cycles,
+            },
+            pb::api::trace_event::Kind::PageOut(event) => TraceEvent::PageOut {
+                cycles: event.cycles,
             },
         })
     }

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -331,10 +331,20 @@ message TraceEvent {
     bytes region = 3;
   }
 
+  message PageIn {
+    uint64 cycles = 1;
+  }
+
+  message PageOut {
+    uint64 cycles = 1;
+  }
+
   oneof kind {
     InstructionStart insn_start = 1;
     RegisterSet register_set = 2;
     MemorySet memory_set = 3;
+    PageIn page_in = 4;
+    PageOut page_out = 5;
   }
 }
 

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -607,7 +607,7 @@ pub mod posix_cmd {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TraceEvent {
-    #[prost(oneof = "trace_event::Kind", tags = "1, 2, 3")]
+    #[prost(oneof = "trace_event::Kind", tags = "1, 2, 3, 4, 5")]
     pub kind: ::core::option::Option<trace_event::Kind>,
 }
 /// Nested message and enum types in `TraceEvent`.
@@ -641,6 +641,18 @@ pub mod trace_event {
         pub region: ::prost::alloc::vec::Vec<u8>,
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct PageIn {
+        #[prost(uint64, tag = "1")]
+        pub cycles: u64,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct PageOut {
+        #[prost(uint64, tag = "1")]
+        pub cycles: u64,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
         #[prost(message, tag = "1")]
@@ -649,6 +661,10 @@ pub mod trace_event {
         RegisterSet(RegisterSet),
         #[prost(message, tag = "3")]
         MemorySet(MemorySet),
+        #[prost(message, tag = "4")]
+        PageIn(PageIn),
+        #[prost(message, tag = "5")]
+        PageOut(PageOut),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/risc0/zkvm/src/host/server/exec/profiler.rs
+++ b/risc0/zkvm/src/host/server/exec/profiler.rs
@@ -496,9 +496,13 @@ impl Profiler {
     ) -> Result<(), anyhow::Error> {
         match op {
             CallStackOp::Push => {
-                self.call_stack_path.push(FunctionStart::Real { pc });
-                self.pop_stack.push(orig_pc);
-                *update_stack = true;
+                // Sometimes we confuse a jump and a function call. See if we are jumping to the
+                // start of a function or not to disambiguate.
+                if self.profile.symbol_table.contains_key(&(pc as u64)) {
+                    self.call_stack_path.push(FunctionStart::Real { pc });
+                    self.pop_stack.push(orig_pc);
+                    *update_stack = true;
+                }
             }
             CallStackOp::Pop => loop {
                 while matches!(self.call_stack_path.last(), Some(FunctionStart::Inline(_))) {

--- a/risc0/zkvm/src/host/server/exec/profiler.rs
+++ b/risc0/zkvm/src/host/server/exec/profiler.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,9 +23,12 @@
 //! paging, and it does not include padding to extend the trace to
 //! the nearest power of two.
 
+mod inline;
+
 use std::{
     cell::RefCell,
     collections::HashMap,
+    fmt,
     fmt::Write,
     hash::{Hash, Hasher},
     rc::Rc,
@@ -33,8 +36,8 @@ use std::{
 
 use addr2line::{
     fallible_iterator::FallibleIterator,
-    gimli::{EndianRcSlice, RunTimeEndian},
-    object::{File, Object, ObjectSegment},
+    gimli::{self, EndianRcSlice, RunTimeEndian},
+    object::{self, File, Object, ObjectSegment},
     LookupResult, ObjectContext,
 };
 use anyhow::{anyhow, Result};
@@ -46,6 +49,7 @@ use rustc_demangle::demangle;
 
 use super::proto;
 use crate::{TraceCallback, TraceEvent};
+use inline::{InlineFunction, InlineFunctionTable};
 
 /// Operations effecting the function call stack.
 #[derive(Debug)]
@@ -91,6 +95,39 @@ fn extract_call_stack_op(insn: u32) -> Option<CallStackOp> {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+enum FunctionStart {
+    Real { pc: u32 },
+    Inline(InlineFunction),
+}
+
+impl FunctionStart {
+    fn get_pc(&self) -> u32 {
+        match self {
+            Self::Real { pc } => *pc,
+            Self::Inline(InlineFunction { low_pc, .. }) => *low_pc as u32,
+        }
+    }
+}
+
+impl fmt::Display for FunctionStart {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Real { pc } => write!(f, "0x{pc:x}"),
+            Self::Inline(InlineFunction {
+                abstract_origin,
+                low_pc,
+                high_pc,
+            }) => {
+                write!(
+                    f,
+                    "[inline function: 0x{abstract_origin:x} (0x{low_pc:x}..0x{high_pc:x}]"
+                )
+            }
+        }
+    }
+}
+
 /// Node in a tree tracking the call stacks and assigning cycles to stacks.
 ///
 /// Each node represents a unique call-stack as defined by a list of return
@@ -98,10 +135,10 @@ fn extract_call_stack_op(insn: u32) -> Option<CallStackOp> {
 #[derive(Clone, Debug, Default)]
 struct CallNode {
     /// Counter by program counter with the current call stack.
-    pub(crate) counts: HashMap<u32, usize>,
+    pub(crate) counts: HashMap<FunctionStart, usize>,
 
     /// Nodes representing further calls from this context.
-    pub(crate) calls: HashMap<u32, Rc<RefCell<CallNode>>>,
+    pub(crate) calls: HashMap<FunctionStart, Rc<RefCell<CallNode>>>,
 }
 
 impl CallNode {
@@ -112,9 +149,8 @@ impl CallNode {
 
         writeln!(output, "{indent_str}Counts:").unwrap();
         for (key, value) in &self.counts {
-            let frames = &profiler.lookup_pc(*key as u64);
-            if !frames.is_empty() {
-                let name = &frames[0].name;
+            if let Some(frame) = &profiler.lookup_function_start(*key) {
+                let name = &frame.name;
                 writeln!(output, "{indent_str}  {name} ({key}): {value}").unwrap();
             }
         }
@@ -146,7 +182,7 @@ pub struct Profiler {
 
     // Path of the call stack as a series of program counters,
     // representing the journey to the current node from the root
-    call_stack_path: Vec<u32>,
+    call_stack_path: Vec<FunctionStart>,
 
     // Root of the tree used to store samples attributable to a call stack.
     root: Rc<RefCell<CallNode>>,
@@ -155,7 +191,7 @@ pub struct Profiler {
     current_node: Option<Rc<RefCell<CallNode>>>,
 
     // Current CallNode key in the stack
-    current_key: u32,
+    current_key: Option<FunctionStart>,
 
     ctx: ObjectContext,
 
@@ -163,7 +199,7 @@ pub struct Profiler {
 }
 
 /// Represents a frame.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Frame {
     /// Function name
     pub name: String,
@@ -183,7 +219,7 @@ fn decode_frame(fr: addr2line::Frame<EndianRcSlice<RunTimeEndian>>) -> Option<Fr
     })
 }
 
-fn lookup_pc(pc: u32, ctx: &ObjectContext) -> Vec<Frame> {
+fn lookup_pc_in_dwarf(pc: u32, ctx: &ObjectContext) -> Vec<Frame> {
     let frames = match ctx.find_frames(pc as u64) {
         LookupResult::Output(result) => result.unwrap(),
         LookupResult::Load {
@@ -206,11 +242,43 @@ fn demangle_name(name: String) -> String {
     }
 }
 
+fn load_dwarf<'data, O: object::Object<'data>>(
+    file: &O,
+) -> Result<gimli::Dwarf<gimli::EndianRcSlice<gimli::RunTimeEndian>>> {
+    let endian = if file.is_little_endian() {
+        gimli::RunTimeEndian::Little
+    } else {
+        gimli::RunTimeEndian::Big
+    };
+
+    fn load_section<'data, O, Endian>(
+        id: gimli::SectionId,
+        file: &O,
+        endian: Endian,
+    ) -> std::result::Result<gimli::EndianRcSlice<Endian>, gimli::Error>
+    where
+        O: object::Object<'data>,
+        Endian: gimli::Endianity,
+    {
+        use object::ObjectSection as _;
+
+        let data = file
+            .section_by_name(id.name())
+            .and_then(|section| section.uncompressed_data().ok())
+            .unwrap_or(std::borrow::Cow::Borrowed(&[]));
+        Ok(gimli::EndianRcSlice::new(Rc::from(&*data), endian))
+    }
+
+    Ok(gimli::Dwarf::load(|id| load_section(id, file, endian))?)
+}
+
 impl Profiler {
     /// Return a new profile from the given RISC-V ELF.
     pub fn new(elf_data: &[u8], filename: Option<&str>) -> Result<Self> {
         let file = File::parse(elf_data)?;
-        let ctx = ObjectContext::new(&file)?;
+        let dwarf = load_dwarf(&file)?;
+        let inline_function_table_result = InlineFunctionTable::build_from_dwarf(&dwarf);
+        let ctx = ObjectContext::from_dwarf(dwarf)?;
         let root = Rc::new(RefCell::new(CallNode::default()));
         let mut profiler = Profiler {
             pc: u32::MAX,
@@ -219,7 +287,7 @@ impl Profiler {
             pop_stack: Vec::new(),
             root: Rc::clone(&root),
             current_node: Some(root),
-            current_key: 0,
+            current_key: None,
             call_stack_path: Vec::new(),
             ctx,
             profile: ProfileBuilder::new(),
@@ -244,67 +312,64 @@ impl Profiler {
             }
         }
 
-        let elf = ElfBytes::<LittleEndian>::minimal_parse(elf_data)?;
-        if let Some((symtab, strtab)) = elf.symbol_table()? {
-            for sym in symtab {
-                if sym.st_symtype() == STT_FUNC {
-                    let name = strtab.get(sym.st_name as usize)?;
-                    profiler
-                        .profile
-                        .function_lookup
-                        .insert(sym.st_value, demangle(name).to_string());
-                }
+        profiler.profile.symbol_table = build_symbol_table(elf_data)?;
+        match inline_function_table_result {
+            Ok(inline_function_table) => {
+                profiler.profile.inline_function_table = inline_function_table
+            }
+            Err(error) => {
+                tracing::warn!("Error decoding DWARF data, inline functions not available: {error}")
             }
         }
 
         Ok(profiler)
     }
 
-    /// Returns the frames name at the given pc.
-    pub fn lookup_pc(&self, pc: u64) -> Vec<Frame> {
-        let frames = if let Some(symbol) = self.profile.function_lookup.get(&pc).cloned() {
-            let mut dwarf_frames = lookup_pc(pc as u32, &self.ctx);
-            dwarf_frames.reverse();
-            let name = demangle_name(symbol).replace('&', "");
-            let mut lineno: i64 = 0;
-            let mut filename = "unknown".to_string();
-            if !dwarf_frames.is_empty() {
-                let debug_frame = &dwarf_frames[0];
-                let debug_name = debug_frame.name.replace('&', "");
-                if name == debug_name {
-                    lineno = debug_frame.lineno;
-                    filename = debug_frame.filename.clone();
-                }
-            }
-            let mut frames = vec![Frame {
-                name,
-                lineno,
-                filename,
-            }];
-            if dwarf_frames.len() > 1 {
-                for fr in dwarf_frames[1..].iter() {
-                    frames.push(fr.clone())
-                }
-            }
-            frames
+    fn lookup_function_start(&self, f: FunctionStart) -> Option<Frame> {
+        match f {
+            FunctionStart::Real { pc } => self.lookup_pc(pc),
+            FunctionStart::Inline(InlineFunction {
+                abstract_origin, ..
+            }) => self.lookup_inline_function(abstract_origin as u32),
+        }
+    }
+
+    fn lookup_pc(&self, pc: u32) -> Option<Frame> {
+        let dwarf_frames = lookup_pc_in_dwarf(pc, &self.ctx);
+        let symbol = self.profile.symbol_table.get(&(pc as u64)).cloned();
+
+        if !dwarf_frames.is_empty() {
+            Some(dwarf_frames.last().unwrap().clone())
         } else {
-            // only used when debug is set. However, it currently misinterprets when no_std
-            // lookup_pc(pc as u32, &self.ctx)
-            vec![]
-        };
-        frames
+            symbol.map(|symbol| Frame {
+                name: demangle_name(symbol).replace('&', ""),
+                lineno: 0,
+                filename: "unknown".into(),
+            })
+        }
+    }
+
+    fn lookup_inline_function(&self, abstract_origin: u32) -> Option<Frame> {
+        Some(
+            self.profile
+                .inline_function_table
+                .frames
+                .get(&(abstract_origin as u64))?
+                .clone(),
+        )
     }
 
     /// Walk the profile tree rooted at node_ref, adding all call stacks in the profile to the
     /// profile under construction. All call stacks encountered build on top of the base_stack.
     fn walk_stacks(&mut self, node_ref: Rc<RefCell<CallNode>>, base_stack: Vec<Frame>) {
         let node = node_ref.borrow();
-        for (&pc, count) in &node.counts {
+        for (function_start, count) in &node.counts {
             let mut new_stack = base_stack.clone();
-            let frames = self.lookup_pc(pc.into());
-            if !frames.is_empty() {
-                new_stack.extend(frames);
+            if let Some(frame) = self.lookup_function_start(*function_start) {
+                new_stack.push(frame);
             }
+
+            let pc = function_start.get_pc();
 
             let location_ids: Vec<_> = new_stack
                 .iter()
@@ -328,11 +393,11 @@ impl Profiler {
                 ..Default::default()
             };
 
-            if !sample.location_id.is_empty() {
+            if !sample.location_id.is_empty() && *count > 0 {
                 self.profile.add_sample(sample);
             }
 
-            if let Some(next_node_ref) = node.calls.get(&pc) {
+            if let Some(next_node_ref) = node.calls.get(function_start) {
                 self.walk_stacks(next_node_ref.clone(), new_stack);
             }
         }
@@ -355,6 +420,146 @@ impl Profiler {
         self.walk_stacks(root_ref, Vec::new());
         self.profile.profile.encode_to_vec()
     }
+
+    fn add_cycles_to_current_stack(&mut self, cycles: u64) {
+        if !self.call_stack_path.is_empty() {
+            let current_node = self
+                .current_node
+                .as_ref()
+                .expect("current_node should always be Some after initialization");
+            let mut current_node_borrowed = current_node.borrow_mut();
+            let current_key = self
+                .current_key
+                .expect("current_key should always be Some after initialization");
+            current_node_borrowed
+                .counts
+                .entry(current_key)
+                .and_modify(|e| *e += cycles as usize)
+                .or_insert(cycles as usize);
+        }
+    }
+
+    fn handle_function_call(
+        &mut self,
+        op: CallStackOp,
+        pc: u32,
+        orig_pc: u32,
+        update_stack: &mut bool,
+    ) -> Result<(), anyhow::Error> {
+        match op {
+            CallStackOp::Push => {
+                self.call_stack_path.push(FunctionStart::Real { pc });
+                self.pop_stack.push(orig_pc);
+                *update_stack = true;
+            }
+            CallStackOp::Pop => loop {
+                while matches!(self.call_stack_path.last(), Some(FunctionStart::Inline(_))) {
+                    self.call_stack_path.pop();
+                }
+
+                self.call_stack_path.pop().ok_or_else(|| {
+                    anyhow!("attempted to follow a return with an empty call stack")
+                })?;
+                let popped = self.pop_stack.pop().ok_or_else(|| {
+                    anyhow!("attempted to follow a return with an empty call stack")
+                })?;
+                *update_stack = true;
+                if popped == pc - 4 {
+                    break;
+                }
+            },
+            CallStackOp::PopPush => {
+                loop {
+                    while matches!(self.call_stack_path.last(), Some(FunctionStart::Inline(_))) {
+                        self.call_stack_path.pop();
+                    }
+
+                    self.call_stack_path.pop().ok_or_else(|| {
+                        anyhow!("attempted to follow a return with an empty call stack")
+                    })?;
+                    let popped = self.pop_stack.pop().ok_or_else(|| {
+                        anyhow!("attempted to follow a return with an empty call stack")
+                    })?;
+                    if popped == pc - 4 {
+                        break;
+                    }
+                }
+                self.call_stack_path.push(FunctionStart::Real { pc });
+                self.pop_stack.push(orig_pc);
+                *update_stack = true;
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_inline_functions(&mut self, pc: u32, update_stack: &mut bool) {
+        loop {
+            let Some(FunctionStart::Inline(InlineFunction {
+                low_pc, high_pc, ..
+            })) = self.call_stack_path.last()
+            else {
+                break;
+            };
+
+            if !(*low_pc..*high_pc).contains(&(pc as u64)) {
+                self.call_stack_path.pop();
+                *update_stack = true;
+                continue;
+            }
+            break;
+        }
+
+        if let Some(inline_functions) = self.profile.inline_function_table.starts.get(&(pc as u64))
+        {
+            for func in inline_functions {
+                let to_add = FunctionStart::Inline(*func);
+                if self.call_stack_path.last() != Some(&to_add) {
+                    self.call_stack_path.push(to_add);
+                }
+            }
+            *update_stack = true;
+        }
+    }
+
+    fn update_stack(&mut self, pc: u32) {
+        tracing::debug!(
+            "updating stack pc={pc:x}, stack={:?}",
+            &self.call_stack_path
+        );
+        let mut curr_node = Rc::clone(&self.root);
+        for (i, &call_stack_key) in self.call_stack_path.iter().enumerate() {
+            if i == self.call_stack_path.len() - 1 {
+                self.current_node = Some(Rc::clone(&curr_node));
+                self.current_key = Some(call_stack_key);
+            }
+            let next_node = {
+                let mut curr_node_borrowed = curr_node.borrow_mut();
+                curr_node_borrowed.counts.entry(call_stack_key).or_default();
+                curr_node_borrowed
+                    .calls
+                    .entry(call_stack_key)
+                    .or_insert_with(|| Rc::new(RefCell::new(CallNode::default())))
+                    .clone()
+            };
+            curr_node = next_node;
+        }
+    }
+}
+
+fn build_symbol_table(elf_data: &[u8]) -> Result<HashMap<u64, String>> {
+    let mut symbol_table = HashMap::new();
+
+    let elf = ElfBytes::<LittleEndian>::minimal_parse(elf_data)?;
+    if let Some((symtab, strtab)) = elf.symbol_table()? {
+        for sym in symtab {
+            if sym.st_symtype() == STT_FUNC {
+                let name = strtab.get(sym.st_name as usize)?;
+                symbol_table.insert(sym.st_value, demangle(name).to_string());
+            }
+        }
+    }
+
+    Ok(symbol_table)
 }
 
 impl TraceCallback for Profiler {
@@ -366,71 +571,18 @@ impl TraceCallback for Profiler {
                 let orig_pc = self.pc;
                 let orig_insn = self.insn;
 
-                if !self.call_stack_path.is_empty() {
-                    let current_node = self
-                        .current_node
-                        .as_ref()
-                        .expect("current_node should always be Some after initialization");
-                    let mut current_node_borrowed = current_node.borrow_mut();
-                    current_node_borrowed
-                        .counts
-                        .entry(self.current_key)
-                        .and_modify(|e| *e += cycles as usize)
-                        .or_insert(cycles as usize);
-                }
+                self.add_cycles_to_current_stack(cycles);
+
+                let mut update_stack = false;
 
                 if let Some(op) = extract_call_stack_op(orig_insn) {
-                    match op {
-                        CallStackOp::Push => {
-                            self.call_stack_path.push(pc);
-                            self.pop_stack.push(orig_pc);
-                        }
-                        CallStackOp::Pop => loop {
-                            self.call_stack_path.pop().ok_or_else(|| {
-                                anyhow!("attempted to follow a return with an empty call stack")
-                            })?;
-                            let popped = self.pop_stack.pop().ok_or_else(|| {
-                                anyhow!("attempted to follow a return with an empty call stack")
-                            })?;
-                            if pc - 4 == popped {
-                                break;
-                            }
-                        },
-                        CallStackOp::PopPush => {
-                            loop {
-                                self.call_stack_path.pop().ok_or_else(|| {
-                                    anyhow!("attempted to follow a return with an empty call stack")
-                                })?;
-                                let popped = self.pop_stack.pop().ok_or_else(|| {
-                                    anyhow!("attempted to follow a return with an empty call stack")
-                                })?;
-                                if pc - 4 == popped {
-                                    break;
-                                }
-                            }
-                            self.call_stack_path.push(pc);
-                            self.pop_stack.push(orig_pc);
-                        }
-                    }
+                    self.handle_function_call(op, pc, orig_pc, &mut update_stack)?;
+                }
 
-                    let mut curr_node = Rc::clone(&self.root);
-                    for (i, &call_stack_key) in self.call_stack_path.iter().enumerate() {
-                        if i == self.call_stack_path.len() - 1 {
-                            self.current_node = Some(Rc::clone(&curr_node));
-                            self.current_key = *self.call_stack_path.last().ok_or_else(|| {
-                                anyhow!("attempted to access an empty call stack")
-                            })?;
-                        }
-                        let next_node = {
-                            let mut curr_node_borrowed = curr_node.borrow_mut();
-                            curr_node_borrowed
-                                .calls
-                                .entry(call_stack_key)
-                                .or_insert_with(|| Rc::new(RefCell::new(CallNode::default())))
-                                .clone()
-                        };
-                        curr_node = next_node;
-                    }
+                self.handle_inline_functions(pc, &mut update_stack);
+
+                if update_stack {
+                    self.update_stack(pc);
                 }
 
                 // Update pc, insn, and cycle
@@ -456,7 +608,8 @@ pub(crate) struct ProfileBuilder {
     strings: HashMap<String, i64>,
     functions: HashMap<(String, String), u64>,
     locations: HashMap<LocationKey, u64>,
-    function_lookup: HashMap<u64, String>,
+    symbol_table: HashMap<u64, String>,
+    inline_function_table: InlineFunctionTable,
     profile: proto::Profile,
 }
 
@@ -467,7 +620,8 @@ impl ProfileBuilder {
             functions: HashMap::new(),
             locations: HashMap::new(),
             profile: Default::default(),
-            function_lookup: Default::default(),
+            symbol_table: Default::default(),
+            inline_function_table: Default::default(),
         };
 
         // First string must always be the empty string

--- a/risc0/zkvm/src/host/server/exec/profiler/inline.rs
+++ b/risc0/zkvm/src/host/server/exec/profiler/inline.rs
@@ -1,0 +1,378 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use addr2line::{
+    demangle_auto,
+    gimli::{self, Reader as _},
+};
+use anyhow::{anyhow, bail, Result};
+
+use super::Frame;
+
+#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
+pub struct InlineFunction {
+    pub abstract_origin: u64,
+    pub low_pc: u64,
+    pub high_pc: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct InlineFunctionTable {
+    /// abstract_origin to inline function frame
+    pub frames: HashMap<u64, Frame>,
+    /// low_pc to inline function
+    pub starts: HashMap<u64, Vec<InlineFunction>>,
+}
+
+fn dwarf_attr_or_error<ReaderT: gimli::Reader>(
+    entry: &gimli::DebuggingInformationEntry<'_, '_, ReaderT>,
+    dw_at: gimli::DwAt,
+) -> Result<gimli::AttributeValue<ReaderT>> {
+    Ok(entry
+        .attr(dw_at)?
+        .ok_or_else(|| anyhow!("{dw_at} missing"))?
+        .value())
+}
+
+fn get_abstract_origin_name(
+    dwarf: &gimli::Dwarf<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+    unit: &gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+    abstract_origin: &gimli::UnitOffset<usize>,
+) -> Result<String> {
+    let mut entries = unit.entries_raw(Some(*abstract_origin))?;
+    let abbrev = if let Some(abbrev) = entries.read_abbreviation()? {
+        abbrev
+    } else {
+        bail!("invalid abstract_origin");
+    };
+
+    for spec in abbrev.attributes() {
+        let attr = entries.read_attribute(*spec)?;
+        match attr.name() {
+            gimli::DW_AT_linkage_name | gimli::DW_AT_MIPS_linkage_name => {
+                return Ok(dwarf
+                    .attr_string(unit, attr.value())?
+                    .to_string_lossy()?
+                    .into());
+            }
+            gimli::DW_AT_name => {
+                return Ok(dwarf
+                    .attr_string(unit, attr.value())?
+                    .to_string_lossy()?
+                    .into());
+            }
+            _ => {}
+        }
+    }
+
+    bail!("invalid abstract origin")
+}
+
+fn find_unit<'a>(
+    units: &'a [gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>],
+    offset: &gimli::DebugInfoOffset<usize>,
+) -> Result<&'a gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>> {
+    match units.binary_search_by_key(&offset.0, |unit| {
+        unit.header.offset().as_debug_info_offset().unwrap().0
+    }) {
+        Ok(_) | Err(0) => bail!("no unit for given offset"),
+        Err(i) => Ok(&units[i - 1]),
+    }
+}
+
+struct InlineFunctionTableBuilder<'dwarf> {
+    language: Option<gimli::DwLang>,
+    dwarf: &'dwarf gimli::Dwarf<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+    units: &'dwarf [gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>],
+    table: InlineFunctionTable,
+}
+
+impl<'dwarf> InlineFunctionTableBuilder<'dwarf> {
+    fn new(
+        dwarf: &'dwarf gimli::Dwarf<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        units: &'dwarf [gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>],
+    ) -> Result<Self> {
+        Ok(Self {
+            language: None,
+            dwarf,
+            units,
+            table: InlineFunctionTable::default(),
+        })
+    }
+
+    fn build(mut self) -> Result<InlineFunctionTable> {
+        for unit in self.units {
+            self.build_from_unit(unit)?;
+        }
+        Ok(self.table)
+    }
+
+    fn build_from_unit(
+        &mut self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+    ) -> Result<()> {
+        let mut entries = unit.entries();
+        while let Some((_, entry)) = entries.next_dfs()? {
+            if entry.tag() == gimli::DW_TAG_compile_unit {
+                if let Ok(gimli::AttributeValue::Language(unit_language)) =
+                    dwarf_attr_or_error(entry, gimli::DW_AT_language)
+                {
+                    self.language = Some(unit_language);
+                }
+            }
+            if entry.tag() == gimli::DW_TAG_inlined_subroutine {
+                if let Err(error) = self.build_from_inline_subroutine(unit, entry) {
+                    tracing::warn!("Error decoding DWARF for DW_TAG_inlined_subroutine: {error}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_pc_ranges_from_entry(
+        &self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+    ) -> Result<Vec<(u64, u64)>> {
+        let Ok(value) = dwarf_attr_or_error(entry, gimli::DW_AT_ranges) else {
+            return Ok(vec![]);
+        };
+
+        let Some(ranges_offset) = self.dwarf.attr_ranges_offset(unit, value)? else {
+            return Ok(vec![]);
+        };
+
+        let mut ranges = vec![];
+        let mut range_iter = self.dwarf.ranges(unit, ranges_offset)?;
+        while let Some(gimli::Range { begin, end }) = range_iter.next()? {
+            if begin < end && begin != 0 {
+                ranges.push((begin, end));
+            }
+        }
+        Ok(ranges)
+    }
+
+    fn read_low_pc_from_entry(
+        &self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+    ) -> Result<Option<u64>> {
+        let Ok(value) = dwarf_attr_or_error(entry, gimli::DW_AT_low_pc) else {
+            return Ok(None);
+        };
+        let low_pc = match value {
+            gimli::AttributeValue::Addr(val) => val,
+            gimli::AttributeValue::DebugAddrIndex(index) => self.dwarf.address(unit, index)?,
+            _ => bail!("DW_AT_low_pc not as expected"),
+        };
+        Ok((low_pc != 0).then_some(low_pc))
+    }
+
+    fn read_high_pc_from_entry(
+        &self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+        low_pc: u64,
+    ) -> Result<u64> {
+        Ok(match dwarf_attr_or_error(entry, gimli::DW_AT_high_pc)? {
+            gimli::AttributeValue::Addr(val) => val,
+            gimli::AttributeValue::DebugAddrIndex(index) => self.dwarf.address(unit, index)?,
+            gimli::AttributeValue::Udata(val) => low_pc + val,
+            _ => bail!("DW_AT_high_pc not as expected"),
+        })
+    }
+
+    fn read_low_pc_and_high_pc_from_entry(
+        &self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+    ) -> Result<Option<(u64, u64)>> {
+        let Some(low_pc) = self.read_low_pc_from_entry(unit, entry)? else {
+            return Ok(None);
+        };
+        let high_pc = self.read_high_pc_from_entry(unit, entry, low_pc)?;
+
+        Ok(Some((low_pc, high_pc)))
+    }
+
+    fn read_abstract_origin_from_entry(
+        &self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+    ) -> Result<(String, gimli::DebugInfoOffset)> {
+        match dwarf_attr_or_error(entry, gimli::DW_AT_abstract_origin)? {
+            gimli::AttributeValue::UnitRef(unit_offset) => Ok((
+                get_abstract_origin_name(self.dwarf, unit, &unit_offset)?,
+                unit_offset
+                    .to_debug_info_offset(&unit.header)
+                    .ok_or_else(|| anyhow!("invalid attribute abstract_origin"))?,
+            )),
+            gimli::AttributeValue::DebugInfoRef(debug_info_offset) => {
+                let unit = find_unit(self.units, &debug_info_offset)?;
+                let unit_offset = debug_info_offset
+                    .to_unit_offset(&unit.header)
+                    .ok_or_else(|| anyhow!("invalid attribute abstract_origin"))?;
+                Ok((
+                    get_abstract_origin_name(self.dwarf, unit, &unit_offset)?,
+                    debug_info_offset,
+                ))
+            }
+            _ => bail!("DW_AT_abstract_origin not as expected"),
+        }
+    }
+
+    fn read_file_name_from_entry(
+        &self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+    ) -> Result<Option<String>> {
+        let Ok(value) = dwarf_attr_or_error(entry, gimli::DW_AT_call_file) else {
+            return Ok(None);
+        };
+        let gimli::AttributeValue::FileIndex(idx) = value else {
+            return Ok(None);
+        };
+
+        let line_program = unit
+            .line_program
+            .as_ref()
+            .ok_or_else(|| anyhow!("line_program missing"))?;
+
+        let header = line_program.header();
+        let file = header
+            .file(idx)
+            .ok_or_else(|| anyhow!("file index {idx} missing"))?;
+
+        let mut file_path = PathBuf::new();
+        if let Some(comp_dir) = unit.comp_dir.as_ref() {
+            file_path.push(comp_dir.to_string_lossy()?.as_ref());
+        }
+
+        if file.directory_index() != 0 {
+            let directory = file
+                .directory(header)
+                .ok_or_else(|| anyhow!("file directory missing"))?;
+            let value = self.dwarf.attr_string(unit, directory)?;
+            file_path.push(value.to_string_lossy()?.as_ref());
+        }
+
+        let s = self.dwarf.attr_string(unit, file.path_name())?;
+        file_path.push(s.to_string_lossy()?.as_ref());
+        Ok(Some(file_path.to_string_lossy().into()))
+    }
+
+    fn read_line_number_from_entry(
+        &self,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+    ) -> Option<i64> {
+        if let Ok(gimli::AttributeValue::Udata(val)) =
+            dwarf_attr_or_error(entry, gimli::DW_AT_call_line)
+        {
+            Some(val as i64)
+        } else {
+            None
+        }
+    }
+
+    fn build_from_inline_subroutine(
+        &mut self,
+        unit: &'dwarf gimli::Unit<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+        entry: &gimli::DebuggingInformationEntry<
+            '_,
+            '_,
+            gimli::EndianRcSlice<gimli::RunTimeEndian>,
+        >,
+    ) -> Result<()> {
+        let mut ranges = vec![];
+
+        if let Some(range) = self.read_low_pc_and_high_pc_from_entry(unit, entry)? {
+            ranges.push(range);
+        } else {
+            ranges.extend(self.read_pc_ranges_from_entry(unit, entry)?);
+        }
+
+        let (name, abstract_origin) = self.read_abstract_origin_from_entry(unit, entry)?;
+
+        for (low_pc, high_pc) in ranges {
+            let starts = self.table.starts.entry(low_pc).or_default();
+            starts.push(InlineFunction {
+                abstract_origin: abstract_origin.0 as u64,
+                low_pc,
+                high_pc,
+            });
+        }
+
+        #[allow(clippy::map_entry)]
+        if !self.table.frames.contains_key(&(abstract_origin.0 as u64)) {
+            let filename = self.read_file_name_from_entry(unit, entry)?;
+            let lineno = self.read_line_number_from_entry(entry);
+
+            let frame = Frame {
+                name: demangle_auto(std::borrow::Cow::Borrowed(&name), self.language).into(),
+                lineno: lineno.unwrap_or_default(),
+                filename: filename.unwrap_or_default(),
+            };
+            self.table.frames.insert(abstract_origin.0 as u64, frame);
+        }
+
+        Ok(())
+    }
+}
+
+impl InlineFunctionTable {
+    pub fn build_from_dwarf(
+        dwarf: &gimli::Dwarf<gimli::EndianRcSlice<gimli::RunTimeEndian>>,
+    ) -> Result<Self> {
+        let mut units = vec![];
+        let mut iter = dwarf.units();
+        while let Some(header) = iter.next()? {
+            units.push(dwarf.unit(header)?);
+        }
+
+        let builder = InlineFunctionTableBuilder::new(dwarf, &units)?;
+        builder.build()
+    }
+}

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ use sha2::{Digest as _, Sha256};
 use crate::{
     host::server::exec::{
         executor2::Executor2,
-        profiler::{Frame, Profiler},
+        profiler::Profiler,
         syscall::{Syscall, SyscallContext},
     },
     serde::to_vec,
@@ -976,75 +976,126 @@ fn profiler() {
 
     let profile = profiler.finalize();
 
-    // Gather up anything containing our profile_test functions.
-    // If the test doesn't pass, we don't want to display the
-    // whole profiling structure.
-    let occurrences: Vec<_> = profile
+    let test_samples: Vec<_> = profile
         .iter()
-        .filter(|(frames, _addr, _count)| frames.iter().any(|fr| fr.name.contains("profile_test")))
+        .filter(|sample| {
+            sample
+                .frames
+                .iter()
+                .any(|fr| fr.frame.name.contains("profile_test"))
+                && sample.frames[0].frame.name != "[PageIn]"
+                && sample.frames[0].frame.name != "[PageOut]"
+        })
         .collect();
 
-    assert!(
-        !occurrences.is_empty(),
-        "{:#?}",
-        Vec::from_iter(profile.iter())
+    let mut named_stacks_and_counts = BTreeMap::new();
+
+    for sample in &test_samples {
+        let frames = Vec::from_iter(sample.frames.iter().map(|fr| fr.frame.name.clone()));
+        *named_stacks_and_counts.entry(frames).or_default() += sample.count;
+    }
+
+    // Check the stacks
+    assert_eq!(
+        Vec::from_iter(named_stacks_and_counts.into_iter()),
+        vec![
+            (
+                vec![
+                    "profile_test_func1".into(),
+                    "multi_test::main".into(),
+                    "main".into(),
+                    "__start".into()
+                ],
+                2 // auicpc + jr
+            ),
+            (
+                vec![
+                    "profile_test_func2".into(),
+                    "profile_test_func1".into(),
+                    "multi_test::main".into(),
+                    "main".into(),
+                    "__start".into(),
+                ],
+                1 // nop
+            ),
+            (
+                vec![
+                    "profile_test_func3".into(),
+                    "profile_test_func1".into(),
+                    "multi_test::main".into(),
+                    "main".into(),
+                    "__start".into(),
+                ],
+                1 // nop
+            ),
+            (
+                vec![
+                    "profile_test_func3".into(),
+                    "profile_test_func5".into(),
+                    "profile_test_func1".into(),
+                    "multi_test::main".into(),
+                    "main".into(),
+                    "__start".into(),
+                ],
+                10 // nop * 10
+            ),
+            (
+                vec![
+                    "profile_test_func4".into(),
+                    "profile_test_func1".into(),
+                    "multi_test::main".into(),
+                    "main".into(),
+                    "__start".into(),
+                ],
+                4 // la, jr, nop
+            ),
+            (
+                vec![
+                    "profile_test_func5".into(),
+                    "profile_test_func1".into(),
+                    "multi_test::main".into(),
+                    "main".into(),
+                    "__start".into(),
+                ],
+                1 // ret
+            ),
+        ]
     );
+
+    // Check the file names and line numbers
+    for sample in &test_samples {
+        for frame in &sample.frames {
+            let frame = &frame.frame;
+            if frame.name.contains("profile_test_func") {
+                assert!(
+                    frame
+                        .filename
+                        .ends_with("/zkvm/methods/guest/src/bin/multi_test/profiler.rs"),
+                    "{}",
+                    frame.filename
+                );
+                assert!(frame.lineno != 0);
+            }
+        }
+    }
 
     let elf_mem = Program::load_elf(MULTI_TEST_ELF, u32::MAX).unwrap().image;
 
-    // stitch frames together
-    let (fr, addr) = occurrences.into_iter().fold(
-        (Vec::new(), 0),
-        |(mut acc_frames, _), (frames, addr, _count)| {
-            acc_frames.extend(frames);
-            (acc_frames, addr)
-        },
-    );
+    // Check that the addresses for these two functions point to the right place
+    for func_name in ["profile_test_func2", "profile_test_func3"] {
+        let test_func = test_samples
+            .iter()
+            .find(|sample| sample.frames[0].frame.name == func_name)
+            .unwrap();
 
-    let check = |fr: &Vec<Frame>, addr: usize| -> bool {
-        match fr.as_slice() {
-            [fr1 @ Frame {
-                name: name1,
-                filename: fn1,
-                ..
-            }, fr2 @ Frame {
-                name: name2,
-                filename: fn2,
-                ..
-            }] => {
-                println!("Inspecting frames:\n{fr1:?}\n{fr2:?}\n");
-                if name1 != "profile_test_func2" || name2 != "profile_test_func1" {
-                    println!("Names did not match: {}, {}", name1, name2);
-                    return false;
-                }
-                if !fn1.ends_with("multi_test.rs") || !fn2.ends_with("multi_test.rs") {
-                    println!("Filenames did not match: {}, {}", fn1, fn2);
-                    return false;
-                }
-                // Check to make sure we hit the "nop" instruction
-                match elf_mem.get(&(addr as u32)) {
-                    None => {
-                        println!("Addr {addr} not present in elf");
-                        return false;
-                    }
-                    Some(0x00_00_00_13) => (),
-                    Some(inst) => {
-                        println!("Looking for 'nop'; got 0x{inst:08x}");
-                        return false;
-                    }
-                }
+        let addr = test_func.frames[0].address;
+        let inst = *elf_mem
+            .get(&(addr as u32))
+            .unwrap_or_else(|| panic!("0x{addr:x} found in elf"));
 
-                // All checks passed; this is the occurrence we were looking for.
-                true
-            }
-            _ => {
-                println!("{:#?}", fr);
-                false
-            }
-        }
-    };
-
-    assert!(check(&fr, addr), "{fr:#?} {addr}");
+        // check its nop
+        assert_eq!(inst, 0x00_00_00_13, "found 0x{inst:08x} instead of nop");
+    }
 }
 
 #[apply(base)]


### PR DESCRIPTION
This adds two main improvements to guest profiling
- Support for inline functions
- Show page events as function calls

### inline functions
To maintain the way the cycle-accurate profiler works we build a table of all the inline function from the DWARF data and then when we enter an inline function we push a frame to the profiler's call stack for that inline function. Once we leave the range of the inline function we pop it off.

### page events
When we incur something that causes a page to be loaded we now magic up a functions called `[PageIn]` and `[PageOut]`. 
Since this can happen somewhat randomly within a segment, functions that normally would be seen as low-cost can incur a high cycle count due to them triggering page events (you can see this in the profile below with `FdReader::new`, that function is only a single instruction which writes a single word to memory)
The emitting of these events was added to the v1 circuit code. The v2 circuit code needs to be updated to work with the profiler first, and that isn't tackled in this PR.

### comparison
These screenshots are from before and after the changes running `tests::keccak_update2::case_1`

before:
<img width="1591" alt="before" src="https://github.com/user-attachments/assets/9b3a4f2c-8dfe-46eb-bc3e-932088e554ab" />
after:
<img width="1584" alt="after" src="https://github.com/user-attachments/assets/f44b408e-ff30-42b0-9945-a5de0fc297f7" />