### PR TITLE
Preflight peformance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5735,6 +5735,7 @@ dependencies = [
  "test-log",
  "tracing",
  "tracing-subscriber 0.3.19",
+ "wide",
 ]
 
 [[package]]
@@ -6272,6 +6273,15 @@ dependencies = [
  "walkdir",
  "xz",
  "yaml-rust2",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -7802,6 +7812,16 @@ dependencies = [
  "home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,12 +739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_ops"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,7 +5706,6 @@ name = "risc0-circuit-rv32im"
 version = "3.0.0"
 dependencies = [
  "anyhow",
- "auto_ops",
  "bit-vec 0.8.0",
  "bytemuck",
  "byteorder",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -390,12 +390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_ops"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,7 +3232,6 @@ name = "risc0-circuit-rv32im"
 version = "3.0.0"
 dependencies = [
  "anyhow",
- "auto_ops",
  "bit-vec",
  "bytemuck",
  "byteorder",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3256,6 +3256,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+ "wide",
 ]
 
 [[package]]
@@ -3547,6 +3548,15 @@ dependencies = [
  "thiserror 2.0.12",
  "toml",
  "yaml-rust2",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -4477,6 +4487,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -436,12 +436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_ops"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,7 +3997,6 @@ name = "risc0-circuit-rv32im"
 version = "3.0.0"
 dependencies = [
  "anyhow",
- "auto_ops",
  "bit-vec",
  "bytemuck",
  "byteorder",

--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -4021,6 +4021,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+ "wide",
 ]
 
 [[package]]
@@ -4388,6 +4389,15 @@ dependencies = [
  "thiserror 2.0.12",
  "toml",
  "yaml-rust2",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -5731,6 +5741,16 @@ checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
  "redox_syscall",
  "wasite",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -410,12 +410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_ops"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,7 +3904,6 @@ name = "risc0-circuit-rv32im"
 version = "3.0.0"
 dependencies = [
  "anyhow",
- "auto_ops",
  "bit-vec",
  "bytemuck",
  "byteorder",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3928,6 +3928,7 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+ "wide",
 ]
 
 [[package]]
@@ -4361,6 +4362,15 @@ dependencies = [
  "thiserror 2.0.12",
  "toml",
  "yaml-rust2",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -5584,6 +5594,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1358,7 +1358,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1542,7 +1542,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1695,15 +1695,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -34,7 +34,6 @@ tracing = { version = "0.1", default-features = false, features = [
 ] }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-auto_ops = { version = "0.3", optional = true }
 bit-vec = "0.8"
 byteorder = { version = "1.5", optional = true }
 cfg-if = { version = "1.0", optional = true }
@@ -71,7 +70,6 @@ default = ["prove"]
 # entropy_finder = []
 execute = [
   "anyhow/backtrace",
-  "dep:auto_ops",
   "dep:byteorder",
   "dep:enum-map",
   "dep:malachite",

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -51,6 +51,7 @@ ringbuffer = { version = "0.15.0", optional = true }
 risc0-circuit-rv32im-sys = { workspace = true, optional = true }
 risc0-sys = { workspace = true, optional = true }
 smallvec = { version = "1.13", optional = true }
+wide = { version = "0.7", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive"] }
@@ -87,6 +88,7 @@ prove = [
   "dep:rayon",
   "dep:risc0-circuit-rv32im-sys",
   "dep:risc0-sys",
+  "dep:wide",
   "execute",
   "risc0-zkp/prove",
 ]

--- a/risc0/circuit/rv32im/src/prove/witgen/bigint.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/bigint.rs
@@ -119,7 +119,9 @@ impl BigInt {
                 let mut carry = 0;
 
                 // Do carry propagation
-                for coeff in self.program.total_carry.coeffs.iter_mut() {
+                for i in 0..self.program.total_carry.len() {
+                    let coeff = self.program.total_carry.get_mut(i);
+
                     *coeff += carry;
                     ensure!(*coeff % 256 == 0, "bad carry");
                     *coeff /= 256;
@@ -131,7 +133,10 @@ impl BigInt {
             let base_point = 128 * 256 * 64;
             for (i, ret) in self.state.bytes.iter_mut().enumerate() {
                 let offset = insn.offset as usize;
-                let coeff = self.program.total_carry.coeffs[offset * BIGINT_WIDTH_BYTES + i] as u32;
+                let coeff = *self
+                    .program
+                    .total_carry
+                    .get(offset * BIGINT_WIDTH_BYTES + i) as u32;
                 let value = coeff.wrapping_add(base_point);
                 match insn.poly_op {
                     PolyOp::Carry1 => *ret = ((value >> 14) & 0xff) as u8,

--- a/risc0/circuit/rv32im/src/prove/witgen/byte_poly.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/byte_poly.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use std::cmp::max;
+use std::ops::{Add, Mul};
 
 use anyhow::{ensure, Result};
-use auto_ops::impl_op_ex;
 use risc0_zkp::field::Elem as _;
 use smallvec::{smallvec, SmallVec};
 
@@ -144,6 +144,7 @@ impl BytePolynomial {
     }
 }
 
+#[inline(always)]
 fn byte_poly_add(lhs: &BytePolynomial, rhs: &BytePolynomial) -> BytePolynomial {
     let mut ret = smallvec![0; max(lhs.coeffs.len(), rhs.coeffs.len())];
     for (i, coeff) in ret.iter_mut().enumerate() {
@@ -157,6 +158,7 @@ fn byte_poly_add(lhs: &BytePolynomial, rhs: &BytePolynomial) -> BytePolynomial {
     BytePolynomial { coeffs: ret }
 }
 
+#[inline(always)]
 fn byte_poly_mul(lhs: &BytePolynomial, rhs: &BytePolynomial) -> BytePolynomial {
     let mut ret = smallvec![0; lhs.coeffs.len() + rhs.coeffs.len()];
     for (i, lhs) in lhs.coeffs.iter().enumerate() {
@@ -167,6 +169,7 @@ fn byte_poly_mul(lhs: &BytePolynomial, rhs: &BytePolynomial) -> BytePolynomial {
     BytePolynomial { coeffs: ret }
 }
 
+#[inline(always)]
 fn byte_poly_mul_const(lhs: &BytePolynomial, rhs: i32) -> BytePolynomial {
     let mut ret = lhs.coeffs.clone();
     for coeff in ret.iter_mut() {
@@ -175,9 +178,95 @@ fn byte_poly_mul_const(lhs: &BytePolynomial, rhs: i32) -> BytePolynomial {
     BytePolynomial { coeffs: ret }
 }
 
-impl_op_ex!(+|a: &BytePolynomial, b: &BytePolynomial| -> BytePolynomial { byte_poly_add(a, b) });
-impl_op_ex!(*|a: &BytePolynomial, b: &BytePolynomial| -> BytePolynomial { byte_poly_mul(a, b) });
-impl_op_ex!(*|a: &BytePolynomial, b: i32| -> BytePolynomial { byte_poly_mul_const(a, b) });
+impl Add<&BytePolynomial> for &BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn add(self, rhs: &BytePolynomial) -> Self::Output {
+        byte_poly_add(self, rhs)
+    }
+}
+
+impl Add<BytePolynomial> for &BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn add(self, rhs: BytePolynomial) -> Self::Output {
+        byte_poly_add(self, &rhs)
+    }
+}
+
+impl Add<&BytePolynomial> for BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn add(self, rhs: &BytePolynomial) -> Self::Output {
+        byte_poly_add(&self, rhs)
+    }
+}
+
+impl Add<BytePolynomial> for BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn add(self, rhs: BytePolynomial) -> Self::Output {
+        byte_poly_add(&self, &rhs)
+    }
+}
+
+impl Mul<&BytePolynomial> for &BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn mul(self, rhs: &BytePolynomial) -> Self::Output {
+        byte_poly_mul(self, rhs)
+    }
+}
+
+impl Mul<BytePolynomial> for &BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn mul(self, rhs: BytePolynomial) -> Self::Output {
+        byte_poly_mul(self, &rhs)
+    }
+}
+
+impl Mul<&BytePolynomial> for BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn mul(self, rhs: &BytePolynomial) -> Self::Output {
+        byte_poly_mul(&self, rhs)
+    }
+}
+
+impl Mul<BytePolynomial> for BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn mul(self, rhs: BytePolynomial) -> Self::Output {
+        byte_poly_mul(&self, &rhs)
+    }
+}
+
+impl Mul<i32> for &BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn mul(self, rhs: i32) -> Self::Output {
+        byte_poly_mul_const(self, rhs)
+    }
+}
+
+impl Mul<i32> for BytePolynomial {
+    type Output = BytePolynomial;
+
+    #[inline(always)]
+    fn mul(self, rhs: i32) -> Self::Output {
+        byte_poly_mul_const(&self, rhs)
+    }
+}
 
 const MAX_POWERS: usize = BIGINT_WIDTH_BYTES + 1;
 

--- a/risc0/circuit/rv32im/src/prove/witgen/paged_map.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/paged_map.rs
@@ -61,6 +61,7 @@ impl Default for PagedMap {
 
 impl PagedMap {
     /// Returns the value corresponding to the key.
+    #[inline(always)]
     pub fn get(&mut self, addr: &WordAddr) -> Option<u32> {
         let idx = addr.0 >> 20;
         let mid = self.high.entries.get(idx as usize).unwrap();
@@ -78,6 +79,7 @@ impl PagedMap {
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
+    #[inline(always)]
     pub fn get_mut(&mut self, addr: &WordAddr) -> &mut Option<u32> {
         let high_idx = addr.0 >> 20;
         let mid_idx = (addr.0 >> 10) & PAGED_MAP_MASK;

--- a/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
@@ -540,6 +540,7 @@ impl Risc0Context for Preflight<'_> {
     }
 
     // Pass memory ops to pager + record
+    #[inline(always)]
     fn load_u32(&mut self, op: LoadOp, addr: WordAddr) -> Result<u32> {
         if op == LoadOp::Peek {
             return self.pager.peek(addr);
@@ -570,6 +571,7 @@ impl Risc0Context for Preflight<'_> {
         Ok(word)
     }
 
+    #[inline(always)]
     fn store_u32(&mut self, addr: WordAddr, word: u32) -> Result<()> {
         let cycle = (2 * self.trace.cycles.len() + 1) as u32;
         let prev_word = if addr >= MEMORY_END_ADDR {

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -739,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1792,7 +1792,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2007,15 +2007,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"


### PR DESCRIPTION
These change improve preflight performance by a small amount.

This does it by inlining functions, and vectorizing BytePoly operations.

My own benchmark which does 10 zeth segment preflights improves from ~17s to ~14s