### PR TITLE
ZKVM-1331: Bump the MAX_INSN_CYCLES for po2 >= 15

### DIFF
--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -280,7 +280,6 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
 
             let final_cycles = self.segment_cycles().next_power_of_two();
             let final_po2 = log2_ceil(final_cycles as usize);
-            let segment_threshold = (1 << final_po2) - max_insn_cycles as u32;
             let (pre_image, pre_digest, post_digest) = self.pager.commit();
             let req = ComputePartialImageRequest {
                 image: pre_image,
@@ -292,7 +291,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
                 user_cycles: self.user_cycles,
                 pager_cycles: self.pager.cycles,
                 terminate_state: self.terminate_state,
-                segment_threshold,
+                segment_threshold: 0, // meaningless for final segment
                 pre_digest,
                 post_digest,
                 po2: final_po2 as u32,

--- a/risc0/circuit/rv32im/src/execute/segment.rs
+++ b/risc0/circuit/rv32im/src/execute/segment.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     execute::{CycleLimit, Executor},
-    Rv32imV2Claim, MAX_INSN_CYCLES,
+    Rv32imV2Claim, MAX_INSN_CYCLES, MAX_INSN_CYCLES_LOWER_PO2,
 };
 
 use super::{Syscall, SyscallContext};
@@ -70,9 +70,15 @@ impl Segment {
             read_pos: Cell::new(0),
             write_pos: Cell::new(0),
         };
+
+        let max_insn_cycles = if self.po2 >= 15 {
+            MAX_INSN_CYCLES
+        } else {
+            MAX_INSN_CYCLES_LOWER_PO2
+        };
         Executor::new(self.partial_image.clone(), &handler, None, vec![]).run(
             self.po2 as usize,
-            MAX_INSN_CYCLES,
+            max_insn_cycles,
             CycleLimit::Soft(self.suspend_cycle.into()),
             |_| Ok(()),
         )?;

--- a/risc0/circuit/rv32im/src/lib.rs
+++ b/risc0/circuit/rv32im/src/lib.rs
@@ -39,7 +39,11 @@ pub use self::zirgen::CircuitImpl;
 
 pub const RV32IM_SEAL_VERSION: u32 = 1;
 
-pub const MAX_INSN_CYCLES: usize = 2000; // TODO(flaub): calculate actual value
+/// This number was picked by running `bigint2-analyze` on all the current bigint programs
+pub const MAX_INSN_CYCLES: usize = 25_000;
+
+/// This is a smaller number used by lower po2's < 15 which can't fit a large bigint program.
+pub const MAX_INSN_CYCLES_LOWER_PO2: usize = 2_000;
 
 pub fn verify(seal: &[u32]) -> Result<(), VerificationError> {
     tracing::debug!("verify");

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -29,7 +29,7 @@ use risc0_circuit_rv32im::{
         platform::WORD_SIZE, CycleLimit, Executor, Syscall as CircuitSyscall,
         SyscallContext as CircuitSyscallContext, DEFAULT_SEGMENT_LIMIT_PO2,
     },
-    MAX_INSN_CYCLES,
+    MAX_INSN_CYCLES, MAX_INSN_CYCLES_LOWER_PO2,
 };
 use risc0_core::scope;
 use risc0_zkp::core::digest::Digest;
@@ -180,8 +180,14 @@ impl<'a> ExecutorImpl<'a> {
             self.env.trace.clone(),
         );
 
+        let max_insn_cycles = if segment_limit_po2 >= 15 {
+            MAX_INSN_CYCLES
+        } else {
+            MAX_INSN_CYCLES_LOWER_PO2
+        };
+
         let start_time = Instant::now();
-        let result = exec.run(segment_limit_po2, MAX_INSN_CYCLES, session_limit, |inner| {
+        let result = exec.run(segment_limit_po2, max_insn_cycles, session_limit, |inner| {
             let output = inner
                 .claim
                 .terminate_state


### PR DESCRIPTION
This should help us avoid the large bigint program splitting issue. If a bigint program uses more cycles than this threshold, we may end up overflowing the segment and the execution errors. This threshold was too low, we had bigint programs that use more cycles in practice. After doing some worst-case analysis on the bigint programs we have current I came up with this new threshold.

Here is what the `bigint2-analyze` program estimates for our existing blobs
```
risc0/zkos/v1compat/src/bigint_v1compat/mul_256.blob
total = 8430
risc0/zkos/v1compat/src/bigint_v1compat/modmul_256.blob
total = 10838
risc0/bigint2/src/ec/ec_add_384.blob
total = 12716
risc0/bigint2/src/ec/ec_add_256.blob
total = 12456
risc0/bigint2/src/ec/ec_double_256.blob
total = 11809
risc0/bigint2/src/ec/ec_double_384.blob
total = 12045
risc0/bigint2/src/field/modsub_256.blob
total = 10814
risc0/bigint2/src/field/extfield_deg2_add_384.blob
total = 10986
risc0/bigint2/src/field/extfieldadd_256.blob
total = 10898
risc0/bigint2/src/field/modsub_384.blob
total = 10862
risc0/bigint2/src/field/extfield_deg2_add_256.blob
total = 10898
risc0/bigint2/src/field/modadd_256.blob
total = 10806
risc0/bigint2/src/field/extfield_deg2_sub_384.blob
total = 11010
risc0/bigint2/src/field/modinv_256.blob
total = 10874
risc0/bigint2/src/field/modinv_384.blob
total = 10950
risc0/bigint2/src/field/modmul_4096.blob
total = 14435
risc0/bigint2/src/field/extfieldsub_256.blob
total = 10890
risc0/bigint2/src/field/modadd_384.blob
total = 10850
risc0/bigint2/src/field/extfield_deg2_sub_256.blob
total = 10914
risc0/bigint2/src/field/extfield_deg4_mul_256.blob
total = 19275
risc0/bigint2/src/field/extfield_xxone_mul_256.blob
total = 12212
risc0/bigint2/src/field/extfieldmul_256.blob
total = 12756
risc0/bigint2/src/field/extfield_deg2_mul_256.blob
total = 12756
risc0/bigint2/src/field/extfield_xxone_mul_384.blob
total = 12356
risc0/bigint2/src/field/modmul_256.blob
total = 10838
risc0/bigint2/src/field/modmul_384.blob
total = 10898
```