### PR TITLE
ZKVM-1256: [main.yml] Change a few things to speed up CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,8 @@ jobs:
       - docs-rs
       - examples
       - docker
-      - test
+      - test_workspace
+      - build_extra_cargo_check_benchmark
       # - test-crates
       - web
     runs-on: ubuntu-latest
@@ -210,7 +211,7 @@ jobs:
         run: cargo clippy -F $FEATURE --all-targets
         working-directory: examples
 
-  test:
+  test_workspace:
     if: needs.changes.outputs.test == 'true'
     needs: changes
     runs-on: [self-hosted, prod, "${{ matrix.os }}", "${{ matrix.arch }}", "${{ matrix.device }}"]
@@ -222,14 +223,32 @@ jobs:
             arch: X64
             feature: default
             device: cpu
+            test_command: cargo nextest run --partition hash:1/2
+            partition: 1
+          - os: Linux
+            arch: X64
+            feature: default
+            device: cpu
+            test_command: cargo nextest run --partition hash:2/2
+            partition: 2
           - os: Linux
             arch: X64
             feature: cuda
             device: nvidia_rtx_a5000
+            test_command: cargo test
+            partition: 1
           - os: macOS
             arch: ARM64
             feature: default
             device: apple_m2_pro
+            test_command: cargo nextest run --partition hash:1/2
+            partition: 1
+          - os: macOS
+            arch: ARM64
+            feature: default
+            device: apple_m2_pro
+            test_command: cargo nextest run --partition hash:2/2
+            partition: 2
     env:
       FEATURE: ${{ matrix.feature }}
       RISC0_BUILD_LOCKED: 1
@@ -249,35 +268,87 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_CI_USER }}
           password: ${{ secrets.DOCKERHUB_CI_PAT }}
+      - uses: risc0/cargo-install@9f6037ed331dcf7da101461a20656273fa72abf0
+        with:
+          crate: cargo-binstall
+          version: "1.10.16"
+      - name: Install cargo-nextest
+        run: cargo binstall cargo-nextest
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - name: build workspace
-        run: cargo test -F $FEATURE -F prove -F redis -F unstable --workspace --timings --no-run --exclude doc-test
+        run: cargo test --release -F $FEATURE -F prove -F redis -F unstable --workspace --timings --no-run --exclude doc-test
       - name: test workspace
-        run: cargo test -F $FEATURE -F prove -F redis -F unstable --workspace --timings --exclude doc-test
+        run: ${{ matrix.test_command }} --release -F $FEATURE -F prove -F redis -F unstable --workspace --timings --exclude doc-test
       - uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}
+          name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}-${{ matrix.partition }}
           path: target/cargo-timings/
           retention-days: 5
+      - run: sccache --show-stats
+
+  build_extra_cargo_check_benchmark:
+    if: needs.changes.outputs.test == 'true'
+    needs: changes
+    runs-on: [self-hosted, prod, "${{ matrix.os }}", "${{ matrix.arch }}", "${{ matrix.device }}"]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: Linux
+            arch: X64
+            feature: default
+            device: cpu
+            test_command: cargo nextest run
+          - os: Linux
+            arch: X64
+            feature: cuda
+            device: nvidia_rtx_a5000
+            test_command: cargo test
+          - os: macOS
+            arch: ARM64
+            feature: default
+            device: apple_m2_pro
+            test_command: cargo nextest run
+    env:
+      FEATURE: ${{ matrix.feature }}
+      RISC0_BUILD_LOCKED: 1
+      RUST_BACKTRACE: full
+      # SCCACHE_RECACHE: 1
+    steps:
+      - uses: actions/checkout@v4
+      - if: matrix.feature == 'cuda'
+        uses: ./.github/actions/cuda
+      - uses: ./.github/actions/rustup
+      - uses: ./.github/actions/sccache
+        with:
+          key: ${{ matrix.os }}-${{ matrix.feature }}
+      - uses: risc0/cargo-install@9f6037ed331dcf7da101461a20656273fa72abf0
+        with:
+          crate: cargo-binstall
+          version: "1.10.16"
+      - name: Install cargo-nextest
+        run: cargo binstall cargo-nextest
+      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - name: build risc0-r0vm
-        run: cargo test -p risc0-r0vm -F $FEATURE -F disable-dev-mode --no-run
+        run: cargo test --release -p risc0-r0vm -F $FEATURE -F disable-dev-mode --no-run
       - name: build risc0-zkvm tests without the prove feature
-        run: cargo test -p risc0-zkvm -F $FEATURE --no-run
+        run: cargo test --release -p risc0-zkvm -F $FEATURE --no-run
       - name: build risc0-zkvm tests with the metal feature
         if: matrix.os == 'macOS'
         run: cargo test -p risc0-zkvm -F metal --no-run
       - name: test risc0-r0vm
-        run: cargo test -p risc0-r0vm -F $FEATURE -F disable-dev-mode
-      - run: cargo test -p cargo-risczero -F experimental
+        run: ${{ matrix.test_command }} --release -p risc0-r0vm -F $FEATURE -F disable-dev-mode
+      - run: ${{ matrix.test_command }} --release -p cargo-risczero -F experimental
       - name: run fibonacci benchmark
-        run: cargo run --locked -F $FEATURE -- fibonacci
+        run: cargo run --release --locked -F $FEATURE -- fibonacci
         working-directory: benchmarks
       - name: run datasheet generator (smoke test)
-        run: cargo run --locked -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift
+        run: cargo run --release --locked -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift
       - name: run datasheet generator (CUDA full)
         if: matrix.feature == 'cuda'
-        run: cargo run --locked -F $FEATURE -F prove --example datasheet
+        run: cargo run --release --locked -F $FEATURE -F prove --example datasheet
       - name: check benches
         run: cargo check -F $FEATURE --benches --workspace --exclude doc-test
       - run: cargo check -p risc0-build
@@ -301,14 +372,17 @@ jobs:
             arch: X64
             feature: default
             device: cpu
+            test_command: cargo nextest run
           - os: Linux
             arch: X64
             feature: cuda
             device: nvidia_rtx_a5000
+            test_command: cargo test
           - os: macOS
             arch: ARM64
             feature: default
             device: apple_m2_pro
+            test_command: cargo nextest run
     env:
       FEATURE: ${{ matrix.feature }}
       RISC0_BUILD_LOCKED: 1
@@ -325,17 +399,23 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
+      - uses: risc0/cargo-install@9f6037ed331dcf7da101461a20656273fa72abf0
+        with:
+          crate: cargo-binstall
+          version: "1.10.16"
+      - name: Install cargo-nextest
+        run: cargo binstall cargo-nextest
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo build --release -p risc0-r0vm -F $FEATURE
       - name: build
-        run: cargo test --locked -F $FEATURE --no-run
+        run: cargo test --release --locked -F $FEATURE --no-run
         working-directory: examples
       - name: test in dev mode
-        run: RISC0_DEV_MODE=1 cargo test --locked -F $FEATURE --workspace --exclude prover-example
+        run: RISC0_DEV_MODE=1 ${{ matrix.test_command }} --release --locked -F $FEATURE --workspace --exclude prover-example
         working-directory: examples
       - name: test prover example
-        run: cargo test --locked -F $FEATURE -p prover-example
+        run: ${{ matrix.test_command }} --release --locked -F $FEATURE -p prover-example
         working-directory: examples
       - run: cargo run --locked -F $FEATURE
         env:
@@ -446,7 +526,7 @@ jobs:
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - name: run SemVer checks
-        run: cargo xtask semver-checks
+        run: cargo run --bin xtask --no-default-features semver-checks
       - run: sccache --show-stats
 
   check-template:
@@ -544,8 +624,8 @@ jobs:
           key: Linux-default
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
-      - run: cargo xtask install
-      - run: cargo xtask gen-receipt
+      - run: cargo xfast install
+      - run: cargo xfast gen-receipt
       - run: |
           npm install
           npm test -- --firefox


### PR DESCRIPTION
This PR tries to speed up CI via a few different changes:
- Use `cargo nextest` when testing without cuda (because one test per process messes with cuda resource locking)
- Split up test job into 2 parts, testing the workspace, and the rest
- Split up testing the workspace job into two testing partitions (but not for cuda) 
- When proving with CPU, run the tests in release (this enables LTO), (the time spent on LTO is made up when proving)
- Run xtask stuff in `dev` profile, and disable `zkvm` feature for `semver-checks`

CI times can be pretty variable, but in my testing under ideal circumstances (with the build completely cached) this takes the total time down from about 40m to about 25m

example: https://github.com/risc0/risc0/actions/runs/13980012174