### PR TITLE
ZKVM-1309: use semver::VersionReq for comparisons in rzup build

### DIFF
--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -219,7 +219,7 @@ pub fn build_rust_toolchain(
         message: "./x build".into(),
     });
 
-    let req = semver::VersionReq::parse(">1.81.0")?;
+    let req = semver::VersionReq::parse(">=1.82.0")?;
     let lower_atomic = if req.matches(&version) {
         "-Cpasses=lower-atomic"
     } else {

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -219,7 +219,8 @@ pub fn build_rust_toolchain(
         message: "./x build".into(),
     });
 
-    let lower_atomic = if version > semver::Version::new(1, 81, 0) {
+    let req = semver::VersionReq::parse(">1.81.0")?;
+    let lower_atomic = if req.matches(&version) {
         "-Cpasses=lower-atomic"
     } else {
         "-Cpasses=loweratomic"

--- a/rzup/src/lib.rs
+++ b/rzup/src/lib.rs
@@ -324,6 +324,7 @@ impl Rzup {
 mod tests {
     use super::*;
     use crate::distribution::Os;
+    use std::collections::HashMap;
     use std::convert::Infallible;
     use std::io::Write as _;
     use std::net::SocketAddr;
@@ -2300,7 +2301,7 @@ mod tests {
         std::fs::set_permissions(path, perms).unwrap();
     }
 
-    fn create_fake_rust_repo(tmp_dir: &TempDir) -> (PathBuf, Version) {
+    fn create_fake_rust_repo(tmp_dir: &TempDir, rust_version: Version) -> (PathBuf, Version) {
         let test_repo = tmp_dir.path().join("test-repo");
         std::fs::create_dir(&test_repo).unwrap();
         build::run_command(
@@ -2315,7 +2316,7 @@ mod tests {
         .unwrap();
 
         std::fs::create_dir(test_repo.join("src")).unwrap();
-        std::fs::write(test_repo.join("src/version"), "1.34.0").unwrap();
+        std::fs::write(test_repo.join("src/version"), rust_version.to_string()).unwrap();
         write_script(
             &test_repo.join("x"),
             "\
@@ -2361,6 +2362,8 @@ mod tests {
             touch build/foo/stage2-tools-bin/bar-fmt
             echo 'build output line 1'
             echo 'build output line 2'
+            env >> x_env
+            echo '=====' >> x_env
             ",
         );
 
@@ -2400,7 +2403,7 @@ mod tests {
             Platform::new("x86_64", Os::Linux),
         );
 
-        let (test_repo, version) = create_fake_rust_repo(&tmp_dir);
+        let (test_repo, version) = create_fake_rust_repo(&tmp_dir, Version::new(1, 34, 0));
 
         let repo_url = format!("file://{}", test_repo.display());
 
@@ -2470,7 +2473,7 @@ mod tests {
             Platform::new("x86_64", Os::Linux),
         );
 
-        let (test_repo, master) = create_fake_rust_repo(&tmp_dir);
+        let (test_repo, master) = create_fake_rust_repo(&tmp_dir, Version::new(1, 34, 0));
 
         let repo_url = format!("file://{}", test_repo.display());
         rzup.build_rust_toolchain(&repo_url, &Some("foo".to_string()), &None)
@@ -2494,5 +2497,65 @@ mod tests {
                 format!(".risc0/toolchains/v{foo}-rust-x86_64-unknown-linux-gnu/bin/rustc"),
             ],
         );
+    }
+
+    fn parse_env_output(input: &str) -> Vec<HashMap<&str, &str>> {
+        let Some(last_divider) = input.rfind("====") else {
+            return vec![];
+        };
+
+        input[..last_divider]
+            .split("====")
+            .map(|invocation| {
+                invocation
+                    .split("\n")
+                    .filter_map(|line| line.split_once("="))
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_rust_toolchain_loweratomic_flag() {
+        let expectations = [
+            (Version::new(1, 80, 0), "-Cpasses=loweratomic"),
+            (Version::new(1, 81, 0), "-Cpasses=loweratomic"),
+            (Version::new(1, 81, 1), "-Cpasses=loweratomic"),
+            (Version::new(1, 82, 0), "-Cpasses=lower-atomic"),
+            (Version::new(1, 82, 1), "-Cpasses=lower-atomic"),
+            (Version::new(1, 83, 0), "-Cpasses=lower-atomic"),
+        ];
+
+        for (version, expected_lower_atomic) in expectations {
+            let server = MockDistributionServer::new();
+            let (tmp_dir, mut rzup) = setup_test_env(
+                server.base_urls.clone(),
+                None,
+                Platform::new("x86_64", Os::Linux),
+            );
+
+            let (test_repo, _) = create_fake_rust_repo(&tmp_dir, version.clone());
+            let repo_url = format!("file://{}", test_repo.display());
+
+            rzup.build_rust_toolchain(&repo_url, &Some("master".to_string()), &None)
+                .unwrap();
+
+            // Our fake x script creates this file
+            let env_raw = std::fs::read_to_string(
+                tmp_dir.path().join(".risc0/tmp/build-rust-toolchain/x_env"),
+            )
+            .unwrap();
+            let env = parse_env_output(&env_raw);
+
+            // two ./x invocations
+            assert_eq!(env.len(), 2);
+
+            for e in env {
+                assert_eq!(
+                    e["CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS"], expected_lower_atomic,
+                    "lower atomic unexpected for {version}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #3071 

According to [docs.rs/semver](https://docs.rs/semver/latest/semver/), `semver::VersionReq` should be used for semantic version requirements (hence comparisons) since using standard Rust comparison operators directly on `semver::Version` leads to incorrect results if `semver::BuildMetadata` is present.

Consider this example

```
let mut v1 = semver::Version::new(1,81,0);
v1.build = semver::BuildMetadata::new("72a7a1c4").unwrap();

let min = semver::Version::new(1,81,0);
println!("{v1} > {min} := {}", v1 > min);

let req = semver::VersionReq::parse(">1.81.0").unwrap();
println!("{v1}{req} := {}", req.matches(&v1));
```

which yields

```
1.81.0+72a7a1c4 > 1.81.0 := true
1.81.0+72a7a1c4>1.81.0 := false
```