### PR TITLE
ZKVM-1064: Change rzup version number to 0.3 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,7 +5021,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "clap 4.5.23",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ risc0-zkp = { version = "1.3.0-alpha.1", default-features = false, path = "risc0
 risc0-zkos-v1compat = { version = "0.1.0", path = "risc0/zkos/v1compat" }
 risc0-zkvm = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkvm" }
 risc0-zkvm-platform = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkvm/platform" }
-rzup = { version = "0.3.0-alpha.1", default-features = false, path = "rzup" }
+rzup = { version = "0.3.0", default-features = false, path = "rzup" }
 sppark = "0.1.10"
 
 [profile.bench]

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3321,7 +3321,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4210,7 +4210,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1155,7 +1155,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "ac512d6cf2dbf6e4711184c111c350547a2f0ff621e38422e8897a641defd90d",
+            "fe7ba286b32d797c20d85f6333e55eeaef9a46bda62ea1027fc47267acb12e36",
         );
     }
 }

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1486,7 +1486,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "rzup"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1394,7 +1394,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rzup"
 description = "The RISC Zero version management library and CLI"
-version = "0.3.0-alpha.1"
+version = "0.3.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
We didn't update the version number properly when releasing, this updates the number to what we want the released version to be. We will re-deploy after this commit goes in, then do another PR to bump the version number to the next alpha version.