### PR TITLE
ZKVM-1208: Update crate version numbers with new scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4422,7 +4422,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -4443,14 +4443,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2-methods"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "cc",
  "directories",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "cc",
  "cust",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "cust",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cust",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-tools"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "assert_cmd",
  "clap 4.5.23",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bincode",
  "borsh",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 
 [[package]]
 name = "rlsf"
@@ -5042,7 +5042,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "clap 4.5.23",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,35 +34,35 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
-bonsai-sdk = { version = "1.4.0-alpha.1", default-features = false, path = "bonsai/sdk" }
+bonsai-sdk = { version = "1.4.0", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/bigint2" }
-risc0-binfmt = { version = "2.0.0-alpha.1", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "3.0.0-alpha.1", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-keccak = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/keccak" }
-risc0-circuit-keccak-sys = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/keccak-sys" }
-risc0-circuit-recursion = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "0.1.0", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "0.1.0", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "2.0.0-alpha.1", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "1.4.0-alpha.1", default-features = false, path = "risc0/zkp" }
-risc0-zkos-v1compat = { version = "0.1.0", path = "risc0/zkos/v1compat" }
-risc0-zkvm = { version = "2.0.0-alpha.1", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "2.0.0-alpha.1", default-features = false, path = "risc0/zkvm/platform" }
-rzup = { version = "0.4.0-alpha.1", default-features = false, path = "rzup" }
+risc0-bigint2 = { version = "1.4.0", default-features = false, path = "risc0/bigint2" }
+risc0-binfmt = { version = "2.0.0", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "3.0.0", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "1.4.0", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-keccak = { version = "1.4.0", default-features = false, path = "risc0/circuit/keccak" }
+risc0-circuit-keccak-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/keccak-sys" }
+risc0-circuit-recursion = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "2.0.0", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "2.0.0", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "2.0.0", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "1.4.0", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "2.0.0", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "1.4.0", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "2.0.0", default-features = false, path = "risc0/zkp" }
+risc0-zkos-v1compat = { version = "2.0.0", path = "risc0/zkos/v1compat" }
+risc0-zkvm = { version = "2.0.0", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "2.0.0", default-features = false, path = "risc0/zkvm/platform" }
+rzup = { version = "0.4.0", default-features = false, path = "rzup" }
 sppark = "0.1.10"
 
 [profile.bench]

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "cc",
  "directories",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "cc",
  "cust",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "cust",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cust",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3348,7 +3348,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/bonsai/sdk/Cargo.toml
+++ b/bonsai/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bonsai-sdk"
 description = "Bonsai Software Development Kit"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -3725,7 +3725,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "cc",
  "directories",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "cc",
  "cust",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "cust",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cust",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "ciborium",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 
 [[package]]
 name = "rkyv"
@@ -4275,7 +4275,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec 0.8.0",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bls12_381/methods/guest/Cargo.lock
+++ b/examples/bls12_381/methods/guest/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bn254/methods/guest/Cargo.lock
+++ b/examples/bn254/methods/guest/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -862,7 +862,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1282,7 +1282,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -826,7 +826,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/k256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/k256/methods/guest/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/p256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/p256/methods/guest/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -825,7 +825,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -851,7 +851,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/keccak/methods/guest/Cargo.lock
+++ b/examples/keccak/methods/guest/Cargo.lock
@@ -824,7 +824,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -916,7 +916,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -915,7 +915,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -818,7 +818,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-bigint2"
 description = "RISC Zero's Big Integer Accelerator"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -999,13 +999,13 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-bigint-dig",
- "risc0-bigint2 1.4.0-alpha.1",
+ "risc0-bigint2 1.4.0",
  "risc0-zkvm",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/binfmt/Cargo.toml
+++ b/risc0/binfmt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-binfmt"
 description = "RISC Zero binary format crate"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build"
 description = "RISC Zero zero-knowledge VM build tool"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "bca23f98af42f8884fa8387ff8f191cdc26c3cb520a553fd775e64a8e6095272",
+            "61c290ae691869681145e21a1fa6a1810ac3193362987c60d68ec7fcf08d8b63",
         );
     }
 }

--- a/risc0/build_kernel/Cargo.toml
+++ b/risc0/build_kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build-kernel"
 description = "RISC Zero tool for building kernels"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-risczero"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak-sys/Cargo.toml
+++ b/risc0/circuit/keccak-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-keccak-sys"
 description = "Generated HAL code for keccak cicuit"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak/Cargo.toml
+++ b/risc0/circuit/keccak/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-keccak"
 description = "RISC Zero circuit for keccak"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak/methods/guest/Cargo.lock
+++ b/risc0/circuit/keccak/methods/guest/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/circuit/recursion-sys/Cargo.toml
+++ b/risc0/circuit/recursion-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-recursion-sys"
 description = "Generated HAL code for recursion cicuit"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/recursion/Cargo.toml
+++ b/risc0/circuit/recursion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-recursion"
 description = "RISC Zero circuit for recursion"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im-sys/Cargo.toml
+++ b/risc0/circuit/rv32im-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im-sys"
 description = "Generated HAL code for rv32im cicuit"
-version = "0.1.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im"
 description = "RISC Zero circuit for rv32im"
-version = "0.1.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/core/Cargo.toml
+++ b/risc0/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-core"
 description = "Core types for RISC Zero crates"
-version = { workspace = true }
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/groth16/Cargo.toml
+++ b/risc0/groth16/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-groth16"
 description = "RISC Zero Groth16"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-r0vm"
 description = "RISC Zero zero-knowledge VM executable"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/sys/Cargo.toml
+++ b/risc0/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-sys"
 description = "Generated / Native / HAL code for RISC Zero"
-version = { workspace = true }
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/tools/Cargo.toml
+++ b/risc0/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-tools"
-version = { workspace = true }
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkos/v1compat/Cargo.toml
+++ b/risc0/zkos/v1compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkp"
 description = "RISC Zero zero-knowledge proof system core crate"
-version = { workspace = true }
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm"
 description = "RISC Zero zero-knowledge VM"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1309,7 +1309,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "ciborium",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1601,7 +1601,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "rzup"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -818,7 +818,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "1.4.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bincode",
  "borsh",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1518,7 +1518,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/zkvm/platform/Cargo.toml
+++ b/risc0/zkvm/platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm-platform"
 description = "RISC Zero zero-knowledge VM"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rzup"
 description = "The RISC Zero version management library and CLI"
-version = "0.4.0-alpha.1"
+version = "0.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
In the new crate version numbering scheme each crate will have its own version.
The crates on main will either:
- have the version of the last release if there are no changes since that release
- have the version of the next release if there are changes since the last release

We are going to bump all the version numbers for the next release though (but not all major version numbers), to make things easier to start but also to avoid associating with the 1.3.0 release.

I am also working on changes to the CI semver checks so that these rules are always respected and the PR with changes to a crate will include bumping the version number. Before I can make those checks pass though, I need the main version numbers to be right.