### PR TITLE
backport release-2.0: ZKVM-1290: Statically link in `liblzma` (#3055)

### DIFF
--- a/risc0/circuit/keccak/Cargo.toml
+++ b/risc0/circuit/keccak/Cargo.toml
@@ -29,7 +29,7 @@ risc0-circuit-keccak-sys = { workspace = true, optional = true }
 risc0-circuit-recursion = { workspace = true, default-features = false }
 risc0-sys = { workspace = true, optional = true }
 rayon = { version = "1.10", optional = true }
-xz2 = { version = "0.1", optional = true }
+xz2 = { version = "0.1", optional = true, features = ["static"] }
 
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
No need to depend on the system provided version of this library on Linux, and on Mac it creates an even greater issue of somehow providing this library to users.

See https://github.com/risc0/risc0/issues/3054