### PR TITLE
Restrict some 1.1 branch dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ risc0-build-kernel = { version = "1.1.3", default-features = false, path = "risc
 risc0-circuit-recursion = { version = "1.1.3", default-features = false, path = "risc0/circuit/recursion" }
 risc0-circuit-recursion-sys = { version = "~1.1.3", default-features = false, path = "risc0/circuit/recursion-sys" }
 risc0-circuit-rv32im = { version = "1.1.3", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "1.1.3", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-circuit-rv32im-sys = { version = "~1.1.3", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-core = { version = "1.1.3", default-features = false, path = "risc0/core" }
 risc0-groth16 = { version = "1.1.3", default-features = false, path = "risc0/groth16" }
 risc0-r0vm = { version = "1.1.3", default-features = false, path = "risc0/r0vm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ metal = "0.29"
 risc0-binfmt = { version = "1.1.3", default-features = false, path = "risc0/binfmt" }
 risc0-build = { version = "1.1.3", default-features = false, path = "risc0/build" }
 risc0-build-kernel = { version = "1.1.3", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-recursion = { version = "1.1.3", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion = { version = "~1.1.3", default-features = false, path = "risc0/circuit/recursion" }
 risc0-circuit-recursion-sys = { version = "~1.1.3", default-features = false, path = "risc0/circuit/recursion-sys" }
 risc0-circuit-rv32im = { version = "1.1.3", default-features = false, path = "risc0/circuit/rv32im" }
 risc0-circuit-rv32im-sys = { version = "~1.1.3", default-features = false, path = "risc0/circuit/rv32im-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ risc0-binfmt = { version = "1.1.3", default-features = false, path = "risc0/binf
 risc0-build = { version = "1.1.3", default-features = false, path = "risc0/build" }
 risc0-build-kernel = { version = "1.1.3", default-features = false, path = "risc0/build_kernel" }
 risc0-circuit-recursion = { version = "1.1.3", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.1.3", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-recursion-sys = { version = "~1.1.3", default-features = false, path = "risc0/circuit/recursion-sys" }
 risc0-circuit-rv32im = { version = "1.1.3", default-features = false, path = "risc0/circuit/rv32im" }
 risc0-circuit-rv32im-sys = { version = "1.1.3", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-core = { version = "1.1.3", default-features = false, path = "risc0/core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ risc0-core = { version = "1.1.3", default-features = false, path = "risc0/core" 
 risc0-groth16 = { version = "1.1.3", default-features = false, path = "risc0/groth16" }
 risc0-r0vm = { version = "1.1.3", default-features = false, path = "risc0/r0vm" }
 risc0-sys = { version = "1.1.3", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.1.3", default-features = false, path = "risc0/zkp" }
+risc0-zkp = { version = "~1.1.3", default-features = false, path = "risc0/zkp" }
 risc0-zkvm = { version = "1.1.3", default-features = false, path = "risc0/zkvm" }
 risc0-zkvm-platform = { version = "1.1.3", default-features = false, path = "risc0/zkvm/platform" }
 sppark = "0.1.8"


### PR DESCRIPTION
We made a breaking changes to the following crates in 1.2.X:

- risc0-zkp
- risc0-circuit-recursion
- risc0-circuit-recursion-sys
- risc0-circuit-rv32im
- risc0-circuit-rv32im-sys

The 1.1.X crates won't compile with those version, so we have to restrict them.

These crates really shouldn't be depended on directly by non-risc0 crates, so I think we can just restrict these dependencies to get out of these problems for 1.1.1