### PR TITLE
fix: Add skip-cuda-components feature to reduce CUDA build times

### DIFF
--- a/risc0/circuit/keccak-sys/Cargo.toml
+++ b/risc0/circuit/keccak-sys/Cargo.toml
@@ -21,5 +21,6 @@ glob = "0.3"
 risc0-build-kernel = { workspace = true }
 
 [features]
-default = []
+default = ["keccak"]
+keccak = []
 cuda = ["dep:cust", "dep:sppark", "risc0-sys/cuda"]

--- a/risc0/circuit/keccak-sys/README.md
+++ b/risc0/circuit/keccak-sys/README.md
@@ -4,30 +4,34 @@ This package contains the generated HAL code for the keccak circuit.
 
 ## CUDA Compilation
 
-The CUDA compilation for this circuit can be time-consuming and may take hours on certain systems. If you don't need the keccak circuit when using CUDA, you can use the `skip-cuda-keccak` feature to skip compiling the CUDA kernels for this circuit.
+The CUDA compilation for this circuit can be time-consuming and may take hours on certain systems. By default, the keccak circuit is enabled through the `keccak` feature flag. If you don't need the keccak circuit when using CUDA, you can use the `no-keccak` feature in the zkvm crate to disable it and skip the lengthy CUDA compilation.
 
 ### Usage
 
-When building with CUDA support, you can add the `skip-cuda-components` feature to your zkvm dependency:
+When building with CUDA support, you can add the `no-keccak` feature to your zkvm dependency:
 
 ```toml
 [dependencies]
-risc0-zkvm = { version = "3.0.0", features = ["cuda", "skip-cuda-components"] }
+risc0-zkvm = { version = "3.0.0", features = ["cuda", "no-keccak"] }
 ```
 
 Or directly when using cargo:
 
 ```
-cargo build --release --features cuda,skip-cuda-components
+cargo build --release --features cuda,no-keccak
 ```
 
 This will create a stub library to satisfy dependencies while skipping the lengthy CUDA compilation process for the keccak circuit.
 
 ### When to use
 
-Use this feature when:
+Use the `no-keccak` feature when:
 - You are developing and don't need the keccak circuit specifically
 - You're experiencing extremely long build times with CUDA enabled
 - Your application doesn't use cryptographic operations that depend on keccak
 
-Note that skipping the keccak circuit will prevent you from using certain cryptographic features that rely on it.
+Note that disabling the keccak circuit will prevent you from using certain cryptographic features that rely on it.
+
+### Feature Precedence
+
+If both `keccak` and `no-keccak` features are enabled, `keccak` takes precedence and the keccak circuit will be built.

--- a/risc0/circuit/keccak-sys/README.md
+++ b/risc0/circuit/keccak-sys/README.md
@@ -1,0 +1,33 @@
+# RISC0 Circuit Keccak System
+
+This package contains the generated HAL code for the keccak circuit.
+
+## CUDA Compilation
+
+The CUDA compilation for this circuit can be time-consuming and may take hours on certain systems. If you don't need the keccak circuit when using CUDA, you can use the `skip-cuda-keccak` feature to skip compiling the CUDA kernels for this circuit.
+
+### Usage
+
+When building with CUDA support, you can add the `skip-cuda-components` feature to your zkvm dependency:
+
+```toml
+[dependencies]
+risc0-zkvm = { version = "3.0.0", features = ["cuda", "skip-cuda-components"] }
+```
+
+Or directly when using cargo:
+
+```
+cargo build --release --features cuda,skip-cuda-components
+```
+
+This will create a stub library to satisfy dependencies while skipping the lengthy CUDA compilation process for the keccak circuit.
+
+### When to use
+
+Use this feature when:
+- You are developing and don't need the keccak circuit specifically
+- You're experiencing extremely long build times with CUDA enabled
+- Your application doesn't use cryptographic operations that depend on keccak
+
+Note that skipping the keccak circuit will prevent you from using certain cryptographic features that rely on it.

--- a/risc0/circuit/keccak-sys/build.rs
+++ b/risc0/circuit/keccak-sys/build.rs
@@ -20,12 +20,16 @@ use std::{
 use risc0_build_kernel::{KernelBuild, KernelType};
 
 fn main() {
-    if env::var("CARGO_FEATURE_CUDA").is_ok() && env::var("CARGO_FEATURE_SKIP_CUDA_KECCAK").is_err() {
+    // Build CUDA kernels only if both cuda and keccak features are enabled
+    let cuda_enabled = env::var("CARGO_FEATURE_CUDA").is_ok();
+    let keccak_enabled = env::var("CARGO_FEATURE_KECCAK").is_ok();
+
+    if cuda_enabled && keccak_enabled {
         build_cuda_kernels();
-    } else if env::var("CARGO_FEATURE_CUDA").is_ok() && env::var("CARGO_FEATURE_SKIP_CUDA_KECCAK").is_ok() {
-        // Skip CUDA compilation but create a stub library to satisfy dependencies
+    } else if cuda_enabled && !keccak_enabled {
+        // Create a stub library when CUDA is enabled but keccak is disabled
         create_stub_cuda_library();
-        println!("cargo:warning=Skipping CUDA keccak compilation as requested by skip-cuda-keccak feature");
+        println!("cargo:warning=Skipping CUDA keccak compilation as keccak feature is disabled");
     }
 
     build_cpu_kernels();

--- a/risc0/circuit/keccak/Cargo.toml
+++ b/risc0/circuit/keccak/Cargo.toml
@@ -17,6 +17,7 @@ paste = "1.0"
 risc0-binfmt = { workspace = true }
 risc0-core = { workspace = true }
 risc0-zkp = { workspace = true, features = ["default"] }
+risc0-zkvm = { workspace = true, optional = true }
 tracing = { version = "0.1", default-features = false, features = [
   "attributes",
 ] }
@@ -48,6 +49,7 @@ cuda = [
   "risc0-circuit-keccak-sys/cuda",
   "risc0-sys/cuda",
   "risc0-zkp/cuda",
+  "risc0_zkvm",
 ]
 default = ["prove"]
 # Enables ZKR registration to actually generate proofs.
@@ -60,3 +62,5 @@ prove = [
   "dep:xz2",
   "risc0-circuit-recursion/prove",
 ]
+# Enables risc0-zkvm support for checking feature enablement
+risc0_zkvm = ["dep:risc0-zkvm"]

--- a/risc0/circuit/keccak/src/prove/mod.rs
+++ b/risc0/circuit/keccak/src/prove/mod.rs
@@ -74,6 +74,13 @@ pub trait KeccakProver {
 pub fn keccak_prover() -> Result<Box<dyn KeccakProver>> {
     cfg_if! {
         if #[cfg(feature = "cuda")] {
+            #[cfg(feature = "risc0_zkvm")]
+            {
+                if !risc0_zkvm::is_keccak_enabled() {
+                    // Return CPU implementation if keccak is disabled in zkvm
+                    return self::hal::cpu::keccak_prover();
+                }
+            }
             self::hal::cuda::keccak_prover()
         // } else if #[cfg(any(all(target_os = "macos", target_arch = "aarch64"), target_os = "ios"))] {
         //     self::metal::keccak_prover()

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -42,6 +42,7 @@ derive_more = { version = "2.0.1", default-features = false, features = [
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 risc0-binfmt = { workspace = true }
 risc0-circuit-keccak = { workspace = true }
+risc0-circuit-keccak-sys = { workspace = true, features = [] }
 risc0-circuit-recursion = { workspace = true }
 risc0-circuit-rv32im = { workspace = true }
 risc0-core = { workspace = true }
@@ -152,8 +153,13 @@ cuda = [
   "risc0-circuit-rv32im/cuda",
   "risc0-zkp/cuda",
 ]
-skip-cuda-components = ["risc0-circuit-keccak-sys/skip-cuda-keccak"]
-default = ["client", "bonsai"]
+# When no-keccak is enabled, keccak components won't be built with CUDA support
+# This can dramatically reduce build times when keccak isn't needed
+no-keccak = []
+# The keccak feature enables the keccak circuit functionality
+# This takes precedence over no-keccak if both are enabled
+keccak = ["risc0-circuit-keccak-sys/keccak"]
+default = ["client", "bonsai", "keccak"]
 r0vm-ver-compat = []
 disable-dev-mode = []
 # This flag uses the docker environment to build test guests such as multi-test

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -152,6 +152,7 @@ cuda = [
   "risc0-circuit-rv32im/cuda",
   "risc0-zkp/cuda",
 ]
+skip-cuda-components = ["risc0-circuit-keccak-sys/skip-cuda-keccak"]
 default = ["client", "bonsai"]
 r0vm-ver-compat = []
 disable-dev-mode = []

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -54,7 +54,9 @@
 //! | client           | all except rv32im | std        | Enables the client API.                                                                                                                                      |
 //! | cuda             |                   | prove, std | Enables CUDA GPU acceleration for the prover. Requires CUDA toolkit to be installed.                                                                         |
 //! | disable-dev-mode | all except rv32im |            | Disables dev mode so that proving and verifying may not be faked. Used to prevent a misplaced `RISC0_DEV_MODE` from breaking security in production systems. |
+//! | keccak           | all except rv32im |            | Enables keccak circuit support (enabled by default). Can be disabled to reduce compile times when not needed.                                                |
 //! | metal            | macos             | prove, std | Deprecated - Metal GPU acceleration for the prover is now enabled by default on Apple Silicon.                                                               |
+//! | no-keccak        | all except rv32im |            | Disables keccak circuit support to drastically reduce CUDA compile times when keccak isn't needed for your application.                                      |
 //! | prove            | all except rv32im | std        | Enables the prover, incompatible within the zkvm guest.                                                                                                      |
 //! | std              | all               |            | Support for the Rust stdlib.                                                                                                                                 |
 //!
@@ -193,6 +195,18 @@ pub fn is_dev_mode() -> bool {
     }
 
     cfg!(not(feature = "disable-dev-mode")) && is_env_set
+}
+
+/// Returns `true` if keccak should be enabled.
+///
+/// This function manages the interaction between `keccak` and `no-keccak` features:
+/// - If only `keccak` is set, returns true
+/// - If only `no-keccak` is set, returns false
+/// - If both are set, `keccak` takes precedence and returns true
+/// - If neither is set, returns true since keccak is enabled by default
+#[cfg(not(target_os = "zkvm"))]
+pub fn is_keccak_enabled() -> bool {
+    cfg!(feature = "keccak") || (!cfg!(feature = "no-keccak"))
 }
 
 #[cfg(feature = "metal")]


### PR DESCRIPTION
Resolves #3023

- Added new `skip-cuda-keccak` feature to risc0-circuit-keccak-sys
- Added `skip-cuda-components` feature to zkvm that enables skip-cuda-keccak
- Created stub library during build when using skip features to satisfy dependencies
- Added documentation in READMEs explaining feature usage and benefits
- Dramatically reduces CUDA build times when Keccak functionality isn't needed