### PR TITLE
ZKVM-1146: bump version to 1.4.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4348,7 +4348,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -4369,14 +4369,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2-methods"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "cc",
  "directories",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "cc",
  "cust",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -4545,7 +4545,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-tools"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "assert_cmd",
  "clap 4.5.23",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 
 [[package]]
 name = "rlsf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,36 +36,36 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
-bonsai-sdk = { version = "1.3.0-alpha.1", default-features = false, path = "bonsai/sdk" }
+bonsai-sdk = { version = "1.4.0-alpha.1", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/bigint2" }
-risc0-binfmt = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "2.0.0", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-keccak = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/keccak" }
-risc0-circuit-keccak-sys = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/keccak-sys" }
-risc0-circuit-recursion = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-bigint2 = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/bigint2" }
+risc0-binfmt = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "2.1.0-alpha.1", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-keccak = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/keccak" }
+risc0-circuit-keccak-sys = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/keccak-sys" }
+risc0-circuit-recursion = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-circuit-rv32im-v2 = { version = "0.1.0", default-features = false, path = "risc0/circuit/rv32im-v2" }
 risc0-circuit-rv32im-v2-sys = { version = "0.1.0", default-features = false, path = "risc0/circuit/rv32im-v2-sys" }
-risc0-core = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkp" }
+risc0-core = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/zkp" }
 risc0-zkos-v1compat = { version = "0.1.0", path = "risc0/zkos/v1compat" }
-risc0-zkvm = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "1.3.0-alpha.1", default-features = false, path = "risc0/zkvm/platform" }
+risc0-zkvm = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/zkvm/platform" }
 rzup = { version = "0.4.0-alpha.1", default-features = false, path = "rzup" }
 sppark = "0.1.10"
 

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "cc",
  "directories",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "cc",
  "cust",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -3635,7 +3635,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "cc",
  "directories",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "cc",
  "cust",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "borsh",
  "ciborium",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 
 [[package]]
 name = "rkyv"

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bls12_381/methods/guest/Cargo.lock
+++ b/examples/bls12_381/methods/guest/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bn254/methods/guest/Cargo.lock
+++ b/examples/bn254/methods/guest/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -783,7 +783,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -745,7 +745,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -721,7 +721,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/k256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/k256/methods/guest/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/p256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/p256/methods/guest/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -720,7 +720,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -728,7 +728,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/keccak/methods/guest/Cargo.lock
+++ b/examples/keccak/methods/guest/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -750,7 +750,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -767,7 +767,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -792,7 +792,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -720,7 +720,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -888,13 +888,13 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-bigint-dig",
- "risc0-bigint2 1.3.0-alpha.1",
+ "risc0-bigint2 1.4.0-alpha.1",
  "risc0-zkvm",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build"
 description = "RISC Zero zero-knowledge VM build tool"
-version = "2.0.0"
+version = "2.1.0-alpha.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -269,7 +269,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "f2b37f2d4f13a3310179a3096526410de3d28b2c9896723c6537b9175324d40d",
+            "b92bb20166ca7e3ab7868d4f3d3996737511336fb1ad5e636db2b2673402af30",
         );
     }
 }

--- a/risc0/circuit/keccak/methods/guest/Cargo.lock
+++ b/risc0/circuit/keccak/methods/guest/Cargo.lock
@@ -699,7 +699,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/compat/tests/compat.rs
+++ b/risc0/zkvm/compat/tests/compat.rs
@@ -128,6 +128,7 @@ fn new_client(version: &str) -> ApiClient {
             .join(version)
             .join("bin/r0vm")
     };
+    println!("path: {}", server_path.display());
     ApiClient::new_sub_process_any(server_path).unwrap()
 }
 

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "borsh",
  "ciborium",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -759,7 +759,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1140,7 +1140,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0-alpha.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "bytemuck",
  "cfg-if",


### PR DESCRIPTION
we also discussed bumping to 2.0, so this could be 2.0.0-alpha.1 as well