### PR TITLE
docs: Improve P256 precompile example documentation

### DIFF
--- a/examples/ecdsa/p256/README.md
+++ b/examples/ecdsa/p256/README.md
@@ -1,6 +1,6 @@
-# ECDSA Example
+# ECDSA P256 (secp256r1) Example
 
-This example demonstrates how to verify an ECDSA signature inside the zkVM using secp256r1 signatures.
+This example demonstrates how to verify an ECDSA signature inside the zkVM using secp256r1 signatures, also known as NIST P-256. The secp256r1 curve is widely used in TLS, secure hardware enclaves, and various security protocols.
 
 ## Quick Start
 
@@ -16,28 +16,85 @@ cargo run --release
 
 Verifying digital signatures is a primary method of authentication for many protocols, and ECDSA is
 a widely deployed cryptographic signature scheme. This example shows how to efficiently verify an
-ECDSA signature on curve secp256r1.
+ECDSA signature on curve secp256r1 (NIST P-256), which is commonly used in:
+
+* TLS/SSL security protocols
+* Trusted Execution Environment (TEE) attestations
+* Secure hardware modules
+* Smart cards and security tokens
+* Various government and industry standards
 
 Signature verification can be combined with other application logic for powerful results such as
 [anonymous group signatures][1], [applying transformations to authenticated data][2], and [fully succinct
 transaction ledgers][3].
 
-## Precompile Patch
+## P256 Precompile Implementation
 
-ECDSA verification is relatively expensive in the zkVM guest. In order to speed this up, the zkVM 
-implements a 256-bit big integer multiplication precompile, which targets
-the main bottleneck for signature verification. Additionally, RISC Zero implements a patched version
-of the `p256` crate which uses this precompile. Using these patches, **ECDSA
-signature verification takes about 220k cycles**, down from ~12m cycles.
+ECDSA verification is relatively expensive in the zkVM guest without acceleration. To speed this up, the zkVM implements specialized precompile circuits for elliptic curve operations. The RISC Zero patched version of the `p256` crate uses these precompiles to significantly accelerate operations.
 
-You can see an example of how to apply these patches in the [`methods/guest/Cargo.toml`][4] file.
+Using these precompiles, **ECDSA signature verification on the P-256 curve takes about 220K cycles**, down from ~12M cycles without acceleration - an improvement of approximately 55x.
 
-For more information on how to use the precompile, see the [precompile documentation][5].
+The precompile works by optimizing the core elliptic curve operations:
+
+* Point addition
+* Point doubling
+* Scalar multiplication
+
+### How to Use the P256 Precompile
+
+To use the P256 precompile in your own project:
+
+1. Add the patched dependency to your guest's Cargo.toml:
+
+```toml
+[dependencies]
+p256 = { version = "=0.13.2", features = ["serde", "expose-field", "std", "ecdsa"] }
+
+[patch.crates-io]
+p256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "p256/v0.13.2-risczero.1" }
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
+crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
+```
+
+2. Enable the "unstable" feature in your risc0-zkvm dependency:
+
+```toml
+risc0-zkvm = { version = "1.2.0", default-features = false, features = ["std", "unstable"] }
+```
+
+3. Use the p256 crate as you normally would - the optimizations are automatically applied:
+
+```rust
+use p256::{
+    ecdsa::{signature::Verifier, Signature, VerifyingKey},
+    EncodedPoint,
+};
+
+// ... code to load key and signature ...
+
+// This verification will be accelerated automatically
+verifying_key
+    .verify(&message, &signature)
+    .expect("ECDSA signature verification failed");
+```
+
+You can see the complete working example in the source code of this example. For more reference implementation details, look at:
+
+* [p256\_verify.rs](methods/guest/src/bin/p256_verify.rs) - Guest code that uses the precompile
+* [main.rs](src/main.rs) - Host code that calls the guest
+
+For more information on how to use the precompile and other available precompiles, see the [precompile documentation][5].
 
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
+
 [RustCrypto]: https://docs.rs/p256/latest/p256/
+
 [1]: https://semaphore.appliedzkp.org/
+
 [2]: https://medium.com/@boneh/using-zk-proofs-to-fight-disinformation-17e7d57fe52f
+
 [3]: https://minaprotocol.com/
+
 [4]: methods/guest/Cargo.toml
+
 [5]: https://dev.risczero.com/api/zkvm/precompiles


### PR DESCRIPTION
Improved documentation on the use of P256 (secp256r1) predefined functions:

- Added a detailed description of the P256 curve (NIST P-256) and its applications
- Expanded section with use cases (TLS, TEE, smart cards, etc.)
- Added performance information (~55x speedup)
- Detailed steps for integrating P256 predefined functions
- Added code samples with explanations
- Explained the requirement to include the “unstable” flag
- Added links to source code and other resources

These improvements will help developers to effectively use accelerated 
ECDSA signature verification on secp256r1 curve in zkVM.
