### PR TITLE
ZKVM-1210: Reduce bigint executor work

### DIFF
--- a/risc0/circuit/rv32im/src/execute/bigint.rs
+++ b/risc0/circuit/rv32im/src/execute/bigint.rs
@@ -14,19 +14,14 @@
 
 use std::{collections::HashMap, io::Cursor};
 
-use anyhow::{anyhow, bail, ensure, Result};
-use derive_more::Debug;
+use anyhow::Result;
 use malachite::Natural;
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive as _;
 use risc0_binfmt::WordAddr;
 
 use super::{
     bibc::{self, BigIntIO},
-    byte_poly::BytePolyProgram,
     platform::*,
     r0vm::{LoadOp, Risc0Context},
-    CycleState,
 };
 
 pub(crate) const BIGINT_STATE_COUNT: usize = 5 + 16;
@@ -39,165 +34,7 @@ pub(crate) const BIGINT_WIDTH_WORDS: usize = 4;
 pub(crate) const BIGINT_WIDTH_BYTES: usize = BIGINT_WIDTH_WORDS * WORD_SIZE;
 
 pub(crate) type BigIntBytes = [u8; BIGINT_WIDTH_BYTES];
-type BigIntWitness = HashMap<WordAddr, BigIntBytes>;
-
-#[derive(Clone, Debug)]
-pub(crate) struct BigIntState {
-    pub is_ecall: bool,
-    pub pc: WordAddr,
-    pub poly_op: PolyOp,
-    pub coeff: u32,
-    pub bytes: BigIntBytes,
-    pub next_state: CycleState,
-}
-
-struct BigInt {
-    state: BigIntState,
-    program: BytePolyProgram,
-}
-
-#[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
-pub(crate) enum PolyOp {
-    Reset,
-    Shift,
-    SetTerm,
-    AddTotal,
-    Carry1,
-    Carry2,
-    EqZero,
-}
-
-#[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
-pub(crate) enum MemoryOp {
-    Read,
-    Write,
-    Check,
-}
-
-#[derive(Debug)]
-#[debug("{poly_op:?}({mem_op:?}, c:{coeff}, r:{reg}, o:{offset})")]
-pub(crate) struct Instruction {
-    pub poly_op: PolyOp,
-    pub mem_op: MemoryOp,
-    pub coeff: i32,
-    pub reg: u32,
-    pub offset: u32,
-}
-
-impl Instruction {
-    // instruction encoding:
-    // 3  2   2  2    1               0
-    // 1  8   4  1    6               0
-    // mmmmppppcccaaaaaoooooooooooooooo
-    pub fn decode(insn: u32) -> Result<Self> {
-        Ok(Self {
-            mem_op: MemoryOp::from_u32(insn >> 28 & 0x0f)
-                .ok_or_else(|| anyhow!("Invalid mem_op in bigint program"))?,
-            poly_op: PolyOp::from_u32(insn >> 24 & 0x0f)
-                .ok_or_else(|| anyhow!("Invalid poly_op in bigint program"))?,
-            coeff: (insn >> 21 & 0x07) as i32 - 4,
-            reg: insn >> 16 & 0x1f,
-            offset: insn & 0xffff,
-        })
-    }
-}
-
-impl BigInt {
-    fn run(&mut self, ctx: &mut dyn Risc0Context, witness: &BigIntWitness) -> Result<()> {
-        ctx.on_bigint_cycle(CycleState::BigIntEcall, &self.state);
-        while self.state.next_state == CycleState::BigIntStep {
-            self.step(ctx, witness)?;
-        }
-        Ok(())
-    }
-
-    fn step(&mut self, ctx: &mut dyn Risc0Context, witness: &BigIntWitness) -> Result<()> {
-        self.state.pc.inc();
-        let insn = Instruction::decode(ctx.load_u32(LoadOp::Record, self.state.pc)?)?;
-
-        let base =
-            ctx.load_aligned_addr_from_machine_register(LoadOp::Record, insn.reg as usize)?;
-        let addr = base + insn.offset * BIGINT_WIDTH_WORDS as u32;
-
-        tracing::trace!("step({:?}, {insn:?}, {addr:?})", self.state.pc);
-        if insn.mem_op == MemoryOp::Check && insn.poly_op != PolyOp::Reset {
-            if !self.program.in_carry {
-                self.program.in_carry = true;
-                self.program.total_carry = self.program.total.clone();
-                let mut carry = 0;
-
-                // Do carry propagation
-                for coeff in self.program.total_carry.coeffs.iter_mut() {
-                    *coeff += carry;
-                    ensure!(*coeff % 256 == 0, "bad carry");
-                    *coeff /= 256;
-                    carry = *coeff;
-                }
-                tracing::trace!("carry propagate complete");
-            }
-
-            let base_point = 128 * 256 * 64;
-            for (i, ret) in self.state.bytes.iter_mut().enumerate() {
-                let offset = insn.offset as usize;
-                let coeff = self.program.total_carry.coeffs[offset * BIGINT_WIDTH_BYTES + i] as u32;
-                let value = coeff.wrapping_add(base_point);
-                match insn.poly_op {
-                    PolyOp::Carry1 => *ret = ((value >> 14) & 0xff) as u8,
-                    PolyOp::Carry2 => *ret = ((value >> 8) & 0x3f) as u8,
-                    PolyOp::Shift | PolyOp::EqZero => *ret = (value & 0xff) as u8,
-                    _ => {
-                        bail!("Invalid poly_op in bigint program")
-                    }
-                }
-            }
-        } else if insn.mem_op == MemoryOp::Read {
-            for i in 0..BIGINT_WIDTH_WORDS {
-                let word = ctx.load_u32(LoadOp::Record, addr + i)?;
-                for (j, byte) in word.to_le_bytes().iter().enumerate() {
-                    self.state.bytes[i * WORD_SIZE + j] = *byte;
-                }
-            }
-        } else if !addr.is_null() {
-            self.state.bytes = *witness
-                .get(&addr)
-                .ok_or_else(|| anyhow!("Missing bigint witness: {addr:?}"))?;
-            if insn.mem_op == MemoryOp::Write {
-                let words: &[u32] = bytemuck::cast_slice(&self.state.bytes);
-                for (i, word) in words.iter().enumerate() {
-                    ctx.store_u32(addr + i, *word)?;
-                }
-            }
-        }
-
-        self.program.step(&insn, &self.state.bytes)?;
-
-        self.state.is_ecall = false;
-        self.state.poly_op = insn.poly_op;
-        self.state.coeff = (insn.coeff + 4) as u32;
-        self.state.next_state = if !self.state.is_ecall && insn.poly_op == PolyOp::Reset {
-            CycleState::Decode
-        } else {
-            CycleState::BigIntStep
-        };
-
-        ctx.on_bigint_cycle(CycleState::BigIntStep, &self.state);
-        Ok(())
-    }
-}
-
-struct BigIntIOImpl<'a> {
-    ctx: &'a mut dyn Risc0Context,
-    pub witness: BigIntWitness,
-}
-
-impl<'a> BigIntIOImpl<'a> {
-    pub fn new(ctx: &'a mut dyn Risc0Context) -> Self {
-        Self {
-            ctx,
-            witness: HashMap::new(),
-        }
-    }
-}
+pub(crate) type BigIntWitness = HashMap<WordAddr, BigIntBytes>;
 
 fn bytes_le_to_bigint(bytes: &[u8]) -> Natural {
     let mut limbs = Vec::with_capacity((bytes.len() + 3) / 4);
@@ -219,6 +56,20 @@ fn bigint_to_bytes_le(value: &Natural) -> Vec<u8> {
         out.extend_from_slice(&limb.to_le_bytes());
     }
     out
+}
+
+struct BigIntIOImpl<'a> {
+    ctx: &'a mut dyn Risc0Context,
+    pub witness: BigIntWitness,
+}
+
+impl<'a> BigIntIOImpl<'a> {
+    pub fn new(ctx: &'a mut dyn Risc0Context) -> Self {
+        Self {
+            ctx,
+            witness: HashMap::new(),
+        }
+    }
 }
 
 impl BigIntIO for BigIntIOImpl<'_> {
@@ -257,7 +108,25 @@ impl BigIntIO for BigIntIOImpl<'_> {
     }
 }
 
-pub fn ecall(ctx: &mut dyn Risc0Context) -> Result<()> {
+pub(crate) struct BigIntExec {
+    pub(crate) verify_program_ptr: WordAddr,
+    pub(crate) verify_program_size: usize,
+    pub(crate) witness: BigIntWitness,
+}
+
+pub fn ecall_execute(ctx: &mut dyn Risc0Context) -> Result<usize> {
+    let exec = ecall(ctx)?;
+    let cycles = exec.verify_program_size + 1;
+    for (addr, bytes) in exec.witness {
+        for (i, chunk) in bytes.chunks_exact(WORD_SIZE).enumerate() {
+            let word = u32::from_le_bytes(chunk.try_into().unwrap());
+            ctx.store_u32(addr + i, word)?;
+        }
+    }
+    Ok(cycles)
+}
+
+pub(crate) fn ecall(ctx: &mut dyn Risc0Context) -> Result<BigIntExec> {
     tracing::debug!("ecall");
 
     let blob_ptr = ctx.load_aligned_addr_from_machine_register(LoadOp::Load, REG_A0)?;
@@ -267,7 +136,7 @@ pub fn ecall(ctx: &mut dyn Risc0Context) -> Result<()> {
     let consts_ptr = ctx.load_aligned_addr_from_machine_register(LoadOp::Load, REG_T3)?;
 
     let nondet_program_size = ctx.load_u32(LoadOp::Load, blob_ptr)?;
-    let verify_program_size = ctx.load_u32(LoadOp::Load, blob_ptr + 1)?;
+    let verify_program_size = ctx.load_u32(LoadOp::Load, blob_ptr + 1)? as usize;
     let consts_size = ctx.load_u32(LoadOp::Load, blob_ptr + 2)?;
     tracing::debug!("blob_ptr: {blob_ptr:?}");
     tracing::debug!(
@@ -292,7 +161,7 @@ pub fn ecall(ctx: &mut dyn Risc0Context) -> Result<()> {
     ctx.load_region(
         LoadOp::Load,
         verify_program_ptr.baddr(),
-        verify_program_size as usize * WORD_SIZE,
+        verify_program_size * WORD_SIZE,
     )?;
     ctx.load_region(
         LoadOp::Load,
@@ -300,21 +169,9 @@ pub fn ecall(ctx: &mut dyn Risc0Context) -> Result<()> {
         consts_size as usize * WORD_SIZE,
     )?;
 
-    // let cycles = verify_program_size as usize + 1;
-
-    let state = BigIntState {
-        is_ecall: true,
-        pc: verify_program_ptr,
-        poly_op: PolyOp::Reset,
-        coeff: 0,
-        bytes: Default::default(),
-        next_state: CycleState::BigIntStep,
-    };
-
-    let mut bigint = BigInt {
-        state,
-        program: BytePolyProgram::new(),
-    };
-
-    bigint.run(ctx, &witness)
+    Ok(BigIntExec {
+        verify_program_ptr,
+        verify_program_size,
+        witness,
+    })
 }

--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 use super::{
-    bigint::BigIntState,
+    bigint,
     pager::{compute_partial_image, PageTraceEvent, PagedMemory},
     platform::*,
     poseidon2::Poseidon2State,
@@ -504,8 +504,10 @@ impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
         self.phys_cycles += 1;
     }
 
-    fn on_bigint_cycle(&mut self, _cur_state: CycleState, _bigint: &BigIntState) {
-        self.phys_cycles += 1;
+    fn ecall_bigint(&mut self) -> Result<()> {
+        let cycles = bigint::ecall_execute(self)?;
+        self.phys_cycles += cycles as u32;
+        Ok(())
     }
 }
 

--- a/risc0/circuit/rv32im/src/execute/mod.rs
+++ b/risc0/circuit/rv32im/src/execute/mod.rs
@@ -14,7 +14,6 @@
 
 pub(crate) mod bibc;
 pub(crate) mod bigint;
-pub(crate) mod byte_poly;
 mod executor;
 pub(crate) mod pager;
 pub mod platform;

--- a/risc0/circuit/rv32im/src/execute/r0vm.rs
+++ b/risc0/circuit/rv32im/src/execute/r0vm.rs
@@ -18,7 +18,6 @@ use anyhow::{anyhow, bail, Result};
 use risc0_binfmt::{ByteAddr, WordAddr};
 
 use super::{
-    bigint::{self, BigIntState},
     platform::*,
     poseidon2::{Poseidon2, Poseidon2State},
     rv32im::{DecodedInstruction, EmuContext, Emulator, Exception, Instruction},
@@ -51,10 +50,6 @@ pub(crate) trait Risc0Context {
     fn on_insn_start(&mut self, insn: &Instruction, decoded: &DecodedInstruction) -> Result<()>;
 
     fn on_insn_end(&mut self, insn: &Instruction, decoded: &DecodedInstruction) -> Result<()>;
-
-    fn store_register(&mut self, base: WordAddr, idx: usize, word: u32) -> Result<()> {
-        self.store_u32(base + idx, word)
-    }
 
     fn load_u32(&mut self, op: LoadOp, addr: WordAddr) -> Result<u32>;
 
@@ -90,6 +85,10 @@ pub(crate) trait Risc0Context {
     }
 
     fn store_u32(&mut self, addr: WordAddr, word: u32) -> Result<()>;
+
+    fn store_register(&mut self, base: WordAddr, idx: usize, word: u32) -> Result<()> {
+        self.store_u32(base + idx, word)
+    }
 
     fn on_ecall_cycle(
         &mut self,
@@ -130,7 +129,7 @@ pub(crate) trait Risc0Context {
 
     fn on_poseidon2_cycle(&mut self, cur_state: CycleState, p2: &Poseidon2State);
 
-    fn on_bigint_cycle(&mut self, cur_state: CycleState, bigint: &BigIntState);
+    fn ecall_bigint(&mut self) -> Result<()>;
 }
 
 fn check_aligned_addr(addr: ByteAddr) -> Result<WordAddr> {
@@ -360,7 +359,7 @@ impl<'a, T: Risc0Context> Risc0Machine<'a, T> {
         self.next_pc();
         self.ctx
             .on_ecall_cycle(CycleState::MachineEcall, CycleState::BigIntEcall, 0, 0, 0)?;
-        bigint::ecall(self.ctx)?;
+        self.ctx.ecall_bigint()?;
         Ok(false)
     }
 

--- a/risc0/circuit/rv32im/src/prove/witgen/byte_poly.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/byte_poly.rs
@@ -19,9 +19,14 @@ use auto_ops::impl_op_ex;
 use risc0_zkp::field::Elem as _;
 use smallvec::{smallvec, SmallVec};
 
-use crate::zirgen::circuit::ExtVal;
+use crate::{
+    execute::bigint::{BIGINT_ACCUM_STATE_COUNT, BIGINT_WIDTH_BYTES},
+    zirgen::circuit::{BigIntAccumStateLayout, ExtVal, LAYOUT_TOP_ACCUM},
+};
 
-use super::bigint::{BigIntState, Instruction, PolyOp, BIGINT_WIDTH_BYTES};
+use super::bigint::{BigIntState, Instruction, PolyOp};
+
+const BIGINT_ACCUM_STATE_LAYOUT: &BigIntAccumStateLayout = LAYOUT_TOP_ACCUM.user._0.state;
 
 #[derive(Debug)]
 pub(crate) struct BytePolyProgram {
@@ -189,6 +194,44 @@ impl BigIntAccumState {
             term: ExtVal::ONE,
             total: ExtVal::ZERO,
         }
+    }
+
+    pub(crate) const fn offsets() -> [usize; BIGINT_ACCUM_STATE_COUNT] {
+        [
+            BIGINT_ACCUM_STATE_LAYOUT.poly._super.offset,
+            BIGINT_ACCUM_STATE_LAYOUT.poly._super.offset + 1,
+            BIGINT_ACCUM_STATE_LAYOUT.poly._super.offset + 2,
+            BIGINT_ACCUM_STATE_LAYOUT.poly._super.offset + 3,
+            BIGINT_ACCUM_STATE_LAYOUT.term._super.offset,
+            BIGINT_ACCUM_STATE_LAYOUT.term._super.offset + 1,
+            BIGINT_ACCUM_STATE_LAYOUT.term._super.offset + 2,
+            BIGINT_ACCUM_STATE_LAYOUT.term._super.offset + 3,
+            BIGINT_ACCUM_STATE_LAYOUT.total._super.offset,
+            BIGINT_ACCUM_STATE_LAYOUT.total._super.offset + 1,
+            BIGINT_ACCUM_STATE_LAYOUT.total._super.offset + 2,
+            BIGINT_ACCUM_STATE_LAYOUT.total._super.offset + 3,
+        ]
+    }
+
+    pub(crate) fn as_array(&self) -> [u32; BIGINT_ACCUM_STATE_COUNT] {
+        let poly = self.poly.elems();
+        let term = self.term.elems();
+        let total = self.total.elems();
+
+        [
+            poly[0].into(),
+            poly[1].into(),
+            poly[2].into(),
+            poly[3].into(),
+            term[0].into(),
+            term[1].into(),
+            term[2].into(),
+            term[3].into(),
+            total[0].into(),
+            total[1].into(),
+            total[2].into(),
+            total[3].into(),
+        ]
     }
 }
 

--- a/risc0/circuit/rv32im/src/prove/witgen/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub(crate) mod bigint;
+pub(crate) mod byte_poly;
 pub(crate) mod paged_map;
 pub(crate) mod poseidon2;
 pub(crate) mod preflight;
@@ -33,15 +34,15 @@ use risc0_zkp::{
     hal::Hal,
 };
 
-use self::preflight::Back;
+use self::{
+    bigint::BigIntState,
+    byte_poly::{BigIntAccum, BigIntAccumState},
+    preflight::Back,
+};
 use super::hal::{CircuitAccumulator, CircuitWitnessGenerator, MetaBuffer, StepMode};
 use crate::{
     execute::{
-        bigint::BigIntState,
-        byte_poly::{BigIntAccum, BigIntAccumState},
-        platform::MERKLE_TREE_END_ADDR,
-        poseidon2::Poseidon2State,
-        segment::Segment,
+        platform::MERKLE_TREE_END_ADDR, poseidon2::Poseidon2State, segment::Segment,
         sha2::Sha2State,
     },
     zirgen::circuit::{


### PR DESCRIPTION
The `BytePolyProgram` only needs to be run during preflight.