### PR TITLE
backport 2.0: prepare risc0-build and rzup for toolchains >= 1.85.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,6 +4481,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rzup",
+ "semver",
  "serde",
  "serde_json",
  "stability",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2968,6 +2968,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rzup",
+ "semver",
  "serde",
  "serde_json",
  "stability",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3753,6 +3753,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rzup",
+ "semver",
  "serde",
  "serde_json",
  "stability",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1099,6 +1099,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rzup",
+ "semver",
  "serde",
  "serde_json",
  "stability",

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -19,6 +19,7 @@ risc0-zkos-v1compat = { workspace = true }
 risc0-zkp = { workspace = true, features = ["std"] }
 risc0-zkvm-platform = { workspace = true }
 rzup = { workspace = true }
+semver = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0.134"
 stability = "0.2"

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "829b22d13f75ab6dfd9eabaaae73cfb467c83bc2b4b6be4007220e01123c15ef",
+            "415cb85c2bb5d7117d19a0a29451cabbf0094d0e232e44d34adcab76abc8eb21",
         );
     }
 }

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rzup",
+ "semver",
  "serde",
  "serde_json",
  "stability",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rzup",
+ "semver",
  "serde",
  "serde_json",
  "stability",

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -115,7 +115,7 @@ fn git_clone(src: &str, dest: &Path) -> Result<()> {
 }
 
 fn git_checkout(path: &Path, tag_or_commit: &str) -> Result<()> {
-    run_command("git", &["checkout", tag_or_commit], Some(path), &[])?;
+    run_command("git", &["checkout", "-f", tag_or_commit], Some(path), &[])?;
     Ok(())
 }
 
@@ -170,7 +170,8 @@ fn find_build_directories(build_dir: &Path) -> Result<(PathBuf, PathBuf)> {
 pub fn build_rust_toolchain(
     env: &Environment,
     repo_url: &str,
-    tag_or_commit: &str,
+    tag_or_commit: &Option<String>,
+    path: &Option<String>,
 ) -> Result<Version> {
     env.emit(RzupEvent::BuildingRustToolchain);
 
@@ -180,16 +181,23 @@ pub fn build_rust_toolchain(
         message: "cloning git repository".into(),
     });
 
-    let repo_dir = env.tmp_dir().join("build-rust-toolchain");
-
-    if !repo_dir.join(".git").exists() {
-        git_clone(repo_url, &repo_dir)?;
-    } else {
-        git_fetch(&repo_dir)?;
-    }
-    git_checkout(&repo_dir, tag_or_commit)?;
-    git_reset_hard(&repo_dir)?;
-    git_submodule_update(&repo_dir)?;
+    // if building from commit
+    let repo_dir = match path {
+        None => {
+            let repo_dir = env.tmp_dir().join("build-rust-toolchain");
+            if !repo_dir.join(".git").exists() {
+                git_clone(repo_url, &repo_dir)?;
+            } else {
+                git_fetch(&repo_dir)?;
+            }
+            let tag_or_commit = tag_or_commit.as_ref().unwrap();
+            git_checkout(&repo_dir, tag_or_commit)?;
+            git_reset_hard(&repo_dir)?;
+            git_submodule_update(&repo_dir)?;
+            repo_dir
+        }
+        Some(path) => path.into(),
+    };
 
     let commit = git_short_rev_parse(&repo_dir, "HEAD")?;
 
@@ -218,7 +226,7 @@ pub fn build_rust_toolchain(
         Some(&repo_dir),
         &[(
             "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",
-            "-Cpasses=loweratomic",
+            "-Cpasses=lower-atomic",
         )],
         |line| {
             env.emit(RzupEvent::BuildingRustToolchainUpdate {
@@ -238,7 +246,7 @@ pub fn build_rust_toolchain(
         Some(&repo_dir),
         &[(
             "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",
-            "-Cpasses=loweratomic",
+            "-Cpasses=lower-atomic",
         )],
         |line| {
             env.emit(RzupEvent::BuildingRustToolchainUpdate {

--- a/rzup/src/cli/commands.rs
+++ b/rzup/src/cli/commands.rs
@@ -16,7 +16,7 @@ use crate::error::Result;
 use crate::events::RzupEvent;
 use crate::{Rzup, RzupError};
 
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use colored::Colorize;
 use semver::Version;
 
@@ -272,13 +272,23 @@ pub const BUILD_HELP: &str = "Discussion:
     the default version. The resulting component version contains the commit hash.";
 
 #[derive(Parser)]
+#[clap(group(
+    ArgGroup::new("mode")
+        .args(&["tag_or_commit", "path"])
+        .required(true)
+))]
 pub(crate) struct BuildCommand {
-    /// Name of component to uninstall
+    /// Name of component to build
     #[arg(value_parser=parser("build"))]
     name: String,
 
-    /// Tag or commit of the component to uninstall
-    tag_or_commit: String,
+    /// Tag or commit of the component to build
+    #[arg(short, long)]
+    tag_or_commit: Option<String>,
+
+    /// optional local path to build from
+    #[arg(short, long)]
+    path: Option<String>,
 }
 
 impl BuildCommand {
@@ -288,6 +298,10 @@ impl BuildCommand {
             return Err(RzupError::Other(format!("cannot build {component}")));
         }
 
-        rzup.build_rust_toolchain("https://github.com/risc0/rust.git", &self.tag_or_commit)
+        rzup.build_rust_toolchain(
+            "https://github.com/risc0/rust.git",
+            &self.tag_or_commit,
+            &self.path,
+        )
     }
 }

--- a/rzup/src/lib.rs
+++ b/rzup/src/lib.rs
@@ -309,9 +309,11 @@ impl Rzup {
     pub(crate) fn build_rust_toolchain(
         &mut self,
         repo_url: &str,
-        tag_or_commit: &str,
+        tag_or_commit: &Option<String>,
+        path: &Option<String>,
     ) -> Result<()> {
-        let version = build::build_rust_toolchain(&self.environment, repo_url, tag_or_commit)?;
+        let version =
+            build::build_rust_toolchain(&self.environment, repo_url, tag_or_commit, path)?;
         self.set_default_version(&Component::RustToolchain, version)?;
         Ok(())
     }
@@ -2344,7 +2346,8 @@ mod tests {
         run_and_assert_events(
             &mut rzup,
             |rzup| {
-                rzup.build_rust_toolchain(&repo_url, "master").unwrap();
+                rzup.build_rust_toolchain(&repo_url, &Some("master".to_string()), &None)
+                    .unwrap();
             },
             vec![
                 RzupEvent::BuildingRustToolchain,
@@ -2409,13 +2412,15 @@ mod tests {
         let (test_repo, master) = create_fake_rust_repo(&tmp_dir);
 
         let repo_url = format!("file://{}", test_repo.display());
-        rzup.build_rust_toolchain(&repo_url, "foo").unwrap();
+        rzup.build_rust_toolchain(&repo_url, &Some("foo".to_string()), &None)
+            .unwrap();
 
         let foo_commit = build::git_short_rev_parse(&test_repo, "foo").unwrap();
         let mut foo = master.clone();
         foo.build = semver::BuildMetadata::new(&foo_commit).unwrap();
 
-        rzup.build_rust_toolchain(&repo_url, "master").unwrap();
+        rzup.build_rust_toolchain(&repo_url, &Some("master".to_string()), &None)
+            .unwrap();
 
         std::fs::remove_dir_all(tmp_dir.path().join(".risc0/tmp")).unwrap();
         assert_files(


### PR DESCRIPTION
Recent LLVM versions have changed `loweratomic` to `lower-atomic`. Change this for `rzup` and `risc0-build` and add ability to build rust toolchain from a local directory.