### PR TITLE
ZKVM-1252: Rename bigint field unchecked & FFI ops

### DIFF
--- a/risc0/bigint2/src/field/ffi.rs
+++ b/risc0/bigint2/src/field/ffi.rs
@@ -22,7 +22,7 @@ pub extern "C" fn risc0_bigint_modadd_256_unchecked(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modadd_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::modadd_256(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -33,7 +33,7 @@ pub extern "C" fn risc0_bigint_modadd_384_unchecked(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modadd_384_unchecked(lhs, rhs, modulus, result);
+    unchecked::modadd_384(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -43,7 +43,7 @@ pub extern "C" fn risc0_bigint_modinv_256_unchecked(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modinv_256_unchecked(inp, modulus, result);
+    unchecked::modinv_256(inp, modulus, result);
 }
 
 #[stability::unstable]
@@ -53,7 +53,7 @@ pub extern "C" fn risc0_bigint_modinv_384_unchecked(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modinv_384_unchecked(inp, modulus, result);
+    unchecked::modinv_384(inp, modulus, result);
 }
 
 #[stability::unstable]
@@ -64,7 +64,7 @@ pub extern "C" fn risc0_bigint_modmul_256_unchecked(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modmul_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::modmul_256(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -75,7 +75,7 @@ pub extern "C" fn risc0_bigint_modmul_384_unchecked(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modmul_384_unchecked(lhs, rhs, modulus, result);
+    unchecked::modmul_384(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -86,7 +86,7 @@ pub extern "C" fn risc0_bigint_modsub_256_unchecked(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modsub_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::modsub_256(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -97,7 +97,7 @@ pub extern "C" fn risc0_bigint_modsub_384_unchecked(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modsub_384_unchecked(lhs, rhs, modulus, result);
+    unchecked::modsub_384(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -108,7 +108,7 @@ pub extern "C" fn risc0_bigint_extfield_deg2_add_256_unchecked(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_add_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::extfield_deg2_add_256(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -119,7 +119,7 @@ pub extern "C" fn risc0_bigint_extfield_deg2_add_384_unchecked(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_add_384_unchecked(lhs, rhs, modulus, result);
+    unchecked::extfield_deg2_add_384(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -130,7 +130,7 @@ pub extern "C" fn risc0_bigint_extfield_deg2_sub_256_unchecked(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_sub_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::extfield_deg2_sub_256(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -141,7 +141,7 @@ pub extern "C" fn risc0_bigint_extfield_deg2_sub_384_unchecked(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_sub_384_unchecked(lhs, rhs, modulus, result);
+    unchecked::extfield_deg2_sub_384(lhs, rhs, modulus, result);
 }
 
 #[stability::unstable]
@@ -153,7 +153,7 @@ pub extern "C" fn risc0_bigint_extfield_xxone_mul_256_unchecked(
     modsqr: &[u32; 2 * FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_xxone_mul_256_unchecked(lhs, rhs, modulus, modsqr, result);
+    unchecked::extfield_xxone_mul_256(lhs, rhs, modulus, modsqr, result);
 }
 
 #[stability::unstable]
@@ -165,7 +165,7 @@ pub extern "C" fn risc0_bigint_extfield_xxone_mul_384_unchecked(
     modsqr: &[u32; 2 * FIELD_384_WIDTH_WORDS],
     result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_xxone_mul_384_unchecked(lhs, rhs, modulus, modsqr, result);
+    unchecked::extfield_xxone_mul_384(lhs, rhs, modulus, modsqr, result);
 }
 
 #[stability::unstable]

--- a/risc0/bigint2/src/field/mod.rs
+++ b/risc0/bigint2/src/field/mod.rs
@@ -12,321 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Accelerated finite field arithmetic operations
+//!
+//! Provides acceleration for certain finite field arithmetic operations. The operations in the root
+//! of this module include verification that the result is less than the modulus (for prime fields),
+//! or that the result's coefficients are less than the characteristic (for extension fields). In
+//! cases where it is known that these restrictions aren't necessary for security, there are
+//! versions that omit this check in the [unchecked] submodule.
+
 #[cfg(test)]
 mod tests;
 
-pub mod ffi_field;
+mod ffi;
+pub mod unchecked;
 
-use include_bytes_aligned::include_bytes_aligned;
-
-use crate::{
-    ffi::{sys_bigint2_3, sys_bigint2_4, sys_bigint2_5},
-    WORD_SIZE,
-};
+use crate::WORD_SIZE;
 
 pub const FIELD_256_WIDTH_WORDS: usize = 256 / (WORD_SIZE * 8);
 pub const FIELD_384_WIDTH_WORDS: usize = 384 / (WORD_SIZE * 8);
 pub const EXT_DEGREE_2: usize = 2;
 pub const EXT_DEGREE_4: usize = 4;
-
-const MODADD_256_BLOB: &[u8] = include_bytes_aligned!(4, "modadd_256.blob");
-const MODADD_384_BLOB: &[u8] = include_bytes_aligned!(4, "modadd_384.blob");
-const MODINV_256_BLOB: &[u8] = include_bytes_aligned!(4, "modinv_256.blob");
-const MODINV_384_BLOB: &[u8] = include_bytes_aligned!(4, "modinv_384.blob");
-const MODMUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "modmul_256.blob");
-const MODMUL_384_BLOB: &[u8] = include_bytes_aligned!(4, "modmul_384.blob");
-const MODSUB_256_BLOB: &[u8] = include_bytes_aligned!(4, "modsub_256.blob");
-const MODSUB_384_BLOB: &[u8] = include_bytes_aligned!(4, "modsub_384.blob");
-const EXTFIELD_DEG2_ADD_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_add_256.blob");
-const EXTFIELD_DEG2_ADD_384_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_add_384.blob");
-const EXTFIELD_DEG2_MUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_mul_256.blob");
-const EXTFIELD_DEG4_MUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg4_mul_256.blob");
-const EXTFIELD_DEG2_SUB_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_sub_256.blob");
-const EXTFIELD_DEG2_SUB_384_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_sub_384.blob");
-const EXTFIELD_XXONE_MUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_xxone_mul_256.blob");
-const EXTFIELD_XXONE_MUL_384_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_xxone_mul_384.blob");
-
-// These "unchecked" modular arithmetic operations provide no guarantee that `result < modulus`
-// This can be acceptable when computing internal results during a series of finite field
-// operations, but will not work for other use cases (e.g. comparing to a hash value).
-
-pub fn modadd_256_unchecked(
-    lhs: &[u32; FIELD_256_WIDTH_WORDS],
-    rhs: &[u32; FIELD_256_WIDTH_WORDS],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [u32; FIELD_256_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_4(
-            MODADD_256_BLOB.as_ptr(),
-            lhs.as_ptr(),
-            rhs.as_ptr(),
-            modulus.as_ptr(),
-            result.as_mut_ptr(),
-        );
-    }
-}
-
-pub fn modadd_384_unchecked(
-    lhs: &[u32; FIELD_384_WIDTH_WORDS],
-    rhs: &[u32; FIELD_384_WIDTH_WORDS],
-    modulus: &[u32; FIELD_384_WIDTH_WORDS],
-    result: &mut [u32; FIELD_384_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_4(
-            MODADD_384_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr() as *const u32,
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn modinv_256_unchecked(
-    inp: &[u32; FIELD_256_WIDTH_WORDS],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [u32; FIELD_256_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_3(
-            MODINV_256_BLOB.as_ptr(),
-            inp.as_ptr(),
-            modulus.as_ptr(),
-            result.as_mut_ptr(),
-        );
-    }
-}
-
-pub fn modinv_384_unchecked(
-    inp: &[u32; FIELD_384_WIDTH_WORDS],
-    modulus: &[u32; FIELD_384_WIDTH_WORDS],
-    result: &mut [u32; FIELD_384_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_3(
-            MODINV_384_BLOB.as_ptr(),
-            inp.as_ptr() as *const u32,
-            modulus.as_ptr() as *const u32,
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn modmul_256_unchecked(
-    lhs: &[u32; FIELD_256_WIDTH_WORDS],
-    rhs: &[u32; FIELD_256_WIDTH_WORDS],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [u32; FIELD_256_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_4(
-            MODMUL_256_BLOB.as_ptr(),
-            lhs.as_ptr(),
-            rhs.as_ptr(),
-            modulus.as_ptr(),
-            result.as_mut_ptr(),
-        );
-    }
-}
-
-pub fn modmul_384_unchecked(
-    lhs: &[u32; FIELD_384_WIDTH_WORDS],
-    rhs: &[u32; FIELD_384_WIDTH_WORDS],
-    modulus: &[u32; FIELD_384_WIDTH_WORDS],
-    result: &mut [u32; FIELD_384_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_4(
-            MODMUL_384_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr() as *const u32,
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn modsub_256_unchecked(
-    lhs: &[u32; FIELD_256_WIDTH_WORDS],
-    rhs: &[u32; FIELD_256_WIDTH_WORDS],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [u32; FIELD_256_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_4(
-            MODSUB_256_BLOB.as_ptr(),
-            lhs.as_ptr(),
-            rhs.as_ptr(),
-            modulus.as_ptr(),
-            result.as_mut_ptr(),
-        );
-    }
-}
-
-pub fn modsub_384_unchecked(
-    lhs: &[u32; FIELD_384_WIDTH_WORDS],
-    rhs: &[u32; FIELD_384_WIDTH_WORDS],
-    modulus: &[u32; FIELD_384_WIDTH_WORDS],
-    result: &mut [u32; FIELD_384_WIDTH_WORDS],
-) {
-    unsafe {
-        sys_bigint2_4(
-            MODSUB_384_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr() as *const u32,
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_deg2_add_256_unchecked(
-    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-) {
-    unsafe {
-        sys_bigint2_4(
-            EXTFIELD_DEG2_ADD_256_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_deg2_add_384_unchecked(
-    lhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-    rhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-    modulus: &[u32; FIELD_384_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-) {
-    unsafe {
-        sys_bigint2_4(
-            EXTFIELD_DEG2_ADD_384_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_deg2_mul_256_unchecked(
-    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    monic_irr: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-) {
-    unsafe {
-        sys_bigint2_5(
-            EXTFIELD_DEG2_MUL_256_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            monic_irr.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_deg4_mul_256_unchecked(
-    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
-    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
-    monic_irr: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
-) {
-    unsafe {
-        sys_bigint2_5(
-            EXTFIELD_DEG4_MUL_256_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            monic_irr.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_deg2_sub_256_unchecked(
-    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-) {
-    unsafe {
-        sys_bigint2_4(
-            EXTFIELD_DEG2_SUB_256_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_deg2_sub_384_unchecked(
-    lhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-    rhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-    modulus: &[u32; FIELD_384_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-) {
-    unsafe {
-        sys_bigint2_4(
-            EXTFIELD_DEG2_SUB_384_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_xxone_mul_256_unchecked(
-    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-    modulus: &[u32; FIELD_256_WIDTH_WORDS],
-    modsqr: &[u32; 2 * FIELD_256_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
-) {
-    unsafe {
-        sys_bigint2_5(
-            EXTFIELD_XXONE_MUL_256_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            modsqr.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-pub fn extfield_xxone_mul_384_unchecked(
-    lhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-    rhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-    modulus: &[u32; FIELD_384_WIDTH_WORDS],
-    modsqr: &[u32; 2 * FIELD_384_WIDTH_WORDS],
-    result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
-) {
-    unsafe {
-        sys_bigint2_5(
-            EXTFIELD_XXONE_MUL_384_BLOB.as_ptr(),
-            lhs.as_ptr() as *const u32,
-            rhs.as_ptr() as *const u32,
-            modulus.as_ptr(),
-            modsqr.as_ptr(),
-            result.as_mut_ptr() as *mut u32,
-        );
-    }
-}
-
-// These "checked" versions verify that `result < modulus`
 
 pub fn modadd_256(
     lhs: &[u32; FIELD_256_WIDTH_WORDS],
@@ -334,7 +39,7 @@ pub fn modadd_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modadd_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::modadd_256(lhs, rhs, modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -347,7 +52,7 @@ pub fn modadd_384(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modadd_384_unchecked(&lhs, &rhs, &modulus, result);
+    unchecked::modadd_384(&lhs, &rhs, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -369,7 +74,7 @@ pub fn modinv_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modinv_256_unchecked(inp, modulus, result);
+    unchecked::modinv_256(inp, modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -381,7 +86,7 @@ pub fn modinv_384(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modinv_384_unchecked(&inp, &modulus, result);
+    unchecked::modinv_384(&inp, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -394,7 +99,7 @@ pub fn modmul_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modmul_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::modmul_256(lhs, rhs, modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -407,7 +112,7 @@ pub fn modmul_384(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modmul_384_unchecked(&lhs, &rhs, &modulus, result);
+    unchecked::modmul_384(&lhs, &rhs, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -420,7 +125,7 @@ pub fn modsub_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [u32; FIELD_256_WIDTH_WORDS],
 ) {
-    modsub_256_unchecked(lhs, rhs, modulus, result);
+    unchecked::modsub_256(lhs, rhs, modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -433,7 +138,7 @@ pub fn modsub_384(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [u32; FIELD_384_WIDTH_WORDS],
 ) {
-    modsub_384_unchecked(&lhs, &rhs, &modulus, result);
+    unchecked::modsub_384(&lhs, &rhs, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -446,7 +151,7 @@ pub fn extfield_deg2_add_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_add_256_unchecked(&lhs, &rhs, &modulus, result);
+    unchecked::extfield_deg2_add_256(&lhs, &rhs, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -460,7 +165,7 @@ pub fn extfield_deg2_add_384(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_add_384_unchecked(&lhs, &rhs, &modulus, result);
+    unchecked::extfield_deg2_add_384(&lhs, &rhs, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -475,7 +180,7 @@ pub fn extfield_deg2_mul_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_mul_256_unchecked(&lhs, &rhs, &monic_irr, &modulus, result);
+    unchecked::extfield_deg2_mul_256(&lhs, &rhs, &monic_irr, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -490,7 +195,7 @@ pub fn extfield_deg4_mul_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
 ) {
-    extfield_deg4_mul_256_unchecked(&lhs, &rhs, &monic_irr, &modulus, result);
+    unchecked::extfield_deg4_mul_256(&lhs, &rhs, &monic_irr, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -506,7 +211,7 @@ pub fn extfield_deg2_sub_256(
     modulus: &[u32; FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_sub_256_unchecked(&lhs, &rhs, &modulus, result);
+    unchecked::extfield_deg2_sub_256(&lhs, &rhs, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -520,7 +225,7 @@ pub fn extfield_deg2_sub_384(
     modulus: &[u32; FIELD_384_WIDTH_WORDS],
     result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_deg2_sub_384_unchecked(&lhs, &rhs, &modulus, result);
+    unchecked::extfield_deg2_sub_384(&lhs, &rhs, &modulus, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -535,7 +240,7 @@ pub fn extfield_xxone_mul_256(
     modsqr: &[u32; 2 * FIELD_256_WIDTH_WORDS],
     result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_xxone_mul_256_unchecked(&lhs, &rhs, &modulus, &modsqr, result);
+    unchecked::extfield_xxone_mul_256(&lhs, &rhs, &modulus, &modsqr, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.
@@ -550,7 +255,7 @@ pub fn extfield_xxone_mul_384(
     modsqr: &[u32; 2 * FIELD_384_WIDTH_WORDS],
     result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
 ) {
-    extfield_xxone_mul_384_unchecked(&lhs, &rhs, &modulus, &modsqr, result);
+    unchecked::extfield_xxone_mul_384(&lhs, &rhs, &modulus, &modsqr, result);
 
     // An honest host will always return a result less than the modulus. A dishonest prover can
     // sometimes return a result greater than the modulus, so enforce that we're in the honest case.

--- a/risc0/bigint2/src/field/unchecked.rs
+++ b/risc0/bigint2/src/field/unchecked.rs
@@ -20,14 +20,14 @@
 //! when computing internal results during a series of finite field operations, provided the other
 //! finite field operations expect that inputs may violate this constraint, but using these
 //! functions can create security holes in certain other use cases (e.g. comparing to a hash value).
-//! 
+//!
 //! There are checking wrappers available in [crate::field] for use cases where `result < modulus`
 //! checking is necessary; you should also avoid these functions and prefer the checked versions in
 //! [crate::field] if you are uncertain about the security implications of this choice.
 
 use crate::{
     ffi::{sys_bigint2_3, sys_bigint2_4, sys_bigint2_5},
-    field::{FIELD_256_WIDTH_WORDS, FIELD_384_WIDTH_WORDS, EXT_DEGREE_2, EXT_DEGREE_4},
+    field::{EXT_DEGREE_2, EXT_DEGREE_4, FIELD_256_WIDTH_WORDS, FIELD_384_WIDTH_WORDS},
 };
 
 use include_bytes_aligned::include_bytes_aligned;

--- a/risc0/bigint2/src/field/unchecked.rs
+++ b/risc0/bigint2/src/field/unchecked.rs
@@ -1,0 +1,326 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Operations that don't constrain `result < modulus`
+//!
+//! These finite field arithmetic acceleration operations are "unchecked" in the sense that they
+//! provide no guarantee that `result < modulus` (or, in the case of extension field operations,
+//! provide no guarantee for any coefficient that `result < characteristic`). This can be acceptable
+//! when computing internal results during a series of finite field operations, provided the other
+//! finite field operations expect that inputs may violate this constraint, but using these
+//! functions can create security holes in certain other use cases (e.g. comparing to a hash value).
+//! 
+//! There are checking wrappers available in [crate::field] for use cases where `result < modulus`
+//! checking is necessary; you should also avoid these functions and prefer the checked versions in
+//! [crate::field] if you are uncertain about the security implications of this choice.
+
+use crate::{
+    ffi::{sys_bigint2_3, sys_bigint2_4, sys_bigint2_5},
+    field::{FIELD_256_WIDTH_WORDS, FIELD_384_WIDTH_WORDS, EXT_DEGREE_2, EXT_DEGREE_4},
+};
+
+use include_bytes_aligned::include_bytes_aligned;
+
+const MODADD_256_BLOB: &[u8] = include_bytes_aligned!(4, "modadd_256.blob");
+const MODADD_384_BLOB: &[u8] = include_bytes_aligned!(4, "modadd_384.blob");
+const MODINV_256_BLOB: &[u8] = include_bytes_aligned!(4, "modinv_256.blob");
+const MODINV_384_BLOB: &[u8] = include_bytes_aligned!(4, "modinv_384.blob");
+const MODMUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "modmul_256.blob");
+const MODMUL_384_BLOB: &[u8] = include_bytes_aligned!(4, "modmul_384.blob");
+const MODSUB_256_BLOB: &[u8] = include_bytes_aligned!(4, "modsub_256.blob");
+const MODSUB_384_BLOB: &[u8] = include_bytes_aligned!(4, "modsub_384.blob");
+const EXTFIELD_DEG2_ADD_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_add_256.blob");
+const EXTFIELD_DEG2_ADD_384_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_add_384.blob");
+const EXTFIELD_DEG2_MUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_mul_256.blob");
+const EXTFIELD_DEG4_MUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg4_mul_256.blob");
+const EXTFIELD_DEG2_SUB_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_sub_256.blob");
+const EXTFIELD_DEG2_SUB_384_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_deg2_sub_384.blob");
+const EXTFIELD_XXONE_MUL_256_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_xxone_mul_256.blob");
+const EXTFIELD_XXONE_MUL_384_BLOB: &[u8] = include_bytes_aligned!(4, "extfield_xxone_mul_384.blob");
+
+pub fn modadd_256(
+    lhs: &[u32; FIELD_256_WIDTH_WORDS],
+    rhs: &[u32; FIELD_256_WIDTH_WORDS],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [u32; FIELD_256_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_4(
+            MODADD_256_BLOB.as_ptr(),
+            lhs.as_ptr(),
+            rhs.as_ptr(),
+            modulus.as_ptr(),
+            result.as_mut_ptr(),
+        );
+    }
+}
+
+pub fn modadd_384(
+    lhs: &[u32; FIELD_384_WIDTH_WORDS],
+    rhs: &[u32; FIELD_384_WIDTH_WORDS],
+    modulus: &[u32; FIELD_384_WIDTH_WORDS],
+    result: &mut [u32; FIELD_384_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_4(
+            MODADD_384_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr() as *const u32,
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn modinv_256(
+    inp: &[u32; FIELD_256_WIDTH_WORDS],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [u32; FIELD_256_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_3(
+            MODINV_256_BLOB.as_ptr(),
+            inp.as_ptr(),
+            modulus.as_ptr(),
+            result.as_mut_ptr(),
+        );
+    }
+}
+
+pub fn modinv_384(
+    inp: &[u32; FIELD_384_WIDTH_WORDS],
+    modulus: &[u32; FIELD_384_WIDTH_WORDS],
+    result: &mut [u32; FIELD_384_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_3(
+            MODINV_384_BLOB.as_ptr(),
+            inp.as_ptr() as *const u32,
+            modulus.as_ptr() as *const u32,
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn modmul_256(
+    lhs: &[u32; FIELD_256_WIDTH_WORDS],
+    rhs: &[u32; FIELD_256_WIDTH_WORDS],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [u32; FIELD_256_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_4(
+            MODMUL_256_BLOB.as_ptr(),
+            lhs.as_ptr(),
+            rhs.as_ptr(),
+            modulus.as_ptr(),
+            result.as_mut_ptr(),
+        );
+    }
+}
+
+pub fn modmul_384(
+    lhs: &[u32; FIELD_384_WIDTH_WORDS],
+    rhs: &[u32; FIELD_384_WIDTH_WORDS],
+    modulus: &[u32; FIELD_384_WIDTH_WORDS],
+    result: &mut [u32; FIELD_384_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_4(
+            MODMUL_384_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr() as *const u32,
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn modsub_256(
+    lhs: &[u32; FIELD_256_WIDTH_WORDS],
+    rhs: &[u32; FIELD_256_WIDTH_WORDS],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [u32; FIELD_256_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_4(
+            MODSUB_256_BLOB.as_ptr(),
+            lhs.as_ptr(),
+            rhs.as_ptr(),
+            modulus.as_ptr(),
+            result.as_mut_ptr(),
+        );
+    }
+}
+
+pub fn modsub_384(
+    lhs: &[u32; FIELD_384_WIDTH_WORDS],
+    rhs: &[u32; FIELD_384_WIDTH_WORDS],
+    modulus: &[u32; FIELD_384_WIDTH_WORDS],
+    result: &mut [u32; FIELD_384_WIDTH_WORDS],
+) {
+    unsafe {
+        sys_bigint2_4(
+            MODSUB_384_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr() as *const u32,
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_deg2_add_256(
+    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+) {
+    unsafe {
+        sys_bigint2_4(
+            EXTFIELD_DEG2_ADD_256_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_deg2_add_384(
+    lhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+    rhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+    modulus: &[u32; FIELD_384_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+) {
+    unsafe {
+        sys_bigint2_4(
+            EXTFIELD_DEG2_ADD_384_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_deg2_mul_256(
+    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    monic_irr: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+) {
+    unsafe {
+        sys_bigint2_5(
+            EXTFIELD_DEG2_MUL_256_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            monic_irr.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_deg4_mul_256(
+    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
+    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
+    monic_irr: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_4],
+) {
+    unsafe {
+        sys_bigint2_5(
+            EXTFIELD_DEG4_MUL_256_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            monic_irr.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_deg2_sub_256(
+    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+) {
+    unsafe {
+        sys_bigint2_4(
+            EXTFIELD_DEG2_SUB_256_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_deg2_sub_384(
+    lhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+    rhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+    modulus: &[u32; FIELD_384_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+) {
+    unsafe {
+        sys_bigint2_4(
+            EXTFIELD_DEG2_SUB_384_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_xxone_mul_256(
+    lhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    rhs: &[[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+    modulus: &[u32; FIELD_256_WIDTH_WORDS],
+    modsqr: &[u32; 2 * FIELD_256_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_256_WIDTH_WORDS]; EXT_DEGREE_2],
+) {
+    unsafe {
+        sys_bigint2_5(
+            EXTFIELD_XXONE_MUL_256_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            modsqr.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}
+
+pub fn extfield_xxone_mul_384(
+    lhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+    rhs: &[[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+    modulus: &[u32; FIELD_384_WIDTH_WORDS],
+    modsqr: &[u32; 2 * FIELD_384_WIDTH_WORDS],
+    result: &mut [[u32; FIELD_384_WIDTH_WORDS]; EXT_DEGREE_2],
+) {
+    unsafe {
+        sys_bigint2_5(
+            EXTFIELD_XXONE_MUL_384_BLOB.as_ptr(),
+            lhs.as_ptr() as *const u32,
+            rhs.as_ptr() as *const u32,
+            modulus.as_ptr(),
+            modsqr.as_ptr(),
+            result.as_mut_ptr() as *mut u32,
+        );
+    }
+}


### PR DESCRIPTION
Redo the naming conventions for `risc0_bigint2::field` operations. This leaves the "`risc0_bigint2::field::modadd_256`"-type operations with their existing names, but pulls the "unchecked" operations into an `unchecked` submodule, and renames the FFI module from `ffi_field` to plain `ffi`.

This also removes `pub` from the `ffi` module.