### PR TITLE
Bump version numbers to fix 1.2 build and backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5580,7 +5580,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "clap 4.5.32",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "cust",
@@ -5709,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,23 +44,23 @@ repository = "https://github.com/risc0/risc0/"
 bonsai-sdk = { version = "1.4.0", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.4.0", default-features = false, path = "risc0/bigint2" }
+risc0-bigint2 = { version = "1.4.1", default-features = false, path = "risc0/bigint2" }
 risc0-binfmt = { version = "2.0.0", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "2.0.1", default-features = false, path = "risc0/build" }
+risc0-build = { version = "2.1.0", default-features = false, path = "risc0/build" }
 risc0-build-kernel = { version = "2.0.0", default-features = false, path = "risc0/build_kernel" }
-risc0-circuit-keccak = { version = "1.4.0", default-features = false, path = "risc0/circuit/keccak" }
-risc0-circuit-keccak-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/keccak-sys" }
-risc0-circuit-recursion = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion" }
-risc0-circuit-recursion-sys = { version = "1.4.0", default-features = false, path = "risc0/circuit/recursion-sys" }
-risc0-circuit-rv32im = { version = "2.0.1", default-features = false, path = "risc0/circuit/rv32im" }
+risc0-circuit-keccak = { version = "2.0.0", default-features = false, path = "risc0/circuit/keccak" }
+risc0-circuit-keccak-sys = { version = "2.0.0", default-features = false, path = "risc0/circuit/keccak-sys" }
+risc0-circuit-recursion = { version = "2.0.0", default-features = false, path = "risc0/circuit/recursion" }
+risc0-circuit-recursion-sys = { version = "2.0.0", default-features = false, path = "risc0/circuit/recursion-sys" }
+risc0-circuit-rv32im = { version = "2.0.2", default-features = false, path = "risc0/circuit/rv32im" }
 risc0-circuit-rv32im-sys = { version = "2.0.1", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-core = { version = "2.0.0", default-features = false, path = "risc0/core" }
-risc0-groth16 = { version = "1.4.0", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "2.0.0", default-features = false, path = "risc0/r0vm" }
+risc0-groth16 = { version = "2.0.0", default-features = false, path = "risc0/groth16" }
+risc0-r0vm = { version = "2.0.1", default-features = false, path = "risc0/r0vm" }
 risc0-sys = { version = "1.4.0", default-features = false, path = "risc0/sys" }
 risc0-zkp = { version = "2.0.0", default-features = false, path = "risc0/zkp" }
 risc0-zkos-v1compat = { version = "2.0.0", path = "risc0/zkos/v1compat" }
-risc0-zkvm = { version = "2.0.0", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm = { version = "2.0.1", default-features = false, path = "risc0/zkvm" }
 risc0-zkvm-platform = { version = "2.0.1", default-features = false, path = "risc0/zkvm/platform" }
 rzup = { version = "0.4.1", default-features = false, path = "rzup" }
 sppark = "0.1.10"

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "cust",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "cust",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec 0.8.0",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/bls12_381/methods/guest/Cargo.lock
+++ b/examples/bls12_381/methods/guest/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/bn254/methods/guest/Cargo.lock
+++ b/examples/bn254/methods/guest/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/ecdsa/k256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/k256/methods/guest/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/ecdsa/p256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/p256/methods/guest/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/keccak/methods/guest/Cargo.lock
+++ b/examples/keccak/methods/guest/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-bigint2"
 description = "RISC Zero's Big Integer Accelerator"
-version = "1.4.0"
+version = "1.4.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -1030,7 +1030,7 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-bigint-dig",
- "risc0-bigint2 1.4.0",
+ "risc0-bigint2 1.4.1",
  "risc0-zkvm",
 ]
 
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build"
 description = "RISC Zero zero-knowledge VM build tool"
-version = "2.0.1"
+version = "2.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -268,7 +268,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "27a5fa18c32ef389caf57c38160add55d4452b38bae172ac49608499e0087aa2",
+            "9637473b4145bdb2b12e86fa7504644b0eeeca1c433768c30b3fbf72da751950",
         );
     }
 }

--- a/risc0/circuit/keccak-sys/Cargo.toml
+++ b/risc0/circuit/keccak-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-keccak-sys"
 description = "Generated HAL code for keccak cicuit"
-version = "1.4.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak/Cargo.toml
+++ b/risc0/circuit/keccak/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-keccak"
 description = "RISC Zero circuit for keccak"
-version = "1.4.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak/methods/guest/Cargo.lock
+++ b/risc0/circuit/keccak/methods/guest/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/circuit/recursion-sys/Cargo.toml
+++ b/risc0/circuit/recursion-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-recursion-sys"
 description = "Generated HAL code for recursion cicuit"
-version = "1.4.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/recursion/Cargo.toml
+++ b/risc0/circuit/recursion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-recursion"
 description = "RISC Zero circuit for recursion"
-version = "1.4.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-circuit-rv32im"
 description = "RISC Zero circuit for rv32im"
-version = "2.0.1"
+version = "2.0.2"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/groth16/Cargo.toml
+++ b/risc0/groth16/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-groth16"
 description = "RISC Zero Groth16"
-version = "1.4.0"
+version = "2.0.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-r0vm"
 description = "RISC Zero zero-knowledge VM executable"
-version = "2.0.0"
+version = "2.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm"
 description = "RISC Zero zero-knowledge VM"
-version = "2.0.0"
+version = "2.0.1"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "borsh",


### PR DESCRIPTION
This version bump covers backports to `risc0-circuit-rv32im` and `risc0-build`.

Also bump the major versions of crates where their risc0 dependencies have had a major version bump. This should allow us to yank the `1.4` versions of these crates and fix the 1.2 build.