### PR TITLE
backport 2.0: Bump guest rust toolchain to 1.85.0

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -20,7 +20,7 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_BUILD_LOCKED: 1
-  RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
 
 jobs:
@@ -77,8 +77,8 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.feature }}
           disable_s3: ${{ env.DISABLE_S3 }}
 
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
 
       - name: Run benchmarks
         run: cargo bench --bench fib -F $FEATURE

--- a/.github/workflows/bench_reports.yml
+++ b/.github/workflows/bench_reports.yml
@@ -24,7 +24,7 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_BUILD_LOCKED: 1
-  RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
 
 jobs:
@@ -65,8 +65,8 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
 
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
 
       - name: Save commit hash to a file
         run: |

--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -26,7 +26,7 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   RISC0_BUILD_LOCKED: 1
-  RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
 
 jobs:
@@ -69,8 +69,8 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.feature }}
           disable_s3: ${{ env.DISABLE_S3 }}
 
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
 
       - name: Run benchmarks
         run: cargo bench -F $FEATURE --bench fib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
 
 defaults:
@@ -243,8 +243,8 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - name: build workspace
         run: cargo test -F $FEATURE -F prove -F redis -F unstable --workspace --timings --no-run --exclude doc-test
       - name: test workspace
@@ -319,8 +319,8 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo build --release -p risc0-r0vm -F $FEATURE
       - name: build
         run: cargo test --locked -F $FEATURE --no-run
@@ -375,8 +375,8 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: macOS-default
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo doc --no-deps --exclude=risc0-zkvm-methods --workspace
       - run: sccache --show-stats
 
@@ -437,8 +437,8 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: ${{ matrix.os }}-default
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - name: run SemVer checks
         run: cargo xtask semver-checks
       - run: sccache --show-stats
@@ -462,8 +462,8 @@ jobs:
         with:
           key: ${{ matrix.os }}-default
       - run: cargo install --force --path risc0/cargo-risczero --locked
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: |
           cargo risczero new \
             --path $(pwd) \
@@ -497,8 +497,8 @@ jobs:
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo install --force --path risc0/cargo-risczero --locked
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo test
@@ -536,8 +536,8 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: Linux-default
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo xtask install
       - run: cargo xtask gen-receipt
       - run: |
@@ -559,8 +559,8 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: Linux-default
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo test -p risc0-build -F docker
       - run: cargo test -p risc0-groth16 -F prove --release
       - run: cargo test -p risc0-zkvm -F docker -F prove -- docker

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   RISC0_BUILD_LOCKED: 1
-  RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
 
 jobs:
@@ -23,8 +23,8 @@ jobs:
 
       - run: cargo install --force --path risc0/cargo-risczero --locked
 
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
 
       - run: cargo build --release
         working-directory: tools/crates-validator/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
   TAG: v2.0.0-rc.3
   VERSION: "2.0.0-rc.3"
@@ -69,8 +69,8 @@ jobs:
           crate: cargo-binstall
           version: "1.10.16"
       - run: cargo binstall -y --force cargo-risczero@${{ env.VERSION }}
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo run

--- a/.github/workflows/risc0-ethereum.yml
+++ b/.github/workflows/risc0-ethereum.yml
@@ -27,7 +27,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
   RISC0_PATH: ${{ github.workspace }}/risc0
   RISC0_ETHEREUM_PATH: ${{ github.workspace }}/risc0-ethereum
@@ -124,8 +124,8 @@ jobs:
       - name: Install risczero toolchain
         run: |
           cargo install --locked --force --path risc0/cargo-risczero
-          cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-          cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+          cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+          cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
         working-directory: risc0
       - uses: risc0/foundry-toolchain@2fe7e70b520f62368a0e3c464f997df07ede420f
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -98,11 +98,11 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: Linux-default
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+          RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
           RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
 
       - name: build
@@ -124,11 +124,11 @@ jobs:
       - uses: ./.github/actions/sccache
         with:
           key: Linux-default
-      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
+          RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
           RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
 
       - name: build

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "cc3d0b5cb2104d4704ed56891ba3672a5c619807738a290b2ff0bf062053f453",
+            "27a5fa18c32ef389caf57c38160add55d4452b38bae172ac49608499e0087aa2",
         );
     }
 }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -143,7 +143,7 @@ fn create_dockerfile(manifest_path: &Path, temp_dir: &Path, guest_info: &GuestIn
     .join(" ");
 
     let mut build = DockerFile::new()
-        .from_alias("build", "risczero/risc0-guest-builder:r0.1.81.0")
+        .from_alias("build", "risczero/risc0-guest-builder:r0.1.85.0")
         .workdir("/src")
         .copy(".", ".")
         .env(manifest_env)
@@ -158,7 +158,7 @@ fn create_dockerfile(manifest_path: &Path, temp_dir: &Path, guest_info: &GuestIn
     build = build
         .env(&[(
             "CC_riscv32im_risc0_zkvm_elf",
-            "/root/.local/share/cargo-risczero/cpp/bin/riscv32-unknown-elf-gcc",
+            "/root/.risc0/cpp/bin/riscv32-unknown-elf-gcc",
         )])
         .env(&[("CFLAGS_riscv32im_risc0_zkvm_elf", "-march=rv32im -nostdlib")]);
 
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "9b84b31f3e193fba6f76933fd29d126d5dcb1523bd901447bb0d4aed54ad7ae5",
+            "e4b55c4526b3302caa06387c9c342e608c3a259c0a7a52fd93c5fa5d8bea4101",
         );
     }
 }

--- a/risc0/cargo-risczero/docker/Dockerfile.release
+++ b/risc0/cargo-risczero/docker/Dockerfile.release
@@ -1,14 +1,15 @@
-# To build run: docker build -f Dockerfile.release --build-arg="RISC0_TOOLCHAIN_VERSION=r0.1.81.0" -t risczero/risc0-guest-builder:r0.1.81.0 .
+# To build run: docker build -f Dockerfile.release --build-arg="RISC0_RUST_TOOLCHAIN_VERSION=1.85.0" -t risczero/risc0-guest-builder:r0.1.85.0 .
 FROM ubuntu:20.04@sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37
 
-ARG RISC0_TOOLCHAIN_VERSION=
+ARG RISC0_RUST_TOOLCHAIN_VERSION=
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates clang curl libssl-dev pkg-config build-essential
 RUN curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL 'https://sh.rustup.rs' | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN cargo install cargo-binstall
-RUN cargo binstall -y --force cargo-risczero
-RUN cargo risczero install --version ${RISC0_TOOLCHAIN_VERSION}
+RUN curl -L https://risczero.com/install | bash
+ENV PATH="/root/.risc0/bin:${PATH}"
+RUN rzup install cpp
+RUN rzup install rust ${RISC0_RUST_TOOLCHAIN_VERSION}
 
 ENTRYPOINT [ "/bin/sh" ]


### PR DESCRIPTION
This PR updates the guest rust toolchain to use 1.85.0. A new guest builder with tag r0.1.85.0 has been uploaded to dockerhub.