### PR TITLE
Backport 1.2: ZKVM-1: fix ProveKeccakRequest alignment issues (#2834)

### DIFF
--- a/risc0/zkvm/src/host/api/client.rs
+++ b/risc0/zkvm/src/host/api/client.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -249,6 +249,8 @@ impl Client {
         Claim: risc0_binfmt::Digestible + std::fmt::Debug + Clone + serde::Serialize,
         crate::MaybePruned<Claim>: TryFrom<pb::core::MaybePruned, Error = anyhow::Error>,
     {
+        use crate::host::api::convert::keccak_input_to_bytes;
+
         let mut conn = self.connect()?;
 
         let request = pb::api::ServerRequest {
@@ -257,7 +259,7 @@ impl Client {
                     claim_digest: Some(proof_request.claim_digest.into()),
                     po2: proof_request.po2 as u32,
                     control_root: Some(proof_request.control_root.into()),
-                    input: proof_request.input,
+                    input: keccak_input_to_bytes(&proof_request.input),
                     receipt_out: Some(receipt_out.try_into()?),
                 },
             )),

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ use std::{fmt::Debug, path::PathBuf};
 use anyhow::{anyhow, bail, Result};
 use prost::{Message, Name};
 use risc0_binfmt::SystemState;
+use risc0_circuit_keccak::KeccakState;
 use risc0_zkp::core::digest::Digest;
 use serde::Serialize;
 
@@ -1032,11 +1033,69 @@ impl TryFrom<pb::api::ProveKeccakRequest> for ProveKeccakRequest {
     type Error = anyhow::Error;
 
     fn try_from(value: pb::api::ProveKeccakRequest) -> Result<Self> {
+        let input = try_keccak_bytes_to_input(&value.input)?;
+
         Ok(Self {
             claim_digest: value.claim_digest.ok_or(malformed_err())?.try_into()?,
             po2: value.po2 as usize,
             control_root: value.control_root.ok_or(malformed_err())?.try_into()?,
-            input: value.input,
+            input,
         })
     }
+}
+
+pub(crate) fn keccak_input_to_bytes(input: &[KeccakState]) -> Vec<u8> {
+    bytemuck::cast_slice(input).to_vec()
+}
+
+pub(crate) fn try_keccak_bytes_to_input(input: &[u8]) -> Result<Vec<KeccakState>> {
+    let chunks = input.chunks_exact(std::mem::size_of::<KeccakState>());
+    if !chunks.remainder().is_empty() {
+        bail!("Input length must be a multiple of KeccakState size");
+    }
+    chunks
+        .map(bytemuck::try_pod_read_unaligned)
+        .collect::<Result<_, _>>()
+        .map_err(|e| anyhow!("Failed to convert input bytes to KeccakState: {}", e))
+}
+
+#[test]
+fn test_keccak_bytes_to_input_alignment() {
+    // Create a buffer with extra padding at the start to test different alignments
+    let padding = 16; // We should hit all alignments by cycling through offsets 0-15
+    let keccak_states = 3; // Test multiple KeccakStates
+    let state_size = std::mem::size_of::<KeccakState>();
+    let mut test_buffer = vec![0u8; padding + (keccak_states * state_size)];
+
+    // Fill with recognizable pattern
+    for (i, byte) in test_buffer.iter_mut().enumerate() {
+        *byte = (i % 256) as u8;
+    }
+
+    // Test each offset
+    for offset in 0..padding {
+        let aligned_slice = &test_buffer[offset..][..(keccak_states * state_size)];
+        let result = try_keccak_bytes_to_input(aligned_slice);
+
+        assert!(result.is_ok(), "Failed to parse at offset {offset}");
+        let states = result.unwrap();
+        assert_eq!(
+            states.len(),
+            keccak_states,
+            "Wrong number of states at offset {offset}",
+        );
+
+        // Verify roundtrip
+        let bytes = keccak_input_to_bytes(&states);
+        assert_eq!(bytes, aligned_slice, "Roundtrip failed at offset {offset}",);
+    }
+}
+
+#[test]
+fn test_keccak_bytes_to_input_invalid_size() {
+    // Test with a buffer that's not a multiple of KeccakState size
+    let invalid_size = std::mem::size_of::<KeccakState>() + 1;
+    let buffer = vec![0u8; invalid_size];
+    let result = try_keccak_bytes_to_input(&buffer);
+    assert!(result.is_err(), "Should fail with invalid size");
 }

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ use super::{malformed_err, path_to_string, pb, ConnectionWrapper, Connector, Tcp
 use crate::{
     get_prover_server, get_version,
     host::{
+        api::convert::keccak_input_to_bytes,
         client::{
             env::{CoprocessorCallback, ProveKeccakRequest, ProveZkrRequest},
             slice_io::SliceIo,
@@ -226,6 +227,7 @@ impl CoprocessorCallback for CoprocessorProxy {
     }
 
     fn prove_keccak(&mut self, proof_request: ProveKeccakRequest) -> Result<()> {
+        let input = keccak_input_to_bytes(&proof_request.input);
         let request = pb::api::ServerReply {
             kind: Some(pb::api::server_reply::Kind::Ok(pb::api::ClientCallback {
                 kind: Some(pb::api::client_callback::Kind::Io(pb::api::OnIoRequest {
@@ -236,7 +238,7 @@ impl CoprocessorCallback for CoprocessorProxy {
                                     claim_digest: Some(proof_request.claim_digest.into()),
                                     po2: proof_request.po2 as u32,
                                     control_root: Some(proof_request.control_root.into()),
-                                    input: proof_request.input,
+                                    input,
                                     receipt_out: None,
                                 }
                             })),

--- a/risc0/zkvm/src/host/client/env.rs
+++ b/risc0/zkvm/src/host/client/env.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ use std::{
 use anyhow::{bail, Result};
 use bytemuck::Pod;
 use bytes::Bytes;
-use risc0_circuit_keccak::KECCAK_PO2_RANGE;
+use risc0_circuit_keccak::{KeccakState, KECCAK_PO2_RANGE};
 use risc0_zkp::core::digest::Digest;
 use risc0_zkvm_platform::{self, fileno};
 use serde::Serialize;
@@ -90,7 +90,7 @@ pub struct ProveKeccakRequest {
     pub control_root: Digest,
 
     /// Input transcript to provide to the keccak circuit.
-    pub input: Vec<u8>,
+    pub input: Vec<KeccakState>,
 }
 
 /// A trait that supports the ability to be notified of proof requests

--- a/risc0/zkvm/src/host/server/exec/syscall/prove_keccak.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall/prove_keccak.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ use anyhow::Result;
 use risc0_circuit_rv32im::prove::emu::addr::ByteAddr;
 use risc0_zkvm_platform::{syscall::reg_abi::*, WORD_SIZE};
 
-use crate::{host::client::env::ProveKeccakRequest, Assumption, AssumptionReceipt};
+use crate::{
+    host::{api::convert::try_keccak_bytes_to_input, client::env::ProveKeccakRequest},
+    Assumption, AssumptionReceipt,
+};
 
 use super::{Syscall, SyscallContext, SyscallKind};
 
@@ -38,6 +41,7 @@ impl Syscall for SysProveKeccak {
         let input_ptr = ByteAddr(ctx.load_register(REG_A6));
         let input_len = ctx.load_register(REG_A7);
         let input: Vec<u8> = ctx.load_region(input_ptr, input_len * WORD_SIZE as u32)?;
+        let input = try_keccak_bytes_to_input(&input)?;
 
         let proof_request = ProveKeccakRequest {
             claim_digest: claim,

--- a/risc0/zkvm/src/host/server/prove/dev_mode.rs
+++ b/risc0/zkvm/src/host/server/prove/dev_mode.rs
@@ -73,7 +73,7 @@ impl ProverServer for DevModeProver {
         let mut keccak_assumptions = HashMap::new();
 
         for proof_request in session.pending_keccaks.iter() {
-            let claim = compute_keccak_digest(&proof_request.input);
+            let claim = compute_keccak_digest(bytemuck::cast_slice(proof_request.input.as_slice()));
             let assumption = Assumption {
                 claim,
                 control_root: KECCAK_CONTROL_ROOT,

--- a/risc0/zkvm/src/host/server/prove/keccak.rs
+++ b/risc0/zkvm/src/host/server/prove/keccak.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ use risc0_binfmt::read_sha_halfs;
 use risc0_circuit_keccak::{
     get_control_id,
     prove::{keccak_prover, zkr::get_keccak_zkr},
-    KeccakState, KECCAK_CONTROL_IDS,
+    KECCAK_CONTROL_IDS,
 };
 use risc0_core::field::baby_bear::BabyBearElem;
 use risc0_zkp::core::digest::{Digest, DIGEST_SHORTS};
@@ -32,9 +32,8 @@ use crate::{
 /// Generate a keccak proof that has been lifted.
 pub fn prove_keccak(request: &ProveKeccakRequest) -> Result<SuccinctReceipt<Unknown>> {
     let zkr_input = {
-        let input: &[KeccakState] = bytemuck::cast_slice(&request.input);
         let prover = keccak_prover()?;
-        let seal = prover.prove(input, request.po2)?;
+        let seal = prover.prove(&request.input, request.po2)?;
 
         let claim_digest: Digest = read_sha_halfs(&mut VecDeque::from_iter(
             bytemuck::checked::cast_slice::<_, BabyBearElem>(&seal[0..DIGEST_SHORTS])


### PR DESCRIPTION
The original error reported:

```
thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/bytemuck-1.20.0/src/internal.rs:33:3:
cast_slice>TargetAlignmentGreaterAndInputNotAligned
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at ./rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:74:14
   2: bytemuck::internal::something_went_wrong
             at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/bytemuck-1.20.0/src/internal.rs:33:3
   3: bytemuck::internal::cast_slice
             at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/bytemuck-1.20.0/src/internal.rs:257:15
   4: bytemuck::cast_slice
             at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/bytemuck-1.20.0/src/lib.rs:377:12
   5: risc0_zkvm::host::server::prove::keccak::prove_keccak
             at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/risc0-zkvm-1.2.1/src/host/server/prove/keccak.rs:35:37
   6: <risc0_zkvm::host::server::prove::prover_impl::ProverImpl as risc0_zkvm::host::server::prove::ProverServer>::prove_keccak
             at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/risc0-zkvm-1.2.1/src/host/server/prove/prover_impl.rs:255:9
...
```

Where the issue here is that the input is just `Vec<u8>` and a reference to is being cast to `&[[u64; 25]]` which should require 8 byte alignment, but is not guaranteed by the `Vec<u8>`.