### PR TITLE
Executor Bigint Smallvec Spillage

### DIFF
--- a/risc0/circuit/rv32im/src/execute/bigint.rs
+++ b/risc0/circuit/rv32im/src/execute/bigint.rs
@@ -70,7 +70,7 @@ impl<Risc0ContextT: Risc0Context> BigIntIO for BigIntIOImpl<'_, Risc0ContextT> {
         check_bigint_addr(start_addr, self.mode)?;
 
         let word_count = (count + 3) / 4;
-        let mut limbs = SmallVec::<[u32; 8]>::with_capacity(word_count as usize);
+        let mut limbs = SmallVec::<[u32; 12]>::with_capacity(word_count as usize);
         let mut addr = start_addr;
         while addr < start_addr + word_count {
             limbs.push(self.ctx.load_u32(LoadOp::Load, addr)?);


### PR DESCRIPTION
In the executor where bigints are handled, when loading, a Smallvec is allocated to read limbs into. Currently the inlined smallvec value is optimized for 8 u32 limbs. Although this code isn't related to BLS, BLS is used often by many people in the ZKVM and limbs sizes (at least in blst are 12 u32s), so through some profiling, I observed that we are constantly spilling over and heap allocating here anyways. 