### PR TITLE
chore: speed up build times

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,7 @@ xtask = "run --package xtask --release --"
 
 [build]
 rustflags = ["-Dclippy::all", "-Dwarnings"]
+rustc-wrapper = "sccache"
+
+[registries.crates-io]
+protocol = "sparse"


### PR DESCRIPTION
Using:
 - [sparse registry protocol](https://doc.rust-lang.org/cargo/reference/registries.html) to reduce fetching
 - [`sccache`](https://github.com/mozilla/sccache) to cache builds
 
 Future suggestion: Cache to the cloud in the future