### PR TITLE
Update cd path in Hello World tutorial

### DIFF
--- a/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
@@ -15,7 +15,6 @@ Secondly, using the `cargo-risczero` tool create a `hello-world` project from th
 
 ```bash
 ## Create a project from our starter template
-cargo risczero new hello-world --guest-name hello_guest
 cd risc0/examples/hello-world
 ```
 

--- a/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.19/zkvm/tutorials/hello-world.md
@@ -16,7 +16,7 @@ Secondly, using the `cargo-risczero` tool create a `hello-world` project from th
 ```bash
 ## Create a project from our starter template
 cargo risczero new hello-world --guest-name hello_guest
-cd hello-world
+cd risc0/examples/hello-world
 ```
 
 In the project folder, `hello-world`, build and run the project using `cargo run --release`.

--- a/website/api_versioned_docs/version-0.20/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.20/zkvm/tutorials/hello-world.md
@@ -18,7 +18,7 @@ program:
 
 ```bash
 cargo risczero new hello-world --guest-name hello_guest
-cd hello-world
+cd risc0/examples/hello-world
 ```
 
 In the project folder, `hello-world`, build and run the project using `cargo run --release`. Use this command any time you'd like to check your progress.

--- a/website/api_versioned_docs/version-0.20/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.20/zkvm/tutorials/hello-world.md
@@ -17,7 +17,6 @@ project from the command line. The `cargo-risczero` tool provides a
 program:
 
 ```bash
-cargo risczero new hello-world --guest-name hello_guest
 cd risc0/examples/hello-world
 ```
 

--- a/website/api_versioned_docs/version-0.21/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.21/zkvm/tutorials/hello-world.md
@@ -18,7 +18,7 @@ program:
 
 ```bash
 cargo risczero new hello-world --guest-name hello_guest
-cd hello-world
+cd risc0/examples/hello-world
 ```
 
 In the project folder, `hello-world`, build and run the project using `cargo run --release`. Use this command any time you'd like to check your progress.

--- a/website/api_versioned_docs/version-0.21/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-0.21/zkvm/tutorials/hello-world.md
@@ -17,7 +17,6 @@ project from the command line. The `cargo-risczero` tool provides a
 program:
 
 ```bash
-cargo risczero new hello-world --guest-name hello_guest
 cd risc0/examples/hello-world
 ```
 

--- a/website/api_versioned_docs/version-1.0/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-1.0/zkvm/tutorials/hello-world.md
@@ -18,7 +18,7 @@ program:
 
 ```bash
 cargo risczero new hello-world --guest-name hello_guest
-cd hello-world
+cd risc0/examples/hello-world
 ```
 
 In the project folder, `hello-world`, build and run the project using `cargo run --release`. Use this command any time you'd like to check your progress.

--- a/website/api_versioned_docs/version-1.0/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-1.0/zkvm/tutorials/hello-world.md
@@ -17,7 +17,6 @@ project from the command line. The `cargo-risczero` tool provides a
 program:
 
 ```bash
-cargo risczero new hello-world --guest-name hello_guest
 cd risc0/examples/hello-world
 ```
 

--- a/website/api_versioned_docs/version-1.1/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/tutorials/hello-world.md
@@ -18,7 +18,7 @@ program:
 
 ```bash
 cargo risczero new hello-world --guest-name hello_guest
-cd hello-world
+cd risc0/examples/hello-world
 ```
 
 In the project folder, `hello-world`, build and run the project using `cargo run --release`. Use this command any time you'd like to check your progress.

--- a/website/api_versioned_docs/version-1.1/zkvm/tutorials/hello-world.md
+++ b/website/api_versioned_docs/version-1.1/zkvm/tutorials/hello-world.md
@@ -17,7 +17,6 @@ project from the command line. The `cargo-risczero` tool provides a
 program:
 
 ```bash
-cargo risczero new hello-world --guest-name hello_guest
 cd risc0/examples/hello-world
 ```
 


### PR DESCRIPTION
The old path cd hello-world assumes the project is created in the current directory. However, in the context of using the cloned risc0 monorepo, the actual path is risc0/examples/hello-world. This change corrects the path and prevents user confusion or errors like No such file or directory.