### PR TITLE
chore: optimized schema structure for version handling and data types

### DIFF
--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/_components/applications-benchmarks-table-schema.ts
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/applications-benchmarks/[slug]/_components/applications-benchmarks-table-schema.ts
@@ -1,63 +1,33 @@
 import { z } from "zod";
 
-const applicationsBenchmarksTableSchema = {
-  main: z.object({
-    name: z.string(),
-    size: z.string(),
-    speed: z.string(),
-    total_duration: z.string(),
-    total_cycles: z.string(),
-    user_cycles: z.string(),
-    proof_bytes: z.string(),
-  }),
-  "release-0.21": z.object({
-    job_name: z.string(),
-    job_size: z.string(),
-    exec_duration: z.string(),
-    proof_duration: z.string(),
-    total_duration: z.string(),
-    verify_duration: z.string(),
-    insn_cycles: z.string(),
-    prove_cycles: z.string(),
-    proof_bytes: z.string(),
-  }),
-  "release-1.0": z.object({
-    name: z.string(),
-    size: z.string(),
-    speed: z.string(),
-    total_duration: z.string(),
-    total_cycles: z.string(),
-    user_cycles: z.string(),
-    proof_bytes: z.string(),
-  }),
-  "release-1.1": z.object({
-    name: z.string(),
-    size: z.string(),
-    speed: z.string(),
-    total_duration: z.string(),
-    total_cycles: z.string(),
-    user_cycles: z.string(),
-    proof_bytes: z.string(),
-  }),
-  "release-1.2": z.object({
-    name: z.string(),
-    size: z.string(),
-    speed: z.string(),
-    total_duration: z.string(),
-    total_cycles: z.string(),
-    user_cycles: z.string(),
-    proof_bytes: z.string(),
-  }),
-  "release-2.0": z.object({
-    name: z.string(),
-    size: z.string(),
-    speed: z.string(),
-    total_duration: z.string(),
-    total_cycles: z.string(),
-    user_cycles: z.string(),
-    proof_bytes: z.string(),
-  }),
-};
+const baseSchema = z.object({
+  name: z.string(),
+  size: z.string(),
+  speed: z.string(),
+  total_duration: z.string().transform(val => Number(val)),
+  total_cycles: z.string().transform(val => Number(val)),
+  user_cycles: z.string().transform(val => Number(val)),
+  proof_bytes: z.string().transform(val => Number(val)),
+});
+
+const release0_21Schema = baseSchema.extend({
+  job_name: z.string(),
+  job_size: z.string(),
+  exec_duration: z.string().transform(val => Number(val)),
+  proof_duration: z.string().transform(val => Number(val)),
+  verify_duration: z.string().transform(val => Number(val)),
+  insn_cycles: z.string().transform(val => Number(val)),
+  prove_cycles: z.string().transform(val => Number(val)),
+});
+
+const versions = ["main", "release-0.21", "release-1.0", "release-1.1", "release-1.2", "release-2.0"] as const;
+
+const applicationsBenchmarksTableSchema = Object.fromEntries(
+  versions.map(version => [
+    version,
+    version === "release-0.21" ? release0_21Schema : baseSchema
+  ])
+);
 
 export type ApplicationsBenchmarksTableSchema<T extends keyof typeof applicationsBenchmarksTableSchema> = z.infer<
   (typeof applicationsBenchmarksTableSchema)[T]


### PR DESCRIPTION
I’ve made several improvements to streamline the schema structure and make it more maintainable. Here’s a brief overview:

- **Merged common fields**: Created a `baseSchema` that includes shared fields (e.g., name, size, speed, etc.) to reduce code repetition across all versions.
  
- **Extended schema for specific versions**: For `release-0.21`, which has additional fields (e.g., job_name, job_size), I used the `.extend()` method to add only the unique fields for that version, keeping other versions clean and consistent.

- **Version handling**: Introduced an array `versions` to dynamically generate the `applicationsBenchmarksTableSchema` using `Object.fromEntries()` and `.map()`. This simplifies the addition of new versions in the future.

- **String-to-number transformation**: Added `.transform()` to convert relevant fields (like `total_duration`, `total_cycles`) from strings to numbers automatically, ensuring proper data types during processing.

These changes make the code more compact, manageable, and less error-prone.