### PR TITLE
Add way to use cuda to compute control id for bootstrap

### DIFF
--- a/risc0/circuit/recursion/src/prove/program.rs
+++ b/risc0/circuit/recursion/src/prove/program.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 use risc0_zkp::{
     core::{digest::Digest, hash::HashSuite},
     field::baby_bear::{BabyBear, BabyBearElem},
-    hal::{cpu::CpuHal, Hal},
+    hal::{self, Hal},
     prove::poly_group::PolyGroup,
     ZK_CYCLES,
 };
@@ -70,7 +70,17 @@ impl Program {
     /// of the code group. This uniquely identifies the program running on the recursion circuit
     /// (e.g. lift_20 or join)
     pub fn compute_control_id(&self, hash_suite: HashSuite<BabyBear>) -> Digest {
-        let hal = CpuHal::new(hash_suite);
+        #[cfg(feature = "cuda")]
+        let digest =
+            self.compute_control_id_inner(&hal::cuda::CudaHal::new_from_hash_suite(hash_suite));
+
+        #[cfg(not(feature = "cuda"))]
+        let digest = self.compute_control_id_inner(&hal::cpu::CpuHal::new(hash_suite));
+
+        digest
+    }
+
+    fn compute_control_id_inner(&self, hal: &impl Hal<Elem = BabyBearElem>) -> Digest {
         let cycles = 1 << self.po2;
 
         let mut code = vec![BabyBearElem::default(); cycles * self.code_size];
@@ -85,7 +95,7 @@ impl Program {
         hal.batch_interpolate_ntt(&coeffs, self.code_size);
         hal.zk_shift(&coeffs, self.code_size);
         // Make the poly-group & extract the root
-        let code_group = PolyGroup::new(&hal, coeffs, self.code_size, cycles, "code");
+        let code_group = PolyGroup::new(hal, coeffs, self.code_size, cycles, "code");
         let root = *code_group.merkle.root();
         tracing::trace!("Computed recursion code: {root:?}");
         root

--- a/risc0/zkp/src/hal/cuda.rs
+++ b/risc0/zkp/src/hal/cuda.rs
@@ -61,7 +61,9 @@ unsafe impl DeviceCopy for DeviceExtElem {}
 
 pub trait CudaHash {
     /// Create a hash implementation
-    fn new() -> Self;
+    fn new() -> Self
+    where
+        Self: Sized;
 
     /// Run the hash_fold function
     fn hash_fold(&self, io: &BufferImpl<Digest>, output_size: usize);
@@ -219,7 +221,7 @@ impl CudaHash for CudaHashPoseidon254 {
     }
 }
 
-pub struct CudaHal<Hash: CudaHash> {
+pub struct CudaHal<Hash: CudaHash + ?Sized> {
     pub max_threads: u32,
     hash: Option<Box<Hash>>,
     _context: Context,
@@ -384,8 +386,15 @@ impl<CH: CudaHash> Default for CudaHal<CH> {
     }
 }
 
-impl<CH: CudaHash> CudaHal<CH> {
-    pub fn new() -> Self {
+impl<CH: CudaHash + ?Sized> CudaHal<CH> {
+    pub fn new() -> Self
+    where
+        CH: Sized,
+    {
+        Self::new_from_hash(Box::new(CH::new()))
+    }
+
+    fn new_from_hash(hash: Box<CH>) -> Self {
         let _lock = singleton().lock();
 
         let err = unsafe { sppark_init() };
@@ -407,7 +416,6 @@ impl<CH: CudaHash> CudaHal<CH> {
             hash: None,
             _lock,
         };
-        let hash = Box::new(CH::new());
         hal.hash = Some(hash);
         hal
     }
@@ -438,7 +446,19 @@ impl<CH: CudaHash> CudaHal<CH> {
     }
 }
 
-impl<CH: CudaHash> Hal for CudaHal<CH> {
+impl CudaHal<dyn CudaHash> {
+    pub fn new_from_hash_suite(hash_suite: HashSuite<BabyBear>) -> Self {
+        let hash_suite_box = match &hash_suite.name[..] {
+            "poseidon2" => Box::new(CudaHashPoseidon2::new()) as Box<dyn CudaHash>,
+            "poseidon254" => Box::new(CudaHashPoseidon254::new()) as Box<dyn CudaHash>,
+            "sha-256" => Box::new(CudaHashSha256::new()) as Box<dyn CudaHash>,
+            other => unimplemented!("unsupported hash_fn {other}"),
+        };
+        Self::new_from_hash(hash_suite_box)
+    }
+}
+
+impl<CH: CudaHash + ?Sized> Hal for CudaHal<CH> {
     type Field = BabyBear;
     type Elem = BabyBearElem;
     type ExtElem = BabyBearExtElem;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -43,6 +43,7 @@ release = false
 
 [features]
 default = ["zkvm"]
+cuda = ["risc0-zkvm/cuda"]
 zkvm = [
   "dep:risc0-circuit-keccak",
   "dep:risc0-circuit-recursion",


### PR DESCRIPTION
This lets us compute the control id for bootstrap using the GPU.
It significantly speeds up bootstrap when enabled since doing these hashes on the CPU can take a long time.