### PR TITLE
ZKVM-1306: Restrict Docker Hub Login to Internal PRs Only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,7 +265,9 @@ jobs:
         with:
           key: ${{ matrix.os }}-${{ matrix.feature }}
       - name: Login to Docker Hub
-        if: matrix.os == 'Linux'
+        if: >
+          matrix.os == 'Linux' &&
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_CI_USER }}
@@ -652,6 +654,7 @@ jobs:
         with:
           key: Linux-default
       - name: Login to Docker Hub
+        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_CI_USER }}


### PR DESCRIPTION
- GitHub secrets are not usable from external PRs by design, so the `Login to Docker Hub` steps in the `main.yml` workflow fail for external PRs:
  - Example: https://github.com/risc0/risc0/actions/runs/14224739449/job/39861422302?pr=3042
- This change only triggers the login step for internal PRs