### PR TITLE
ZKVM-1296: client/server: fix version mismatch message

### DIFF
--- a/risc0/zkvm/src/host/api/mod.rs
+++ b/risc0/zkvm/src/host/api/mod.rs
@@ -175,7 +175,7 @@ impl ParentProcessConnector {
             let server_suggestion = if client_version.pre.is_empty() {
                 format!(
                     "1. Install r0vm server version {}.{}\n",
-                    server_version.major, server_version.minor
+                    client_version.major, client_version.minor
                 )
             } else {
                 format!("1. Your risc0 dependencies are using a pre-released version {client_version}.\n   \


### PR DESCRIPTION
This version mismatch error message suggests the user to install a version of r0vm that the user already has installed. Fix this by suggesting that they install the version of r0vm that matches the client version instead.