### PR TITLE
ZKVM-1333: Improve Executor Segment Creation Performance

### DIFF
--- a/risc0/binfmt/src/image.rs
+++ b/risc0/binfmt/src/image.rs
@@ -340,7 +340,7 @@ impl MemoryImage {
         }
     }
 
-    /// Returns a partial image of a clean image. Panics if indexes are not available.
+    /// Returns a partial image from indices. Panics if indexes are not available.
     pub fn partial_image(&self, indexes: BTreeSet<u32>) -> Result<MemoryImage> {
         let mut image = MemoryImage::default();
         for node_idx in &indexes {
@@ -350,8 +350,6 @@ impl MemoryImage {
                 image
                     .digests
                     .insert(*node_idx, *self.get_existing_digest(*node_idx));
-                // TODO(ec2): Can we actually just not do this check?
-                // I've only ever seen the children included in `indexes`
                 if !indexes.contains(&lhs_idx) {
                     image
                         .digests

--- a/risc0/binfmt/src/image.rs
+++ b/risc0/binfmt/src/image.rs
@@ -340,46 +340,40 @@ impl MemoryImage {
         }
     }
 
-    /// Returns a partial image of a clean image
-    pub fn to_partial_image(&self, indexes: BTreeSet<u32>) -> Result<MemoryImage> {
+    /// Returns a partial image of a clean image. Panics if indexes are not available and returns error if dirty.
+    pub fn partial_image(&self, indexes: BTreeSet<u32>) -> Result<MemoryImage> {
         if !self.dirty.is_empty() {
             bail!("Cannot create partial image with dirty nodes");
         }
         let mut image = MemoryImage::default();
         for node_idx in &indexes {
+            // non page (leaf) nodes
             if *node_idx < MEMORY_PAGES as u32 {
                 let lhs_idx = *node_idx * 2;
                 let rhs_idx = *node_idx * 2 + 1;
 
                 // Otherwise, add whichever child digest (if any) is not loaded
                 if !indexes.contains(&lhs_idx) {
-                    // image.set_digest(lhs_idx, *self.get_existing_digest(lhs_idx));
                     image
                         .digests
                         .insert(lhs_idx, *self.get_existing_digest(lhs_idx));
                 }
                 if !indexes.contains(&rhs_idx) {
-                    // image.set_digest(rhs_idx, *self.get_existing_digest(rhs_idx));
                     image
                         .digests
                         .insert(rhs_idx, *self.get_existing_digest(rhs_idx));
                 }
-                continue;
+            } else {
+                let page_idx = *node_idx - MEMORY_PAGES as u32;
+                image
+                    .digests
+                    .insert(*node_idx, *self.get_existing_digest(*node_idx));
+                image
+                    .pages
+                    .insert(page_idx, self.get_existing_page(page_idx));
             }
-
-            let page_idx = *node_idx - MEMORY_PAGES as u32;
-            image
-                .digests
-                .insert(*node_idx, *self.get_existing_digest(*node_idx));
-            // Copy original state of all pages accessed in this segment.
-            image
-                .pages
-                .insert(page_idx, self.get_existing_page(page_idx));
-            // image.set_page(page_idx, self.get_existing_page(page_idx));
         }
 
-        // image.update_digests();
-        // tracing::info!("Input image: {:?}, Partial image: {:?}", input_image, image,);
         Ok(image)
     }
 }

--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -160,9 +160,8 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
                     self.pc
                 );
                 Risc0Machine::suspend(self)?;
-
-                let (pre_digest, post_digest) = self.pager.commit();
                 let partial_image = self.pager.image.partial_image(self.pager.page_indexes())?;
+                let (pre_digest, post_digest) = self.pager.commit();
 
                 callback(Segment {
                     partial_image,
@@ -207,9 +206,8 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
         }
 
         Risc0Machine::suspend(self)?;
-
-        let (pre_digest, post_digest) = self.pager.commit();
         let partial_image = self.pager.image.partial_image(self.pager.page_indexes())?;
+        let (pre_digest, post_digest) = self.pager.commit();
 
         let final_cycles = self.segment_cycles().next_power_of_two();
         let final_po2 = log2_ceil(final_cycles as usize);
@@ -272,9 +270,8 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
                 "Execution failure, saving segment to {}:",
                 dump_path.to_string_lossy()
             );
-
-            let (pre_digest, post_digest) = self.pager.commit();
             let partial_image = self.pager.image.partial_image(self.pager.page_indexes())?;
+            let (pre_digest, post_digest) = self.pager.commit();
 
             let segment = Segment {
                 partial_image,

--- a/risc0/circuit/rv32im/src/execute/pager.rs
+++ b/risc0/circuit/rv32im/src/execute/pager.rs
@@ -452,6 +452,39 @@ impl PagedMemory {
         (pre_image, pre_state, post_state)
     }
 
+    /// Similar to commit, but does not clone and return the pre-image.
+    pub(crate) fn flush(&mut self) -> (Digest, Digest) {
+        // tracing::trace!("commit: {self:#?}");
+
+        self.write_registers();
+
+        let pre_state = self.image.image_id();
+
+        let mut sorted_keys: Vec<_> = self.page_states.keys().collect();
+        sorted_keys.sort();
+
+        for node_idx in sorted_keys {
+            if node_idx < MEMORY_PAGES as u32 {
+                continue;
+            }
+
+            let page_state = self.page_states.get(node_idx);
+            let page_idx = page_idx(node_idx);
+            tracing::trace!("commit: {page_idx:#08x}, state: {page_state:?}");
+
+            // Update dirty pages into the image that accumulates over a session.
+            if page_state == PageState::Dirty {
+                let cache_idx = self.page_table.get(page_idx).unwrap();
+                let page = &self.page_cache[cache_idx];
+                self.image.set_page(page_idx, page.clone());
+            }
+        }
+        self.image.update_digests();
+
+        let post_state = self.image.image_id();
+        (pre_state, post_state)
+    }
+
     fn load_page(&mut self, page_idx: u32) -> Result<()> {
         tracing::trace!("load_page: {page_idx:#08x}");
         let page = self.image.get_page(page_idx)?;
@@ -519,6 +552,16 @@ pub(crate) fn compute_partial_image(
 
     for node_idx in &indexes {
         if *node_idx < MEMORY_PAGES as u32 {
+            let lhs_idx = *node_idx * 2;
+            let rhs_idx = *node_idx * 2 + 1;
+
+            // Otherwise, add whichever child digest (if any) is not loaded
+            if !indexes.contains(&lhs_idx) {
+                image.set_digest(lhs_idx, *input_image.get_existing_digest(lhs_idx));
+            }
+            if !indexes.contains(&rhs_idx) {
+                image.set_digest(rhs_idx, *input_image.get_existing_digest(rhs_idx));
+            }
             continue;
         }
 
@@ -528,26 +571,6 @@ pub(crate) fn compute_partial_image(
         image.set_page(page_idx, input_image.get_existing_page(page_idx));
     }
 
-    // Add minimal needed 'uncles'
-    for node_idx in &indexes {
-        // If this is a leaf, break
-        if *node_idx >= MEMORY_PAGES as u32 {
-            break;
-        }
-
-        let lhs_idx = *node_idx * 2;
-        let rhs_idx = *node_idx * 2 + 1;
-
-        // Otherwise, add whichever child digest (if any) is not loaded
-        if !indexes.contains(&lhs_idx) {
-            image.set_digest(lhs_idx, *input_image.get_existing_digest(lhs_idx));
-        }
-        if !indexes.contains(&rhs_idx) {
-            image.set_digest(rhs_idx, *input_image.get_existing_digest(rhs_idx));
-        }
-    }
-
     image.update_digests();
-
     image
 }


### PR DESCRIPTION
Before, every time the executor creates a Segment, it cloned the whole MemoryImage which is expensive and then it rehashes everything as well.  

Before:
```
┌─────────┬────────┬────────────┬──────────┬─────────┬─────┬──────┐
│ name    │ hashfn │ throughput │ duration │ cycles  │ ram │ seal │
├─────────┼────────┼────────────┼──────────┼─────────┼─────┼──────┤
│ execute │ N/A    │ 40.8MHz    │ 24.3ms   │ 1014.1K │ N/A │ N/A  │
└─────────┴────────┴────────────┴──────────┴─────────┴─────┴──────┘
```
After:
```
┌─────────┬────────┬────────────┬──────────┬─────────┬─────┬──────┐
│ name    │ hashfn │ throughput │ duration │ cycles  │ ram │ seal │
├─────────┼────────┼────────────┼──────────┼─────────┼─────┼──────┤
│ execute │ N/A    │ 44.5MHz    │ 22.3ms   │ 1014.1K │ N/A │ N/A  │
└─────────┴────────┴────────────┴──────────┴─────────┴─────┴──────┘
```

I've ran this against zeth as well ` RUST_LOG="info" RISC0_INFO=1 target/release/zeth-ethereum run --cache=cache --block-number=22176200 --block-count=1 `

Before:
```
[2025-04-16T21:17:07Z INFO  risc0_zkvm::host::server::exec::executor] execution time: 27.017512174s
[2025-04-16T21:17:07Z INFO  risc0_zkvm::host::server::session] number of segments: 575
[2025-04-16T21:17:07Z INFO  risc0_zkvm::host::server::session] 602931200 total cycles
[2025-04-16T21:17:07Z INFO  risc0_zkvm::host::server::session] 502496192 user cycles (83.34%)
[2025-04-16T21:17:07Z INFO  risc0_zkvm::host::server::session] 96775344 paging cycles (16.05%)
[2025-04-16T21:17:07Z INFO  risc0_zkvm::host::server::session] 3659664 reserved cycles (0.61%)
```

After:
```
[2025-04-16T22:00:01Z INFO  risc0_zkvm::host::server::exec::executor] execution time: 23.589958846s
[2025-04-16T22:00:01Z INFO  risc0_zkvm::host::server::session] number of segments: 575
[2025-04-16T22:00:01Z INFO  risc0_zkvm::host::server::session] 602931200 total cycles
[2025-04-16T22:00:01Z INFO  risc0_zkvm::host::server::session] 502555065 user cycles (83.35%)
[2025-04-16T22:00:01Z INFO  risc0_zkvm::host::server::session] 96868690 paging cycles (16.07%)
[2025-04-16T22:00:01Z INFO  risc0_zkvm::host::server::session] 3507445 reserved cycles (0.58%)
```

