### PR TITLE
docs: Add dev mode information to example READMEs

### DIFF
--- a/examples/bevy/README.md
+++ b/examples/bevy/README.md
@@ -2,6 +2,10 @@
 
 This code demonstrates a minimal example of how to use the [bevy] game engine inside the RISC Zero [zkVM].
 
+## Performance
+
+Game engines like Bevy can be computationally intensive when run inside a zkVM. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -10,6 +14,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
 ```
 
 ## Use Cases
@@ -35,6 +45,8 @@ For more information about building, running, and testing zkVM applications, see
 [`src/main.rs`]: src/main.rs
 [bevy]: https://bevyengine.org/
 [Bonsai application]: https://dev.bonsai.xyz
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode
 [developer docs]: https://dev.risczero.com/zkvm
 [ECDSA]: https://github.com/risc0/risc0/tree/main/examples/ecdsa
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples

--- a/examples/bls12_381/README.md
+++ b/examples/bls12_381/README.md
@@ -1,5 +1,9 @@
 # BLS12_381 Example
 
+## Performance
+
+Elliptic curve operations on BLS12_381 can be computationally intensive in a zkVM. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -10,4 +14,12 @@ Then, run the example with:
 cargo run --release
 ```
 
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
+```
+
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode

--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -4,6 +4,10 @@ This code demonstrates a minimal example of how to use the RISC Zero [zkVM] to m
 
 The demo uses the [shakmaty] crate to prove that a chess position has a checkmate without revealing what that checkmate is.
 
+## Performance
+
+Chess validation can be computationally intensive. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -12,6 +16,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
 ```
 
 Congratulations! You just constructed a zero-knowledge proof that includes a mate-in-one.
@@ -50,6 +60,8 @@ The [guest code] checks that applying the move to the initial board state is leg
 - For more information about building, running, and testing zkVM applications, see our [developer docs].
 
 [Bonsai application]: https://dev.bonsai.xyz
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode
 [developer docs]: https://dev.risczero.com
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
 [excerpt from our workshop at ZK HACK III]: https://www.youtube.com/watch?v=vxqxRiTXGBI&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5&index=9

--- a/examples/digital-signature/README.md
+++ b/examples/digital-signature/README.md
@@ -2,6 +2,10 @@
 
 A simple digital signature scheme built on the RISC Zero platform.
 
+## Performance
+
+Cryptographic signature generation and verification in the zkVM can be resource-intensive. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -10,6 +14,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release -- "This is a signed message" --passphrase="passw0rd"
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release -- "This is a signed message" --passphrase="passw0rd"
 ```
 
 ## Summary
@@ -40,3 +50,5 @@ passphrase. Sending those along with the message covers the full scope of a
 typical digital signature scheme.
 
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode

--- a/examples/ecdsa/k256/README.md
+++ b/examples/ecdsa/k256/README.md
@@ -2,6 +2,10 @@
 
 This example demonstrates how to verify an ECDSA signature inside the zkVM using secp256k1 signatures.
 
+## Performance
+
+Even with the optimizations described below, ECDSA signature verification requires significant computational resources. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -10,6 +14,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
 ```
 
 ## Use Cases
@@ -53,3 +63,5 @@ For more information on how to use the precompile, see the [precompile documenta
 [4]: methods/guest/Cargo.toml
 [5]: https://github.com/risc0/RustCrypto-elliptic-curves/pull/1
 [6]: https://dev.risczero.com/api/zkvm/precompiles
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode

--- a/examples/ecdsa/p256/README.md
+++ b/examples/ecdsa/p256/README.md
@@ -2,6 +2,10 @@
 
 This example demonstrates how to verify an ECDSA signature inside the zkVM using secp256r1 signatures.
 
+## Performance
+
+Even with the optimizations described below, ECDSA signature verification requires significant computational resources. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -10,6 +14,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
 ```
 
 ## Use Cases
@@ -41,3 +51,5 @@ For more information on how to use the precompile, see the [precompile documenta
 [3]: https://minaprotocol.com/
 [4]: methods/guest/Cargo.toml
 [5]: https://dev.risczero.com/api/zkvm/precompiles
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -8,6 +8,10 @@ designed to help you get started building zkVM applications.
 For a step-by-step guide to building your first zkVM application, we recommend
 [this tutorial][tutorial].
 
+## Performance
+
+As zkVM applications may require significant computational resources to prove, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE] for faster iteration during development.
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -16,6 +20,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
 ```
 
 Congratulations! You just constructed a zero-knowledge proof that you know the
@@ -74,3 +84,4 @@ tutorial][tutorial]. For more materials, check out the [developer docs].
 [tutorial]: https://dev.risczero.com/api/zkvm/tutorials/hello-world
 [verify]: https://dev.risczero.com/terminology#verify
 [zkVM]: https://dev.risczero.com/zkvm
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode

--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -2,6 +2,10 @@
 
 This code demonstrates how to prove that a JSON file contains a specific field and value using the RISC Zero zkVM. The JSON file is identified by SHA-256 hash, allowing users to commit to a specific JSON file and then prove some of its contents without revealing the full file.
 
+## Performance
+
+JSON parsing and validation in the zkVM can be resource-intensive. For development and testing purposes, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE] for faster execution.
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -12,8 +16,16 @@ Then, run the example with:
 cargo run --release
 ```
 
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
+```
+
 ## Video Tutorial
 
 For a walk-through of this example, check out this [excerpt from our workshop at ZK HACK III](https://www.youtube.com/watch?v=6vIgBHx61vc\&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5\&index=7).
 
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode

--- a/examples/password-checker/README.md
+++ b/examples/password-checker/README.md
@@ -4,6 +4,10 @@ This simple password checker is implemented in Rust. The program is implemented 
 
 The policy checker accepts a password string and a salt from the host driver and checks the validity of the password. A password validity-checking function then examines the password and panics if criteria are not met. If the password meets validity criteria, execution proceeds and the zkVM appends a hash of the salted password to the journal. The journal is a readable record of all values committed by code in the zkVM; it is attached to the receipt (a record of correct execution).
 
+## Performance
+
+Cryptographic operations in the zkVM can be resource-intensive. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -12,6 +16,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
 ```
 
 ## Why use zkVM to run this?
@@ -36,3 +46,5 @@ This is example code meant to illustrate the fundamentals of programming with th
 For a walk-through of the fundamentals of this example, check out this [excerpt from our workshop at ZK HACK III](https://www.youtube.com/watch?v=Yg_BGqj_6lg\&list=PLcPzhUaCxlCgig7ofeARMPwQ8vbuD6hC5\&index=5).
 
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode

--- a/examples/sha/README.md
+++ b/examples/sha/README.md
@@ -2,6 +2,10 @@
 
 This code demonstrates how to provably compute the SHA-256 hash of a string using RISC Zero.
 
+## Performance
+
+While the SHA-256 implementation in the zkVM is optimized using hardware acceleration, generating zero-knowledge proofs still requires computational resources. For faster development and testing, we recommend running this example on [Bonsai] or using the [`DEV_MODE`][DEV_MODE].
+
 ## Quick Start
 
 First, follow the [examples guide] to install dependencies and check out the correct version of the example.
@@ -10,6 +14,12 @@ Then, run the example with:
 
 ```bash
 cargo run --release
+```
+
+Or in [`DEV_MODE`][DEV_MODE] for much faster execution:
+
+```bash
+RISC0_DEV_MODE=1 cargo run --release
 ```
 
 Notable details:
@@ -27,3 +37,5 @@ Note that the code snippets in this video are based on the 0.14 version of the z
 
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
 [RustCrypto]: https://docs.rs/sha2/latest/sha2/
+[Bonsai]: https://dev.bonsai.xyz/apply
+[DEV_MODE]: https://dev.risczero.com/api/generating-proofs/dev-mode


### PR DESCRIPTION
Addresses issue #1977

Updated examples:
- bevy
- bls12_381
- chess
- ecdsa (k256 & p256)
- hello-world
- json
- password-checker
- sha
- digital-signature