### PR TITLE
docs: fix dead link in `eth-examples.md`

### DIFF
--- a/website/api/blockchain-integration/eth-examples.md
+++ b/website/api/blockchain-integration/eth-examples.md
@@ -32,7 +32,7 @@ This [example app][governance-example] uses Bonsai as an Ethereum coprocessor. T
 [signature-aggregation]: https://github.com/risc0/risc0-ethereum/blob/main/examples/governance/methods/guest/src/bin/finalize_votes.rs
 [steel-blog]: https://www.risczero.com/blog/introducing-steel-1.0
 [steel-repo]: https://crates.io/crates/risc0-steel
-[steel-src]: https://github.com/risc0/risc0-ethereum/tree/main/steel
+[steel-src]: https://github.com/risc0/risc0-ethereum/tree/main/crates/steel
 [verifier-contracts]: https://github.com/risc0/risc0-ethereum/tree/main/contracts
 [zeth-article]: https://www.risczero.com/news/zeth-release
 [zeth-repo]: https://github.com/risc0/zeth


### PR DESCRIPTION
Hi! I found a broken link in the `eth-examples.md` documentation file. The link to the `risc0-steel` crate source code was pointing to an outdated path `https://github.com/risc0/risc0-ethereum/tree/main/steel`