### PR TITLE
ZKVM-1302: datasheet: remove sha256

### DIFF
--- a/risc0/zkvm/benches/fib.rs
+++ b/risc0/zkvm/benches/fib.rs
@@ -77,7 +77,6 @@ fn prove_segment(group: &mut BenchGroup, hashfn: &str) {
 }
 
 fn prove(group: &mut BenchGroup) {
-    prove_segment(group, "sha-256");
     prove_segment(group, "poseidon2");
 }
 


### PR DESCRIPTION
As of now, proof generation ignores the hash function and always generates poseidon2 proofs. Remove sha256 from the datasheet for now.