### PR TITLE
ci: switch risc0/actions-cache to v3 (Node 20)

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -78,7 +78,7 @@ runs:
     - if: >
         runner.os == 'Linux' && inputs.disable_s3 == 'false' &&
         github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-      uses: risc0/actions-cache@cba095d7af782a955b8f4fa13396fbf0ab62bd4b
+      uses: risc0/actions-cache@3
       with:
         path: |
           ~/.cache/risc0


### PR DESCRIPTION
Replace pinned SHA `cba095d7af78…` with `risc0/actions-cache@v3`.
- v3.0.2 is the latest release and runs on the Node 20 runtime required by GitHub Actions after the Node 16 deprecation.
- Keeps S3-backend cache while receiving ongoing bug-fixes and security updates.

[Ref](https://github.com/risc0/actions-cache-s3/releases/tag/v3.0.2)