### PR TITLE
ZKVM-1214: pin reqwest to 0.12.12

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -31,7 +31,7 @@ fs_extra = "1.3.0"
 hex = "0.4"
 human-repr = { version = "1.0", features = ["1024"] }
 regex = "1.11.1"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "=0.12.12", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }


### PR DESCRIPTION
The last `reqwest` update (v0.12.13) broke `cargo-risczero`

```console
error[E0599]: no method named `fetch_mode_no_cors` found for struct `reqwest::RequestBuilder` in the current scope
   --> /.cargo/registry/src/index.crates.io-6f17d22bba15001f/reqwest-middleware-0.3.3/src/client.rs:530:31
    |
530 |             inner: self.inner.fetch_mode_no_cors(),
    |                               ^^^^^^^^^^^^^^^^^^ method not found in `RequestBuilder`

``` 