### PR TITLE
ZKVM-1336: Executor adds soft cycle limit for per-segment execution

### DIFF
--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -92,6 +92,11 @@ pub struct SimpleSession {
     pub result: ExecutorResult,
 }
 
+pub enum CycleLimit {
+    Hard(u64), // it is an error to exceed this limit
+    None,
+}
+
 struct ComputePartialImageRequest {
     image: MemoryImage,
     page_indexes: BTreeSet<u32>,
@@ -170,7 +175,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
         &mut self,
         segment_po2: usize,
         max_insn_cycles: usize,
-        max_cycles: Option<u64>,
+        max_cycles: CycleLimit,
         callback: impl FnMut(Segment) -> Result<()> + Send,
     ) -> Result<ExecutorResult> {
         let segment_limit: u32 = 1 << segment_po2;
@@ -193,7 +198,7 @@ impl<'a, 'b, S: Syscall> Executor<'a, 'b, S> {
                 scope.spawn(move || compute_partial_images(commit_recv, callback));
 
             while self.terminate_state.is_none() {
-                if let Some(max_cycles) = max_cycles {
+                if let CycleLimit::Hard(max_cycles) = max_cycles {
                     if self.cycles.user >= max_cycles {
                         bail!(
                             "Session limit exceeded: {} >= {max_cycles}",

--- a/risc0/circuit/rv32im/src/execute/mod.rs
+++ b/risc0/circuit/rv32im/src/execute/mod.rs
@@ -29,7 +29,7 @@ pub mod testutil;
 
 pub use self::{
     bigint::analyze::analyze as bigint_analyze,
-    executor::{EcallMetric, Executor, ExecutorResult, SimpleSession},
+    executor::{CycleLimit, EcallMetric, Executor, ExecutorResult, SimpleSession},
     platform::*,
     segment::Segment,
     syscall::{Syscall, SyscallContext},

--- a/risc0/circuit/rv32im/src/execute/segment.rs
+++ b/risc0/circuit/rv32im/src/execute/segment.rs
@@ -20,7 +20,7 @@ use risc0_binfmt::MemoryImage;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    execute::{Executor, CycleLimit},
+    execute::{CycleLimit, Executor},
     Rv32imV2Claim, MAX_INSN_CYCLES,
 };
 

--- a/risc0/circuit/rv32im/src/execute/segment.rs
+++ b/risc0/circuit/rv32im/src/execute/segment.rs
@@ -20,7 +20,7 @@ use risc0_binfmt::MemoryImage;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    execute::{testutil, Executor},
+    execute::{Executor, CycleLimit},
     Rv32imV2Claim, MAX_INSN_CYCLES,
 };
 
@@ -73,7 +73,7 @@ impl Segment {
         Executor::new(self.partial_image.clone(), &handler, None, vec![]).run(
             self.po2 as usize,
             MAX_INSN_CYCLES,
-            testutil::DEFAULT_SESSION_LIMIT,
+            CycleLimit::Soft(self.suspend_cycle.into()),
             |_| Ok(()),
         )?;
         Ok(())

--- a/risc0/circuit/rv32im/src/execute/testutil.rs
+++ b/risc0/circuit/rv32im/src/execute/testutil.rs
@@ -23,11 +23,11 @@ use risc0_zkp::{
 };
 
 use super::{
-    pager::RESERVED_PAGING_CYCLES, platform::*, syscall::Syscall, Executor, SimpleSession,
-    SyscallContext,
+    executor::CycleLimit, pager::RESERVED_PAGING_CYCLES, platform::*, syscall::Syscall, Executor,
+    SimpleSession, SyscallContext,
 };
 
-pub const DEFAULT_SESSION_LIMIT: Option<u64> = Some(1 << 24);
+pub const DEFAULT_SESSION_LIMIT: CycleLimit = CycleLimit::Hard(1 << 24);
 pub const MIN_CYCLES_PO2: usize = log2_ceil(RESERVED_CYCLES + RESERVED_PAGING_CYCLES as usize);
 
 #[derive(Default)]
@@ -50,7 +50,7 @@ pub fn execute<S: Syscall>(
     image: MemoryImage,
     segment_limit_po2: usize,
     max_insn_cycles: usize,
-    max_cycles: Option<u64>,
+    max_cycles: CycleLimit,
     syscall_handler: &S,
     input_digest: Option<Digest>,
 ) -> Result<SimpleSession> {

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -28,6 +28,7 @@ use risc0_circuit_rv32im::{
     execute::{
         platform::WORD_SIZE, Executor, Syscall as CircuitSyscall,
         SyscallContext as CircuitSyscallContext, DEFAULT_SEGMENT_LIMIT_PO2,
+        CycleLimit,
     },
     MAX_INSN_CYCLES,
 };
@@ -167,6 +168,11 @@ impl<'a> ExecutorImpl<'a> {
             .segment_limit_po2
             .unwrap_or(DEFAULT_SEGMENT_LIMIT_PO2 as u32) as usize;
 
+        let session_limit = match self.env.session_limit {
+            Some(limit) => CycleLimit::Hard(limit),
+            None => CycleLimit::None,
+        };
+
         let mut refs = Vec::new();
         let mut exec = Executor::new(
             self.image.clone(),
@@ -179,7 +185,7 @@ impl<'a> ExecutorImpl<'a> {
         let result = exec.run(
             segment_limit_po2,
             MAX_INSN_CYCLES,
-            self.env.session_limit,
+            session_limit,
             |inner| {
                 let output = inner
                     .claim


### PR DESCRIPTION
The `max_cycles` termination behavior on `Executor::run` is now configurable: the existing behavior is a "hard limit", which errors out if the limit is reached, but one can also request a "soft limit", which simply stops the VM and returns. This allows `Segment::execute` to provide the recorded suspend cycle as the cycle limit, which prevents execution from continuing to the next segment, for which there are no IO records.