### PR TITLE
ZKVM-1359: Remove extra copies from extract_zkr

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -268,7 +268,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "2eabe772c99d13aab5bfce46c2c54a7c3feb16e350703df6da3c34241cc10b8a",
+            "03bbc2f1aa1b1fbbcf31d650c59be8a9feb02dac82ba8f423f6a3a0370c50d0f",
         );
     }
 }

--- a/risc0/circuit/keccak/Cargo.toml
+++ b/risc0/circuit/keccak/Cargo.toml
@@ -38,6 +38,9 @@ risc0-circuit-keccak-methods = { path = "methods" }
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[build-dependencies]
+xz2 = { version = "0.1", optional = true, features = ["static"] }
+
 [features]
 # Enables CUDA GPU support
 cuda = [

--- a/risc0/circuit/keccak/build.rs
+++ b/risc0/circuit/keccak/build.rs
@@ -1,0 +1,52 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "prove")]
+fn generate_zkr_table() {
+    use std::fmt::Write as _;
+    use std::path::Path;
+
+    use xz2::read::XzDecoder;
+
+    let mut output = String::new();
+
+    writeln!(&mut output, "const ZKRS: &[(&[u8], usize)] = &[").unwrap();
+
+    // Pre-calculate the sizes of these to help make decoding faster later. This is a bit
+    // quick-and-dirty, probably better to invent some way for zirgen bootstrap to save this
+    // information.
+    for po2 in 14..=18 {
+        let zkr_name = format!("keccak_lift_{po2}.zkr.xz");
+        let zkr_path = std::fs::canonicalize(Path::new("src/prove").join(&zkr_name)).unwrap();
+        println!("cargo:rerun-if-changed={}", zkr_path.display());
+        let mut decoder = XzDecoder::new(std::fs::File::open(&zkr_path).unwrap());
+        std::io::copy(&mut decoder, &mut std::io::sink()).unwrap();
+        let size = decoder.total_out();
+        writeln!(
+            &mut output,
+            "(include_bytes!(\"{}\"), {size}),",
+            zkr_path.display()
+        )
+        .unwrap();
+    }
+    writeln!(&mut output, "];").unwrap();
+
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    std::fs::write(Path::new(&out_dir).join("zkr_table.rs"), &output).unwrap();
+}
+
+fn main() {
+    #[cfg(feature = "prove")]
+    generate_zkr_table();
+}

--- a/risc0/circuit/keccak/src/prove/zkr.rs
+++ b/risc0/circuit/keccak/src/prove/zkr.rs
@@ -20,14 +20,7 @@ use xz2::read::XzDecoder;
 
 use crate::{KECCAK_PO2_RANGE, RECURSION_PO2};
 
-// The compressed bytes and their size uncompressed in bytes
-const ZKRS: &[(&[u8], usize)] = &[
-    (include_bytes!("keccak_lift_14.zkr.xz"), 18_207_076),
-    (include_bytes!("keccak_lift_15.zkr.xz"), 19_064_516),
-    (include_bytes!("keccak_lift_16.zkr.xz"), 20_236_412),
-    (include_bytes!("keccak_lift_17.zkr.xz"), 20_475_244),
-    (include_bytes!("keccak_lift_18.zkr.xz"), 21_276_564),
-];
+include!(concat!(env!("OUT_DIR"), "/zkr_table.rs"));
 
 pub fn get_keccak_zkr(po2: usize) -> Result<Program> {
     let idx = po2 - KECCAK_PO2_RANGE.min().unwrap();

--- a/risc0/circuit/keccak/src/prove/zkr.rs
+++ b/risc0/circuit/keccak/src/prove/zkr.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,25 +14,31 @@
 
 use std::io::Read as _;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use risc0_circuit_recursion::prove::Program;
 use xz2::read::XzDecoder;
 
 use crate::{KECCAK_PO2_RANGE, RECURSION_PO2};
 
-const ZKRS: &[&[u8]] = &[
-    include_bytes!("keccak_lift_14.zkr.xz"),
-    include_bytes!("keccak_lift_15.zkr.xz"),
-    include_bytes!("keccak_lift_16.zkr.xz"),
-    include_bytes!("keccak_lift_17.zkr.xz"),
-    include_bytes!("keccak_lift_18.zkr.xz"),
+// The compressed bytes and their size uncompressed in bytes
+const ZKRS: &[(&[u8], usize)] = &[
+    (include_bytes!("keccak_lift_14.zkr.xz"), 18_207_076),
+    (include_bytes!("keccak_lift_15.zkr.xz"), 19_064_516),
+    (include_bytes!("keccak_lift_16.zkr.xz"), 20_236_412),
+    (include_bytes!("keccak_lift_17.zkr.xz"), 20_475_244),
+    (include_bytes!("keccak_lift_18.zkr.xz"), 21_276_564),
 ];
 
 pub fn get_keccak_zkr(po2: usize) -> Result<Program> {
     let idx = po2 - KECCAK_PO2_RANGE.min().unwrap();
-    let mut decoder = XzDecoder::new(ZKRS[idx]);
-    let mut bytes = vec![];
-    decoder.read_to_end(&mut bytes)?;
-    let u32s = bytemuck::cast_slice(&bytes);
-    Ok(Program::from_encoded(u32s, RECURSION_PO2))
+    let (xz_bytes, uncompressed_size) = ZKRS[idx];
+
+    if uncompressed_size % std::mem::size_of::<u32>() != 0 {
+        bail!(".zkr is incorrect size");
+    }
+
+    let mut decoder = XzDecoder::new(xz_bytes);
+    let mut u32s = vec![0u32; uncompressed_size / std::mem::size_of::<u32>()];
+    decoder.read_exact(bytemuck::cast_slice_mut(&mut u32s))?;
+    Ok(Program::from_encoded(&u32s, RECURSION_PO2))
 }


### PR DESCRIPTION
There are extra copies going on here when we realloc the `Vec` inside `read_to_end` and when we call `Vec::from`.

The larger the zkr the more of an issue this is. The zip format should have the size of the entry in it, so we can do better.

Additionally the cast from `[u8]` -> `[u32]` is one of higher alignment and kinda questionable. bytemuck will crash if the alignment is not high enough and likely or allocation aligns all allocations at > 4, but if we use a different memory allocator in the future this might not be true.

This was just something small I noticed when reading the recent recursion witgen GPU patch.