### PR TITLE
lower noisy bento log levels

### DIFF
--- a/bento/crates/workflow/src/tasks/executor.rs
+++ b/bento/crates/workflow/src/tasks/executor.rs
@@ -283,7 +283,7 @@ pub async fn executor(agent: &Agent, job_id: &Uuid, request: &ExecutorReq) -> Re
 
     // Fetch ELF binary data
     let elf_key = format!("{ELF_BUCKET_DIR}/{}", request.image);
-    tracing::info!("Downloading - {}", elf_key);
+    tracing::debug!("Downloading - {}", elf_key);
     let elf_data = agent.s3_client.read_buf_from_s3(&elf_key).await?;
 
     // Write the image_id for pulling later
@@ -356,7 +356,7 @@ pub async fn executor(agent: &Agent, job_id: &Uuid, request: &ExecutorReq) -> Re
     if let Some(req_exec_limit) = request.exec_limit {
         let req_exec_limit = req_exec_limit * 1024 * 1024;
         if req_exec_limit < exec_limit {
-            tracing::info!(
+            tracing::debug!(
                 "Assigning a requested lower execution limit of: {req_exec_limit} cycles"
             );
             exec_limit = req_exec_limit;
@@ -686,7 +686,7 @@ pub async fn executor(agent: &Agent, job_id: &Uuid, request: &ExecutorReq) -> Re
         }
     }
 
-    tracing::info!("Done with all IO tasks");
+    tracing::debug!("Done with all IO tasks");
 
     let resp = ExecutorResp {
         segments: session.segment_count as u64,

--- a/bento/crates/workflow/src/tasks/finalize.rs
+++ b/bento/crates/workflow/src/tasks/finalize.rs
@@ -60,7 +60,7 @@ pub async fn finalize(agent: &Agent, job_id: &Uuid, request: &FinalizeReq) -> Re
     }
 
     let key = &format!("{RECEIPT_BUCKET_DIR}/{STARK_BUCKET_DIR}/{job_id}.bincode");
-    tracing::info!("Uploading rollup receipt to S3: {}", key);
+    tracing::debug!("Uploading rollup receipt to S3: {}", key);
     agent
         .s3_client
         .write_to_s3(key, rollup_receipt)

--- a/bento/crates/workflow/src/tasks/join.rs
+++ b/bento/crates/workflow/src/tasks/join.rs
@@ -35,7 +35,7 @@ pub async fn join(agent: &Agent, job_id: &Uuid, request: &JoinReq) -> Result<()>
     let right_receipt =
         deserialize_obj(&right_receipt).context("Failed to deserialize right receipt")?;
 
-    tracing::info!(
+    tracing::trace!(
         "Joining {job_id} - {} + {} -> {}",
         request.left,
         request.right,
@@ -57,7 +57,7 @@ pub async fn join(agent: &Agent, job_id: &Uuid, request: &JoinReq) -> Result<()>
     )
     .await?;
 
-    tracing::info!("Join Complete {job_id} - {}", request.left);
+    tracing::debug!("Join Complete {job_id} - {}", request.left);
 
     Ok(())
 }

--- a/bento/crates/workflow/src/tasks/keccak.rs
+++ b/bento/crates/workflow/src/tasks/keccak.rs
@@ -51,7 +51,7 @@ pub async fn keccak(
         );
     }
 
-    tracing::info!("Keccak proving {}", request.claim_digest);
+    tracing::debug!("Keccak proving {}", request.claim_digest);
 
     let keccak_receipt = agent
         .prover
@@ -74,7 +74,7 @@ pub async fn keccak(
     .await
     .context("Failed to write keccak receipt to redis")?;
 
-    tracing::info!("Completed keccak proving {}", request.claim_digest);
+    tracing::debug!("Completed keccak proving {}", request.claim_digest);
 
     Ok(())
 }

--- a/bento/crates/workflow/src/tasks/prove.rs
+++ b/bento/crates/workflow/src/tasks/prove.rs
@@ -18,7 +18,7 @@ pub async fn prover(agent: &Agent, job_id: &Uuid, task_id: &str, request: &Prove
     let job_prefix = format!("job:{job_id}");
     let segment_key = format!("{job_prefix}:{SEGMENTS_PATH}:{index}");
 
-    tracing::info!("Starting proof of idx: {job_id} - {index}");
+    tracing::debug!("Starting proof of idx: {job_id} - {index}");
     let segment_vec: Vec<u8> = conn
         .get::<_, Vec<u8>>(&segment_key)
         .await
@@ -33,9 +33,9 @@ pub async fn prover(agent: &Agent, job_id: &Uuid, task_id: &str, request: &Prove
         .prove_segment(&agent.verifier_ctx, &segment)
         .context("Failed to prove segment")?;
 
-    tracing::info!("Completed proof: {job_id} - {index}");
+    tracing::debug!("Completed proof: {job_id} - {index}");
 
-    tracing::info!("lifting {job_id} - {index}");
+    tracing::debug!("lifting {job_id} - {index}");
     let lift_receipt = agent
         .prover
         .as_ref()
@@ -43,7 +43,7 @@ pub async fn prover(agent: &Agent, job_id: &Uuid, task_id: &str, request: &Prove
         .lift(&segment_receipt)
         .with_context(|| format!("Failed to lift segment {index}"))?;
 
-    tracing::info!("lifting complete {job_id} - {index}");
+    tracing::debug!("lifting complete {job_id} - {index}");
 
     let output_key = format!("{job_prefix}:{RECUR_RECEIPT_PATH}:{task_id}");
     // Write out lifted receipt

--- a/bento/crates/workflow/src/tasks/resolve.rs
+++ b/bento/crates/workflow/src/tasks/resolve.rs
@@ -20,7 +20,7 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
     let receipts_key = format!("{job_prefix}:{RECEIPT_PATH}");
     let root_receipt_key = format!("{job_prefix}:{RECUR_RECEIPT_PATH}:{max_idx}");
 
-    tracing::info!("Starting resolve for job_id: {job_id}, max_idx: {max_idx}");
+    tracing::debug!("Starting resolve for job_id: {job_id}, max_idx: {max_idx}");
 
     let mut conn = agent.redis_pool.get().await?;
     let receipt: Vec<u8> = conn
@@ -30,7 +30,7 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
             format!("segment data not found for root receipt key: {root_receipt_key}")
         })?;
 
-    tracing::info!("Root receipt size: {} bytes", receipt.len());
+    tracing::debug!("Root receipt size: {} bytes", receipt.len());
     let mut conditional_receipt: SuccinctReceipt<ReceiptClaim> = deserialize_obj(&receipt)?;
 
     let mut assumptions_len: Option<u64> = None;
@@ -55,7 +55,7 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
                     .context("Failed unwrap the assumptions of the guest output")?
                     .iter();
 
-                tracing::info!("Resolving {} assumption(s)", assumptions.len());
+                tracing::debug!("Resolving {} assumption(s)", assumptions.len());
                 assumptions_len = Some(
                     assumptions
                         .len()
@@ -67,7 +67,7 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
                 if let Some(idx) = request.union_max_idx {
                     let union_root_receipt_key =
                         format!("{job_prefix}:{KECCAK_RECEIPT_PATH}:{idx}");
-                    tracing::info!(
+                    tracing::debug!(
                         "Deserializing union_root_receipt_key: {union_root_receipt_key}"
                     );
                     let union_receipt: Vec<u8> = conn.get(&union_root_receipt_key).await?;
@@ -77,7 +77,7 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
                     union_claim = union_receipt.claim.digest().to_string();
 
                     // Resolve union receipt
-                    tracing::info!("Resolving union claim digest: {union_claim}");
+                    tracing::debug!("Resolving union claim digest: {union_claim}");
                     conditional_receipt = agent
                         .prover
                         .as_ref()
@@ -89,11 +89,11 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
                 for assumption in assumptions {
                     let assumption_claim = assumption.as_value()?.claim.to_string();
                     if assumption_claim.eq(&union_claim) {
-                        tracing::info!("Skipping already resolved union claim: {union_claim}");
+                        tracing::debug!("Skipping already resolved union claim: {union_claim}");
                         continue;
                     }
                     let assumption_key = format!("{receipts_key}:{assumption_claim}");
-                    tracing::info!("Deserializing assumption with key: {assumption_key}");
+                    tracing::debug!("Deserializing assumption with key: {assumption_key}");
                     let assumption_bytes: Vec<u8> = conn
                         .get(&assumption_key)
                         .await
@@ -112,17 +112,17 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
                         .resolve(&conditional_receipt, &assumption_receipt)
                         .context("Failed to resolve the conditional receipt")?;
                 }
-                tracing::info!("Resolve complete");
+                tracing::debug!("Resolve complete for job_id: {job_id}");
             }
         }
     }
 
     // Write out the resolved receipt
-    tracing::info!("Serializing resolved receipt");
+    tracing::debug!("Serializing resolved receipt");
     let serialized_asset =
         serialize_obj(&conditional_receipt).context("Failed to serialize resolved receipt")?;
 
-    tracing::info!("Writing resolved receipt to Redis key: {root_receipt_key}");
+    tracing::debug!("Writing resolved receipt to Redis key: {root_receipt_key}");
     redis::set_key_with_expiry(
         &mut conn,
         &root_receipt_key,

--- a/bento/crates/workflow/src/tasks/snark.rs
+++ b/bento/crates/workflow/src/tasks/snark.rs
@@ -33,23 +33,23 @@ pub async fn stark2snark(agent: &Agent, job_id: &str, req: &SnarkReq) -> Result<
         "{RECEIPT_BUCKET_DIR}/{STARK_BUCKET_DIR}/{}.bincode",
         req.receipt
     );
-    tracing::info!("Downloading receipt, {receipt_key}");
+    tracing::debug!("Downloading receipt, {receipt_key}");
     let receipt: Receipt = agent
         .s3_client
         .read_from_s3(&receipt_key)
         .await
         .context("Failed to download receipt from obj store")?;
 
-    tracing::info!("performing identity predicate on receipt, {job_id}");
+    tracing::debug!("performing identity predicate on receipt, {job_id}");
 
     let succinct_receipt = receipt.inner.succinct()?;
     let receipt_ident = risc0_zkvm::recursion::identity_p254(succinct_receipt)
         .context("identity predicate failed")?;
     let seal_bytes = receipt_ident.get_seal_bytes();
 
-    tracing::info!("Completing identity predicate, {job_id}");
+    tracing::debug!("Completing identity predicate, {job_id}");
 
-    tracing::info!("Running seal-to-json, {job_id}");
+    tracing::debug!("Running seal-to-json, {job_id}");
     let seal_path = work_dir.path().join("input.json");
     let seal_json = File::create(&seal_path)?;
     let mut seal_reader = Cursor::new(&seal_bytes);
@@ -60,7 +60,7 @@ pub async fn stark2snark(agent: &Agent, job_id: &str, req: &SnarkReq) -> Result<
         bail!("Missing app path");
     }
 
-    tracing::info!("Running stark_verify, {job_id}");
+    tracing::debug!("Running stark_verify, {job_id}");
     let witness_file = work_dir.path().join(WITNESS_FILE);
 
     // Create a named pipe for the witness data so that the prover can start before
@@ -73,7 +73,7 @@ pub async fn stark2snark(agent: &Agent, job_id: &str, req: &SnarkReq) -> Result<
         .arg(&witness_file)
         .spawn()?;
 
-    tracing::info!("Running gnark, {job_id}");
+    tracing::debug!("Running gnark, {job_id}");
     let cs_file = app_path.join("stark_verify.cs");
     let pk_file = app_path.join("stark_verify_final.pk.dmp");
     let proof_file = work_dir.path().join(PROOF_FILE);
@@ -87,7 +87,7 @@ pub async fn stark2snark(agent: &Agent, job_id: &str, req: &SnarkReq) -> Result<
         .spawn()?;
 
     // Wait for stark_verify to complete
-    tracing::info!("Running prover, {job_id}");
+    tracing::debug!("Running prover, {job_id}");
     match wit_gen.wait().await {
         // Make sure the prover is always killed, otherwise it will wait forever
         Err(err) => {
@@ -106,7 +106,7 @@ pub async fn stark2snark(agent: &Agent, job_id: &str, req: &SnarkReq) -> Result<
         bail!("Failed to run gnark prover");
     }
 
-    tracing::info!("Parsing proof, {job_id}");
+    tracing::debug!("Parsing proof, {job_id}");
     let mut proof = File::open(proof_file)?;
     let mut contents = String::new();
     proof.read_to_string(&mut contents)?;
@@ -126,7 +126,7 @@ pub async fn stark2snark(agent: &Agent, job_id: &str, req: &SnarkReq) -> Result<
     );
 
     let key = &format!("{RECEIPT_BUCKET_DIR}/{GROTH16_BUCKET_DIR}/{job_id}.bincode");
-    tracing::info!("Uploading snark receipt to S3: {}", key);
+    tracing::debug!("Uploading snark receipt to S3: {}", key);
     agent
         .s3_client
         .write_to_s3(key, snark_receipt)

--- a/bento/crates/workflow/src/tasks/union.rs
+++ b/bento/crates/workflow/src/tasks/union.rs
@@ -13,7 +13,7 @@ use workflow_common::{UnionReq, KECCAK_RECEIPT_PATH};
 
 /// Run the union operation
 pub async fn union(agent: &Agent, job_id: &Uuid, request: &UnionReq) -> Result<()> {
-    tracing::info!("Starting union for job_id: {job_id}");
+    tracing::debug!("Starting union for job_id: {job_id}");
     let mut conn = agent.redis_pool.get().await?;
 
     // setup redis keys
@@ -35,7 +35,7 @@ pub async fn union(agent: &Agent, job_id: &Uuid, request: &UnionReq) -> Result<(
         deserialize_obj(&right_receipt_bytes).context("Failed to deserialize right receipt")?;
 
     // run union
-    tracing::info!(
+    tracing::debug!(
         "Union {job_id} - {} + {} -> {}",
         request.left,
         request.right,
@@ -62,7 +62,7 @@ pub async fn union(agent: &Agent, job_id: &Uuid, request: &UnionReq) -> Result<(
     .await
     .context("Failed to set redis key for union receipt")?;
 
-    tracing::info!("Union complete {job_id} - {}", request.left);
+    tracing::debug!("Union complete {job_id} - {}", request.left);
 
     Ok(())
 }


### PR DESCRIPTION
https://github.com/boundless-xyz/boundless/pull/491 seemed to be dropped when migrating to risc0, so applying roughly those changes here as the log levels are very noisy and spam logs by default. Not urgent, but would be nice for the next builds.