### PR TITLE
fix typo in legacy rust format comment

### DIFF
--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -117,7 +117,7 @@ impl Paths {
             // Handle legacy rust format from older versions of rzup
             Version::parse(dir_name.strip_prefix("r0.")?.split('-').next()?).ok()
         } else if dir_name.starts_with("rust_") && component == &Component::RustToolchain {
-            // Handle legacy rust format from cargo riszero install
+            // Handle legacy rust format from cargo risczero install
             let version_str = dir_name.split('_').next_back()?;
             Version::parse(version_str.strip_prefix("r0.")?).ok()
         } else if dir_name.starts_with("c_") && component == &Component::CppToolchain {

--- a/website/api/zkvm/precompiles.md
+++ b/website/api/zkvm/precompiles.md
@@ -61,7 +61,7 @@ crates it may be possible to enable precompile support without code changes by
 applying a [Cargo patch][cargo-patch].
 
 An example of how to use these crates to accelerate ECDSA signature verification
-can be in the [ECDSA example][ecdsa]. Note the [use of the patched
+can be found in the [ECDSA example][ecdsa]. Note the [use of the patched
 versions][ecdsa-patched] of `sha2`, `crypto-bigint` and `k256` crates used in
 the guest's `Cargo.toml`.
 
@@ -92,7 +92,7 @@ precompiles that are still undergoing revision and review, and so users must opt
 features by setting the `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by
 the zkVM guest and by the `risc0-build` crate used to build the guest. These also require using
 versions `>=1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
-working on stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will
+working on stabilizing these precompiles as soon as possible, and the `"unstable"` feature flag will
 no longer be required.
 
 ## Timing Attacks

--- a/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
+++ b/website/api_versioned_docs/version-1.2/zkvm/precompiles.md
@@ -81,7 +81,7 @@ crates it may be possible to enable precompile support without code changes by
 applying a [Cargo patch][cargo-patch].
 
 An example of how to use these crates to accelerate ECDSA signature verification
-can be in the [ECDSA example][ecdsa]. Note the [use of the patched
+can be in found the [ECDSA example][ecdsa]. Note the [use of the patched
 versions][ecdsa-patched] of `sha2`, `crypto-bigint` and `k256` crates used in
 the guest's `Cargo.toml`.
 
@@ -112,7 +112,7 @@ precompiles that are still undergoing revision and review, and so users must opt
 features by setting the `"unstable"` [feature flag][feature-flag] on the `risc0-zkvm` crate used by
 the zkVM guest and by the `risc0-build` crate used to build the guest. These also require using
 versions `>=1.2.0` of `risc0` crates. For users who need a stable, production-ready version we are
-working on stablizing these precompiles as soon as possible, and the `"unstable"` feature flag will
+working on stabilizing these precompiles as soon as possible, and the `"unstable"` feature flag will
 no longer be required.
 
 [^1]: This is similar to the cryptography support such as [AES-NI] or the [SHA


### PR DESCRIPTION

Corrects a typo in the comment for legacy rust format handling, changing "riszero" to "risczero" in the `paths.rs file`. This maintains consistency with the correct spelling used throughout the codebase.

Changes:
- Updated comment from `cargo riszero install` to `cargo risczero install`