### PR TITLE
zkvm: enable 3gb of guest memory

### DIFF
--- a/risc0/zkvm/methods/guest/src/bin/heap_limits.rs
+++ b/risc0/zkvm/methods/guest/src/bin/heap_limits.rs
@@ -29,12 +29,15 @@ risc0_zkvm::entry!(main);
 /// Show that we crash if we try to allocate too much memory instead of something else like re-use
 /// old addresses or some other potentially bad behavior.
 fn heap_overflow_via_alloc() {
-    let ptr = unsafe {
-        alloc(Layout::from_size_align(isize::MAX as usize, 1).unwrap())
-    };
+    let ptr1 = unsafe { alloc(Layout::from_size_align(isize::MAX as usize, 1).unwrap()) };
 
     // Use the pointer in some way to defeat optimizer
-    core::hint::black_box(ptr);
+
+    let ptr2 = unsafe { alloc(Layout::from_size_align(isize::MAX as usize, 1).unwrap()) };
+
+    // Use the pointer in some way to defeat optimizer
+    core::hint::black_box(ptr2);
+    core::hint::black_box(ptr1);
 
     unreachable!("expected a crash in the memory allocator")
 }
@@ -47,9 +50,7 @@ extern "C" {
 /// old addresses or some other potentially bad behavior.
 fn heap_overflow_via_sys_alloc_aligned() {
     for size in [10usize, usize::MAX] {
-        let ptr = unsafe {
-            sys_alloc_aligned(size, 1)
-        };
+        let ptr = unsafe { sys_alloc_aligned(size, 1) };
 
         // Use the pointer in some way to defeat optimizer
         core::hint::black_box(ptr);

--- a/risc0/zkvm/platform/src/memory.rs
+++ b/risc0/zkvm/platform/src/memory.rs
@@ -17,7 +17,7 @@ use super::WORD_SIZE;
 pub const MEM_BITS: usize = 28;
 pub const MEM_SIZE: usize = 1 << MEM_BITS;
 pub const GUEST_MIN_MEM: usize = 0x0000_0400;
-pub const GUEST_MAX_MEM: usize = SYSTEM.start;
+pub const GUEST_MAX_MEM: usize = 0xC000_0000;
 
 /// Top of stack; stack grows down from this location.
 pub const STACK_TOP: u32 = 0x0020_0400;


### PR DESCRIPTION
This is a simple fix to adjust the GUEST_MAX_MEM. There maybe more that we can do to clean up risc0-zkvm-platform but this could result in semver breaking changes such as removing public symbols. This change is meant to do the bare minimum to enable a larger heap for the guest.