### PR TITLE
ZKVM-1042: V2 executor perf

### DIFF
--- a/examples/c-guest/platform/src/lib.rs
+++ b/examples/c-guest/platform/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/binfmt/src/image2.rs
+++ b/risc0/binfmt/src/image2.rs
@@ -309,6 +309,15 @@ impl Page {
         // tracing::trace!("store({addr:?}, {byte_addr:#05x}, {word:#010x})");
         self.0[byte_addr..byte_addr + WORD_SIZE].clone_from_slice(&word.to_le_bytes());
     }
+
+    /// Store a slice of u32 words starting at the given address
+    pub fn store_range(&mut self, addr: WordAddr, words: &[u32]) {
+        let mut byte_addr = addr.page_subaddr().baddr().0 as usize;
+        for word in words {
+            self.0[byte_addr..byte_addr + WORD_SIZE].clone_from_slice(&word.to_le_bytes());
+            byte_addr += WORD_SIZE;
+        }
+    }
 }
 
 pub(crate) struct DigestPair {

--- a/risc0/binfmt/src/image2.rs
+++ b/risc0/binfmt/src/image2.rs
@@ -309,15 +309,6 @@ impl Page {
         // tracing::trace!("store({addr:?}, {byte_addr:#05x}, {word:#010x})");
         self.0[byte_addr..byte_addr + WORD_SIZE].clone_from_slice(&word.to_le_bytes());
     }
-
-    /// Store a slice of u32 words starting at the given address
-    pub fn store_range(&mut self, addr: WordAddr, words: &[u32]) {
-        let mut byte_addr = addr.page_subaddr().baddr().0 as usize;
-        for word in words {
-            self.0[byte_addr..byte_addr + WORD_SIZE].clone_from_slice(&word.to_le_bytes());
-            byte_addr += WORD_SIZE;
-        }
-    }
 }
 
 pub(crate) struct DigestPair {

--- a/risc0/circuit/rv32im-v2/src/execute/rv32im.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/rv32im.rs
@@ -398,7 +398,10 @@ impl Emulator {
         let decoded = DecodedInstruction::new(word);
         let insn = self.table.lookup(&decoded);
         ctx.on_insn_decoded(&insn, &decoded)?;
-        self.ring.push((pc, insn, decoded.clone()));
+        // Only store the ring buffer if we are gonna print it
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            self.ring.push((pc, insn, decoded.clone()));
+        }
 
         if match insn.category {
             InsnCategory::Compute => self.step_compute(ctx, insn.kind, &decoded)?,


### PR DESCRIPTION
* Intercept the load/store operations going to the register regions of memory and instead use a hot set of register files, then save / resume these register files to guest memory when needed
* Removed the dyn dispatch from the Risc0Machine context
* Removed the excessive allocs when attempting to trace MemorySet operations
* Removed the ring buffer of instructions if not in debug mode
* A few other small fixes along the way

V2 exec speed on a non-precompile k256 workload of ~450m cycles:

18mhz -> 39mhz

v1 on the same workload: ~31mhz