### PR TITLE
Release 1.3: Bump version to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -4469,14 +4469,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2-methods"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cc",
  "directories",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4551,14 +4551,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-methods"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cc",
  "cust",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-tools"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "assert_cmd",
  "clap 4.5.23",
@@ -4728,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.3.0"
+version = "1.3.1"
 
 [[package]]
 name = "rlsf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,33 +32,33 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
-bonsai-sdk = { version = "1.3.0", default-features = false, path = "bonsai/sdk" }
+bonsai-sdk = { version = "1.3.1", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.3.0", default-features = false, path = "risc0/bigint2" }
-risc0-binfmt = { version = "1.3.0", default-features = false, path = "risc0/binfmt" }
+risc0-bigint2 = { version = "1.3.1", default-features = false, path = "risc0/bigint2" }
+risc0-binfmt = { version = "1.3.1", default-features = false, path = "risc0/binfmt" }
 risc0-build = { version = "2.0.0", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "1.3.0", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-keccak = { version = "1.3.0", default-features = false, path = "risc0/circuit/keccak" }
-risc0-circuit-keccak-sys = { version = "1.3.0", default-features = false, path = "risc0/circuit/keccak-sys" }
-risc0-circuit-recursion = { version = "1.3.0", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.3.0", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "1.3.0", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "1.3.0", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "1.3.0", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.3.0", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "1.3.0", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.3.0", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.3.0", default-features = false, path = "risc0/zkp" }
-risc0-zkvm = { version = "1.3.0", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "1.3.0", default-features = false, path = "risc0/zkvm/platform" }
+risc0-build-kernel = { version = "1.3.1", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-keccak = { version = "1.3.1", default-features = false, path = "risc0/circuit/keccak" }
+risc0-circuit-keccak-sys = { version = "1.3.1", default-features = false, path = "risc0/circuit/keccak-sys" }
+risc0-circuit-recursion = { version = "1.3.1", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "1.3.1", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "1.3.1", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "1.3.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "1.3.1", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "1.3.1", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "1.3.1", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "1.3.1", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "1.3.1", default-features = false, path = "risc0/zkp" }
+risc0-zkvm = { version = "1.3.1", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "1.3.1", default-features = false, path = "risc0/zkvm/platform" }
 rzup = { version = "0.3.0", default-features = false, path = "rzup" }
 sppark = "0.1.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hotbench = { path = "tools/hotbench" }
 metal = "0.29"
 risc0-bigint2 = { version = "1.3.1", default-features = false, path = "risc0/bigint2" }
 risc0-binfmt = { version = "1.3.1", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "2.0.0", default-features = false, path = "risc0/build" }
+risc0-build = { version = "2.0.1", default-features = false, path = "risc0/build" }
 risc0-build-kernel = { version = "1.3.1", default-features = false, path = "risc0/build_kernel" }
 risc0-circuit-keccak = { version = "1.3.1", default-features = false, path = "risc0/circuit/keccak" }
 risc0-circuit-keccak-sys = { version = "1.3.1", default-features = false, path = "risc0/circuit/keccak-sys" }

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cc",
  "directories",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cc",
  "cust",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cc",
  "directories",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cc",
  "cust",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "cust",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "borsh",
  "ciborium",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.3.0"
+version = "1.3.1"
 
 [[package]]
 name = "rkyv"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -900,7 +900,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -820,7 +820,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/k256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/k256/methods/guest/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/p256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/p256/methods/guest/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -839,7 +839,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -819,7 +819,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/keccak/methods/guest/Cargo.lock
+++ b/examples/keccak/methods/guest/Cargo.lock
@@ -818,7 +818,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -910,7 +910,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -839,7 +839,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -909,7 +909,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -812,7 +812,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -831,7 +831,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -1008,13 +1008,13 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-bigint-dig",
- "risc0-bigint2 1.3.0",
+ "risc0-bigint2 1.3.1",
  "risc0-zkvm",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build"
 description = "RISC Zero zero-knowledge VM build tool"
-version = "2.0.0"
+version = "2.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "91e1f23b2928f07fea0071bee70fa5283d463007b3bda59ab5d91472588ee013",
+            "5dd000dc7aafd04bc207178112086751261618f0998a14d8c873786ff4e2156d",
         );
     }
 }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "5dd000dc7aafd04bc207178112086751261618f0998a14d8c873786ff4e2156d",
+            "d06e05ac3c97cc2792f3a22abf37e34680a82dff75ebd231bee0bffc213d9d50",
         );
     }
 }

--- a/risc0/cargo-risczero/src/commands/new.rs
+++ b/risc0/cargo-risczero/src/commands/new.rs
@@ -129,9 +129,9 @@ impl NewCommand {
             template_variables.push((Regex::new(r"\{\{ *risc0_zkvm *\}\}")?, zkvm));
         } else {
             let zkvm_spec = format!("version = \"{risc0_version}\"");
-            // This hard-coding of 2.0.0 for `risc0-build` is a temporary fix until we can come up
+            // This hard-coding of 2.0.1 for `risc0-build` is a temporary fix until we can come up
             // with something more robust.
-            let build_spec = "version = \"2.0.0\"".into();
+            let build_spec = "version = \"2.0.1\"".into();
             template_variables.push((Regex::new(r"\{\{ *risc0_build *\}\}")?, build_spec));
             template_variables.push((Regex::new(r"\{\{ *risc0_zkvm *\}\}")?, zkvm_spec));
         }

--- a/risc0/circuit/keccak/methods/guest/Cargo.lock
+++ b/risc0/circuit/keccak/methods/guest/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -815,7 +815,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -831,7 +831,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1312,7 +1312,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "borsh",
  "ciborium",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -870,7 +870,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -812,7 +812,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "metal",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bincode",
  "borsh",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/tools/smoke-test/Cargo.toml
+++ b/tools/smoke-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = "1.3.0"
+risc0-zkvm = "1.3.1"
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../risc0/zkvm" }
 methods = { path = "methods" }

--- a/tools/smoke-test/methods/Cargo.toml
+++ b/tools/smoke-test/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = "2.0.0"
+risc0-build = "2.0.1"
 # Use this only for testing locally before a release.
 # risc0-build = { path = "../../../risc0/build" }
 

--- a/tools/smoke-test/methods/guest/Cargo.toml
+++ b/tools/smoke-test/methods/guest/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.3.0", default-features = false }
+risc0-zkvm = { version = "1.3.1", default-features = false }
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../../../risc0/zkvm", default-features = false }


### PR DESCRIPTION
This commit bumps the version of most crates to 1.3.1, and risc0-build to 2.0.1.