### PR TITLE
ZKVM-1071: Bring v2 profiler in-line with v1 capabilities

### DIFF
--- a/risc0/circuit/rv32im-v2/src/execute/executor.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/executor.rs
@@ -25,7 +25,7 @@ use crate::{Rv32imV2Claim, TerminateState};
 
 use super::{
     bigint::BigIntState,
-    pager::PagedMemory,
+    pager::{PageTraceEvent, PagedMemory},
     platform::*,
     poseidon2::Poseidon2State,
     r0vm::{LoadOp, Risc0Context, Risc0Machine},
@@ -90,7 +90,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
             machine_mode: 0,
             user_cycles: 0,
             phys_cycles: 0,
-            pager: PagedMemory::new(image),
+            pager: PagedMemory::new(image, !trace.is_empty() /* tracing_enabled */),
             terminate_state: None,
             read_record: Vec::new(),
             write_record: Vec::new(),
@@ -259,6 +259,19 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
         }
         Ok(())
     }
+
+    fn trace_pager(&mut self) -> Result<()> {
+        if !self.trace.is_empty() {
+            for &event in self.pager.trace_events() {
+                let event = TraceEvent::from(event);
+                for trace in self.trace.iter() {
+                    trace.borrow_mut().trace_callback(event.clone())?;
+                }
+            }
+            self.pager.clear_trace_events();
+        }
+        Ok(())
+    }
 }
 
 impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
@@ -309,6 +322,7 @@ impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
     fn on_insn_end(&mut self, _insn: &Instruction, _decoded: &DecodedInstruction) -> Result<()> {
         self.user_cycles += 1;
         self.phys_cycles += 1;
+        self.trace_pager()?;
         Ok(())
     }
 
@@ -321,6 +335,7 @@ impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
         _s2: u32,
     ) -> Result<()> {
         self.phys_cycles += 1;
+        self.trace_pager()?;
         Ok(())
     }
 
@@ -421,5 +436,18 @@ impl<S: Syscall> SyscallContext for Executor<'_, '_, S> {
 
     fn get_pc(&self) -> u32 {
         self.user_pc.0
+    }
+}
+
+impl From<PageTraceEvent> for TraceEvent {
+    fn from(event: PageTraceEvent) -> Self {
+        match event {
+            PageTraceEvent::PageIn { cycles } => TraceEvent::PageIn {
+                cycles: cycles as u64,
+            },
+            PageTraceEvent::PageOut { cycles } => TraceEvent::PageOut {
+                cycles: cycles as u64,
+            },
+        }
     }
 }

--- a/risc0/circuit/rv32im-v2/src/execute/mod.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/mod.rs
@@ -27,7 +27,7 @@ mod syscall;
 #[cfg(test)]
 mod tests;
 pub mod testutil;
-mod trace;
+pub mod trace;
 
 pub use self::{
     executor::{Executor, ExecutorResult, SimpleSession},

--- a/risc0/circuit/rv32im-v2/src/execute/trace.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/trace.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,12 @@ pub enum TraceEvent {
         #[debug("{region:#04x?}")]
         region: Vec<u8>,
     },
+
+    /// A page is read for the first time in a segment
+    PageIn { cycles: u64 },
+
+    /// A page has been written to for the first time in a segment
+    PageOut { cycles: u64 },
 }
 
 /// A callback used to collect [TraceEvent]s.

--- a/risc0/circuit/rv32im-v2/src/prove/witgen/preflight.rs
+++ b/risc0/circuit/rv32im-v2/src/prove/witgen/preflight.rs
@@ -126,7 +126,10 @@ impl<'a> Preflight<'a> {
                 ..Default::default()
             },
             segment,
-            pager: PagedMemory::new(segment.partial_image.clone()),
+            pager: PagedMemory::new(
+                segment.partial_image.clone(),
+                false, /* tracing_enabled */
+            ),
             pc: ByteAddr(0),
             machine_mode: 0,
             cur_write: 0,

--- a/risc0/zkvm/src/host/server/exec/executor2.rs
+++ b/risc0/zkvm/src/host/server/exec/executor2.rs
@@ -297,6 +297,10 @@ fn v1_trace_event_from_v2(event: trace_v2::TraceEvent) -> crate::TraceEvent {
         trace_v2::TraceEvent::MemorySet { addr, region } => {
             crate::TraceEvent::MemorySet { addr, region }
         }
+
+        trace_v2::TraceEvent::PageIn { cycles } => crate::TraceEvent::PageIn { cycles },
+
+        trace_v2::TraceEvent::PageOut { cycles } => crate::TraceEvent::PageOut { cycles },
     }
 }
 

--- a/risc0/zkvm/src/host/server/exec/executor2.rs
+++ b/risc0/zkvm/src/host/server/exec/executor2.rs
@@ -24,7 +24,7 @@ use risc0_binfmt::{ByteAddr as ByteAddr2, ExitCode, MemoryImage2, Program, Syste
 use risc0_circuit_rv32im::prove::emu::addr::ByteAddr;
 use risc0_circuit_rv32im_v2::{
     execute::{
-        platform::WORD_SIZE, Executor, Syscall as CircuitSyscall,
+        platform::WORD_SIZE, trace as trace_v2, Executor, Syscall as CircuitSyscall,
         SyscallContext as CircuitSyscallContext, DEFAULT_SEGMENT_LIMIT_PO2, USER_END_ADDR,
     },
     MAX_INSN_CYCLES,
@@ -164,7 +164,7 @@ impl<'a> Executor2<'a> {
             self.image.clone(),
             self,
             self.env.input_digest,
-            vec![], // TODO(flaub)
+            convert_trace_callbacks(self.env.trace.clone()),
         );
 
         let start_time = Instant::now();
@@ -282,6 +282,36 @@ impl<'a> Executor2<'a> {
 
         Ok(session)
     }
+}
+
+fn v1_trace_event_from_v2(event: trace_v2::TraceEvent) -> crate::TraceEvent {
+    match event {
+        trace_v2::TraceEvent::InstructionStart { cycle, pc, insn } => {
+            crate::TraceEvent::InstructionStart { cycle, pc, insn }
+        }
+
+        trace_v2::TraceEvent::RegisterSet { idx, value } => {
+            crate::TraceEvent::RegisterSet { idx, value }
+        }
+
+        trace_v2::TraceEvent::MemorySet { addr, region } => {
+            crate::TraceEvent::MemorySet { addr, region }
+        }
+    }
+}
+
+fn convert_trace_callbacks<'a>(
+    trace: Vec<Rc<RefCell<dyn crate::TraceCallback + 'a>>>,
+) -> Vec<Rc<RefCell<dyn trace_v2::TraceCallback + 'a>>> {
+    trace
+        .into_iter()
+        .map(|cb| {
+            Rc::new(RefCell::new(move |event| {
+                cb.borrow_mut()
+                    .trace_callback(v1_trace_event_from_v2(event))
+            })) as Rc<RefCell<dyn trace_v2::TraceCallback + 'a>>
+        })
+        .collect()
 }
 
 struct ContextAdapter<'a, 'b> {


### PR DESCRIPTION
This hooks up the v2 executor with the guest profiling, and implements the paging events.

This converts the v2 `TraceEvents` to the v1 `TraceEvents` that the profiler expects. The v1 and v2 `TraceEvents` are identical though, and when we go to delete v1 we can just swap out the profiler's `TraceEvent` with the v2 one and remove the conversion.

I ran the `execute` benchmark from the datasheet on v2 before and after these changes to confirm that there was no regression.

Here is a sample of the guest profile running on v2 with the paging events
<img width="1579" alt="Screenshot 2025-02-13 at 2 17 38 PM" src="https://github.com/user-attachments/assets/b8f83083-b640-4acc-ac11-409e80ae7daa" />