### PR TITLE
Add `found` to ECDSA example references and update Hello World tutorial link

### DIFF
--- a/website/api_versioned_docs/version-0.18/zkvm/developer-guide/host-code-101.md
+++ b/website/api_versioned_docs/version-0.18/zkvm/developer-guide/host-code-101.md
@@ -77,7 +77,7 @@ You can file an issue on [these docs] or the [examples], and we're happy to answ
 [guest]: /terminology#guest
 [guest program]: /terminology#guest-program
 [Hello World demo]: https://github.com/risc0/risc0/tree/release-0.18/examples/hello-world
-[Hello World Tutorial]: https://github.com/risc0/risc0/blob/release-0.18/examples/hello-world/tutorial.md
+[Hello World Tutorial]: https://github.com/risc0/risc0/blob/release-0.19/examples/hello-world/README.md
 [host]: /terminology#host
 [journal]: /terminology#journal
 [JSON demo]: https://github.com/risc0/risc0/blob/release-0.18/examples/json/src/main.rs

--- a/website/api_versioned_docs/version-0.19/zkvm/developer-guide/precompiles.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/developer-guide/precompiles.md
@@ -27,7 +27,7 @@ tag = "sha2-v0.10.6-risczero.0"
 
 When using cryptography indirectly, e.g. via the `cookie`, `oauth2`, or `revm`, crates it may be possible to enable acceleration support without code changes by applying a [Cargo patch system](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section).
 
-An example of how to use these crates to accelerate ECDSA signature verification can be in the [ECDSA example](https://github.com/risc0/risc0/tree/release-0.19/examples/ecdsa). Note the [use of the patched versions](https://github.com/risc0/risc0/blob/release-0.19/examples/ecdsa/methods/guest/Cargo.toml#L13-L18) of `sha2`, `crypto-bigint` and `k256` crates used in the guest's `Cargo.toml`.
+An example of how to use these crates to accelerate ECDSA signature verification can be found in the [ECDSA example](https://github.com/risc0/risc0/tree/release-0.19/examples/ecdsa). Note the [use of the patched versions](https://github.com/risc0/risc0/blob/release-0.19/examples/ecdsa/methods/guest/Cargo.toml#L13-L18) of `sha2`, `crypto-bigint` and `k256` crates used in the guest's `Cargo.toml`.
 
 ## Adding Accelerator Support to Crates
 

--- a/website/api_versioned_docs/version-0.20/zkvm/precompiles.md
+++ b/website/api_versioned_docs/version-0.20/zkvm/precompiles.md
@@ -38,7 +38,7 @@ crates it may be possible to enable acceleration support without code changes by
 applying a [Cargo patch][cargo-patch].
 
 An example of how to use these crates to accelerate ECDSA signature verification
-can be in the [ECDSA example][ecdsa]. Note the [use of the patched
+can be found in the [ECDSA example][ecdsa]. Note the [use of the patched
 versions][ecdsa-patched] of `sha2`, `crypto-bigint` and `k256` crates used in
 the guest's `Cargo.toml`.
 


### PR DESCRIPTION
**This PR makes the following improvements to documentation:**
Adds missing word `found` to `ECDSA` example references for better readability:
1. Updates `can be in the [ECDSA example]` to `can be found in the [ECDSA example]`

Updates Hello World tutorial link:
1. Changes from `/tutorial.md to /README.md`
2. Updates version from 0.18 to 0.19 in the path

These changes improve documentation clarity and ensure correct resource linking.