### PR TITLE
Backport #2967

### DIFF
--- a/.github/workflows/risc0-ethereum.yml
+++ b/.github/workflows/risc0-ethereum.yml
@@ -132,10 +132,10 @@ jobs:
           version: nightly-5c69a9d9fd4e2ec07fc398ab5ef9d706c33890c2
       # Apply local patch
       - name: Local patch on risc0-ethereum
-        run: python ${{ env.RISC0_PATH }}/.github/cargo_local_patch.py  .
+        run: python ${{ env.RISC0_PATH }}/.github/cargo_local_patch.py --ignore lib .
         working-directory:  ${{ env.RISC0_ETHEREUM_PATH }}
       - name: Local patch on risc0-foundry-template
-        run: python ${{ env.RISC0_PATH }}/.github/cargo_local_patch.py  .
+        run: python ${{ env.RISC0_PATH }}/.github/cargo_local_patch.py --ignore lib .
         working-directory:  ${{ env.RISC0_FOUNDRY_TEMPLATE_PATH }}
       # Run Bootstrap-groth16 to update test receipt for checking
       # the latest groth16 prover against the solidity verifier on risc0-ethereum


### PR DESCRIPTION
When applying the `cargo_local_patch.py` during the `risc0-ethereum` CI workflow, we also modify the git submodules if a match is found. That by itself is not an issue; however since we added the `--locked` when running the `risc0-forge-ffi` binary, we can produce an error like

```console
ERROR cheatcodes: non-empty stderr input=["cargo", "run", "--locked", "--manifest-path", "lib/risc0-ethereum/crates/ffi/Cargo.toml", "--bin", "risc0-forge-ffi", "-q", "prove", "/opt/actions-runner/_work/risc0/risc0/risc0-foundry-template/target/riscv-guest/methods/guests/riscv32im-risc0-zkvm-elf/release/is-even.bin", "0x0000000000000000000000000000000000000000000000000000000000bc614e"] stderr="\u{1b}[1m\u{1b}[31merror\u{1b}[0m\u{1b}[1m:\u{1b}[0m the lock file /opt/actions-runner/_work/risc0/risc0/risc0-foundry-template/lib/risc0-ethereum/Cargo.lock needs to be updated but --locked was passed to prevent this\nIf you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.\n"
```