### PR TITLE
chore: Correct typos in comments

### DIFF
--- a/bonsai/sdk/src/lib.rs
+++ b/bonsai/sdk/src/lib.rs
@@ -442,7 +442,7 @@ pub mod module_type {
             Ok(())
         }
 
-        /// Fetchs a journal from execute_only jobs
+        /// Fetches a journal from execute_only jobs
         ///
         /// After the Execution phase of a execute_only session it is possible to fetch the journal
         /// contents from the executor

--- a/risc0/sys/cxx/vendor/nvtx3/nvToolsExt.h
+++ b/risc0/sys/cxx/vendor/nvtx3/nvToolsExt.h
@@ -26,9 +26,9 @@
  * \section INITIALIZATION_SECTION Initialization
  *
  * Typically the tool's library that plugs into NVTX is indirectly 
- * loaded via enviromental properties that are platform specific. 
+ * loaded via environmental properties that are platform specific. 
  * For some platform or special cases, the user may be required 
- * to instead explicity initialize instead though.   This can also
+ * to instead explicitly initialize instead though.   This can also
  * be helpful to control when the API loads a tool's library instead
  * of what would typically be the first function call to emit info.
  * For these rare case, see \ref INITIALIZATION for additional information.
@@ -112,7 +112,7 @@
  * to enable filtering and sorting.  The category naming functions allow 
  * the application to associate a user friendly name with the integer 
  * category.  Support for domains have been added in NVTX_VERSION_2 to 
- * avoid collisions when domains are developed independantly. 
+ * avoid collisions when domains are developed independently. 
  *
  * \subsection RESOURCE_OBJECTS Resource Objects
  *
@@ -718,7 +718,7 @@ NVTX_DECLSPEC nvtxRangeId_t NVTX_API nvtxRangeStartW(const wchar_t* message);
 * \param id - The correlation ID returned from a nvtxRangeStart call.
 *
 * \remarks This function is offered completeness but is an alias for ::nvtxRangeEnd. 
-* It does not need a domain param since that is associated iwth the range ID at ::nvtxDomainRangeStartEx
+* It does not need a domain param since that is associated with the range ID at ::nvtxDomainRangeStartEx
 *
 * \par Example:
 * \code

--- a/risc0/sys/cxx/vendor/nvtx3/nvtx3.hpp
+++ b/risc0/sys/cxx/vendor/nvtx3/nvtx3.hpp
@@ -111,7 +111,7 @@
  * \code{.cpp}
  * #include "nvtx3.hpp"
  * void some_function() {
- *    // Begins a NVTX range with the messsage "some_function"
+ *    // Begins a NVTX range with the message "some_function"
  *    // The range ends when some_function() returns and `r` is destroyed
  *    nvtx3::scoped_range r{"some_function"};
  *
@@ -1612,7 +1612,7 @@ using registered_string = registered_string_in<domain::global>;
  * nvtx3::scoped_range range1{attr1};
  *
  * // `range2` contains message "message 2"
- * nvtx3::scoped_range range2{nvtx3::Mesage{"message 2"}};
+ * nvtx3::scoped_range range2{nvtx3::Message{"message 2"}};
  *
  * // `std::string` and string literals are implicitly assumed to be
  * // the contents of an `nvtx3::message`
@@ -1900,7 +1900,7 @@ class payload {
  * nvtx3::scoped_range r{attr};
  *
  * // For convenience, `event_attributes` constructor arguments may be passed
- * // to the `scoped_range_in` contructor -- they are forwarded to the
+ * // to the `scoped_range_in` constructor -- they are forwarded to the
  * // `event_attributes` constructor
  * nvtx3::scoped_range r{nvtx3::payload{42}, nvtx3::category{1}, "message"};
  *


### PR DESCRIPTION
## Description
This PR fixes several typos found in code comments and documentation across multiple files:

- `bonsai/sdk/src/lib.rs`
- `risc0/sys/cxx/vendor/nvtx3/nvToolsExt.h`
- `risc0/sys/cxx/vendor/nvtx3/nvtx3.hpp`

## Changes
- Fixed grammatical errors in code comments
- Corrected spelling mistakes in documentation
- Improved clarity of technical descriptions

## Testing
- No functional changes were made
- All existing tests continue to pass
- Code formatting and style remain consistent

## Additional Notes
These changes are purely documentation-related and do not affect the functionality of the codebase.