### PR TITLE
fix: update path 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
             test:
               - *base
               - bonsai/sdk/**
-              - compact_proof/**
+              - groth16_proof/**
               - external/**
               - risc0/**
             test-crates:


### PR DESCRIPTION
Updates the path in the test job filter from compact_proof/** to groth16_proof/** to match the current directory structure. This ensures changes in the groth16_proof directory properly trigger CI tests.