### PR TITLE
ZKVM-1258: Disable CI docker login on Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,6 +244,7 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       - name: Login to Docker Hub
+        if: matrix.os == 'Linux'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_CI_USER }}


### PR DESCRIPTION
We don't want to support docker on Mac