### PR TITLE
Fix broken link to guest code file in password-checker README

### DIFF
--- a/examples/password-checker/README.md
+++ b/examples/password-checker/README.md
@@ -22,7 +22,7 @@ Because the validity-checking and hashing functionality runs on the zkVM, it gen
 ## Project organization
 
 The main program that calls a method in the guest zkVM is in [src/main.rs](src/main.rs).
-The code that runs inside the zkVM is in [`methods/guest/src/bin/pw_checker.rs`](methods/guest/src/bin/pw_checker.rs).
+The code that runs inside the zkVM is in [`methods/guest/src/main.rs`](methods/guest/src/main.rs).
 The rest of the project is build support.
 
 For the main RISC Zero project, see [here](https://github.com/risc0/risc0).


### PR DESCRIPTION
This pull request fixes an incorrect file path reference in the password-checker example README on line 29. The previous path pointed to a non-existent file. The correct path is 'methods/guest/src/main.rs', which contains the password policy implementation (lines 12-25), PBKDF2 password hashing (lines 46-50), and password validation logic (lines 53-59). The file contains the core zkVM guest code that validates passwords against security requirements and generates secure password hashes