### PR TITLE
Remove .rc.3 and bump appropriate versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ permissions:
 env:
   RISC0_RUST_TOOLCHAIN_VERSION: 1.81.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
-  TAG: v2.0.0-rc.3
-  VERSION: "2.0.0-rc.3"
+  TAG: v2.0.0
+  VERSION: "2.0.0"
 
 jobs:
   release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5580,7 +5580,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "clap 4.5.32",
@@ -5601,14 +5601,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2-methods"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "risc0-build",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5650,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "cc",
  "directories 5.0.1",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "cc",
  "cust",
@@ -5709,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "cc",
  "cust",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5851,7 +5851,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cust",
@@ -5861,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-tools"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "assert_cmd",
  "clap 4.5.32",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -5880,7 +5880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bincode",
  "borsh",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 
 [[package]]
 name = "rlsf"
@@ -6257,7 +6257,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.1-rc.3"
+version = "0.4.1"
 dependencies = [
  "clap 4.5.32",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ risc0-circuit-keccak = { version = "1.4.0", default-features = false, path = "ri
 risc0-circuit-keccak-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/keccak-sys" }
 risc0-circuit-recursion = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion" }
 risc0-circuit-recursion-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "2.0.0", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "2.0.0", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-circuit-rv32im = { version = "2.0.1", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "2.0.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-core = { version = "2.0.0", default-features = false, path = "risc0/core" }
 risc0-groth16 = { version = "1.4.0", default-features = false, path = "risc0/groth16" }
 risc0-r0vm = { version = "2.0.0", default-features = false, path = "risc0/r0vm" }
@@ -61,7 +61,7 @@ risc0-sys = { version = "1.4.0", default-features = false, path = "risc0/sys" }
 risc0-zkp = { version = "2.0.0", default-features = false, path = "risc0/zkp" }
 risc0-zkos-v1compat = { version = "2.0.0", path = "risc0/zkos/v1compat" }
 risc0-zkvm = { version = "2.0.0", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "2.0.0", default-features = false, path = "risc0/zkvm/platform" }
+risc0-zkvm-platform = { version = "2.0.1", default-features = false, path = "risc0/zkvm/platform" }
 rzup = { version = "0.4.1", default-features = false, path = "rzup" }
 sppark = "0.1.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,35 +34,35 @@ members = [
 exclude = ["tools/crates-validator"]
 
 [workspace.package]
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://risczero.com/"
 repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
-bonsai-sdk = { version = "1.4.0-rc.3", default-features = false, path = "bonsai/sdk" }
+bonsai-sdk = { version = "1.4.0", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.4.0-rc.3", default-features = false, path = "risc0/bigint2" }
-risc0-binfmt = { version = "2.0.0-rc.3", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "2.0.1-rc.3", default-features = false, path = "risc0/build" }
-risc0-build-kernel = { version = "2.0.0-rc.3", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-keccak = { version = "1.4.0-rc.3", default-features = false, path = "risc0/circuit/keccak" }
-risc0-circuit-keccak-sys = { version = "1.4.0-rc.3", default-features = false, path = "risc0/circuit/keccak-sys" }
-risc0-circuit-recursion = { version = "1.4.0-rc.3", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.4.0-rc.3", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "2.0.0-rc.3", default-features = false, path = "risc0/circuit/rv32im" }
-risc0-circuit-rv32im-sys = { version = "2.0.0-rc.3", default-features = false, path = "risc0/circuit/rv32im-sys" }
-risc0-core = { version = "2.0.0-rc.3", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.4.0-rc.3", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "2.0.0-rc.3", default-features = false, path = "risc0/r0vm" }
-risc0-sys = { version = "1.4.0-rc.3", default-features = false, path = "risc0/sys" }
-risc0-zkp = { version = "2.0.0-rc.3", default-features = false, path = "risc0/zkp" }
-risc0-zkos-v1compat = { version = "2.0.0-rc.3", path = "risc0/zkos/v1compat" }
-risc0-zkvm = { version = "2.0.0-rc.3", default-features = false, path = "risc0/zkvm" }
-risc0-zkvm-platform = { version = "2.0.0-rc.3", default-features = false, path = "risc0/zkvm/platform" }
-rzup = { version = "0.4.1-rc.3", default-features = false, path = "rzup" }
+risc0-bigint2 = { version = "1.4.0", default-features = false, path = "risc0/bigint2" }
+risc0-binfmt = { version = "2.0.0", default-features = false, path = "risc0/binfmt" }
+risc0-build = { version = "2.0.1", default-features = false, path = "risc0/build" }
+risc0-build-kernel = { version = "2.0.0", default-features = false, path = "risc0/build_kernel" }
+risc0-circuit-keccak = { version = "1.4.0", default-features = false, path = "risc0/circuit/keccak" }
+risc0-circuit-keccak-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/keccak-sys" }
+risc0-circuit-recursion = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "2.0.0", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-rv32im-sys = { version = "2.0.0", default-features = false, path = "risc0/circuit/rv32im-sys" }
+risc0-core = { version = "2.0.0", default-features = false, path = "risc0/core" }
+risc0-groth16 = { version = "1.4.0", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "2.0.0", default-features = false, path = "risc0/r0vm" }
+risc0-sys = { version = "1.4.0", default-features = false, path = "risc0/sys" }
+risc0-zkp = { version = "2.0.0", default-features = false, path = "risc0/zkp" }
+risc0-zkos-v1compat = { version = "2.0.0", path = "risc0/zkos/v1compat" }
+risc0-zkvm = { version = "2.0.0", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm-platform = { version = "2.0.0", default-features = false, path = "risc0/zkvm/platform" }
+rzup = { version = "0.4.1", default-features = false, path = "rzup" }
 sppark = "0.1.10"
 
 [profile.bench]

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "cc",
  "directories",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "cc",
  "cust",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "cc",
  "cust",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cust",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3466,7 +3466,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "rzup"
-version = "0.4.1-rc.3"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/bonsai/sdk/Cargo.toml
+++ b/bonsai/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bonsai-sdk"
 description = "Bonsai Software Development Kit"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -3770,7 +3770,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "cc",
  "directories",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "cc",
  "cust",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "cc",
  "cust",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cust",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "ciborium",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-receipts"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 
 [[package]]
 name = "rkyv"
@@ -4338,7 +4338,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "rzup"
-version = "0.4.1-rc.3"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec 0.8.0",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bls12_381/methods/guest/Cargo.lock
+++ b/examples/bls12_381/methods/guest/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/bn254/methods/guest/Cargo.lock
+++ b/examples/bn254/methods/guest/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -936,7 +936,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -892,7 +892,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1315,7 +1315,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.1-rc.3"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -856,7 +856,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/k256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/k256/methods/guest/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/ecdsa/p256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/p256/methods/guest/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -875,7 +875,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -855,7 +855,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -881,7 +881,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/keccak/methods/guest/Cargo.lock
+++ b/examples/keccak/methods/guest/Cargo.lock
@@ -854,7 +854,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -903,7 +903,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -946,7 +946,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -914,7 +914,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -875,7 +875,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -945,7 +945,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -848,7 +848,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-bigint2"
 description = "RISC Zero's Big Integer Accelerator"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -1030,13 +1030,13 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-bigint-dig",
- "risc0-bigint2 1.4.0-rc.3",
+ "risc0-bigint2 1.4.0",
  "risc0-zkvm",
 ]
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/binfmt/Cargo.toml
+++ b/risc0/binfmt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-binfmt"
 description = "RISC Zero binary format crate"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build"
 description = "RISC Zero zero-knowledge VM build tool"
-version = "2.0.1-rc.3"
+version = "2.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -263,7 +263,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "9b84b31f3e193fba6f76933fd29d126d5dcb1523bd901447bb0d4aed54ad7ae5",
+            "cc3d0b5cb2104d4704ed56891ba3672a5c619807738a290b2ff0bf062053f453",
         );
     }
 }

--- a/risc0/build_kernel/Cargo.toml
+++ b/risc0/build_kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build-kernel"
 description = "RISC Zero tool for building kernels"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-risczero"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak-sys/Cargo.toml
+++ b/risc0/circuit/keccak-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-keccak-sys"
 description = "Generated HAL code for keccak cicuit"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak/Cargo.toml
+++ b/risc0/circuit/keccak/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-keccak"
 description = "RISC Zero circuit for keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak/methods/guest/Cargo.lock
+++ b/risc0/circuit/keccak/methods/guest/Cargo.lock
@@ -840,7 +840,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/circuit/recursion-sys/Cargo.toml
+++ b/risc0/circuit/recursion-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-recursion-sys"
 description = "Generated HAL code for recursion cicuit"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/recursion/Cargo.toml
+++ b/risc0/circuit/recursion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-recursion"
 description = "RISC Zero circuit for recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im-sys/Cargo.toml
+++ b/risc0/circuit/rv32im-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im-sys"
 description = "Generated HAL code for rv32im cicuit"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im-sys/Cargo.toml
+++ b/risc0/circuit/rv32im-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im-sys"
 description = "Generated HAL code for rv32im cicuit"
-version = "2.0.0"
+version = "2.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im"
 description = "RISC Zero circuit for rv32im"
-version = "2.0.0"
+version = "2.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im"
 description = "RISC Zero circuit for rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/core/Cargo.toml
+++ b/risc0/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-core"
 description = "Core types for RISC Zero crates"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/groth16/Cargo.toml
+++ b/risc0/groth16/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-groth16"
 description = "RISC Zero Groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-r0vm"
 description = "RISC Zero zero-knowledge VM executable"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/sys/Cargo.toml
+++ b/risc0/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-sys"
 description = "Generated / Native / HAL code for RISC Zero"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/tools/Cargo.toml
+++ b/risc0/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-tools"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkos/v1compat/Cargo.toml
+++ b/risc0/zkos/v1compat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkos-v1compat"
 description = "RISC Zero zero-knowledge VM kernel for v1 compatibility"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkp"
 description = "RISC Zero zero-knowledge proof system core crate"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm"
 description = "RISC Zero zero-knowledge VM"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -851,7 +851,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1323,7 +1323,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "ciborium",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1618,7 +1618,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "rzup"
-version = "0.4.1-rc.3"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -906,7 +906,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -848,7 +848,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1265,7 +1265,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0-rc.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-methods"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 dependencies = [
  "bincode",
  "borsh",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1535,7 +1535,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "rzup"
-version = "0.4.1-rc.3"
+version = "0.4.1"
 dependencies = [
  "semver",
  "serde",

--- a/risc0/zkvm/platform/Cargo.toml
+++ b/risc0/zkvm/platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm-platform"
 description = "RISC Zero zero-knowledge VM"
-version = "2.0.0"
+version = "2.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/platform/Cargo.toml
+++ b/risc0/zkvm/platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm-platform"
 description = "RISC Zero zero-knowledge VM"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rzup"
 description = "The RISC Zero version management library and CLI"
-version = "0.4.1-rc.3"
+version = "0.4.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/tools/smoke-test/Cargo.toml
+++ b/tools/smoke-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = "2.0.0-rc.3"
+risc0-zkvm = "2.0.0"
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../risc0/zkvm" }
 methods = { path = "methods" }

--- a/tools/smoke-test/methods/Cargo.toml
+++ b/tools/smoke-test/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = "2.0.1-rc.3"
+risc0-build = "2.0.1"
 # Use this only for testing locally before a release.
 # risc0-build = { path = "../../../risc0/build" }
 


### PR DESCRIPTION
Prepare for official release by updating version numbers
- remove .rc.3 from all version numbers
- bump patch version of risc0-circuit-rv32im{-sys} and risc0-zkvm-platform so as to not conflict with already published versions, these crates we accidentally already published and yanked v2.0.0