### PR TITLE
ZKVM-1244: add support for building 1.85 toolchain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -91,6 +91,7 @@
   ],
   "rust-analyzer.showUnlinkedFileNotification": false,
   "rust-analyzer.linkedProjects": [
+    "rzup/Cargo.toml",
     "Cargo.toml",
     "benchmarks/Cargo.toml",
     "examples/Cargo.toml",

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -226,7 +226,7 @@ pub fn build_rust_toolchain(
     };
 
     let stage2_flags: &[&str] = if version > semver::Version::new(1, 84, 0) {
-        &["build", "--stage", "2", "compiler/rustc", "library"]
+        &["build", "--stage", "2", "compiler/rustc", "library", "src/tools/cargo", "src/tools/clippy", "src/tools/rustfmt"]
     } else {
         &["build", "--stage", "2"]
     };

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -229,15 +229,9 @@ pub fn build_rust_toolchain(
     });
 
     let lower_atomic = if version > semver::Version::new(1, 81, 0) {
-<<<<<<< HEAD
         "-Cpasses=lower-atomic"
     } else {
         "-Cpasses=loweratomic"
-=======
-        "passes=lower-atomic"
-    } else {
-        "passes=loweratomic"
->>>>>>> 0b1eae0f5 (rzup build rust: set lower-atomic based on version number)
     };
 
     run_command_and_stream_output(

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -180,6 +180,10 @@ pub fn build_rust_toolchain(
     // if building from commit
     let repo_dir = match path {
         None => {
+            env.emit(RzupEvent::BuildingRustToolchainUpdate {
+                message: "using git repository".into(),
+            });
+
             let repo_dir = env.tmp_dir().join("build-rust-toolchain");
             if !repo_dir.join(".git").exists() {
                 env.emit(RzupEvent::BuildingRustToolchainUpdate {
@@ -195,7 +199,12 @@ pub fn build_rust_toolchain(
             git_submodule_update(&repo_dir)?;
             repo_dir
         }
-        Some(path) => path.into(),
+        Some(path) => {
+            env.emit(RzupEvent::BuildingRustToolchainUpdate {
+                message: format!("using path {}", path),
+            });
+            path.into()
+        }
     };
 
     let commit = git_short_rev_parse(&repo_dir, "HEAD")?;
@@ -220,9 +229,15 @@ pub fn build_rust_toolchain(
     });
 
     let lower_atomic = if version > semver::Version::new(1, 81, 0) {
+<<<<<<< HEAD
         "-Cpasses=lower-atomic"
     } else {
         "-Cpasses=loweratomic"
+=======
+        "passes=lower-atomic"
+    } else {
+        "passes=loweratomic"
+>>>>>>> 0b1eae0f5 (rzup build rust: set lower-atomic based on version number)
     };
 
     run_command_and_stream_output(

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -238,13 +238,13 @@ pub fn build_rust_toolchain(
 
 fn build_185_toolchain(env: &Environment, version: Version, repo_dir: &Path) -> Result<Version> {
     env.emit(RzupEvent::BuildingRustToolchainUpdate {
-        message: format!("./x dist dist rustc cargo clippy rustfmt rust-std"),
+        message: "./x dist dist rustc cargo clippy rustfmt rust-std".to_string(),
     });
 
     run_command_and_stream_output(
         "./x",
         &["dist", "rustc", "cargo", "clippy", "rustfmt", "rust-std"],
-        Some(&repo_dir),
+        Some(repo_dir),
         &[(
             "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",
             "-Cpasses=lower-atomic",
@@ -271,7 +271,7 @@ fn build_185_toolchain(env: &Environment, version: Version, repo_dir: &Path) -> 
             "rustfmt",
             "library/std",
         ],
-        Some(&repo_dir),
+        Some(repo_dir),
         &[],
         |line| {
             env.emit(RzupEvent::BuildingRustToolchainUpdate {
@@ -309,7 +309,7 @@ fn build_older_toolchain(
     run_command_and_stream_output(
         "./x",
         stage2_flags,
-        Some(&repo_dir),
+        Some(repo_dir),
         &[(
             "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",
             lower_atomic,
@@ -331,7 +331,7 @@ fn build_older_toolchain(
     }
 
     let (stage2, stage2_tools) = find_build_directories(&repo_dir.join("build"))?;
-    std::fs::rename(stage2, &dest_dir)?;
+    std::fs::rename(stage2, dest_dir)?;
 
     for tool in std::fs::read_dir(stage2_tools)? {
         let tool = tool?;

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -180,10 +180,6 @@ pub fn build_rust_toolchain(
     // if building from commit
     let repo_dir = match path {
         None => {
-            env.emit(RzupEvent::BuildingRustToolchainUpdate {
-                message: "using git repository".into(),
-            });
-
             let repo_dir = env.tmp_dir().join("build-rust-toolchain");
             if !repo_dir.join(".git").exists() {
                 env.emit(RzupEvent::BuildingRustToolchainUpdate {
@@ -199,12 +195,7 @@ pub fn build_rust_toolchain(
             git_submodule_update(&repo_dir)?;
             repo_dir
         }
-        Some(path) => {
-            env.emit(RzupEvent::BuildingRustToolchainUpdate {
-                message: format!("using path {}", path),
-            });
-            path.into()
-        }
+        Some(path) => path.into(),
     };
 
     let commit = git_short_rev_parse(&repo_dir, "HEAD")?;

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -225,6 +225,12 @@ pub fn build_rust_toolchain(
         "-Cpasses=loweratomic"
     };
 
+    let stage2_flags: &[&str] = if version > semver::Version::new(1, 84, 0) {
+        &["build", "--stage", "2", "compiler/rustc", "library"]
+    } else {
+        &["build", "--stage", "2"]
+    };
+
     run_command_and_stream_output(
         "./x",
         &["build"],
@@ -247,7 +253,7 @@ pub fn build_rust_toolchain(
 
     run_command_and_stream_output(
         "./x",
-        &["build", "--stage", "2"],
+        stage2_flags,
         Some(&repo_dir),
         &[(
             "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",

--- a/rzup/src/lib.rs
+++ b/rzup/src/lib.rs
@@ -315,7 +315,9 @@ impl Rzup {
     ) -> Result<()> {
         let version =
             build::build_rust_toolchain(&self.environment, repo_url, tag_or_commit, path)?;
-        self.set_default_version(&Component::RustToolchain, version)?;
+        if std::env::var("RISC0_RUST_DEST_DIR").is_err() {
+            self.set_default_version(&Component::RustToolchain, version)?;
+        }
         Ok(())
     }
 }

--- a/rzup/src/rust-toolchain-build-config.toml
+++ b/rzup/src/rust-toolchain-build-config.toml
@@ -1,7 +1,7 @@
 [build]
 target = ["riscv32im-risc0-zkvm-elf"]
 extended = true
-tools = ["cargo", "cargo-clippy", "clippy", "rustfmt"]
+tools = ["cargo", "clippy", "rustfmt"]
 configure-args = []
 cargo-native-static = true
 


### PR DESCRIPTION
This PR adds support for building 1.85 toolchain. This is done by calling `./x dist` and `./x install` commands. For ease of use in CI environments, I've added `RISC0_RUST_DEST_DIR` variable. If this is used, we ignore the version check.