### PR TITLE
ZKVM-1257: Update bigint2 version to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5580,7 +5580,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap 4.5.32",

--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-bigint2"
 description = "RISC Zero's Big Integer Accelerator"
-version = "1.4.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -1030,7 +1030,7 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-bigint-dig",
- "risc0-bigint2 1.4.0",
+ "risc0-bigint2 2.0.0",
  "risc0-zkvm",
 ]
 


### PR DESCRIPTION
I think semver requires us to update the major version given the renames in https://github.com/risc0/risc0/pull/3003. Sorry for the churn