### PR TITLE
ZKVM-1148: TraceEvent handles unknown events from future versions gracefully

### DIFF
--- a/risc0/circuit/rv32im-v2/src/trace.rs
+++ b/risc0/circuit/rv32im-v2/src/trace.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 
 /// An event traced from the running VM.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum TraceEvent {
     /// An instruction has started at the given program counter
     InstructionStart {

--- a/risc0/circuit/rv32im/src/trace.rs
+++ b/risc0/circuit/rv32im/src/trace.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 
 /// An event traced from the running VM.
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum TraceEvent {
     /// An instruction has started at the given program counter
     InstructionStart {

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -142,23 +142,25 @@ impl TryFrom<pb::api::AssetRequest> for AssetRequest {
     }
 }
 
-impl From<TraceEvent> for pb::api::TraceEvent {
-    fn from(event: TraceEvent) -> Self {
+impl TryFrom<TraceEvent> for pb::api::TraceEvent {
+    type Error = anyhow::Error;
+
+    fn try_from(event: TraceEvent) -> Result<Self> {
         match event {
-            TraceEvent::InstructionStart { cycle, pc, insn } => Self {
+            TraceEvent::InstructionStart { cycle, pc, insn } => Ok(Self {
                 kind: Some(pb::api::trace_event::Kind::InsnStart(
                     pb::api::trace_event::InstructionStart { cycle, pc, insn },
                 )),
-            },
-            TraceEvent::RegisterSet { idx, value } => Self {
+            }),
+            TraceEvent::RegisterSet { idx, value } => Ok(Self {
                 kind: Some(pb::api::trace_event::Kind::RegisterSet(
                     pb::api::trace_event::RegisterSet {
                         idx: idx as u32,
                         value,
                     },
                 )),
-            },
-            TraceEvent::MemorySet { addr, region } => Self {
+            }),
+            TraceEvent::MemorySet { addr, region } => Ok(Self {
                 kind: Some(pb::api::trace_event::Kind::MemorySet(
                     pb::api::trace_event::MemorySet {
                         addr,
@@ -166,17 +168,18 @@ impl From<TraceEvent> for pb::api::TraceEvent {
                         region,
                     },
                 )),
-            },
-            TraceEvent::PageIn { cycles } => Self {
+            }),
+            TraceEvent::PageIn { cycles } => Ok(Self {
                 kind: Some(pb::api::trace_event::Kind::PageIn(
                     pb::api::trace_event::PageIn { cycles },
                 )),
-            },
-            TraceEvent::PageOut { cycles } => Self {
+            }),
+            TraceEvent::PageOut { cycles } => Ok(Self {
                 kind: Some(pb::api::trace_event::Kind::PageOut(
                     pb::api::trace_event::PageOut { cycles },
                 )),
-            },
+            }),
+            _ => Err(anyhow!("unknown TraceEvent kind")),
         }
     }
 }

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -167,10 +167,15 @@ impl TraceProxy {
 
 impl TraceCallback for TraceProxy {
     fn trace_callback(&mut self, event: TraceEvent) -> Result<()> {
+        let Ok(event) = event.clone().try_into() else {
+            tracing::trace!("ignoring unknown event {event:?}");
+            return Ok(());
+        };
+
         let request = pb::api::ServerReply {
             kind: Some(pb::api::server_reply::Kind::Ok(pb::api::ClientCallback {
                 kind: Some(pb::api::client_callback::Kind::Io(pb::api::OnIoRequest {
-                    kind: Some(pb::api::on_io_request::Kind::Trace(event.into())),
+                    kind: Some(pb::api::on_io_request::Kind::Trace(event)),
                 })),
             })),
         };

--- a/risc0/zkvm/src/host/server/exec/profiler.rs
+++ b/risc0/zkvm/src/host/server/exec/profiler.rs
@@ -664,10 +664,13 @@ impl TraceCallback for Profiler {
                 self.insn = insn;
                 self.cycle = cycle;
             }
-            TraceEvent::RegisterSet { .. } => (),
-            TraceEvent::MemorySet { .. } => (),
             TraceEvent::PageIn { cycles } => self.add_zkvm_frame(ZkVmFunction::PageIn, cycles),
             TraceEvent::PageOut { cycles } => self.add_zkvm_frame(ZkVmFunction::PageOut, cycles),
+            TraceEvent::RegisterSet { .. } => (),
+            TraceEvent::MemorySet { .. } => (),
+            _ => {
+                tracing::trace!("ignoring unknown event {event:?}");
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
If a newer version of the circuit adds a new event type, the older version of zkvm should just ignore it if received. Since this is expected behavior, the fact that these events are being ignored is only being logged at trace-level.

This change will need to be backported to 1.3, 1.2, and 1.1