### PR TITLE
ZKVM-1286: bump risc0-build to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ hotbench = { path = "tools/hotbench" }
 metal = "0.29"
 risc0-bigint2 = { version = "1.4.1", default-features = false, path = "risc0/bigint2" }
 risc0-binfmt = { version = "2.0.1", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "2.0.1", default-features = false, path = "risc0/build" }
+risc0-build = { version = "2.1.0", default-features = false, path = "risc0/build" }
 risc0-build-kernel = { version = "2.0.0", default-features = false, path = "risc0/build_kernel" }
 risc0-circuit-keccak = { version = "1.4.1", default-features = false, path = "risc0/circuit/keccak" }
 risc0-circuit-keccak-sys = { version = "1.4.1", default-features = false, path = "risc0/circuit/keccak-sys" }

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build"
 description = "RISC Zero zero-knowledge VM build tool"
-version = "2.0.2"
+version = "2.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -268,7 +268,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "5e25a529497691dcbb44775016dec613e50d0327a4ac358f7e9ea19d13bbb2d3",
+            "6fb4f0249fa7a0dc858e295c888096bd6e5d5b6ac58312d59178ab88339505f8",
         );
     }
 }

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",


### PR DESCRIPTION
This version bump is due to #3037