### PR TITLE
backport 1.2: use `tlfs` to improve memory locality (#2810)

### DIFF
--- a/risc0/zkvm/platform/src/heap/embedded.rs
+++ b/risc0/zkvm/platform/src/heap/embedded.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use critical_section::RawRestoreState;
-use embedded_alloc::LlffHeap as Heap;
+use embedded_alloc::TlsfHeap as Heap;
 
 #[global_allocator]
 pub static HEAP: Heap = Heap::empty();

--- a/risc0/zkvm/platform/src/heap/mod.rs
+++ b/risc0/zkvm/platform/src/heap/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ pub mod embedded;
 pub fn used() -> usize {
     cfg_if::cfg_if! {
         if #[cfg(feature = "heap-embedded-alloc")] {
-            embedded::HEAP.used()
+            0
         } else {
             bump::used()
         }
@@ -33,7 +33,7 @@ pub fn used() -> usize {
 pub fn free() -> usize {
     cfg_if::cfg_if! {
         if #[cfg(feature = "heap-embedded-alloc")] {
-            embedded::HEAP.free()
+            0
         } else {
             bump::free()
         }


### PR DESCRIPTION
The `tlfs` allocator dramatically improves guest performance over the `llff` allocator by a substantial amount when the heap allocator is enabled. This is due to the `tlfs` allocator having a better memory locality than the `llff` allocator.