### PR TITLE
ZKVM-1325: Return an error if "sha-256" is used for the hashfn

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -268,7 +268,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "6ebb7949869b15585da87873fd6c21b37b7fcb56d95a88031a04a382aba1bb10",
+            "1db1ae8a6e3ac8a2add00a80dde19c01ac6f6ffba1ff1c2331142f76a63e1d51",
         );
     }
 }

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -69,6 +69,14 @@ impl ProverServer for ProverImpl {
             session.journal.as_ref().map(hex::encode),
             session.segments.len()
         );
+
+        ensure!(
+            self.opts.hashfn == "poseidon2",
+            "provided `ProverOpts` has unsupported `hashfn` value of \"{}\"; \
+            supported `hashfn` values are: \"poseidon2\".",
+            &self.opts.hashfn
+        );
+
         let mut segments = Vec::new();
         for segment_ref in session.segments.iter() {
             let segment = segment_ref.resolve()?;
@@ -214,6 +222,13 @@ impl ProverServer for ProverImpl {
             "segment po2 exceeds max on ProverOpts: {} > {}",
             segment.po2(),
             self.opts.max_segment_po2
+        );
+
+        ensure!(
+            self.opts.hashfn == "poseidon2",
+            "provided `ProverOpts` has unsupported `hashfn` value of \"{}\"; \
+            supported `hashfn` values are: \"poseidon2\".",
+            &self.opts.hashfn
         );
 
         let seal = risc0_circuit_rv32im::prove::segment_prover()?.prove(&segment.inner)?;

--- a/risc0/zkvm/src/receipt/segment.rs
+++ b/risc0/zkvm/src/receipt/segment.rs
@@ -94,6 +94,10 @@ impl SegmentReceipt {
             });
         }
 
+        if self.hashfn != "poseidon2" {
+            return Err(VerificationError::InvalidHashSuite);
+        }
+
         tracing::debug!("SegmentReceipt::verify_integrity_with_context");
         risc0_circuit_rv32im::verify(&self.seal)?;
         let decoded_claim = ReceiptClaim::decode_from_seal_v2(&self.seal, None)


### PR DESCRIPTION
We didn't properly implement "sha-256" support for segment proving in v2. Instead of ignoring the hashfn value, we should check that it is "poseidon2", the only hashfn that we currently support.