### PR TITLE
docs: repair non-working links

### DIFF
--- a/website/api/recursion.md
+++ b/website/api/recursion.md
@@ -58,13 +58,13 @@ All of the recursion programs in the previous section output a [SuccinctReceipt]
 The final step in the recursion process is `compress()`, which outputs a [Groth16Receipt], which can be verified on-chain using the [RISC Zero Verifier Contract].
 
 [`Prover::prove_with_opts`]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[assumption]: /terminology#assumption
+[assumption]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#assumption
 [composite, succinct or groth16 receipts]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/enum.ReceiptKind.html
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.Groth16Receipt.html
 [proof composition]: ./zkvm/composition.md
-[proof system]: /proof-system/proof-system-sequence-diagram
+[proof system]: https://github.com/risc0/risc0/blob/main/website/docs/proof-system/proof-system-sequence-diagram.md
 [Prover]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[receipt claim]: /terminology#receipt-claim
+[receipt claim]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#receipt-claim
 [reports.risczero.com]: https://reports.risczero.com
 [RISC Zero Verifier Contract]: blockchain-integration/contracts/verifier.md
 [SuccinctReceipt]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/struct.SuccinctReceipt.html

--- a/website/api_versioned_docs/version-1.0/recursion.md
+++ b/website/api_versioned_docs/version-1.0/recursion.md
@@ -59,7 +59,7 @@ The final step in the recursion process is `compress()`, which outputs a [Groth1
 [`Prover::prove_with_opts`]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/trait.Prover.html#method.prove_with_opts
 [composite, succinct or groth16 receipts]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/enum.ReceiptKind.html
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/struct.Groth16Receipt.html
-[proof system]: /proof-system/proof-system-sequence-diagram
+[proof system]: https://github.com/risc0/risc0/blob/main/website/docs/proof-system/proof-system-sequence-diagram.md
 [Prover]: https://docs.rs/risc0-zkvm/1.0/risc0_zkvm/trait.Prover.html#method.prove_with_opts
 [reports.risczero.com]: https://reports.risczero.com
 [RISC Zero Verifier Contract]: blockchain-integration/contracts/verifier.md

--- a/website/api_versioned_docs/version-1.1/recursion.md
+++ b/website/api_versioned_docs/version-1.1/recursion.md
@@ -58,13 +58,13 @@ All of the recursion programs in the previous section output a [SuccinctReceipt]
 The final step in the recursion process is `compress()`, which outputs a [Groth16Receipt], which can be verified on-chain using the [RISC Zero Verifier Contract].
 
 [`Prover::prove_with_opts`]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[assumption]: /terminology#assumption
+[assumption]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#assumption
 [composite, succinct or groth16 receipts]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/enum.ReceiptKind.html
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/struct.Groth16Receipt.html
 [proof composition]: ./zkvm/composition.md
-[proof system]: /proof-system/proof-system-sequence-diagram
+[proof system]: https://github.com/risc0/risc0/blob/main/website/docs/proof-system/proof-system-sequence-diagram.md
 [Prover]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[receipt claim]: /terminology#receipt-claim
+[receipt claim]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#receipt-claim
 [reports.risczero.com]: https://reports.risczero.com
 [RISC Zero Verifier Contract]: blockchain-integration/contracts/verifier.md
 [SuccinctReceipt]: https://docs.rs/risc0-zkvm/1.1/risc0_zkvm/struct.SuccinctReceipt.html

--- a/website/api_versioned_docs/version-1.2/recursion.md
+++ b/website/api_versioned_docs/version-1.2/recursion.md
@@ -58,13 +58,13 @@ All of the recursion programs in the previous section output a [SuccinctReceipt]
 The final step in the recursion process is `compress()`, which outputs a [Groth16Receipt], which can be verified on-chain using the [RISC Zero Verifier Contract].
 
 [`Prover::prove_with_opts`]: https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[assumption]: /terminology#assumption
+[assumption]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#assumption
 [composite, succinct or groth16 receipts]: https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/enum.ReceiptKind.html
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.Groth16Receipt.html
 [proof composition]: ./zkvm/composition.md
-[proof system]: /proof-system/proof-system-sequence-diagram
+[proof system]: https://github.com/risc0/risc0/blob/main/website/docs/proof-system/proof-system-sequence-diagram.md
 [Prover]: https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[receipt claim]: /terminology#receipt-claim
+[receipt claim]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#receipt-claim
 [reports.risczero.com]: https://reports.risczero.com
 [RISC Zero Verifier Contract]: blockchain-integration/contracts/verifier.md
 [SuccinctReceipt]: https://docs.rs/risc0-zkvm/1.2/risc0_zkvm/struct.SuccinctReceipt.html

--- a/website/api_versioned_docs/version-2.0.0/recursion.md
+++ b/website/api_versioned_docs/version-2.0.0/recursion.md
@@ -58,13 +58,13 @@ All of the recursion programs in the previous section output a [SuccinctReceipt]
 The final step in the recursion process is `compress()`, which outputs a [Groth16Receipt], which can be verified on-chain using the [RISC Zero Verifier Contract].
 
 [`Prover::prove_with_opts`]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[assumption]: /terminology#assumption
+[assumption]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#assumption
 [composite, succinct or groth16 receipts]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/enum.ReceiptKind.html
 [Groth16Receipt]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/struct.Groth16Receipt.html
 [proof composition]: ./zkvm/composition.md
-[proof system]: /proof-system/proof-system-sequence-diagram
+[proof system]: https://github.com/risc0/risc0/blob/main/website/docs/proof-system/proof-system-sequence-diagram.md
 [Prover]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/trait.Prover.html#method.prove_with_opts
-[receipt claim]: /terminology#receipt-claim
+[receipt claim]: https://github.com/risc0/risc0/blob/main/website/docs/terminology.md#receipt-claim
 [reports.risczero.com]: https://reports.risczero.com
 [RISC Zero Verifier Contract]: blockchain-integration/contracts/verifier.md
 [SuccinctReceipt]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/struct.SuccinctReceipt.html


### PR DESCRIPTION
Fixed it in `website/api/recursion.md` and in files based on it (different versions) 