### PR TITLE
Fix typos in lib.rs documentation comments

### DIFF
--- a/bonsai/sdk/src/lib.rs
+++ b/bonsai/sdk/src/lib.rs
@@ -48,7 +48,7 @@
 //!     // Add a list of assumptions
 //!     let assumptions: Vec<String> = vec![];
 //!
-//!     // Wether to run in execute only mode
+//!     // Whether to run in execute only mode
 //!     let execute_only = false;
 //!
 //!     // Start a session running the prover
@@ -442,7 +442,7 @@ pub mod module_type {
             Ok(())
         }
 
-        /// Fetchs a journal from execute_only jobs
+        /// Fetches a journal from execute_only jobs
         ///
         /// After the Execution phase of a execute_only session it is possible to fetch the journal
         /// contents from the executor


### PR DESCRIPTION



Description:
This PR fixes two typos in the documentation comments of `lib.rs`:
1. Corrected `Wether` to `Whether` in the execute-only mode comment
2. Fixed `Fetchs` to `Fetches` in the journal retrieval documentation

These changes improve code documentation clarity and maintain consistent grammar throughout the codebase.
