### PR TITLE
Fix typo in Bonsai SDK README.md

### DIFF
--- a/bonsai/sdk/README.md
+++ b/bonsai/sdk/README.md
@@ -29,7 +29,7 @@ fn run_bonsai(input_data: Vec<u8>) -> Result<()> {
     // Add a list of assumptions
     let assumptions: Vec<String> = vec![];
 
-    // Wether to run in execute only mode
+    // Whether to run in execute only mode
     let execute_only = false;
 
     // Start a session running the prover


### PR DESCRIPTION
This PR fixes a typo in the Bonsai SDK documentation:

1. Corrected `Wether` to `Whether` in the execute-only mode comment in `bonsai/sdk/README.md`

This change improves documentation clarity and maintains consistent spelling in the codebase.