### PR TITLE
fix(risc0-build): canonicalize manifest dir

### DIFF
--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -241,7 +241,9 @@ impl GuestBuilder for GuestListEntry {
 /// Returns the given cargo Package from the metadata in the Cargo.toml manifest
 /// within the provided `manifest_dir`.
 pub fn get_package(manifest_dir: impl AsRef<Path>) -> Package {
-    let manifest_dir = manifest_dir.as_ref();
+    // Canonicalize the manifest directory specified by the user.
+    let manifest_dir =
+        fs::canonicalize(manifest_dir.as_ref()).expect("could not canonicalize manifest path");
     let manifest_path = manifest_dir.join("Cargo.toml");
     let manifest_meta = MetadataCommand::new()
         .manifest_path(&manifest_path)


### PR DESCRIPTION
## Description

I have a project that has guest methods located in the parent directory. e.g. 
```toml
[package.metadata.risc0]
methods = ["../../programs/risc0"]
```

Calling `risc0_build::embed_methods()` in `build.rs` results in
```
 ERROR: No package found in "<PATH>/../../programs/risc0"
```
because vanilla `Path` comparison here
https://github.com/risc0/risc0/blob/3df2b55e611bbd7c65303bc7ef35be69f5a93b4d/risc0/build/src/lib.rs#L258
only normalizes `.` occurrences.