### PR TITLE
ZKVM-1059: Update CI to pass `--locked` for these two `cargo run` commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,10 +264,10 @@ jobs:
         run: cargo test -p risc0-r0vm -F $FEATURE -F disable-dev-mode
       - run: cargo test -p cargo-risczero -F experimental
       - name: run fibonacci benchmark
-        run: cargo run -F $FEATURE -- fibonacci
+        run: cargo run --locked -F $FEATURE -- fibonacci
         working-directory: benchmarks
       - name: run datasheet generator
-        run: cargo run -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift
+        run: cargo run --locked -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift
       - name: check benches
         run: cargo check -F $FEATURE --benches --workspace --exclude doc-test
       - run: cargo check -p risc0-build

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1857,6 +1857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3118,7 @@ dependencies = [
 name = "risc0-zkos-v1compat"
 version = "0.1.0"
 dependencies = [
+ "include_bytes_aligned",
  "no_std_strings",
 ]
 


### PR DESCRIPTION
These commands are what ensure some directories, like benchmarks/ get built. By passing `--locked` we add insurance that the lock file is up-to-date.

This commit also fixes the out-of-date benchmarks/Cargo.lock that happened as a consequence of this.