### PR TITLE
Rename reserved0 to reserved_0 in NvtxExportTableVersionInfo struct for consistent naming

### DIFF
--- a/risc0/sys/cxx/vendor/nvtx3/nvtxDetail/nvtxTypes.h
+++ b/risc0/sys/cxx/vendor/nvtx3/nvtxDetail/nvtxTypes.h
@@ -286,7 +286,7 @@ typedef struct NvtxExportTableVersionInfo
     uint32_t version;
 
     /* Reserved for alignment, do not use */
-    uint32_t reserved0;
+    uint32_t reserved_0;
 
     /* This must be set by tools when attaching to provide applications
     *  the ability to, in emergency situations, detect problematic tools


### PR DESCRIPTION
Updated variable name in nvtxTypes.h to follow C++ naming convention with underscores for reserved variables.