### PR TITLE
[release-2.0]: Add missing -rc.2 to 3 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "cc",
  "cust",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "cc",
  "cust",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "cc",
  "cust",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec 0.8.0",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bls12_381/methods/guest/Cargo.lock
+++ b/examples/bls12_381/methods/guest/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bn254/methods/guest/Cargo.lock
+++ b/examples/bn254/methods/guest/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/k256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/k256/methods/guest/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/p256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/p256/methods/guest/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/keccak/methods/guest/Cargo.lock
+++ b/examples/keccak/methods/guest/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "35709e808fe748d2f6ac9c1543c9653f2bd9cb5adeaf5918b9564d25a4a1a2ea",
+            "5552f5c1e248cdeff1073657078a2e39f7d80ef1e0c9b350e2b3007bc74f5127",
         );
     }
 }

--- a/risc0/circuit/keccak/methods/guest/Cargo.lock
+++ b/risc0/circuit/keccak/methods/guest/Cargo.lock
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/circuit/rv32im-sys/Cargo.toml
+++ b/risc0/circuit/rv32im-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im-sys"
 description = "Generated HAL code for rv32im cicuit"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im"
 description = "RISC Zero circuit for rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/platform/Cargo.toml
+++ b/risc0/zkvm/platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm-platform"
 description = "RISC Zero zero-knowledge VM"
-version = "2.0.0"
+version = "2.0.0-rc.2"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
I made a mistake and somehow got the version number wrong for these crates. I want to fix it in crates.io by republishing these crates with the right version and yanking the old version. This is in large part due to fixing the semver checks, but also for posterity.