### PR TITLE
ZKVM-1179: More executor performance improvements

### DIFF
--- a/risc0/binfmt/src/image2.rs
+++ b/risc0/binfmt/src/image2.rs
@@ -168,6 +168,11 @@ impl MemoryImage2 {
         bail!("Unavailable page: {page_idx}")
     }
 
+    /// Return the page data, panics if not available
+    pub fn get_existing_page(&self, page_idx: u32) -> Page {
+        self.pages.get(&page_idx).unwrap().clone()
+    }
+
     /// Set the data for a page
     pub fn set_page(&mut self, page_idx: u32, page: Page) {
         // tracing::trace!("set_page({page_idx:#08x})");
@@ -185,6 +190,11 @@ impl MemoryImage2 {
         self.digests
             .get(&digest_idx)
             .ok_or_else(|| anyhow!("Unavailable digest: {digest_idx}"))
+    }
+
+    /// Get a digest, panics if not available
+    pub fn get_existing_digest(&self, digest_idx: u32) -> &Digest {
+        self.digests.get(&digest_idx).unwrap()
     }
 
     /// Set a digest

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -269,7 +269,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "1eb4af2479172266b463fa3edd95bc28b846d21af86d83186e97b22db5a5a14f",
+            "ac1a323332b9246e7a60971a9f99e45e4e587d415d51f33756ce2f5b2ba05374",
         );
     }
 }

--- a/risc0/circuit/rv32im-v2/src/execute/executor.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/executor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
 use anyhow::{bail, Result};
 use risc0_binfmt::{ByteAddr, MemoryImage2, WordAddr};
@@ -85,6 +85,58 @@ pub struct SimpleSession {
     pub result: ExecutorResult,
 }
 
+struct ComputePartialImageRequest {
+    image: MemoryImage2,
+    page_indexes: BTreeSet<u32>,
+
+    input_digest: Digest,
+    output_digest: Option<Digest>,
+    read_record: Vec<Vec<u8>>,
+    write_record: Vec<u32>,
+    user_cycles: u32,
+    phys_cycles: u32,
+    pager_cycles: u32,
+    terminate_state: Option<TerminateState>,
+    segment_threshold: u32,
+    pre_digest: Digest,
+    post_digest: Digest,
+    po2: u32,
+}
+
+/// Maximum number of segments we can queue up before we block execution
+const MAX_OUTSTANDING_SEGMENTS: usize = 5;
+
+fn compute_partial_images(
+    recv: std::sync::mpsc::Receiver<ComputePartialImageRequest>,
+    mut callback: impl FnMut(Segment) -> Result<()>,
+) -> Result<u64> {
+    let mut segment_counter = 0;
+    while let Ok(req) = recv.recv() {
+        let partial_image = compute_partial_image(req.image, req.page_indexes);
+        callback(Segment {
+            partial_image,
+            claim: Rv32imV2Claim {
+                pre_state: req.pre_digest,
+                post_state: req.post_digest,
+                input: req.input_digest,
+                output: req.output_digest,
+                terminate_state: req.terminate_state,
+                shutdown_cycle: None,
+            },
+            read_record: req.read_record,
+            write_record: req.write_record,
+            user_cycles: req.user_cycles,
+            suspend_cycle: req.phys_cycles,
+            paging_cycles: req.pager_cycles,
+            po2: req.po2,
+            index: segment_counter,
+            segment_threshold: req.segment_threshold,
+        })?;
+        segment_counter += 1;
+    }
+    Ok(segment_counter)
+}
+
 impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
     pub fn new(
         image: MemoryImage2,
@@ -110,17 +162,16 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
         }
     }
 
-    pub fn run<F: FnMut(Segment) -> Result<()>>(
+    pub fn run(
         &mut self,
         segment_po2: usize,
         max_insn_cycles: usize,
         max_cycles: Option<u64>,
-        mut callback: F,
+        callback: impl FnMut(Segment) -> Result<()> + Send,
     ) -> Result<ExecutorResult> {
         let segment_limit: u32 = 1 << segment_po2;
         assert!(max_insn_cycles < segment_limit as usize);
         let segment_threshold = segment_limit - max_insn_cycles as u32;
-        let mut segment_counter = 0;
 
         self.reset();
 
@@ -129,104 +180,112 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
         let initial_digest = self.pager.image.image_id();
         tracing::debug!("initial_digest: {initial_digest}");
 
-        while self.terminate_state.is_none() {
-            if let Some(max_cycles) = max_cycles {
-                if self.cycles.user >= max_cycles {
-                    bail!(
-                        "Session limit exceeded: {} >= {max_cycles}",
-                        self.cycles.user
-                    );
+        let (commit_sender, commit_recv) =
+            std::sync::mpsc::sync_channel(MAX_OUTSTANDING_SEGMENTS - 1);
+
+        let (post_digest, total_num_segments) = std::thread::scope(|scope| {
+            let partial_images_thread =
+                scope.spawn(move || compute_partial_images(commit_recv, callback));
+
+            while self.terminate_state.is_none() {
+                if let Some(max_cycles) = max_cycles {
+                    if self.cycles.user >= max_cycles {
+                        bail!(
+                            "Session limit exceeded: {} >= {max_cycles}",
+                            self.cycles.user
+                        );
+                    }
                 }
-            }
 
-            if self.segment_cycles() >= segment_threshold {
-                tracing::debug!(
-                    "split(phys: {} + pager: {} + reserved: {LOOKUP_TABLE_CYCLES}) = {} >= {segment_threshold}",
-                    self.phys_cycles,
-                    self.pager.cycles,
-                    self.segment_cycles()
-                );
+                if self.segment_cycles() >= segment_threshold {
+                    tracing::debug!(
+                        "split(phys: {} + pager: {} + reserved: {LOOKUP_TABLE_CYCLES}) = {} >= {segment_threshold}",
+                        self.phys_cycles,
+                        self.pager.cycles,
+                        self.segment_cycles()
+                    );
 
-                assert!(
-                    self.segment_cycles() < segment_limit,
-                    "segment limit ({segment_limit}) too small for instruction at pc: {:?}",
-                    self.pc
-                );
-                Risc0Machine::suspend(self)?;
+                    assert!(
+                        self.segment_cycles() < segment_limit,
+                        "segment limit ({segment_limit}) too small for instruction at pc: {:?}",
+                        self.pc
+                    );
+                    Risc0Machine::suspend(self)?;
 
-                let (pre_image, pre_digest, post_digest) = self.pager.commit();
-                callback(Segment {
-                    partial_image: compute_partial_image(pre_image, self.pager.page_indexes()),
-                    claim: Rv32imV2Claim {
-                        pre_state: pre_digest,
-                        post_state: post_digest,
-                        input: self.input_digest,
-                        output: self.output_digest,
+                    let (pre_image, pre_digest, post_digest) = self.pager.commit();
+
+                    let req = ComputePartialImageRequest {
+                        image: pre_image,
+                        page_indexes: self.pager.page_indexes(),
+                        input_digest: self.input_digest,
+                        output_digest: self.output_digest,
+                        read_record: std::mem::take(&mut self.read_record),
+                        write_record: std::mem::take(&mut self.write_record),
+                        user_cycles: self.user_cycles,
+                        phys_cycles: self.phys_cycles,
+                        pager_cycles: self.pager.cycles,
                         terminate_state: self.terminate_state,
-                        shutdown_cycle: None,
-                    },
-                    read_record: std::mem::take(&mut self.read_record),
-                    write_record: std::mem::take(&mut self.write_record),
-                    user_cycles: self.user_cycles,
-                    suspend_cycle: self.phys_cycles,
-                    paging_cycles: self.pager.cycles,
-                    po2: segment_po2 as u32,
-                    index: segment_counter,
-                    segment_threshold,
-                })?;
+                        segment_threshold,
+                        pre_digest,
+                        post_digest,
+                        po2: segment_po2 as u32,
+                    };
+                    if commit_sender.send(req).is_err() {
+                        return Err(partial_images_thread.join().unwrap().unwrap_err());
+                    }
 
-                segment_counter += 1;
-                let total_cycles = 1 << segment_po2;
-                let pager_cycles = self.pager.cycles as u64;
-                let user_cycles = self.user_cycles as u64;
-                self.cycles.total += total_cycles;
-                self.cycles.paging += pager_cycles;
-                self.cycles.reserved += total_cycles - pager_cycles - user_cycles;
-                self.user_cycles = 0;
-                self.phys_cycles = 0;
-                self.pager.reset();
+                    let total_cycles = 1 << segment_po2;
+                    let pager_cycles = self.pager.cycles as u64;
+                    let user_cycles = self.user_cycles as u64;
+                    self.cycles.total += total_cycles;
+                    self.cycles.paging += pager_cycles;
+                    self.cycles.reserved += total_cycles - pager_cycles - user_cycles;
+                    self.user_cycles = 0;
+                    self.phys_cycles = 0;
+                    self.pager.reset();
 
-                Risc0Machine::resume(self)?;
+                    Risc0Machine::resume(self)?;
+                }
+
+                Risc0Machine::step(&mut emu, self)?;
             }
 
-            Risc0Machine::step(&mut emu, self)?;
-        }
+            Risc0Machine::suspend(self)?;
 
-        Risc0Machine::suspend(self)?;
+            let final_cycles = self.segment_cycles().next_power_of_two();
+            let final_po2 = log2_ceil(final_cycles as usize);
+            let segment_threshold = (1 << final_po2) - max_insn_cycles as u32;
+            let (pre_image, pre_digest, post_digest) = self.pager.commit();
+            let req = ComputePartialImageRequest {
+                image: pre_image,
+                page_indexes: self.pager.page_indexes(),
+                input_digest: self.input_digest,
+                output_digest: self.output_digest,
+                read_record: std::mem::take(&mut self.read_record),
+                write_record: std::mem::take(&mut self.write_record),
+                user_cycles: self.user_cycles,
+                phys_cycles: self.phys_cycles,
+                pager_cycles: self.pager.cycles,
+                terminate_state: self.terminate_state,
+                segment_threshold,
+                pre_digest,
+                post_digest,
+                po2: final_po2 as u32,
+            };
+            if commit_sender.send(req).is_err() {
+                return Err(partial_images_thread.join().unwrap().unwrap_err());
+            }
 
-        let (pre_image, pre_digest, post_digest) = self.pager.commit();
-        let final_cycles = self.segment_cycles().next_power_of_two();
-        let final_po2 = log2_ceil(final_cycles as usize);
-        let segment_threshold = (1 << final_po2) - max_insn_cycles as u32;
+            let final_cycles = final_cycles as u64;
+            let user_cycles = self.user_cycles as u64;
+            let pager_cycles = self.pager.cycles as u64;
+            self.cycles.total += final_cycles;
+            self.cycles.paging += pager_cycles;
+            self.cycles.reserved += final_cycles - pager_cycles - user_cycles;
 
-        let final_claim = Rv32imV2Claim {
-            pre_state: pre_digest,
-            post_state: post_digest,
-            input: self.input_digest,
-            output: self.output_digest,
-            terminate_state: self.terminate_state,
-            shutdown_cycle: None,
-        };
-
-        callback(Segment {
-            partial_image: compute_partial_image(pre_image, self.pager.page_indexes()),
-            claim: final_claim,
-            read_record: std::mem::take(&mut self.read_record),
-            write_record: std::mem::take(&mut self.write_record),
-            user_cycles: self.user_cycles,
-            suspend_cycle: self.phys_cycles,
-            paging_cycles: self.pager.cycles,
-            po2: final_po2 as u32,
-            index: segment_counter,
-            segment_threshold,
+            drop(commit_sender);
+            Ok((post_digest, partial_images_thread.join().unwrap()?))
         })?;
-
-        let final_cycles = final_cycles as u64;
-        let user_cycles = self.user_cycles as u64;
-        let pager_cycles = self.pager.cycles as u64;
-        self.cycles.total += final_cycles;
-        self.cycles.paging += pager_cycles;
-        self.cycles.reserved += final_cycles - pager_cycles - user_cycles;
 
         let session_claim = Rv32imV2Claim {
             pre_state: initial_digest,
@@ -238,7 +297,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
         };
 
         Ok(ExecutorResult {
-            segments: segment_counter + 1,
+            segments: total_num_segments,
             post_image: self.pager.image.clone(),
             user_cycles: self.cycles.user,
             total_cycles: self.cycles.total,

--- a/risc0/circuit/rv32im-v2/src/execute/pager.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/pager.rs
@@ -315,10 +315,10 @@ impl PagedMemory {
     pub(crate) fn peek_page(&mut self, page_idx: u32) -> Result<Vec<u8>> {
         if let Some(cache_idx) = self.page_table.get(page_idx) {
             // Loaded, get from cache
-            Ok(self.page_cache[cache_idx].0.clone())
+            Ok(self.page_cache[cache_idx].data().clone())
         } else {
             // Unloaded, peek into image
-            Ok(self.image.get_page(page_idx)?.0.clone())
+            Ok(self.image.get_page(page_idx)?.data().clone())
         }
     }
 

--- a/risc0/circuit/rv32im-v2/src/execute/pager.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/pager.rs
@@ -347,6 +347,16 @@ impl PagedMemory {
         }
     }
 
+    pub(crate) fn load_register(&mut self, base: WordAddr, idx: usize) -> u32 {
+        if base == USER_REGS_ADDR.waddr() {
+            self.user_registers[idx]
+        } else if base == MACHINE_REGS_ADDR.waddr() {
+            self.machine_registers[idx]
+        } else {
+            unimplemented!("unknown register address {base:?}");
+        }
+    }
+
     fn store_ram(&mut self, addr: WordAddr, word: u32) -> Result<()> {
         // tracing::trace!("store: {addr:?}, page: {page_idx:#08x}, word: {word:#010x}");
         let page_idx = addr.page_idx();
@@ -364,6 +374,16 @@ impl PagedMemory {
             Ok(())
         } else {
             self.store_ram(addr, word)
+        }
+    }
+
+    pub(crate) fn store_register(&mut self, base: WordAddr, idx: usize, word: u32) {
+        if base == USER_REGS_ADDR.waddr() {
+            self.user_registers[idx] = word;
+        } else if base == MACHINE_REGS_ADDR.waddr() {
+            self.machine_registers[idx] = word;
+        } else {
+            unimplemented!("unknown register address {base:?}");
         }
     }
 

--- a/risc0/circuit/rv32im-v2/src/execute/pager.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/pager.rs
@@ -426,6 +426,7 @@ impl PagedMemory {
                 self.image.set_page(page_idx, page.clone());
             }
         }
+        self.image.update_digests();
 
         let post_state = self.image.image_id();
         (pre_image, pre_state, post_state)
@@ -525,6 +526,8 @@ pub(crate) fn compute_partial_image(
             image.set_digest(rhs_idx, *input_image.get_existing_digest(rhs_idx));
         }
     }
+
+    image.update_digests();
 
     image
 }

--- a/risc0/circuit/rv32im-v2/src/execute/r0vm.rs
+++ b/risc0/circuit/rv32im-v2/src/execute/r0vm.rs
@@ -477,15 +477,15 @@ impl<T: Risc0Context> EmuContext for Risc0Machine<'_, T> {
 
     fn store_register(&mut self, idx: usize, word: u32) -> Result<()> {
         // tracing::trace!("store_reg: x{idx} <= {word:#010x}");
-        let mut base = self.regs_base_addr();
+        let base = self.regs_base_addr();
 
         // To avoid the use of a degree in the circuit, all writes to REG_ZERO
         // are shunted to a memory location that is never read from.
         if idx == REG_ZERO {
-            base += REG_MAX * 2;
+            self.ctx.store_u32(base + REG_MAX * 2, word)
+        } else {
+            self.ctx.store_register(base, idx, word)
         }
-
-        self.ctx.store_register(base, idx, word)
     }
 
     fn load_memory(&mut self, addr: WordAddr) -> Result<u32> {

--- a/risc0/circuit/rv32im-v2/src/prove/witgen/preflight.rs
+++ b/risc0/circuit/rv32im-v2/src/prove/witgen/preflight.rs
@@ -182,7 +182,7 @@ impl<'a> Preflight<'a> {
     // Do page out
     pub fn write_pages(&mut self) -> Result<()> {
         let activity = self.pager.dirty_pages();
-        self.pager.commit()?;
+        self.pager.commit();
         Poseidon2::write_start(self)?;
         for &page_idx in activity.pages.iter().rev() {
             Poseidon2::write_page(self, page_idx)?;

--- a/risc0/zkvm/src/host/server/exec/mod.rs
+++ b/risc0/zkvm/src/host/server/exec/mod.rs
@@ -25,20 +25,23 @@ pub(crate) mod syscall;
 #[cfg(test)]
 mod tests;
 
-use std::{cell::RefCell, io::Write, rc::Rc};
+use std::{
+    io::Write,
+    sync::{Arc, Mutex},
+};
 
 // Capture the journal output in a buffer that we can access afterwards.
 #[derive(Clone, Default)]
 struct Journal {
-    buf: Rc<RefCell<Vec<u8>>>,
+    buf: Arc<Mutex<Vec<u8>>>,
 }
 
 impl Write for Journal {
     fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-        self.buf.borrow_mut().write(bytes)
+        self.buf.lock().unwrap().write(bytes)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.buf.borrow_mut().flush()
+        self.buf.lock().unwrap().flush()
     }
 }

--- a/risc0/zkvm/src/host/server/exec/syscall/mod.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall/mod.rs
@@ -29,7 +29,12 @@ mod slice_io;
 mod verify;
 mod verify2;
 
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 
 use anyhow::{anyhow, Result};
 use enum_map::{Enum, EnumMap};
@@ -134,7 +139,7 @@ pub(crate) struct SyscallTable<'a> {
     pub(crate) inner: HashMap<String, Rc<RefCell<dyn Syscall + 'a>>>,
     pub(crate) posix_io: Rc<RefCell<PosixIo<'a>>>,
     pub(crate) assumptions: Rc<RefCell<AssumptionReceipts>>,
-    pub(crate) assumptions_used: Rc<RefCell<AssumptionUsage>>,
+    pub(crate) assumptions_used: Arc<Mutex<AssumptionUsage>>,
     pub(crate) mmr_assumptions: Rc<RefCell<Vec<AssumptionReceipt>>>,
     pub(crate) coprocessor: Option<CoprocessorCallbackRef<'a>>,
     pub(crate) pending_zkrs: Rc<RefCell<Vec<ProveZkrRequest>>>,

--- a/risc0/zkvm/src/host/server/exec/syscall/verify.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall/verify.rs
@@ -57,7 +57,8 @@ impl Syscall for SysVerify {
         // Mark the assumption as accessed, pushing it to the head of the list, and return the success code.
         ctx.syscall_table()
             .assumptions_used
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(0, assumption);
 
         let metric = &mut ctx.syscall_table().metrics.borrow_mut()[SyscallKind::VerifyIntegrity];

--- a/risc0/zkvm/src/host/server/exec/syscall/verify2.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall/verify2.rs
@@ -66,7 +66,8 @@ impl Syscall for SysVerify2 {
         // Mark the assumption as accessed, pushing it to the head of the list, and return the success code.
         ctx.syscall_table()
             .assumptions_used
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(0, (assumption, assumption_receipt));
 
         let metric = &mut ctx.syscall_table().metrics.borrow_mut()[SyscallKind::VerifyIntegrity2];


### PR DESCRIPTION
This PR does the following:

- Run partial_image computation on a separate thread
- Make pages copy-on-write
- Update MemoryImage2 digests all at once
- Add special path for load / store register

This produces improvements on my machine of the execute benchmark

before:
```
┌─────────┬────────┬────────────┬──────────┬────────┬─────┬──────┐
│ name    │ hashfn │ throughput │ duration │ cycles │ ram │ seal │
├─────────┼────────┼────────────┼──────────┼────────┼─────┼──────┤
│ execute │ N/A    │ 26.4MHz    │ 37.9ms   │ 1M     │ N/A │ N/A  │
└─────────┴────────┴────────────┴──────────┴────────┴─────┴──────┘
```

after:
```
┌─────────┬────────┬────────────┬──────────┬────────┬─────┬──────┐
│ name    │ hashfn │ throughput │ duration │ cycles │ ram │ seal │
├─────────┼────────┼────────────┼──────────┼────────┼─────┼──────┤
│ execute │ N/A    │ 31.8MHz    │ 31.5ms   │ 1M     │ N/A │ N/A  │
└─────────┴────────┴────────────┴──────────┴────────┴─────┴──────┘
```

http://remi-dev1/perf-graphs/v2_executor_c68360f7e9089a6beddfe2ca4c954afbd6041a84_perf3.svg