### PR TITLE
Constrain versions of internal deps to minor version for 1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,28 +41,28 @@ homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
-bonsai-sdk = { version = "1.2.4", default-features = false, path = "bonsai/sdk" }
+bonsai-sdk = { version = "~1.2.4", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.2.4", default-features = false, path = "risc0/bigint2" }
-risc0-binfmt = { version = "1.2.4", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "1.2.4", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "1.2.4", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-keccak = { version = "1.2.4", default-features = false, path = "risc0/circuit/keccak" }
-risc0-circuit-keccak-sys = { version = "1.2.4", default-features = false, path = "risc0/circuit/keccak-sys" }
-risc0-circuit-recursion = { version = "1.2.4", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.2.4", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "1.2.4", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "1.2.4", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-bigint2 = { version = "~1.2.4", default-features = false, path = "risc0/bigint2" }
+risc0-binfmt = { version = "~1.2.4", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "~1.2.4", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "~1.2.4", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-keccak = { version = "~1.2.4", default-features = false, path = "risc0/circuit/keccak" }
+risc0-circuit-keccak-sys = { version = "~1.2.4", default-features = false, path = "risc0/circuit/keccak-sys" }
+risc0-circuit-recursion = { version = "~1.2.4", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "~1.2.4", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "~1.2.4", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "~1.2.4", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-circuit-rv32im-v2 = { version = "0.1.2", default-features = false, path = "risc0/circuit/rv32im-v2" }
 risc0-circuit-rv32im-v2-sys = { version = "0.1.2", default-features = false, path = "risc0/circuit/rv32im-v2-sys" }
-risc0-core = { version = "1.2.4", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.2.4", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "1.2.4", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.2.4", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.2.4", default-features = false, path = "risc0/zkp" }
-risc0-zkvm = { version = "1.2.4", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "1.2.4", default-features = false, path = "risc0/zkvm/platform" }
+risc0-core = { version = "~1.2.4", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "~1.2.4", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "~1.2.4", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "~1.2.4", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "~1.2.4", default-features = false, path = "risc0/zkp" }
+risc0-zkvm = { version = "~1.2.4", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "~1.2.4", default-features = false, path = "risc0/zkvm/platform" }
 sppark = "0.1.10"
 
 [profile.bench]


### PR DESCRIPTION
This prevents 1.3 or any other minor version to be used for indirect references with any imported crate as they are not semver compatible.

related https://linear.app/risczero/issue/ZKVM-741/minor-versions-not-constrained-for-risc0-internal-sub-dependencies and https://github.com/risc0/risc0/issues/2439

although this doesn't resolve for future versions yet, will follow up this PR