### PR TITLE
fix: type inconsistency in NVTX function pointer types

### DIFF
--- a/risc0/sys/cxx/vendor/nvtx3/nvtxDetail/nvtxImpl.h
+++ b/risc0/sys/cxx/vendor/nvtx3/nvtxDetail/nvtxImpl.h
@@ -138,10 +138,10 @@ typedef struct nvtxGlobals_t
 
     nvtxNameCudaDeviceA_impl_fntype nvtxNameCudaDeviceA_impl_fnptr;
     nvtxNameCudaDeviceW_impl_fntype nvtxNameCudaDeviceW_impl_fnptr;
-    nvtxNameCudaStreamA_fakeimpl_fntype nvtxNameCudaStreamA_impl_fnptr;
-    nvtxNameCudaStreamW_fakeimpl_fntype nvtxNameCudaStreamW_impl_fnptr;
-    nvtxNameCudaEventA_fakeimpl_fntype nvtxNameCudaEventA_impl_fnptr;
-    nvtxNameCudaEventW_fakeimpl_fntype nvtxNameCudaEventW_impl_fnptr;
+    nvtxNameCudaStreamA_impl_fntype nvtxNameCudaStreamA_impl_fnptr;
+    nvtxNameCudaStreamW_impl_fntype nvtxNameCudaStreamW_impl_fnptr;
+    nvtxNameCudaEventA_impl_fntype nvtxNameCudaEventA_impl_fnptr;
+    nvtxNameCudaEventW_impl_fntype nvtxNameCudaEventW_impl_fnptr;
 
     nvtxDomainMarkEx_impl_fntype nvtxDomainMarkEx_impl_fnptr;
     nvtxDomainRangeStartEx_impl_fntype nvtxDomainRangeStartEx_impl_fnptr;

--- a/risc0/sys/cxx/vendor/nvtx3/nvtxDetail/nvtxTypes.h
+++ b/risc0/sys/cxx/vendor/nvtx3/nvtxDetail/nvtxTypes.h
@@ -91,10 +91,10 @@ typedef void (NVTX_API * nvtxNameClEventW_fakeimpl_fntype)(nvtx_cl_event evnt, c
 /* Real impl types are defined in nvtxImplCudaRt_v3.h, where CUDART headers are included */
 typedef void (NVTX_API * nvtxNameCudaDeviceA_impl_fntype)(int device, const char* name);
 typedef void (NVTX_API * nvtxNameCudaDeviceW_impl_fntype)(int device, const wchar_t* name);
-typedef void (NVTX_API * nvtxNameCudaStreamA_fakeimpl_fntype)(nvtx_cudaStream_t stream, const char* name);
-typedef void (NVTX_API * nvtxNameCudaStreamW_fakeimpl_fntype)(nvtx_cudaStream_t stream, const wchar_t* name);
-typedef void (NVTX_API * nvtxNameCudaEventA_fakeimpl_fntype)(nvtx_cudaEvent_t event, const char* name);
-typedef void (NVTX_API * nvtxNameCudaEventW_fakeimpl_fntype)(nvtx_cudaEvent_t event, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameCudaStreamA_impl_fntype)(nvtx_cudaStream_t stream, const char* name);
+typedef void (NVTX_API * nvtxNameCudaStreamW_impl_fntype)(nvtx_cudaStream_t stream, const wchar_t* name);
+typedef void (NVTX_API * nvtxNameCudaEventA_impl_fntype)(nvtx_cudaEvent_t event, const char* name);
+typedef void (NVTX_API * nvtxNameCudaEventW_impl_fntype)(nvtx_cudaEvent_t event, const wchar_t* name);
 
 typedef void (NVTX_API * nvtxDomainMarkEx_impl_fntype)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);
 typedef nvtxRangeId_t (NVTX_API * nvtxDomainRangeStartEx_impl_fntype)(nvtxDomainHandle_t domain, const nvtxEventAttributes_t* eventAttrib);


### PR DESCRIPTION
Fixed inconsistency in CUDA Stream and Event function pointer type names in nvtxTypes.h and nvtxImpl.h by replacing _fakeimpl_fntype with _impl_fntype to match definitions in nvtxImplCudaRt_v3.h.