### PR TITLE
ZKVM-1195: Fix bug with rzup concerning r0vm version containing `-`

### DIFF
--- a/rzup/src/lib.rs
+++ b/rzup/src/lib.rs
@@ -2253,7 +2253,10 @@ mod tests {
             "git",
             &["-c", "init.defaultBranch=master", "init"],
             Some(&test_repo),
-            &[],
+            &[
+                ("GIT_CONFIG_SYSTEM", "/dev/null"),
+                ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ],
         )
         .unwrap();
 
@@ -2285,7 +2288,10 @@ mod tests {
                 "initial commit",
             ],
             Some(&test_repo),
-            &[],
+            &[
+                ("GIT_CONFIG_SYSTEM", "/dev/null"),
+                ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ],
         )
         .unwrap();
         build::run_command("git", &["tag", "foo"], Some(&test_repo), &[]).unwrap();
@@ -2317,7 +2323,10 @@ mod tests {
                 "bar",
             ],
             Some(&test_repo),
-            &[],
+            &[
+                ("GIT_CONFIG_SYSTEM", "/dev/null"),
+                ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ],
         )
         .unwrap();
 

--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -79,6 +79,7 @@ impl Paths {
                 }
             }
         }
+
         Ok(res)
     }
 
@@ -132,8 +133,7 @@ impl Paths {
                 // New format with platform suffix
                 extract_version(&version_part[..p])
             } else {
-                let p = version_part.find('-')?;
-                extract_version(&version_part[..p])
+                None
             }
         } else {
             None
@@ -205,6 +205,14 @@ mod tests {
             Component::CargoRiscZero,
             "v1.2.1-rc.0-cargo-risczero",
             Version::parse("1.2.1-rc.0").unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_get_and_parse_cargo_risczero_version_fails() {
+        assert_eq!(
+            Paths::parse_version_from_path("v1.2.1-rc.0-foobar", &Component::CargoRiscZero),
+            None
         );
     }
 

--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -129,12 +129,10 @@ impl Paths {
             parse_cpp_version(dir_name.split('-').next()?).ok()
         } else if dir_name.starts_with('v') {
             let version_part = dir_name.strip_prefix('v')?;
-            if let Some(p) = version_part.find(&format!("-{component}")) {
+            version_part.find(&format!("-{component}")).and_then(|p| {
                 // New format with platform suffix
                 extract_version(&version_part[..p])
-            } else {
-                None
-            }
+            })
         } else {
             None
         }

--- a/rzup/src/registry.rs
+++ b/rzup/src/registry.rs
@@ -114,8 +114,9 @@ impl Registry {
         env: &Environment,
         component: &Component,
     ) -> Result<Option<(Version, std::path::PathBuf)>> {
+        let component_installed = component.parent_component().unwrap_or(*component);
         if let Some(version) = self.settings.get_default_version(component) {
-            if let Some(path) = Paths::find_version_dir(env, component, &version)? {
+            if let Some(path) = Paths::find_version_dir(env, &component_installed, &version)? {
                 return Ok(Some((version, path)));
             }
         }
@@ -123,7 +124,7 @@ impl Registry {
         // Components installed by old versions might leave us in a state where there is a
         // component installed, but no active version
         if let Some(version) = self.find_highest_installed_version(env, component)? {
-            if let Some(path) = Paths::find_version_dir(env, component, &version)? {
+            if let Some(path) = Paths::find_version_dir(env, &component_installed, &version)? {
                 return Ok(Some((version, path)));
             }
         }
@@ -137,7 +138,8 @@ impl Registry {
         component: &Component,
         version: Version,
     ) -> Result<()> {
-        if Paths::find_version_dir(env, component, &version)?.is_none() {
+        let component_installed = component.parent_component().unwrap_or(*component);
+        if Paths::find_version_dir(env, &component_installed, &version)?.is_none() {
             return Err(RzupError::InvalidVersion(format!(
                 "Version {version} is not installed",
             )));


### PR DESCRIPTION
This was a little bit of a convoluted bug.

When we were checking for the existence of `r0vm` being installed, we were asking the path-finding code to look for directories with `r0vm` in the path, this was a bug.

This bug was masked though by the fact that the extension finding part had a fallback part where it would just parse the version from the string until the first `-`. Since versions with `-rc` in them have this `-` it broke this logic.

This fallback part never needed to exist, we could instead just pass the right component into this function. This fixes the bug because the regular version finding logic works correctly using the component name as a way to find the version number.