### PR TITLE
ZKVM-1140: Run all datasheet commands in main.yml when using CUDA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,8 +266,11 @@ jobs:
       - name: run fibonacci benchmark
         run: cargo run --locked -F $FEATURE -- fibonacci
         working-directory: benchmarks
-      - name: run datasheet generator
+      - name: run datasheet generator (smoke test)
         run: cargo run --locked -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift
+      - name: run datasheet generator (CUDA full)
+        if: matrix.feature == 'cuda'
+        run: cargo run --locked -F $FEATURE -F prove --example datasheet
       - name: check benches
         run: cargo check -F $FEATURE --benches --workspace --exclude doc-test
       - run: cargo check -p risc0-build


### PR DESCRIPTION
Breaking the datasheet now seems to be quite disruptive, lets run all of the commands in CI instead of just "lift".
This only runs when when we are using CUDA, since without it, it can take 11m

This is a follow up to https://github.com/risc0/risc0/pull/2875