### PR TITLE
fix: replace deprecated #[clap]

### DIFF
--- a/bento/crates/api/src/lib.rs
+++ b/bento/crates/api/src/lib.rs
@@ -161,50 +161,50 @@ impl IntoResponse for AppError {
 }
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[arg(author, version, about, long_about = None)]
 pub struct Args {
     /// Bind address for REST api
-    #[clap(long, default_value = "0.0.0.0:8080")]
+    #[arg(long, default_value = "0.0.0.0:8080")]
     bind_addr: String,
 
     /// SQL DB Connection pool connections
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     db_max_connections: u32,
 
     /// taskdb postgres DATABASE_URL
-    #[clap(env)]
+    #[arg(env)]
     database_url: String,
 
     /// S3 / Minio bucket
-    #[clap(env)]
+    #[arg(env)]
     s3_bucket: String,
 
     /// S3 / Minio access key
-    #[clap(env)]
+    #[arg(env)]
     s3_access_key: String,
 
     /// S3 / Minio secret key
-    #[clap(env)]
+    #[arg(env)]
     s3_secret_key: String,
 
     /// S3 / Minio url
-    #[clap(env)]
+    #[arg(env)]
     s3_url: String,
 
     /// Executor timeout in seconds
-    #[clap(long, default_value_t = 4 * 60 * 60)]
+    #[arg(long, default_value_t = 4 * 60 * 60)]
     exec_timeout: i32,
 
     /// Executor retries
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     exec_retries: i32,
 
     /// Snark timeout in seconds
-    #[clap(long, default_value_t = 60 * 2)]
+    #[arg(long, default_value_t = 60 * 2)]
     snark_timeout: i32,
 
     /// Snark retries
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     snark_retries: i32,
 }
 

--- a/bento/crates/bento-client/src/bento_cli.rs
+++ b/bento/crates/bento-client/src/bento_cli.rs
@@ -14,13 +14,13 @@ use std::path::PathBuf;
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// Risc0 ZKVM elf file on disk
-    #[clap(short = 'f', long)]
+    #[arg(short = 'f', long)]
     elf_file: Option<PathBuf>,
 
     /// ZKVM encoded input to be supplied to ExecEnv .write() method
     ///
     /// Should be `risc0_zkvm::serde::to_vec` encoded binary data
-    #[clap(short, long, conflicts_with = "iter_count")]
+    #[arg(short, long, conflicts_with = "iter_count")]
     input_file: Option<PathBuf>,
 
     /// Optional test vector to run the sample guest with the supplied iteration count
@@ -28,21 +28,21 @@ pub struct Args {
     /// Allows for rapid testing of arbitrary large cycle count guests
     ///
     /// NOTE: TODO remove this flag and simplify client
-    #[clap(short = 'c', long, conflicts_with = "input_file")]
+    #[arg(short = 'c', long, conflicts_with = "input_file")]
     iter_count: Option<u64>,
 
     /// Optionally Create a SNARK proof
-    #[clap(short, long, default_value_t = false, conflicts_with = "exec_only")]
+    #[arg(short, long, default_value_t = false, conflicts_with = "exec_only")]
     snarkify: bool,
 
     /// Run a execute only job, aka preflight
     ///
     /// Useful for capturing metrics on a STARK proof like cycles.
-    #[clap(short, long, default_value_t = false, conflicts_with = "snarkify")]
+    #[arg(short, long, default_value_t = false, conflicts_with = "snarkify")]
     exec_only: bool,
 
     /// Bento HTTP API Endpoint
-    #[clap(short = 't', long, default_value = "http://localhost:8081")]
+    #[arg(short = 't', long, default_value = "http://localhost:8081")]
     endpoint: String,
 }
 

--- a/bento/crates/workflow/src/lib.rs
+++ b/bento/crates/workflow/src/lib.rs
@@ -49,92 +49,92 @@ pub struct Args {
     pub poll_time: u64,
 
     /// taskdb postgres DATABASE_URL
-    #[clap(env)]
+    #[arg(env)]
     pub database_url: String,
 
     /// redis connection URL
-    #[clap(env)]
+    #[arg(env)]
     pub redis_url: String,
 
     /// risc0 segment po2 arg
-    #[clap(short, long, default_value_t = 20)]
+    #[arg(short, long, default_value_t = 20)]
     pub segment_po2: u32,
 
     /// max connections to SQL db in connection pool
-    #[clap(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 1)]
     pub db_max_connections: u32,
 
     /// Redis TTL, seconds before objects expire automatically
     ///
     /// Defaults to 8 hours
-    #[clap(long, default_value_t = 8 * 60 * 60)]
+    #[arg(long, default_value_t = 8 * 60 * 60)]
     pub redis_ttl: u64,
 
     /// Executor limit, in millions of cycles
-    #[clap(short, long, default_value_t = 100_000)]
+    #[arg(short, long, default_value_t = 100_000)]
     pub exec_cycle_limit: u64,
 
     /// S3 / Minio bucket
-    #[clap(env)]
+    #[arg(env)]
     pub s3_bucket: String,
 
     /// S3 / Minio access key
-    #[clap(env)]
+    #[arg(env)]
     pub s3_access_key: String,
 
     /// S3 / Minio secret key
-    #[clap(env)]
+    #[arg(env)]
     pub s3_secret_key: String,
 
     /// S3 / Minio url
-    #[clap(env)]
+    #[arg(env)]
     pub s3_url: String,
 
     /// Enables a background thread to monitor for tasks that need to be retried / timed-out
-    #[clap(long, default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     monitor_requeue: bool,
 
     // Task flags
     /// How many times a prove+lift can fail before hard failure
-    #[clap(long, default_value_t = 3)]
+    #[arg(long, default_value_t = 3)]
     prove_retries: i32,
 
     /// How long can a prove+lift can be running for, before it is marked as timed-out
-    #[clap(long, default_value_t = 30)]
+    #[arg(long, default_value_t = 30)]
     prove_timeout: i32,
 
     /// How many times a join can fail before hard failure
-    #[clap(long, default_value_t = 3)]
+    #[arg(long, default_value_t = 3)]
     join_retries: i32,
 
     /// How long can a join can be running for, before it is marked as timed-out
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     join_timeout: i32,
 
     /// How many times a resolve can fail before hard failure
-    #[clap(long, default_value_t = 3)]
+    #[arg(long, default_value_t = 3)]
     resolve_retries: i32,
 
     /// How long can a resolve can be running for, before it is marked as timed-out
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     resolve_timeout: i32,
 
     /// How many times a finalize can fail before hard failure
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     finalize_retries: i32,
 
     /// How long can a finalize can be running for, before it is marked as timed-out
     ///
     /// NOTE: This value is multiplied by the assumption count
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     finalize_timeout: i32,
 
     /// Snark timeout in seconds
-    #[clap(long, default_value_t = 60 * 4)]
+    #[arg(long, default_value_t = 60 * 4)]
     snark_timeout: i32,
 
     /// Snark retries
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     snark_retries: i32,
 }
 

--- a/risc0/cargo-risczero/src/commands/guest.rs
+++ b/risc0/cargo-risczero/src/commands/guest.rs
@@ -44,13 +44,13 @@ pub enum GuestSubCommands {
 #[derive(Debug, Args)]
 pub struct CommonArgs {
     /// Path to the Cargo.toml file for the crate to be built.
-    #[clap(long, default_value = "./Cargo.toml")]
+    #[arg(long, default_value = "./Cargo.toml")]
     pub manifest_path: PathBuf,
 
     /// Output directory for build artifacts.
     ///
     /// Determined from package metadata if not supplied.
-    #[clap(long)]
+    #[arg(long)]
     pub target_dir: Option<PathBuf>,
 
     /// Additional arguments to pass to "cargo build" on the guest


### PR DESCRIPTION
Closes #2936 

Suggestion : .
Let’s enable a feature like clap/deprecated in the project so that everyone automatically gets warnings.
This way, if someone in the team accidentally uses old #[clap(...)] attributes or name, they will immediately get a warning.
Otherwise, people might unknowingly keep adding deprecated code again and again.

I Can take it. If team is ok.

I noticed that the #[clap changes I made in #2945 have been reintroduced. They were added again 3 weeks ago. We can fix this as well if that's okay.

This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

