### PR TITLE
ZKVM-1101: Change rv32imv2 `eqz` to panic rather than throw an exception

### DIFF
--- a/risc0/circuit/rv32im-v2-sys/kernels/cxx/witgen.h
+++ b/risc0/circuit/rv32im-v2-sys/kernels/cxx/witgen.h
@@ -94,10 +94,10 @@ inline Val inRange(Val low, Val mid, Val high) {
 }
 
 inline void eqz(Val a, const char* loc) {
-  if (a.asUInt32()) {
-    std::stringstream ss;
-    ss << "eqz failure at: " << loc;
-    throw std::runtime_error(ss.str());
+  uint32_t v = a.asUInt32();
+  if (v) {
+    fprintf(stderr, "eqz failure at %s: %u != 0\n", loc, v);
+    abort();
   }
 }
 


### PR DESCRIPTION
This lets us actually see eqz failures instead of getting difficult-to-track-down memory corruption, since poolstl's parallel for doesn't wait for all threads to finish before propagating exceptions.