### PR TITLE
ZKVM-1282: risc0-build: make docker container tag configurable

### DIFF
--- a/risc0/build/src/config.rs
+++ b/risc0/build/src/config.rs
@@ -36,6 +36,7 @@ pub struct DockerOptions {
     pub env: Vec<(String, String)>,
 
     /// Docker container tag to use
+    #[builder(setter(into, strip_option))]
     pub docker_container_tag: Option<String>,
 }
 

--- a/risc0/build/src/config.rs
+++ b/risc0/build/src/config.rs
@@ -19,6 +19,8 @@ use derive_builder::Builder;
 use risc0_zkos_v1compat::V1COMPAT_ELF;
 use serde::{Deserialize, Serialize};
 
+use crate::DEFAULT_DOCKER_TAG;
+
 /// Options for configuring a docker build environment.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Builder)]
 #[builder(default)]
@@ -32,6 +34,9 @@ pub struct DockerOptions {
 
     /// Additional environment variables for the build container.
     pub env: Vec<(String, String)>,
+
+    /// Docker container tag to use
+    pub docker_container_tag: Option<String>,
 }
 
 impl DockerOptions {
@@ -48,6 +53,19 @@ impl DockerOptions {
             .iter()
             .map(|(key, val)| (key.as_str(), val.as_str()))
             .collect()
+    }
+
+    /// Get the docker container tag, or default container tag if none
+    ///
+    /// This value may be set by using the `RISC0_DOCKER_CONTAINER_TAG` environment variable.
+    pub fn docker_container_tag(&self) -> String {
+        if let Ok(tag) = env::var("RISC0_DOCKER_CONTAINER_TAG") {
+            return tag;
+        }
+
+        self.docker_container_tag
+            .clone()
+            .unwrap_or(DEFAULT_DOCKER_TAG.to_string())
     }
 }
 

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -142,8 +142,14 @@ fn create_dockerfile(manifest_path: &Path, temp_dir: &Path, guest_info: &GuestIn
     .concat()
     .join(" ");
 
+    let docker_opts = guest_info.options.use_docker.clone().unwrap_or_default();
+    let docker_tag = format!(
+        "risczero/risc0-guest-builder:{}",
+        docker_opts.docker_container_tag()
+    );
+
     let mut build = DockerFile::new()
-        .from_alias("build", "risczero/risc0-guest-builder:r0.1.85.0")
+        .from_alias("build", &docker_tag)
         .workdir("/src")
         .copy(".", ".")
         .env(manifest_env)
@@ -162,7 +168,6 @@ fn create_dockerfile(manifest_path: &Path, temp_dir: &Path, guest_info: &GuestIn
         )])
         .env(&[("CFLAGS_riscv32im_risc0_zkvm_elf", "-march=rv32im -nostdlib")]);
 
-    let docker_opts = guest_info.options.use_docker.clone().unwrap_or_default();
     let docker_env = docker_opts.env();
     if !docker_env.is_empty() {
         build = build.env(&docker_env);

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -54,6 +54,7 @@ pub use self::{
 };
 
 const RISC0_TARGET_TRIPLE: &str = "riscv32im-risc0-zkvm-elf";
+const DEFAULT_DOCKER_TAG: &str = "r0.1.85.0";
 
 #[derive(Debug, Deserialize)]
 struct Risc0Metadata {


### PR DESCRIPTION
This change allows users to set the docker container used for reproducible programmatically or by setting the `RISC0_DOCKER_CONTAINER_TAG` environment variable.