### PR TITLE
Fix store peeking

### DIFF
--- a/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/emu/exec/mod.rs
@@ -455,7 +455,7 @@ impl<S: Syscall> Executor<'_, '_, S> {
             bail!("{into_guest_ptr:?} is an invalid guest address");
         }
 
-        if into_guest_len > 0 && !into_guest_ptr.is_null() {
+        if into_guest_len > 0 {
             let end_addr = into_guest_ptr
                 .checked_add(into_guest_len as u32)
                 .ok_or_else(|| anyhow!("invalid guest address range"))?;
@@ -490,7 +490,7 @@ impl<S: Syscall> Executor<'_, '_, S> {
 
         // The guest uses a null pointer to indicate that a transfer from host
         // to guest is not needed.
-        if into_guest_len > 0 && !into_guest_ptr.is_null() {
+        if into_guest_len > 0 {
             self.store_region(into_guest_ptr, bytemuck::cast_slice(&syscall.to_guest))?;
         }
 


### PR DESCRIPTION
When storing a region of memory in the guest, the host peeks at each word so it can write it back with the byte replaced. When that guest memory is uninitialized, that causes it to read uninitialized memory, when only a store was necessary. Instead, perform such stores directly over word-aligned regions instead of byte-aligned. Since the pointers used in practice are already word-aligned, this makes it simpler.

Also, fix a bounds check which used a byte length when a word length was given.

See https://github.com/risc0/risc0/issues/2853.