### PR TITLE
Update README.md and CONTRIBUTING.md to use xfast instead of xtask

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ rzup install
 #### xtask wasm tools (if testing [browser-verify](./examples/browser-verify))
 
 ```bash
-cargo xtask install
-cargo xtask gen-receipt
+cargo xfast install
+cargo xfast gen-receipt
 ```
 
 ## PR Checklist

--- a/examples/browser-verify/README.md
+++ b/examples/browser-verify/README.md
@@ -7,8 +7,8 @@ Verify that a RISC Zero program is in your browser using WASM!
 In addition to [Rust] and [Node.js], you will need to run from the root of the repository:
 
 ```bash
-cargo xtask install
-cargo xtask gen-receipt
+cargo xfast install
+cargo xfast gen-receipt
 ```
 
 Next, install the `cargo-risczero` tool and install the toolchain with:


### PR DESCRIPTION


**Description:**
This PR updates the documentation to replace `cargo xtask` commands with `cargo xfast` commands in both CONTRIBUTING.md and the browser-verify example README. This change reflects the updated tooling nomenclature for the project's build system.
