### PR TITLE
fix: incorrect handling of result in `run` method

### DIFF
--- a/risc0/cargo-risczero/src/commands/verify.rs
+++ b/risc0/cargo-risczero/src/commands/verify.rs
@@ -66,7 +66,7 @@ impl VerifyCommand {
             }
         }
 
-        Ok(result?)
+        Ok(())
     }
 
     fn get_image_id(&self) -> Result<Digest> {


### PR DESCRIPTION
I addressed an issue in the `run` method where the line `Ok(result?)` was incorrectly used. Since `result` is already the outcome of `verify()`, using `result?` didn't make sense and caused issues. I replaced it with `Ok(())`, as the value of `result` isn't needed after the error handling.