### PR TITLE
ZKVM-1123: prover example: fix union creation when finalizing unions

### DIFF
--- a/examples/prover/src/task_mgr.rs
+++ b/examples/prover/src/task_mgr.rs
@@ -118,6 +118,12 @@ impl TaskManager {
                 break;
             }
         }
+        if let Some(ref receipt) = union_root_receipt {
+            println!(
+                "union root receipt: claim {:?} control id: {}",
+                receipt.claim, receipt.control_id
+            );
+        }
         (*join_root_receipt.unwrap(), union_root_receipt)
     }
 


### PR DESCRIPTION
The prover example's algorithm for merging the remaining peaks diverges from the guest's MMR construction. This change fixes this by changing the prover example to create union tasks by uniting the peaks starting with the peak with the largest height and ending with the smallest height.