### PR TITLE
ZKVM-1334: Hard disable fake receipt verification in the zkVM

### DIFF
--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -431,7 +431,7 @@ where
     /// RISC0_DEV_MODE environment variable is not set) this will always reject. When in dev mode,
     /// this will always pass.
     pub fn verify_integrity(&self) -> Result<(), VerificationError> {
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_os = "zkvm")))]
         if crate::is_dev_mode() {
             return Ok(());
         }


### PR DESCRIPTION
In https://github.com/risc0/risc0/pull/2415 we disabled environment variables by default in the guest, so without explicitly enabling `sys-getenv`, a fake receipt will never verify. This PR goes further by disabling the verification of fake receipt and preventing any option from turning it on, bolstering the misuse resistance of the `Receipt::verify` API in the guest.
