### PR TITLE
executor perf: Various performance improvemnts

### DIFF
--- a/risc0/binfmt/src/image.rs
+++ b/risc0/binfmt/src/image.rs
@@ -376,6 +376,7 @@ impl Page {
     /// Thus, if you pass a [WordAddr] belonging to a different page,
     /// [Page::load] will load from the address in _this_ page with the same
     /// [WordAddr::page_subaddr].
+    #[inline(always)]
     pub fn load(&self, addr: WordAddr) -> u32 {
         let byte_addr = addr.page_subaddr().baddr().0 as usize;
         let mut bytes = [0u8; WORD_SIZE];
@@ -387,11 +388,13 @@ impl Page {
     }
 
     #[cfg(feature = "std")]
+    #[inline(always)]
     fn ensure_writable(&mut self) -> &mut [u8] {
         &mut Arc::make_mut(&mut self.0)[..]
     }
 
     #[cfg(not(feature = "std"))]
+    #[inline(always)]
     fn ensure_writable(&mut self) -> &mut [u8] {
         &mut self.0
     }
@@ -403,6 +406,7 @@ impl Page {
     /// this page. Thus, if you pass a [WordAddr] belonging to a different page,
     /// [Page::store] will store to the address in _this_ page with the same
     /// [WordAddr::page_subaddr].
+    #[inline(always)]
     pub fn store(&mut self, addr: WordAddr, word: u32) {
         let writable_ref = self.ensure_writable();
 
@@ -412,6 +416,7 @@ impl Page {
     }
 
     /// Get a shared reference to the underlying data in the page
+    #[inline(always)]
     pub fn data(&self) -> &Vec<u8> {
         &self.0
     }

--- a/risc0/binfmt/src/image.rs
+++ b/risc0/binfmt/src/image.rs
@@ -222,6 +222,15 @@ impl MemoryImage {
         self.mark_dirty(digest_idx);
     }
 
+    /// Set the data for a page and with the given digest
+    pub fn set_page_with_digest(&mut self, page_idx: u32, page: Page, digest: Digest) {
+        let digest_idx = MEMORY_PAGES as u32 + page_idx;
+        self.expand_if_zero(digest_idx);
+        self.digests.insert(digest_idx, digest);
+        self.pages.insert(page_idx, page);
+        self.mark_dirty(digest_idx);
+    }
+
     /// Get a digest, fails if unavailable
     pub fn get_digest(&mut self, digest_idx: u32) -> Result<&Digest> {
         // Expand if needed

--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -574,6 +574,7 @@ impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
         Ok(())
     }
 
+    #[inline(always)]
     fn load_u32(&mut self, op: LoadOp, addr: WordAddr) -> Result<u32> {
         let word = match op {
             LoadOp::Peek => self.pager.peek(addr)?,
@@ -583,12 +584,14 @@ impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
         Ok(word)
     }
 
+    #[inline(always)]
     fn load_register(&mut self, _op: LoadOp, base: WordAddr, idx: usize) -> Result<u32> {
         let word = self.pager.load_register(base, idx);
         // tracing::trace!("load_register({:?}) -> {word:#010x}", addr.baddr());
         Ok(word)
     }
 
+    #[inline(always)]
     fn store_u32(&mut self, addr: WordAddr, word: u32) -> Result<()> {
         // tracing::trace!(
         //     "store_u32({:?}, {word:#010x}), pc: {:?}",
@@ -604,6 +607,7 @@ impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
         self.pager.store(addr, word)
     }
 
+    #[inline(always)]
     fn store_register(&mut self, base: WordAddr, idx: usize, word: u32) -> Result<()> {
         // tracing::trace!("store_register({:?}, {word:#010x})", addr.baddr());
         if !self.trace.is_empty() {

--- a/risc0/circuit/rv32im/src/execute/mod.rs
+++ b/risc0/circuit/rv32im/src/execute/mod.rs
@@ -40,3 +40,24 @@ pub const DEFAULT_SEGMENT_LIMIT_PO2: usize = 20;
 pub(crate) fn node_idx(page_idx: u32) -> u32 {
     MEMORY_PAGES as u32 + page_idx
 }
+
+#[inline]
+#[cold]
+fn cold() {}
+
+#[inline]
+#[allow(dead_code)]
+fn likely(b: bool) -> bool {
+    if !b {
+        cold()
+    }
+    b
+}
+
+#[inline]
+fn unlikely(b: bool) -> bool {
+    if b {
+        cold()
+    }
+    b
+}

--- a/risc0/circuit/rv32im/src/execute/pager.rs
+++ b/risc0/circuit/rv32im/src/execute/pager.rs
@@ -23,6 +23,7 @@ use derive_more::Debug;
 use risc0_binfmt::{MemoryImage, Page, WordAddr};
 
 use super::{node_idx, platform::*};
+use crate::execute::unlikely;
 
 pub const PAGE_WORDS: usize = PAGE_BYTES / WORD_SIZE;
 
@@ -83,6 +84,7 @@ impl PageStates {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn set(&mut self, index: u32, value: PageState) {
         let set_before = self.get(index) != PageState::Unloaded;
         match value {
@@ -103,6 +105,7 @@ impl PageStates {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn get(&self, index: u32) -> PageState {
         if self.states.get(index as usize * 2).unwrap() {
             // b10 | b11 => Dirty
@@ -181,11 +184,13 @@ impl PageTable {
         }
     }
 
+    #[inline(always)]
     fn get(&self, index: u32) -> Option<usize> {
         let value = self.table[index as usize] as usize;
         value.checked_sub(1)
     }
 
+    #[inline(always)]
     fn set(&mut self, index: u32, value: usize) {
         self.table[index as usize] = (value + 1) as u32
     }
@@ -228,6 +233,7 @@ pub(crate) struct WorkingImage {
 }
 
 impl WorkingImage {
+    #[inline(always)]
     fn get_page(&mut self, page_idx: u32) -> Result<Page> {
         // If page exists, return it
         if let Some(page) = self.pages.get(&page_idx) {
@@ -299,6 +305,7 @@ impl PagedMemory {
         self.page_states.keys().collect()
     }
 
+    #[inline(always)]
     fn try_load_register(&self, addr: WordAddr) -> Option<u32> {
         if addr >= USER_REGS_ADDR.waddr() && addr < USER_REGS_ADDR.waddr() + REG_MAX {
             let reg_idx = addr - USER_REGS_ADDR.waddr();
@@ -338,7 +345,7 @@ impl PagedMemory {
     }
 
     pub(crate) fn peek(&mut self, addr: WordAddr) -> Result<u32> {
-        if addr >= MEMORY_END_ADDR {
+        if unlikely(addr >= MEMORY_END_ADDR) {
             bail!("Invalid peek address: {addr:?}");
         }
 
@@ -373,8 +380,9 @@ impl PagedMemory {
         Ok(self.page_cache[cache_idx].load(addr))
     }
 
+    #[inline(always)]
     pub(crate) fn load(&mut self, addr: WordAddr) -> Result<u32> {
-        if addr >= MEMORY_END_ADDR {
+        if unlikely(addr >= MEMORY_END_ADDR) {
             bail!("Invalid load address: {addr:?}");
         }
 
@@ -384,6 +392,7 @@ impl PagedMemory {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn load_register(&mut self, base: WordAddr, idx: usize) -> u32 {
         if base == USER_REGS_ADDR.waddr() {
             self.user_registers[idx]
@@ -405,7 +414,7 @@ impl PagedMemory {
 
     #[inline(always)]
     pub(crate) fn store(&mut self, addr: WordAddr, word: u32) -> Result<()> {
-        if addr >= MEMORY_END_ADDR {
+        if unlikely(addr >= MEMORY_END_ADDR) {
             bail!("Invalid store address: {addr:?}");
         }
 
@@ -416,6 +425,7 @@ impl PagedMemory {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn store_register(&mut self, base: WordAddr, idx: usize, word: u32) {
         if base == USER_REGS_ADDR.waddr() {
             self.user_registers[idx] = word;
@@ -426,6 +436,7 @@ impl PagedMemory {
         }
     }
 
+    #[inline(always)]
     fn page_for_writing(&mut self, page_idx: u32) -> Result<&mut Page> {
         let node_idx = node_idx(page_idx);
         let mut state = self.page_states.get(node_idx);
@@ -533,14 +544,16 @@ impl PagedMemory {
         self.trace_events.clear();
     }
 
+    #[inline(always)]
     fn trace_page_in(&mut self, cycles: u32) {
-        if self.tracing_enabled {
+        if unlikely(self.tracing_enabled) {
             self.trace_events.push(PageTraceEvent::PageIn { cycles });
         }
     }
 
+    #[inline(always)]
     fn trace_page_out(&mut self, cycles: u32) {
-        if self.tracing_enabled {
+        if unlikely(self.tracing_enabled) {
             self.trace_events.push(PageTraceEvent::PageOut { cycles });
         }
     }

--- a/risc0/circuit/rv32im/src/execute/pager.rs
+++ b/risc0/circuit/rv32im/src/execute/pager.rs
@@ -311,6 +311,7 @@ impl PagedMemory {
         }
     }
 
+    #[inline(always)]
     fn try_store_register(&mut self, addr: WordAddr, word: u32) -> bool {
         if addr >= USER_REGS_ADDR.waddr() && addr < USER_REGS_ADDR.waddr() + REG_MAX {
             let reg_idx = addr - USER_REGS_ADDR.waddr();
@@ -357,6 +358,7 @@ impl PagedMemory {
         }
     }
 
+    #[inline(always)]
     fn load_ram(&mut self, addr: WordAddr) -> Result<u32> {
         let page_idx = addr.page_idx();
         let node_idx = node_idx(page_idx);
@@ -392,6 +394,7 @@ impl PagedMemory {
         }
     }
 
+    #[inline(always)]
     fn store_ram(&mut self, addr: WordAddr, word: u32) -> Result<()> {
         let page_idx = addr.page_idx();
         // tracing::trace!("store: {addr:?}, page: {page_idx:#08x}, word: {word:#010x}");
@@ -400,6 +403,7 @@ impl PagedMemory {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn store(&mut self, addr: WordAddr, word: u32) -> Result<()> {
         if addr >= MEMORY_END_ADDR {
             bail!("Invalid store address: {addr:?}");
@@ -485,6 +489,7 @@ impl PagedMemory {
         partial_image
     }
 
+    #[inline(always)]
     fn load_page(&mut self, page_idx: u32) -> Result<()> {
         tracing::trace!("load_page: {page_idx:#08x}");
         let page = self.image.get_page(page_idx)?;
@@ -496,6 +501,7 @@ impl PagedMemory {
         Ok(())
     }
 
+    #[inline(always)]
     fn fixup_costs(&mut self, mut node_idx: u32, goal: PageState) {
         tracing::trace!("fixup: {node_idx:#010x}: {goal:?}");
         while node_idx != 0 {

--- a/risc0/circuit/rv32im/src/execute/poseidon2.rs
+++ b/risc0/circuit/rv32im/src/execute/poseidon2.rs
@@ -73,7 +73,7 @@ impl Poseidon2State {
 
     fn step(
         &mut self,
-        ctx: &mut dyn Risc0Context,
+        ctx: &mut impl Risc0Context,
         cur_state: &mut CycleState,
         next_state: CycleState,
         sub_state: u32,
@@ -86,7 +86,7 @@ impl Poseidon2State {
 
     pub(crate) fn rest(
         &mut self,
-        ctx: &mut dyn Risc0Context,
+        ctx: &mut impl Risc0Context,
         final_state: CycleState,
     ) -> Result<()> {
         let mut cur_state = self.next_state;
@@ -282,7 +282,7 @@ fn sbox2(x: u32) -> u32 {
 pub(crate) struct Poseidon2;
 
 impl Poseidon2 {
-    pub fn ecall(ctx: &mut dyn Risc0Context) -> Result<()> {
+    pub fn ecall(ctx: &mut impl Risc0Context) -> Result<()> {
         tracing::trace!("ecall");
         let state_addr = ctx.load_machine_register(LoadOp::Record, REG_A0)?;
         let buf_in_addr = ctx.load_machine_register(LoadOp::Record, REG_A1)?;

--- a/risc0/circuit/rv32im/src/execute/r0vm.rs
+++ b/risc0/circuit/rv32im/src/execute/r0vm.rs
@@ -173,6 +173,7 @@ pub struct Risc0Machine<'a, C: Risc0Context> {
 }
 
 impl<'a, C: Risc0Context> Risc0Machine<'a, C> {
+    #[inline(always)]
     pub fn step(emu: &mut Emulator, ctx: &'a mut C) -> Result<()> {
         emu.step(&mut Risc0Machine { ctx })
     }

--- a/risc0/circuit/rv32im/src/execute/r0vm.rs
+++ b/risc0/circuit/rv32im/src/execute/r0vm.rs
@@ -69,14 +69,17 @@ pub(crate) trait Risc0Context {
 
     fn load_u32(&mut self, op: LoadOp, addr: WordAddr) -> Result<u32>;
 
+    #[inline(always)]
     fn load_register(&mut self, op: LoadOp, base: WordAddr, idx: usize) -> Result<u32> {
         self.load_u32(op, base + idx)
     }
 
+    #[inline(always)]
     fn load_machine_register(&mut self, op: LoadOp, idx: usize) -> Result<u32> {
         self.load_register(op, MACHINE_REGS_ADDR.waddr(), idx)
     }
 
+    #[inline(always)]
     fn load_aligned_addr_from_machine_register(
         &mut self,
         op: LoadOp,
@@ -85,6 +88,7 @@ pub(crate) trait Risc0Context {
         check_aligned_addr(ByteAddr(self.load_machine_register(op, idx)?))
     }
 
+    #[inline(always)]
     fn load_u8(&mut self, op: LoadOp, addr: ByteAddr) -> Result<u8> {
         let word = self.load_u32(op, addr.waddr())?;
         let bytes = word.to_le_bytes();
@@ -92,6 +96,7 @@ pub(crate) trait Risc0Context {
         Ok(bytes[byte_offset])
     }
 
+    #[inline(always)]
     fn load_region(&mut self, op: LoadOp, addr: ByteAddr, size: usize) -> Result<Vec<u8>> {
         let mut region = Vec::with_capacity(size);
         if addr.is_aligned() && (0 == size % WORD_SIZE) {
@@ -110,6 +115,7 @@ pub(crate) trait Risc0Context {
 
     fn store_u32(&mut self, addr: WordAddr, word: u32) -> Result<()>;
 
+    #[inline(always)]
     fn store_register(&mut self, base: WordAddr, idx: usize, word: u32) -> Result<()> {
         self.store_u32(base + idx, word)
     }
@@ -544,12 +550,14 @@ impl<T: Risc0Context> EmuContext for Risc0Machine<'_, T> {
         self.ctx.set_pc(addr);
     }
 
+    #[inline(always)]
     fn load_register(&mut self, idx: usize) -> Result<u32> {
         // tracing::trace!("load_reg: x{idx}");
         let base = self.regs_base_addr();
         self.ctx.load_register(LoadOp::Record, base, idx)
     }
 
+    #[inline(always)]
     fn store_register(&mut self, idx: usize, word: u32) -> Result<()> {
         // tracing::trace!("store_reg: x{idx} <= {word:#010x}");
         let base = self.regs_base_addr();
@@ -563,10 +571,12 @@ impl<T: Risc0Context> EmuContext for Risc0Machine<'_, T> {
         }
     }
 
+    #[inline(always)]
     fn load_memory(&mut self, addr: WordAddr) -> Result<u32> {
         self.ctx.load_u32(LoadOp::Record, addr)
     }
 
+    #[inline(always)]
     fn store_memory(&mut self, addr: WordAddr, word: u32) -> Result<()> {
         self.ctx.store_u32(addr, word)
     }

--- a/risc0/circuit/rv32im/src/execute/rv32im.rs
+++ b/risc0/circuit/rv32im/src/execute/rv32im.rs
@@ -437,6 +437,7 @@ impl Emulator {
         Ok(Some(kind))
     }
 
+    #[inline(always)]
     fn step_load<M: EmuContext>(
         &mut self,
         ctx: &mut M,
@@ -490,6 +491,7 @@ impl Emulator {
         Ok(Some(kind))
     }
 
+    #[inline(always)]
     fn step_store<M: EmuContext>(
         &mut self,
         ctx: &mut M,
@@ -537,6 +539,7 @@ impl Emulator {
         Ok(Some(kind))
     }
 
+    #[inline(always)]
     fn step_system<M: EmuContext>(
         &mut self,
         ctx: &mut M,

--- a/risc0/circuit/rv32im/src/execute/rv32im.rs
+++ b/risc0/circuit/rv32im/src/execute/rv32im.rs
@@ -289,6 +289,7 @@ impl Emulator {
         }
     }
 
+    #[inline(always)]
     pub fn step<C: EmuContext>(&mut self, ctx: &mut C) -> Result<()> {
         let pc = ctx.get_pc();
 
@@ -310,6 +311,7 @@ impl Emulator {
         Ok(())
     }
 
+    #[inline(always)]
     fn step_compute<M: EmuContext>(
         &mut self,
         ctx: &mut M,

--- a/risc0/circuit/rv32im/src/execute/sha2.rs
+++ b/risc0/circuit/rv32im/src/execute/sha2.rs
@@ -45,7 +45,7 @@ pub(crate) struct Sha2State {
 impl Sha2State {
     fn step(
         &mut self,
-        ctx: &mut dyn Risc0Context,
+        ctx: &mut impl Risc0Context,
         cur_state: &mut CycleState,
         next_state: CycleState,
     ) {
@@ -55,7 +55,7 @@ impl Sha2State {
     }
 }
 
-pub fn ecall(ctx: &mut dyn Risc0Context) -> Result<()> {
+pub fn ecall(ctx: &mut impl Risc0Context) -> Result<()> {
     let state_in_addr = guest_addr(ctx.load_machine_register(LoadOp::Record, REG_A0)?)?.waddr();
     let state_out_addr = guest_addr(ctx.load_machine_register(LoadOp::Record, REG_A1)?)?.waddr();
     let data_addr = guest_addr(ctx.load_machine_register(LoadOp::Record, REG_A2)?)?.waddr();

--- a/risc0/circuit/rv32im/src/prove/witgen/poseidon2.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/poseidon2.rs
@@ -180,52 +180,52 @@ impl Poseidon2State {
 }
 
 impl Poseidon2 {
-    pub fn read_start(ctx: &mut dyn Risc0Context) -> Result<()> {
+    pub fn read_start(ctx: &mut impl Risc0Context) -> Result<()> {
         // tracing::trace!("read_start");
         let p2 = Poseidon2State::new_start(0);
         ctx.on_poseidon2_cycle(CycleState::PoseidonEntry, &p2);
         Ok(())
     }
 
-    pub fn read_node(ctx: &mut dyn Risc0Context, node_idx: u32) -> Result<()> {
+    pub fn read_node(ctx: &mut impl Risc0Context, node_idx: u32) -> Result<()> {
         // tracing::trace!("read_node: {node_idx:#010x}");
         let mut p2 = Poseidon2State::new_node(node_idx, true);
         p2.rest(ctx, CycleState::PoseidonPaging)
     }
 
-    pub fn read_page(ctx: &mut dyn Risc0Context, page_idx: u32) -> Result<()> {
+    pub fn read_page(ctx: &mut impl Risc0Context, page_idx: u32) -> Result<()> {
         // tracing::trace!("read_page: {page_idx:#010x}");
         let mut p2 = Poseidon2State::new_page(page_idx, true);
         p2.rest(ctx, CycleState::PoseidonPaging)
     }
 
-    pub fn read_done(ctx: &mut dyn Risc0Context) -> Result<()> {
+    pub fn read_done(ctx: &mut impl Risc0Context) -> Result<()> {
         // tracing::trace!("read_done");
         let p2 = Poseidon2State::new_done(MERKLE_TREE_START_ADDR.0, CycleState::Resume, 2);
         ctx.on_poseidon2_cycle(CycleState::PoseidonPaging, &p2);
         Ok(())
     }
 
-    pub fn write_start(ctx: &mut dyn Risc0Context) -> Result<()> {
+    pub fn write_start(ctx: &mut impl Risc0Context) -> Result<()> {
         // tracing::trace!("write_start");
         let p2 = Poseidon2State::new_start(3);
         ctx.on_poseidon2_cycle(CycleState::PoseidonEntry, &p2);
         Ok(())
     }
 
-    pub fn write_node(ctx: &mut dyn Risc0Context, node_idx: u32) -> Result<()> {
+    pub fn write_node(ctx: &mut impl Risc0Context, node_idx: u32) -> Result<()> {
         // tracing::trace!("write_node: {node_idx:#010x}");
         let mut p2 = Poseidon2State::new_node(node_idx, false);
         p2.rest(ctx, CycleState::PoseidonPaging)
     }
 
-    pub fn write_page(ctx: &mut dyn Risc0Context, page_idx: u32) -> Result<()> {
+    pub fn write_page(ctx: &mut impl Risc0Context, page_idx: u32) -> Result<()> {
         // tracing::trace!("write_page: {page_idx:#010x}");
         let mut p2 = Poseidon2State::new_page(page_idx, false);
         p2.rest(ctx, CycleState::PoseidonPaging)
     }
 
-    pub fn write_done(ctx: &mut dyn Risc0Context) -> Result<()> {
+    pub fn write_done(ctx: &mut impl Risc0Context) -> Result<()> {
         // tracing::trace!("write_done");
         let p2 = Poseidon2State::new_done(MERKLE_TREE_END_ADDR.0, CycleState::StoreRoot, 5);
         ctx.on_poseidon2_cycle(CycleState::PoseidonPaging, &p2);


### PR DESCRIPTION
This includes a few small wins that take zeth execute down from about 17s to 10s on my coreweave machine

- Force a bunch of hot functions around doing memory IO to be inlined
- Remove usage of trait object to allow more inlining
- Optimize bigint IO functions w.r.t heap allocations and copies
- Remove extra hashing of memory pages