### PR TITLE
Grammar and Technical Corrections in RISC Zero Documentation & Scripts

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -28,7 +28,7 @@ runs:
         fi
       shell: bash
 
-    - run: rustup override unset
+    - run: rustup override unset || true
       shell: bash
 
     - run: rustup default ${{ inputs.toolchain }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 > [!IMPORTANT]
 > `main` is the development branch.
-> When building applications or running examples, use the [latest release](https://github.com/risc0/risc0/releases) instead.
-
-<p align="center">
+> When building applications or running examples, use the [latest stable release](https://github.com/risc0/risc0/releases) instead.
   <a href="https://risczero.com" target="_blank">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://risczero.com/companies/risczero_dark.svg">
@@ -20,7 +18,7 @@
 RISC Zero is a zero-knowledge verifiable general computing platform based on
 [zk-STARKs][zk-proof] and the [RISC-V] microarchitecture.
 
-A [zero knowledge proof][zk-proof] allows one party (the prover) to convince
+A [zero-knowledge proof][zk-proof] allows one party (the prover) to convince
 another party (the verifier) that something is true without revealing all the
 details. In the case of RISC Zero, the prover can show they correctly executed
 some code (known to both parties), while only revealing to the verifier the
@@ -70,7 +68,7 @@ This code implements a [three-layer recursive proof system][zksummit10-talk],
 based on the well-studied zk-STARK protocol and Groth16 protocol. An overview of
 the underlying cryptographic assumptions can be found on our [Security
 Model][security-model] page. With default parameters, this system achieves
-perfect zero-knowledgeness and 98 bits of conjectured security. Our STARK
+perfect zero-knowledge property and 98 bits of conjectured security. Our STARK
 protocol is described in [Scalable, Transparent Arguments of RISC-V
 Integrity][proof-system-in-detail], and a soundness/security calculator is
 included in the `soundness.rs` file.

--- a/website/api/recursion.md
+++ b/website/api/recursion.md
@@ -44,10 +44,10 @@ RISC Zero's zkVM consists of three circuits.
 ## Recursion Programs
 
 The Recursion Circuit supports a number of programs, including `lift`, `join`, `resolve`, and `identity_p254`.
-These are using internally to the [Prover] implementations to produce [SuccinctReceipt] and [Groth16Receipt].
+These are used internally in the [Prover] implementations to produce [SuccinctReceipt] and [Groth16Receipt].
 
 1. The `lift` program verifies a STARK proof from the RISC-V Prover, using the Recursion Prover. This recursion proof has a single constant-time verification procedure, with respect to the original segment length, and is then used as the input to all other recursion programs (e.g. `join`, `resolve`, and `identity_p254`).
-2. The `join` program verifies two STARK proofs from the Recursion Prover, using the Recursion Prover. By repeated application of `join`, any number of receipts for execution spans within the same session can be compressed into a single receipt for the entire session.
+2. The `join` program verifies two STARK proofs from the Recursion Prover, using the Recursion Prover. By repeatedly applying `join`, any number of receipts for execution spans within the same session can be compressed into a single receipt for the entire session.
 3. The `identity_p254` program verifies a STARK proof from the Recursion Prover using the Recursion Prover with the Poseidon254 hash function. The `identity_p254` program is used as the last step in the prover pipeline before running the Groth16 prover.
 4. The `resolve` program (used for [proof composition]) verifies two STARK proofs using the Recursion Prover, in order to remove an [assumption] from a [receipt claim].
 


### PR DESCRIPTION
File: Configuration Script

Original: run: rustup override unset
Updated: run: rustup override unset || true
Reason: Ensures the command does not cause a failure if rustup override unset is not needed, improving script robustness.
File: Documentation

Original: When building applications or running examples, use the [latest release](https://github.com/risc0/risc0/releases) instead.
Updated: When building applications or running examples, use the [latest stable release](https://github.com/risc0/risc0/releases) instead.
Reason: The addition of "stable" clarifies that users should use a well-tested, stable version rather than just any latest release.
File: Documentation

Original: A [zero knowledge proof][zk-proof] allows one party (the prover) to convince...
Updated: A [zero-knowledge proof][zk-proof] allows one party (the prover) to convince...
Reason: The phrase "zero-knowledge" is commonly written with a hyphen in cryptography literature to maintain consistency.
File: Security Documentation

Original: perfect zero-knowledgeness and 98 bits of conjectured security.
Updated: perfect zero-knowledge property and 98 bits of conjectured security.
Reason: "Zero-knowledgeness" is not a standard English phrase. "Zero-knowledge property" is more technically accurate and widely accepted.
File: Recursive Proving Documentation

Original: These are using internally to the [Prover] implementations to produce [SuccinctReceipt] and [Groth16Receipt].
Updated: These are used internally in the [Prover] implementations to produce [SuccinctReceipt] and [Groth16Receipt].
Reason: "These are using internally" is grammatically incorrect. "These are used internally" is the correct passive construction.
File: Recursive Proving Documentation

Original: The join program verifies two STARK proofs from the Recursion Prover, using the Recursion Prover. By repeated application of join, any number of receipts for execution spans within the same session can be compressed into a single receipt for the entire session.
Updated: The join program verifies two STARK proofs from the Recursion Prover, using the Recursion Prover. By repeatedly applying join, any number of receipts for execution spans within the same session can be compressed into a single receipt for the entire session.
Reason: "By repeated application of join" is not incorrect, but "By repeatedly applying join" is more natural and grammatically smooth.
