### PR TITLE
Fix Bash String Comparison & Correct Cargo.toml Path

### DIFF
--- a/.github/scripts/circom_stable.sh
+++ b/.github/scripts/circom_stable.sh
@@ -1,13 +1,13 @@
 RISC0_LIB_HASH=$(git hash-object -- compact_proof/groth16/risc0.circom | awk '{ print $1 }')
 RISC0_LIB_EXPECTED_HASH="87af73e7d1b24bff3df350136ec6637245a2330a"
-if [ $RISC0_LIB_HASH != $RISC0_LIB_EXPECTED_HASH ]; then
+if [ "$RISC0_LIB_HASH" != "$RISC0_LIB_EXPECTED_HASH" ]; then
     echo "Unexpected hash of risc0.circom: $RISC0_LIB_HASH"
     exit 1
 fi
     
 STARK_VERIFY_HASH=$(git hash-object -- compact_proof/groth16/stark_verify.circom | awk '{ print $1 }')
 STARK_VERIFY_EXPECTED_HASH="81557c4f15ce43f5c7c840c287e76abd3a676cd5"
-if [ $STARK_VERIFY_HASH != $STARK_VERIFY_EXPECTED_HASH ]; then
+if [ "$STARK_VERIFY_HASH" != "$STARK_VERIFY_EXPECTED_HASH" ]; then
     echo "Unexpected hash of stark_verify.circom: $STARK_VERIFY_HASH"
     exit 1
 fi

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -3,7 +3,7 @@
     "Cargo.toml",
     "benchmarks/Cargo.toml",
     "examples/Cargo.toml",
-    "risc0/cargo-risczero/tests/test_crate",
+    "risc0/cargo-risczero/tests/test_crate/Cargo.toml",
     "risc0/zkvm/methods/guest/Cargo.toml",
     "risc0/zkvm/methods/std/Cargo.toml",
     "tools/crates-validator/Cargo.toml"


### PR DESCRIPTION
Changes Made:

Added double quotes around variable comparisons to prevent errors when variables are empty.
Before:
if [ $RISC0_LIB_HASH != $RISC0_LIB_EXPECTED_HASH ]; then
if [ $STARK_VERIFY_HASH != $STARK_VERIFY_EXPECTED_HASH ]; then
After:
if [ "$RISC0_LIB_HASH" != "$RISC0_LIB_EXPECTED_HASH" ]; then
if [ "$STARK_VERIFY_HASH" != "$STARK_VERIFY_EXPECTED_HASH" ]; then

Ensures the script does not break when variables are empty or unset.
Prevents syntax errors in strict shell environments.


Updated Cargo.toml path in .vim/coc-settings.json

Changed "risc0/cargo-risczero/tests/test_crate" to "risc0/cargo-risczero/tests/test_crate/Cargo.toml"
Ensures Rust Analyzer correctly detects dependencies.