### PR TITLE
Bump guest rust toolchain to 1.85.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,6 @@ opt-level = 3
 
 [profile.release]
 lto = true
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }

--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -38,3 +38,6 @@ default = []
 num-bigint-dig = ["dep:num-bigint-dig"]
 num-bigint = ["dep:num-bigint"]
 unstable = []
+
+[lints]
+workspace = true

--- a/risc0/binfmt/Cargo.toml
+++ b/risc0/binfmt/Cargo.toml
@@ -47,3 +47,6 @@ std = [
   "tracing/log",
   "tracing/std",
 ]
+
+[lints]
+workspace = true

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -143,7 +143,7 @@ fn create_dockerfile(manifest_path: &Path, temp_dir: &Path, guest_info: &GuestIn
     .join(" ");
 
     let mut build = DockerFile::new()
-        .from_alias("build", "risczero/risc0-guest-builder:r0.1.81.0")
+        .from_alias("build", "risczero/risc0-guest-builder:r0.1.85.0")
         .workdir("/src")
         .copy(".", ".")
         .env(manifest_env)
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "6869f96012d73a50c535869ff28a24984102833c07dcf7abde8a5c32430616f4",
+            "81ff62848368ff92d37aafbc12b497ed0c76b3884674467ad16533e06deabaa0",
         );
     }
 }

--- a/risc0/cargo-risczero/docker/Dockerfile.release
+++ b/risc0/cargo-risczero/docker/Dockerfile.release
@@ -1,14 +1,15 @@
-# To build run: docker build -f Dockerfile.release --build-arg="RISC0_TOOLCHAIN_VERSION=r0.1.81.0" -t risczero/risc0-guest-builder:r0.1.81.0 .
-FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
+# To build run: docker build -f Dockerfile.release --build-arg="RISC0_RUST_TOOLCHAIN_VERSION=1.85.0" -t risczero/risc0-guest-builder:r0.1.85.0 .
+FROM ubuntu:22.04@sha256:33d782143e3a76315de8570db1673fda6d5b17c854190b74e9e890d8e95c85cf
 
-ARG RISC0_TOOLCHAIN_VERSION=
+ARG RISC0_RUST_TOOLCHAIN_VERSION=
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config build-essential
 RUN curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https://sh.rustup.rs' | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN cargo install cargo-binstall
-RUN cargo binstall -y --force cargo-risczero
-RUN cargo risczero install --version ${RISC0_TOOLCHAIN_VERSION}
+RUN curl -L https://risczero.com/install | bash
+ENV PATH="/root/.risc0/bin:${PATH}"
+RUN rzup install cpp
+RUN rzup install rust ${RISC0_RUST_TOOLCHAIN_VERSION}
 
 ENTRYPOINT [ "/bin/sh" ]

--- a/risc0/core/Cargo.toml
+++ b/risc0/core/Cargo.toml
@@ -26,3 +26,6 @@ all-features = true
 [features]
 perf = ["dep:nvtx", "dep:puffin"]
 std = []
+
+[lints]
+workspace = true

--- a/risc0/groth16/Cargo.toml
+++ b/risc0/groth16/Cargo.toml
@@ -60,3 +60,6 @@ std = [
   "serde/std",
 ]
 unstable = []
+
+[lints]
+workspace = true

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -72,3 +72,6 @@ prove = [
 ]
 std = ["anyhow/std"]
 unstable = []
+
+[lints]
+workspace = true

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -203,3 +203,6 @@ std = [
 ]
 unstable = ["risc0-zkvm-platform/unstable"]
 witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
+
+[lints]
+workspace = true

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -41,3 +41,6 @@ hyper-util = "0.1.10"
 paste = "1.0.15"
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "macros"] }
 walkdir = "2.5.0"
+
+[lints]
+workspace = true


### PR DESCRIPTION
This PR updates the guest rust toolchain to use 1.85.0. A new guest builder with tag r0.1.85.0 has been uploaded to dockerhub. I've updated the guest builder to base off of ubuntu 22.04 because 1.85.0 requires a later glibc version that's not supported by 20.04.

Another item to note about 1.85 guest toolchain: crates with `cfg(test)` get compiled on the guest, these warnings are emitted:

```
risc0-zkvm-methods-guest: warning: unexpected `cfg` condition name: `test`
risc0-zkvm-methods-guest:    --> /Users/erik/risc0/rzup/src/lib.rs:125:11
risc0-zkvm-methods-guest:     |
risc0-zkvm-methods-guest: 125 |     #[cfg(test)]
risc0-zkvm-methods-guest:     |           ^^^^
risc0-zkvm-methods-guest:     |
risc0-zkvm-methods-guest:     = help: consider using a Cargo feature instead
risc0-zkvm-methods-guest:     = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
risc0-zkvm-methods-guest:              [lints.rust]
risc0-zkvm-methods-guest:              unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
risc0-zkvm-methods-guest:     = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(test)");` to the top of the `build.rs`
risc0-zkvm-methods-guest:     = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

According to https://doc.rust-lang.org/nightly/rustc/check-cfg.html#well-known-names-and-values,

> Starting with 1.85.0, the test cfg is consider to be a "userspace" config
> despite being also set by rustc and should be managed by the build system
> itself.

Therefore, I've added this lint to any crate that ends up being built on
the guest.