### PR TITLE
ZKVM-1135: Update bigint2 datasheet benchmark to work with v2

### DIFF
--- a/risc0/bigint2/methods/guest/build.rs
+++ b/risc0/bigint2/methods/guest/build.rs
@@ -16,7 +16,7 @@ use std::{fmt::Write as _, path::Path};
 
 use k256::ecdsa::{signature::Signer as _, Signature, SigningKey, VerifyingKey};
 
-const NUM_SIGNATURES: usize = 5;
+const NUM_SIGNATURES: usize = 7;
 const SIGNING_KEY: [u8; 32] = [
     191, 95, 105, 40, 155, 50, 183, 58, 61, 48, 1, 231, 44, 100, 10, 170, 64, 121, 99, 101, 208,
     121, 205, 143, 242, 81, 225, 52, 158, 95, 99, 36,

--- a/risc0/zkvm/examples/datasheet.rs
+++ b/risc0/zkvm/examples/datasheet.rs
@@ -481,7 +481,8 @@ impl Datasheet {
         let duration = start.elapsed();
 
         // We want this to be comparable to the other execute benchmarks
-        assert!(session.user_cycles - EXPECTED_EXECUTE_USER_CYCLES < 10_000);
+        let cycle_diff = session.user_cycles.abs_diff(EXPECTED_EXECUTE_USER_CYCLES);
+        assert!(cycle_diff < 20_000, "{cycle_diff} not less than 20_000");
 
         let throughput = (session.user_cycles as f64) / duration.as_secs_f64();
         self.results.push(PerformanceData {


### PR DESCRIPTION
The number of cycles for the same workload has changed making it no longer in-line with the other execute benchmarks. I just adjusted the workload to make it closer, and updated the assert since I couldn't get under 10k difference.