### PR TITLE
ZKVM-1176: Add `rustup toolchain install` step to `rustup` action

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -48,8 +48,7 @@ runs:
         echo "RUSTUP_MAX_RETRIES=10" >> $GITHUB_ENV
       shell: bash
 
-    - run: |
-        rustup show active-toolchain || rustup toolchain install
+    - run: rustup show active-toolchain || rustup toolchain install
       shell: bash
 
     - run: rustc --version --verbose


### PR DESCRIPTION
- Per `rustup` changelog: `rustup will no longer automatically install the active toolchain if it is not installed.`
  - https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
- Related issue for reference: https://github.com/rust-lang/rustup/issues/4212