### PR TITLE
ZKVM-1055: BUGFIX: Timeout not properly handled in bonsai-sdk non_blocking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -276,6 +276,7 @@ jobs:
       - run: cargo check -p risc0-sys -F $FEATURE
       - run: cargo check -p risc0-zkp -F $FEATURE
       - run: cargo check -p risc0-zkvm -F $FEATURE
+      - run: cargo check -p bonsai-sdk --all-features
       - run: sccache --show-stats
 
   examples:

--- a/bonsai/sdk/src/lib.rs
+++ b/bonsai/sdk/src/lib.rs
@@ -499,12 +499,22 @@ pub mod module_type {
             )),
             Err(_) => Some(Duration::from_millis(DEFAULT_TIMEOUT)),
         };
-
-        Ok(HttpClient::builder()
-            .default_headers(headers)
-            .pool_max_idle_per_host(0)
-            .timeout(timeout)
-            .build()?)
+        #[cfg(feature = "non_blocking")]
+        {
+            Ok(HttpClient::builder()
+                .default_headers(headers)
+                .pool_max_idle_per_host(0)
+                .timeout(timeout.unwrap_or(Duration::from_millis(DEFAULT_TIMEOUT)))
+                .build()?)
+        }
+        #[cfg(not(feature = "non_blocking"))]
+        {
+            Ok(HttpClient::builder()
+                .default_headers(headers)
+                .pool_max_idle_per_host(0)
+                .timeout(timeout)
+                .build()?)
+        }
     }
 
     impl Client {


### PR DESCRIPTION
Reqwest Client expects an `Option<Duration>` in blocking mode and a `Duration` in non_blocking mode. Due to this the build was failing with the `non_blocking` feature flag to Bonsai SDK.

- Adds an extra feature check and use correct input in each case
- Adds an extra CI check so things like this won't get through again