### PR TITLE
Remove Unused Import: Sha256

### DIFF
--- a/benchmarks/shared/src/lib.rs
+++ b/benchmarks/shared/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risc0_zkvm::sha::{self, Digest, Sha256};
+use risc0_zkvm::sha::{self, Digest};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This PR removes the unused import Sha256 from the use statement in the file. The Sha256 struct was never used in the code, making its import redundant. Removing it enhances code clarity and prevents unnecessary dependencies.