### PR TITLE
ZKVM-1124: fix benchmarks

### DIFF
--- a/risc0/zkvm/examples/datasheet.rs
+++ b/risc0/zkvm/examples/datasheet.rs
@@ -52,7 +52,7 @@ const CYCLES_PO2_ITERS: &[(u32, u32)] = &[
 
 const MIN_CYCLES_PO2: usize = CYCLES_PO2_ITERS[0].0 as usize;
 
-const ITERATIONS_1M_CYCLES: usize = 1024 * 512 - 45;
+const ITERATIONS_1M_CYCLES: usize = 1024 * 512 - 46;
 
 #[serde_as]
 #[derive(Debug, Serialize, Tabled)]
@@ -130,7 +130,7 @@ enum Command {
 }
 
 /// This is the number of user cycles we expect for our "execute" benchmarks.
-const EXPECTED_EXECUTE_USER_CYCLES: u64 = (1 << DEFAULT_SEGMENT_LIMIT_PO2 as u64) - 1;
+const EXPECTED_EXECUTE_USER_CYCLES: u64 = (1 << DEFAULT_SEGMENT_LIMIT_PO2 as u64) - 2;
 
 #[derive(Default)]
 struct Datasheet {


### PR DESCRIPTION
The v2 executor incurs 1 less cycle. I found through testing that each iteration adds 2 cycles so I've lowered the loop count and expected cycle count by 1 to stay under the M1 cycle threshold