### PR TITLE
ZKVM-1328: Add xtask extract-elf subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,6 +8209,7 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "regex",
+ "risc0-binfmt",
  "risc0-circuit-keccak",
  "risc0-circuit-recursion",
  "risc0-core",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 prost-build = "0.12"
 protobuf-src = "1.1"
 regex = "1"
+risc0-binfmt = { workspace = true }
 risc0-circuit-keccak = { workspace = true, features = [
   "prove",
 ], optional = true }

--- a/xtask/src/extract_elf.rs
+++ b/xtask/src/extract_elf.rs
@@ -1,0 +1,40 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::Parser;
+use risc0_binfmt::ProgramBinary;
+
+use std::path::PathBuf;
+
+#[derive(Parser)]
+pub struct ExtractElf {
+    #[arg(long)]
+    input: PathBuf,
+
+    #[arg(long)]
+    user_elf: PathBuf,
+
+    #[arg(long)]
+    kernel_elf: PathBuf,
+}
+
+impl ExtractElf {
+    pub fn run(&self) {
+        let input_bytes = std::fs::read(&self.input).unwrap();
+        let program = ProgramBinary::decode(&input_bytes).unwrap();
+
+        std::fs::write(&self.user_elf, program.user_elf).unwrap();
+        std::fs::write(&self.kernel_elf, program.kernel_elf).unwrap();
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,7 @@ mod bootstrap;
 mod bootstrap_groth16;
 mod bootstrap_poseidon;
 mod bootstrap_protos;
+mod extract_elf;
 #[cfg(feature = "zkvm")]
 mod gen_receipt;
 mod install;
@@ -30,9 +31,9 @@ use clap::{Parser, Subcommand};
 #[cfg(feature = "zkvm")]
 use self::{bootstrap::Bootstrap, bootstrap_groth16::BootstrapGroth16, gen_receipt::GenReceipt};
 use self::{
-    bootstrap_poseidon::BootstrapPoseidon, bootstrap_protos::BootstrapProtos, install::Install,
-    semver_checks::SemverChecks, update_crate_version::UpdateCrateVersion,
-    update_lock_files::UpdateLockFiles,
+    bootstrap_poseidon::BootstrapPoseidon, bootstrap_protos::BootstrapProtos,
+    extract_elf::ExtractElf, install::Install, semver_checks::SemverChecks,
+    update_crate_version::UpdateCrateVersion, update_lock_files::UpdateLockFiles,
 };
 
 #[derive(Parser)]
@@ -55,6 +56,7 @@ enum Commands {
     SemverChecks(SemverChecks),
     UpdateLockFiles(UpdateLockFiles),
     UpdateCrateVersion(UpdateCrateVersion),
+    ExtractElf(ExtractElf),
 }
 
 impl Commands {
@@ -72,6 +74,7 @@ impl Commands {
             Commands::SemverChecks(cmd) => cmd.run(),
             Commands::UpdateLockFiles(cmd) => cmd.run(),
             Commands::UpdateCrateVersion(cmd) => cmd.run(),
+            Commands::ExtractElf(cmd) => cmd.run(),
         }
     }
 }


### PR DESCRIPTION
This command simply extracts the user and kernel elfs from a risc0 binfmt file.

This has been useful to have so things like `objdump` /   `gdb` / `llvm-dwarf-dump` can be run on the user elf.