### PR TITLE
ZKVM-1403: Add `benchmark_label` and values so reports run on same runner each time

### DIFF
--- a/.github/workflows/bench_reports.yml
+++ b/.github/workflows/bench_reports.yml
@@ -43,7 +43,7 @@ jobs:
             arch: X64
             feature: cuda
             device: nvidia_rtx_4090
-            benchmark_label: benchmark_reports
+            benchmark_label: benchmark_pin
           - os: Linux
             arch: X64
             feature: cuda

--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -45,7 +45,7 @@ jobs:
             arch: X64
             feature: cuda
             device: nvidia_rtx_4090
-            benchmark_label: benchmark_trends
+            benchmark_label: benchmark_pin
           - os: Linux
             arch: X64
             feature: cuda


### PR DESCRIPTION
- Add `benchmark_label` and values so reports run on same runner each time for consistent data
- Label added to runner:
  - `lenovo-01` - `benchmark_pin`