### PR TITLE
ZKVM-1326: Don't error in the profiler when it gets confused about the call stack

### DIFF
--- a/risc0/zkvm/src/host/server/exec/profiler.rs
+++ b/risc0/zkvm/src/host/server/exec/profiler.rs
@@ -532,12 +532,12 @@ impl Profiler {
                     self.call_stack_path.pop();
                 }
 
-                self.call_stack_path.pop().ok_or_else(|| {
-                    anyhow!("attempted to follow a return with an empty call stack")
-                })?;
-                let popped = self.pop_stack.pop().ok_or_else(|| {
-                    anyhow!("attempted to follow a return with an empty call stack")
-                })?;
+                if self.call_stack_path.pop().is_none() {
+                    break;
+                }
+                let Some(popped) = self.pop_stack.pop() else {
+                    break;
+                };
                 *update_stack = true;
                 if popped == pc - 4 {
                     break;
@@ -549,12 +549,13 @@ impl Profiler {
                         self.call_stack_path.pop();
                     }
 
-                    self.call_stack_path.pop().ok_or_else(|| {
-                        anyhow!("attempted to follow a return with an empty call stack")
-                    })?;
-                    let popped = self.pop_stack.pop().ok_or_else(|| {
-                        anyhow!("attempted to follow a return with an empty call stack")
-                    })?;
+                    if self.call_stack_path.pop().is_none() {
+                        break;
+                    }
+
+                    let Some(popped) = self.pop_stack.pop() else {
+                        break;
+                    };
                     if popped == pc - 4 {
                         break;
                     }


### PR DESCRIPTION
Its a bug that the profiler is getting confused about the call stack, and as a result may be producing bad samples (although probably just call-stacks which are parented incorrectly)

Its better to not error and produce some kind of profile, even if its less-than-perfect in some ways.