### PR TITLE
ZKVM-1243: Update to Rust 1.85.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6257,7 +6257,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap 4.5.32",
  "colored",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3466,7 +3466,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4338,7 +4338,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1315,7 +1315,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "34b0006e3ed3f40a5d43a6a7d4f34a92fa0f9ab4750a7187ae08b67226812bf3",
+            "16bd77410aa99289b2880ace0a17af5238a7bfae24c507c4ef1212502873f438",
         );
     }
 }

--- a/risc0/circuit/keccak/src/prove/mod.rs
+++ b/risc0/circuit/keccak/src/prove/mod.rs
@@ -148,7 +148,7 @@ where
             for (i, word) in digest.as_mut_words().iter_mut().enumerate() {
                 let low: u32 = slice[i * 2].into();
                 let high: u32 = slice[i * 2 + 1].into();
-                *word = low | high << 16;
+                *word = low | (high << 16);
             }
             tracing::debug!("final digest: {digest}");
 

--- a/risc0/circuit/recursion/src/prove/preflight.rs
+++ b/risc0/circuit/recursion/src/prove/preflight.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -229,7 +229,7 @@ impl<'a, Ext: Externs> Preflight<'a, Ext> {
         if self
             .split_points
             .last()
-            .map_or(false, |cycle| *cycle == ctx.cycle)
+            .is_some_and(|cycle| *cycle == ctx.cycle)
         {
             self.split_points.pop();
         }

--- a/risc0/circuit/rv32im/src/execute/testutil.rs
+++ b/risc0/circuit/rv32im/src/execute/testutil.rs
@@ -325,18 +325,18 @@ fn insn_b(imm: u32, rs2: u32, rs1: u32, funct3: u32, opcode: u32) -> u32 {
     let imm_10_5 = (imm >> 5) & 0b111111;
     let imm_11 = (imm >> 11) & 0b1;
     let imm_4_1 = (imm >> 1) & 0b1111;
-    ((imm_12 << 6 | imm_10_5) << 25)
+    (((imm_12 << 6) | imm_10_5) << 25)
         | (rs2 << 20)
         | (rs1 << 15)
         | (funct3 << 12)
-        | ((imm_4_1 << 1 | imm_11) << 7)
+        | (((imm_4_1 << 1) | imm_11) << 7)
         | opcode
 }
 
 // 31                                   12 | 11        7 | 6    0 |
 //    imm[31:12]                           |      rd     | opcode |
 fn insn_u(imm: u32, rd: u32, opcode: u32) -> u32 {
-    (imm << 12) | rd << 7 | opcode
+    (imm << 12) | (rd << 7) | opcode
 }
 
 fn fence() -> u32 {

--- a/risc0/circuit/rv32im/src/lib.rs
+++ b/risc0/circuit/rv32im/src/lib.rs
@@ -62,7 +62,7 @@ pub struct HighLowU16(pub u16, pub u16);
 
 impl From<HighLowU16> for u32 {
     fn from(x: HighLowU16) -> Self {
-        (x.0 as u32) << 16 | (x.1 as u32)
+        ((x.0 as u32) << 16) | (x.1 as u32)
     }
 }
 

--- a/risc0/circuit/rv32im/src/prove/witgen/bigint.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/bigint.rs
@@ -83,12 +83,12 @@ impl Instruction {
     // mmmmppppcccaaaaaoooooooooooooooo
     pub fn decode(insn: u32) -> Result<Self> {
         Ok(Self {
-            mem_op: MemoryOp::from_u32(insn >> 28 & 0x0f)
+            mem_op: MemoryOp::from_u32((insn >> 28) & 0x0f)
                 .ok_or_else(|| anyhow!("Invalid mem_op in bigint program"))?,
-            poly_op: PolyOp::from_u32(insn >> 24 & 0x0f)
+            poly_op: PolyOp::from_u32((insn >> 24) & 0x0f)
                 .ok_or_else(|| anyhow!("Invalid poly_op in bigint program"))?,
-            coeff: (insn >> 21 & 0x07) as i32 - 4,
-            reg: insn >> 16 & 0x1f,
+            coeff: ((insn >> 21) & 0x07) as i32 - 4,
+            reg: (insn >> 16) & 0x1f,
             offset: insn & 0xffff,
         })
     }

--- a/risc0/groth16/src/seal_format.rs
+++ b/risc0/groth16/src/seal_format.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ pub(crate) enum IopType {
     Digest,
 }
 
-pub(crate) const K_SEAL_TYPES: [IopType; K_SEAL_ELEMS] = [
+pub(crate) static K_SEAL_TYPES: [IopType; K_SEAL_ELEMS] = [
     IopType::Fp,
     IopType::Fp,
     IopType::Fp,

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1618,7 +1618,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "rzup"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1535,7 +1535,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/zkvm/src/guest/env/verify.rs
+++ b/risc0/zkvm/src/guest/env/verify.rs
@@ -84,6 +84,7 @@ pub fn verify(image_id: impl Into<Digest>, journal: &[impl Pod]) -> Result<(), I
 /// [composition]: https://dev.risczero.com/terminology#composition
 pub fn verify_integrity(claim: &ReceiptClaim) -> Result<(), VerifyIntegrityError> {
     // Check that the assumptions list is empty.
+    #[allow(clippy::unnecessary_map_or)]
     let assumptions_empty = claim
         .output
         .as_value()?

--- a/risc0/zkvm/src/host/server/exec/syscall/args.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall/args.rs
@@ -47,10 +47,10 @@ impl Syscall for SysArgs {
                 )
             })?;
 
-            let nbytes = min(to_guest.len() * WORD_SIZE, arg_val.as_bytes().len());
+            let nbytes = min(to_guest.len() * WORD_SIZE, arg_val.len());
             let to_guest_u8s: &mut [u8] = bytemuck::cast_slice_mut(to_guest);
             to_guest_u8s[0..nbytes].clone_from_slice(&arg_val.as_bytes()[0..nbytes]);
-            Ok((arg_val.as_bytes().len() as u32, 0))
+            Ok((arg_val.len() as u32, 0))
         } else {
             bail!("Unknown syscall {syscall}")
         }

--- a/risc0/zkvm/src/host/server/exec/syscall/getenv.rs
+++ b/risc0/zkvm/src/host/server/exec/syscall/getenv.rs
@@ -39,10 +39,10 @@ impl Syscall for SysGetenv {
         match self.0.get(msg) {
             None => Ok((u32::MAX, 0)),
             Some(val) => {
-                let nbytes = min(to_guest.len() * WORD_SIZE, val.as_bytes().len());
+                let nbytes = min(to_guest.len() * WORD_SIZE, val.len());
                 let to_guest_u8s: &mut [u8] = bytemuck::cast_slice_mut(to_guest);
                 to_guest_u8s[0..nbytes].clone_from_slice(&val.as_bytes()[0..nbytes]);
-                Ok((val.as_bytes().len() as u32, 0))
+                Ok((val.len() as u32, 0))
             }
         }
     }

--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -206,7 +206,7 @@ impl<'de, R: WordRead + 'de> Deserializer<'de, R> {
     fn try_take_dword(&mut self) -> Result<u64> {
         let low = self.try_take_word()? as u64;
         let high = self.try_take_word()? as u64;
-        Ok(low | high << 32)
+        Ok(low | (high << 32))
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.83"
+channel = "1.85"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rzup"
 description = "The RISC Zero version management library and CLI"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/rzup/src/cli/commands.rs
+++ b/rzup/src/cli/commands.rs
@@ -130,9 +130,7 @@ impl ShowCommand {
                 sorted_versions.sort_by(|a, b| b.cmp(a)); // sort newest to oldest
 
                 for version in sorted_versions {
-                    let is_default = default_version
-                        .as_ref()
-                        .map_or(false, |(v, _)| v == &version);
+                    let is_default = default_version.as_ref().is_some_and(|(v, _)| v == &version);
                     let marker = if is_default { "* " } else { "  " };
                     rzup.print(format!("{}{version}", marker.bold()));
                 }


### PR DESCRIPTION
Since this change includes a change to `rzup` since it was released, we must bump its version number.