### PR TITLE
chore(workspace): point `repository` to `risc0/risc0` instead of remo…

### DIFF
--- a/bento/Cargo.toml
+++ b/bento/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 homepage = "https://risczero.com/"
-repository = "https://github.com/risc0/bento/"
+repository = "https://github.com/risc0/risc0/"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
- update `[workspace.package] repository` URL in `Cargo.toml` from `https://github.com/risc0/bento/` to `https://github.com/risc0/risc0/`
- fixes broken link in project metadata and CI checks
- no code-base changes; purely metadata