### PR TITLE
ZKVM-1061: Fix perf regression introduced by the addition of page events

### DIFF
--- a/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
@@ -380,10 +380,9 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
         }
         self.output_digest = self.pending.output_digest.take();
         self.exit_code = self.pending.exit_code.take();
-        let page_actions = self.pager.commit_step();
 
         for trace in &self.trace {
-            for action in &page_actions {
+            for action in self.pager.pending_actions() {
                 let event = match action {
                     pager::Action::PageRead(_, cycles) => TraceEvent::PageIn {
                         cycles: *cycles as u64,
@@ -396,6 +395,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
                 trace.borrow_mut().trace_callback(event)?;
             }
         }
+        self.pager.commit_step();
 
         Ok(())
     }

--- a/risc0/circuit/rv32im/src/prove/emu/pager.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/pager.rs
@@ -214,8 +214,12 @@ impl PagedMemory {
         }
     }
 
-    pub fn commit_step(&mut self) -> Vec<Action> {
-        take(&mut self.pending_actions)
+    pub fn pending_actions(&self) -> &[Action] {
+        &self.pending_actions
+    }
+
+    pub fn commit_step(&mut self) {
+        self.pending_actions.clear();
     }
 
     pub fn clear(&mut self) {


### PR DESCRIPTION
Doing a `.clear()` on a vector retains the allocated memory, doing a `mem::take` will consume it and cause an extra free and malloc when we use the collection again.

Instead of doing `mem::take` we just inspect the allocated memory before calling `.clear()`

This returns the execute benchmark on my Linux container to the speed as it was before the original change (14Mhz -> 17Mhz) and hopefully accounts for all the loss in the recent official benchmark runs.