### PR TITLE
Fix dev mode environment variable handling

### DIFF
--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -183,8 +183,8 @@ pub fn get_version() -> Result<Version, semver::Error> {
 pub fn is_dev_mode() -> bool {
     let is_env_set = std::env::var("RISC0_DEV_MODE")
         .ok()
-        .map(|x| x.to_lowercase())
-        .filter(|x| x == "1" || x == "true" || x == "yes")
+        .map(|x| x.to_lowercase().trim().to_string())
+        .filter(|x| x == "1" || x == "true" || x == "yes" || x == "on")
         .is_some();
 
     if cfg!(feature = "disable-dev-mode") && is_env_set {


### PR DESCRIPTION
Improved handling of the RISC0_DEV_MODE environment variable in the is_dev_mode() function:
- Added support for the "on" value
- Added trimming of whitespace using trim()
- Fixed the logic for recognizing valid values
These changes make the function more flexible and resilient to different ways of setting the environment variable, improving the developer experience when using the library, especially when switching between working environments.
The previous implementation would fail to recognize valid environment variable values if they contained whitespace (like " true" or "yes ") or used the common "on" value, potentially leading to unexpected behavior when developers tried to enable dev mode through environment variables.