### PR TITLE
ZKVM-1260: Account for missing ControlDone cycle in executor

### DIFF
--- a/risc0/circuit/rv32im/examples/rv32im.rs
+++ b/risc0/circuit/rv32im/examples/rv32im.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use clap::Parser;
 use risc0_binfmt::MemoryImage;
 use risc0_circuit_rv32im::{
-    execute::{platform::LOOKUP_TABLE_CYCLES, testutil, DEFAULT_SEGMENT_LIMIT_PO2},
+    execute::{platform::RESERVED_CYCLES, testutil, DEFAULT_SEGMENT_LIMIT_PO2},
     prove::segment_prover,
     MAX_INSN_CYCLES,
 };
@@ -41,9 +41,9 @@ struct Cli {
 }
 
 const PAGING_CYCLES: usize = 1821;
-const NON_LOOP_CYCLES: usize = 8;
-const RESERVED_CYCLES: usize =
-    LOOKUP_TABLE_CYCLES + PAGING_CYCLES + NON_LOOP_CYCLES + MAX_INSN_CYCLES;
+const BEFORE_LOOP_CYCLES: usize = 8;
+const NON_LOOP_CYCLES: usize =
+    RESERVED_CYCLES + PAGING_CYCLES + BEFORE_LOOP_CYCLES + MAX_INSN_CYCLES;
 
 fn main() {
     tracing_subscriber::fmt()
@@ -54,8 +54,8 @@ fn main() {
 
     let po2 = args.po2;
     let segment_cycles = 1 << po2;
-    assert!(segment_cycles > RESERVED_CYCLES);
-    let iterations = (segment_cycles - RESERVED_CYCLES) / 2;
+    assert!(segment_cycles > NON_LOOP_CYCLES);
+    let iterations = (segment_cycles - NON_LOOP_CYCLES) / 2;
 
     let program = testutil::kernel::simple_loop(iterations as u32);
     let image = MemoryImage::new_kernel(program);

--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -202,9 +202,9 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
                     }
                 }
 
-                if self.segment_cycles() >= segment_threshold {
+                if self.segment_cycles() > segment_threshold {
                     tracing::debug!(
-                        "split(phys: {} + pager: {} + reserved: {LOOKUP_TABLE_CYCLES}) = {} >= {segment_threshold}",
+                        "split(phys: {} + pager: {} + reserved: {RESERVED_CYCLES}) = {} >= {segment_threshold}",
                         self.user_cycles,
                         self.pager.cycles,
                         self.segment_cycles()
@@ -384,7 +384,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
     }
 
     fn segment_cycles(&self) -> u32 {
-        self.user_cycles + self.pager.cycles + LOOKUP_TABLE_CYCLES as u32
+        self.user_cycles + self.pager.cycles + RESERVED_CYCLES as u32
     }
 
     fn inc_user_cycles(&mut self, count: usize, ecall: Option<EcallKind>) {

--- a/risc0/circuit/rv32im/src/execute/platform.rs
+++ b/risc0/circuit/rv32im/src/execute/platform.rs
@@ -21,6 +21,8 @@ pub const MEMORY_BYTES: u64 = 1 << 32;
 pub const MEMORY_PAGES: usize = (MEMORY_BYTES / PAGE_BYTES as u64) as usize;
 pub const MERKLE_TREE_DEPTH: usize = MEMORY_PAGES.ilog2() as usize;
 pub const LOOKUP_TABLE_CYCLES: usize = ((1 << 8) + (1 << 16)) / 16;
+pub const CONTROL_DONE_CYCLES: usize = 1;
+pub const RESERVED_CYCLES: usize = LOOKUP_TABLE_CYCLES + CONTROL_DONE_CYCLES;
 
 pub const ZERO_PAGE_START_ADDR: ByteAddr = ByteAddr(0x0000_0000);
 pub const ZERO_PAGE_END_ADDR: ByteAddr = ByteAddr(0x0001_0000);

--- a/risc0/circuit/rv32im/src/execute/testutil.rs
+++ b/risc0/circuit/rv32im/src/execute/testutil.rs
@@ -28,7 +28,7 @@ use super::{
 };
 
 pub const DEFAULT_SESSION_LIMIT: Option<u64> = Some(1 << 24);
-pub const MIN_CYCLES_PO2: usize = log2_ceil(LOOKUP_TABLE_CYCLES + RESERVED_PAGING_CYCLES as usize);
+pub const MIN_CYCLES_PO2: usize = log2_ceil(RESERVED_CYCLES + RESERVED_PAGING_CYCLES as usize);
 
 #[derive(Default)]
 pub struct NullSyscall;

--- a/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
@@ -260,6 +260,8 @@ impl<'a> Preflight<'a> {
     }
 
     fn fini(&mut self) -> Result<()> {
+        let start_cycles = self.trace.cycles.len();
+
         for i in (16..256).step_by(16) {
             self.add_cycle_special(
                 CycleState::ControlTable,
@@ -287,6 +289,7 @@ impl<'a> Preflight<'a> {
             0,
             Back::None,
         );
+
         if self.segment.claim.terminate_state.is_none() {
             let segment_threshold = self.segment.segment_threshold as usize;
             if self.trace.cycles.len() < segment_threshold {
@@ -295,6 +298,7 @@ impl<'a> Preflight<'a> {
             let diff = self.trace.cycles.len() - segment_threshold;
             self.trace.cycles[diff / 2].diff_count[diff % 2] += 1;
         }
+
         self.machine_mode = 1;
         self.add_cycle_special(
             CycleState::ControlDone,
@@ -303,6 +307,8 @@ impl<'a> Preflight<'a> {
             0,
             Back::None,
         );
+        assert_eq!(self.trace.cycles.len() - start_cycles, RESERVED_CYCLES);
+
         let last_cycle = 1 << self.segment.po2;
         for _ in self.trace.cycles.len()..last_cycle {
             self.add_cycle_special(

--- a/risc0/zkvm/examples/datasheet.rs
+++ b/risc0/zkvm/examples/datasheet.rs
@@ -23,7 +23,7 @@ use clap::{Parser, Subcommand};
 use enum_iterator::Sequence;
 use risc0_bigint2_methods::ECDSA_ELF as BIGINT2_ELF;
 use risc0_binfmt::ProgramBinary;
-use risc0_circuit_rv32im::{execute::LOOKUP_TABLE_CYCLES, MAX_INSN_CYCLES};
+use risc0_circuit_rv32im::{execute::RESERVED_CYCLES, MAX_INSN_CYCLES};
 use risc0_zkos_v1compat::V1COMPAT_ELF;
 use risc0_zkp::{hal::tracker, MAX_CYCLES_PO2};
 use risc0_zkvm::{
@@ -53,7 +53,7 @@ const CYCLES_PO2_ITERS: &[(u32, u32)] = &[
 const MIN_CYCLES_PO2: usize = CYCLES_PO2_ITERS[0].0 as usize;
 
 const ITERATIONS_1M_CYCLES: usize = 1024 * 507 + 2;
-const EXPECTED_RESERVED_CYCLES: usize = LOOKUP_TABLE_CYCLES + MAX_INSN_CYCLES;
+const EXPECTED_RESERVED_CYCLES: usize = RESERVED_CYCLES + MAX_INSN_CYCLES;
 
 /// Pre-compiled program that simply loops `count: u32` times (read from stdin).
 static LOOP_ELF: LazyLock<Vec<u8>> = LazyLock::new(|| {


### PR DESCRIPTION
The `segment_cycles()` function in the executor accounts for the number of cycles that are used so far in the segment. Its calculation was missing the extra `ControlDone` cycle preflight adds (off by one.) This mistake didn't show up when splitting because there was another bug in the splitting logic where we used `>=` instead of `>`, (this negated the extra `+1`). Later though, when we calculate the po2 for the final segment we use the `segment_cycles()` function again, but this time the off by one issue matters and we calculate the wrong po2 for the segment. This then results in a crash later in preflight.

I'd like to create a guest program that manages to hit this bug without the fix that we can add as a test, but its a bit tricky to accomplish so I wanted to get this out there first without it.