### PR TITLE
[actor-system] Pipeline tasks in the worker 

### DIFF
--- a/risc0/r0vm/src/actors/mod.rs
+++ b/risc0/r0vm/src/actors/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod factory;
 pub(crate) mod job;
 pub(crate) mod manager;
 pub(crate) mod protocol;
+pub(crate) mod rpc;
 #[cfg(test)]
 mod tests;
 pub(crate) mod worker;

--- a/risc0/r0vm/src/actors/mod.rs
+++ b/risc0/r0vm/src/actors/mod.rs
@@ -23,7 +23,6 @@ pub(crate) mod worker;
 
 use std::{error::Error as StdError, net::SocketAddr, path::PathBuf};
 
-use futures::{SinkExt as _, StreamExt};
 use kameo::prelude::*;
 use opentelemetry_otlp::WithExportConfig as _;
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SdkTracerProvider, Resource};
@@ -31,11 +30,7 @@ use protocol::{JobInfo, ProofRequest};
 use risc0_circuit_rv32im::execute::DEFAULT_SEGMENT_LIMIT_PO2;
 use risc0_zkvm::DevModeDelay;
 use serde::{Deserialize, Serialize};
-use tokio::{
-    net::{TcpListener, TcpStream},
-    task::JoinHandle,
-};
-use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+use tokio::{net::TcpListener, task::JoinHandle};
 
 use crate::Cli;
 
@@ -46,6 +41,7 @@ use self::{
         factory::{GetTask, TaskDoneMsg, TaskUpdateMsg},
         TaskKind,
     },
+    rpc::{rpc_system, RpcMessageId, RpcSender},
     worker::Worker,
 };
 
@@ -271,7 +267,7 @@ impl Server {
 
         self.join_handle = Some(tokio::spawn(async move {
             loop {
-                let (mut stream, _addr) = match listener.accept().await {
+                let (stream, _addr) = match listener.accept().await {
                     Ok(result) => result,
                     Err(err) => {
                         tracing::error!("{err}");
@@ -281,9 +277,16 @@ impl Server {
 
                 let factory = factory.clone();
                 tokio::spawn(async move {
-                    while let Some(request) = recv_request(&mut stream).await.unwrap() {
-                        handle_request(&mut stream, request, factory.clone()).await
-                    }
+                    let (rpc_sender, mut rpc_receiver) = rpc_system(stream);
+                    rpc_receiver
+                        .receive_many(move |req, message_id| {
+                            let rpc_sender = rpc_sender.clone();
+                            let factory = factory.clone();
+                            tokio::task::spawn(async move {
+                                handle_request(rpc_sender, req, message_id, factory).await
+                            });
+                        })
+                        .await;
                 });
             }
         }));
@@ -298,24 +301,24 @@ impl Server {
     }
 }
 
-async fn recv_request(stream: &mut TcpStream) -> anyhow::Result<Option<RemoteRequest>> {
-    recv(stream).await
-}
-
 async fn handle_request(
-    stream: &mut TcpStream,
+    rpc_sender: RpcSender,
     request: RemoteRequest,
+    message_id: Option<RpcMessageId>,
     factory: ActorRef<FactoryActor>,
 ) {
     match request {
         RemoteRequest::GetTask(msg) => {
+            let message_id = message_id.expect("request not expecting response");
             let reply = factory.ask(msg).await.unwrap();
-            send(stream, reply).await.unwrap();
+            rpc_sender.respond(&reply, message_id).await.unwrap();
         }
         RemoteRequest::TaskUpdate(msg) => {
+            assert!(message_id.is_none());
             factory.tell(msg).await.unwrap();
         }
         RemoteRequest::TaskDone(msg) => {
+            assert!(message_id.is_none());
             factory.tell(msg).await.unwrap();
         }
     }
@@ -340,37 +343,4 @@ fn init_tracer_provider() -> SdkTracerProvider {
     opentelemetry::global::set_tracer_provider(provider.clone());
 
     provider
-}
-
-pub(crate) async fn send<T: serde::Serialize>(
-    stream: &mut TcpStream,
-    msg: T,
-) -> anyhow::Result<()> {
-    let encoder = LengthDelimitedCodec::builder()
-        .max_frame_length(1024 * 1024 * 1024)
-        .new_codec();
-    let mut writer = FramedWrite::new(stream, encoder);
-
-    let bytes = bincode::serialize(&msg)?;
-    tracing::info!("tx {} bytes", bytes.len());
-    writer.send(bytes.into()).await?;
-
-    Ok(())
-}
-
-pub(crate) async fn recv<T: serde::de::DeserializeOwned>(
-    stream: &mut TcpStream,
-) -> anyhow::Result<Option<T>> {
-    let decoder = LengthDelimitedCodec::builder()
-        .max_frame_length(1024 * 1024 * 1024)
-        .new_codec();
-
-    let mut reader = FramedRead::new(stream, decoder);
-    let frame = match reader.next().await {
-        Some(result) => result?,
-        None => return Ok(None),
-    };
-
-    tracing::info!("rx {} bytes", frame.len());
-    Ok(Some(bincode::deserialize(&frame)?))
 }

--- a/risc0/r0vm/src/actors/rpc.rs
+++ b/risc0/r0vm/src/actors/rpc.rs
@@ -1,0 +1,537 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{tcp, TcpStream};
+use tokio::sync::Mutex as TokioMutex;
+
+/// Create a pair of RPC sender and receiver. The sender is used to send messages to the remote
+/// side, the recevier is used to get responses and remote requests.
+pub fn rpc_system(stream: TcpStream) -> (RpcSender, RpcReceiver) {
+    let (read_half, write_half) = stream.into_split();
+
+    let registry = Arc::new(Mutex::new(RpcRegistry::new()));
+
+    (
+        RpcSender::new(write_half, registry.clone()),
+        RpcReceiver::new(read_half, registry),
+    )
+}
+
+//  ____                 _
+// / ___|  ___ _ __   __| |
+// \___ \ / _ \ '_ \ / _` |
+//  ___) |  __/ | | | (_| |
+// |____/ \___|_| |_|\__,_|
+//
+
+/// Represents a unique request and response between a particular local and remote machine.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RpcMessageId(NonZeroU32);
+
+impl RpcSender {
+    /// Send a message to the remote machine and expect a response. When the response is received,
+    /// the given callback will be called.
+    pub async fn ask<ResponseT: DeserializeOwned>(
+        &self,
+        msg: &impl Serialize,
+        callback: impl FnOnce(ResponseT) + Send + 'static,
+    ) -> Result<()> {
+        let message_id = self.registry.lock().unwrap().add_request(callback);
+        self.send(msg, message_id, RpcMessageKind::ExpectsResponse)
+            .await
+    }
+
+    /// Send a message to the remote machine and expect no response.
+    pub async fn tell(&self, msg: &impl Serialize) -> Result<()> {
+        let message_id = self.registry.lock().unwrap().next_message_id();
+        self.send(msg, message_id, RpcMessageKind::ExpectsNoResponse)
+            .await
+    }
+
+    /// Reply to a ask given to us.
+    pub async fn respond(&self, msg: &impl Serialize, message_id: RpcMessageId) -> Result<()> {
+        self.send(msg, message_id, RpcMessageKind::IsResponse).await
+    }
+
+    /// Shutdown the write side of the socket.
+    async fn shutdown(&self) -> Result<()> {
+        self.stream.lock().await.shutdown().await?;
+        Ok(())
+    }
+}
+
+//  ____               _
+// |  _ \ ___  ___ ___(_)_   _____
+// | |_) / _ \/ __/ _ \ \ \ / / _ \
+// |  _ <  __/ (_|  __/ |\ V /  __/
+// |_| \_\___|\___\___|_| \_/ \___|
+//
+
+impl RpcReceiver {
+    /// Receive RPC messages until the socket is closed. The given callback is called when we
+    /// receive a message which isn't a reply to an ask. That is, its called when the other-side
+    /// sends us an asks or tell.
+    pub async fn receive_many<RemoteMsgT: DeserializeOwned>(
+        &mut self,
+        mut remote_msg_callback: impl FnMut(RemoteMsgT, Option<RpcMessageId>) + Send + 'static,
+    ) {
+        loop {
+            match self.receive_one(&mut remote_msg_callback).await {
+                Ok(false) => {
+                    // The socket was closed, just exit.
+                    break;
+                }
+                Err(error) => {
+                    tracing::error!("RPC error: {error}");
+
+                    // Any IO error is fatal, so don't continue.
+                    if error.downcast::<std::io::Error>().is_ok() {
+                        break;
+                    }
+                }
+                _ => (),
+            }
+        }
+    }
+}
+
+//  ____       _            _
+// |  _ \ _ __(_)_   ____ _| |_ ___
+// | |_) | '__| \ \ / / _` | __/ _ \
+// |  __/| |  | |\ V / (_| | ||  __/
+// |_|   |_|  |_| \_/ \__,_|\__\___|
+//
+
+impl RpcMessageId {
+    const INITIAL: Self = Self(unsafe { NonZeroU32::new_unchecked(1) });
+    const MAX: Self = Self(unsafe { NonZeroU32::new_unchecked(u32::MAX) });
+
+    fn incr(&mut self) {
+        if *self == Self::MAX {
+            *self = Self::INITIAL;
+        } else {
+            self.0 = self.0.saturating_add(1);
+        }
+    }
+}
+
+#[warn(clippy::enum_variant_names)]
+#[derive(Serialize, Deserialize)]
+enum RpcMessageKind {
+    ExpectsResponse,
+    ExpectsNoResponse,
+    IsResponse,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RpcHeader {
+    body_length: u32,
+    message_id: RpcMessageId,
+    kind: RpcMessageKind,
+}
+
+const GIGABYTE: usize = 1024 * 1024 * 1024;
+
+/// The maximum size of the serialized RpcHeader
+const RPC_HEADER_SIZE: usize = 4 + 4 + 4;
+
+/// The maximum size of an RPC body
+const RPC_BODY_MAX: usize = 2 * GIGABYTE;
+
+type RpcRegistryCallback = Box<dyn FnOnce(&[u8]) -> Result<()> + Send>;
+
+struct RpcRegistry {
+    pending_requests: HashMap<RpcMessageId, RpcRegistryCallback>,
+    next_message_id: RpcMessageId,
+}
+
+impl RpcRegistry {
+    fn new() -> Self {
+        Self {
+            pending_requests: Default::default(),
+            next_message_id: RpcMessageId::INITIAL,
+        }
+    }
+
+    fn next_message_id(&mut self) -> RpcMessageId {
+        let message_id = self.next_message_id;
+        self.next_message_id.incr();
+        message_id
+    }
+
+    fn remove_request(&mut self, message_id: RpcMessageId) -> Result<RpcRegistryCallback> {
+        self.pending_requests
+            .remove(&message_id)
+            .ok_or_else(|| anyhow!("received response RPC which didn't have matching request"))
+    }
+
+    fn add_request<ResponseT: DeserializeOwned>(
+        &mut self,
+        callback: impl FnOnce(ResponseT) + Send + 'static,
+    ) -> RpcMessageId {
+        let message_id = self.next_message_id();
+
+        let inserted = self
+            .pending_requests
+            .insert(
+                message_id,
+                Box::new(move |body_bytes| {
+                    let response: ResponseT =
+                        bincode::deserialize(body_bytes).with_context(|| {
+                            format!("error deserializing {}", std::any::type_name::<ResponseT>())
+                        })?;
+                    callback(response);
+                    Ok(())
+                }),
+            )
+            .is_none();
+
+        assert!(inserted, "RPC message_id reuse");
+
+        message_id
+    }
+}
+
+#[derive(Clone)]
+pub struct RpcSender {
+    stream: Arc<TokioMutex<tcp::OwnedWriteHalf>>,
+    registry: Arc<Mutex<RpcRegistry>>,
+}
+
+impl RpcSender {
+    fn new(stream: tcp::OwnedWriteHalf, registry: Arc<Mutex<RpcRegistry>>) -> Self {
+        Self {
+            stream: Arc::new(TokioMutex::new(stream)),
+            registry,
+        }
+    }
+
+    async fn send(
+        &self,
+        msg: &impl Serialize,
+        message_id: RpcMessageId,
+        kind: RpcMessageKind,
+    ) -> Result<()> {
+        // Serialize the body
+        let mut buffer = vec![0; RPC_HEADER_SIZE];
+        bincode::serialize_into(&mut buffer, msg).unwrap();
+
+        // Craft the header
+        let body_length = buffer.len() - RPC_HEADER_SIZE;
+        if body_length > RPC_BODY_MAX {
+            bail!("sending RPC request with too large of a body");
+        }
+
+        let header = RpcHeader {
+            body_length: body_length as u32,
+            message_id,
+            kind,
+        };
+        bincode::serialize_into(&mut buffer[0..RPC_HEADER_SIZE], &header).unwrap();
+
+        // Send the message
+        self.stream
+            .lock()
+            .await
+            .write_all(&buffer)
+            .await
+            .context("error sending RPC message")?;
+
+        Ok(())
+    }
+}
+
+async fn read_detecting_clean_eof(
+    stream: &mut (impl AsyncRead + Unpin),
+    buffer: &mut [u8],
+) -> Result<bool> {
+    let mut i = 0;
+    while i < buffer.len() {
+        let read = stream.read(&mut buffer[i..]).await?;
+
+        if read == 0 {
+            if i == 0 {
+                // if we get no data on the first read, the socket was cleanly closed.
+                return Ok(true);
+            } else {
+                // if we get no data in the middle of reading, this is unexpected.
+                return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof).into());
+            }
+        }
+        i += read;
+    }
+
+    Ok(false)
+}
+
+pub struct RpcReceiver {
+    stream: tcp::OwnedReadHalf,
+    registry: Arc<Mutex<RpcRegistry>>,
+}
+
+impl RpcReceiver {
+    fn new(stream: tcp::OwnedReadHalf, registry: Arc<Mutex<RpcRegistry>>) -> Self {
+        Self { stream, registry }
+    }
+
+    /// Reads and handles one RPC message. Returns true if the socket is still open.
+    async fn receive_one<RemoteMsgT: DeserializeOwned>(
+        &mut self,
+        mut remote_msg_callback: impl FnMut(RemoteMsgT, Option<RpcMessageId>) + Send,
+    ) -> Result<bool> {
+        // Read the header
+        let mut buffer = [0; RPC_HEADER_SIZE];
+        let clean_eof = read_detecting_clean_eof(&mut self.stream, &mut buffer).await?;
+        if clean_eof {
+            return Ok(false);
+        }
+
+        let header: RpcHeader =
+            bincode::deserialize(&buffer).context("received invalid RPC header")?;
+
+        if header.body_length as usize > RPC_BODY_MAX {
+            bail!(
+                "received RPC with message body of length {} which is > {RPC_BODY_MAX}",
+                header.body_length
+            );
+        }
+
+        // Read the body
+        let mut body = vec![0; header.body_length as usize];
+        self.stream
+            .read_exact(&mut body)
+            .await
+            .context("error reading RPC body")?;
+
+        match header.kind {
+            RpcMessageKind::ExpectsResponse => {
+                let msg: RemoteMsgT = bincode::deserialize(&body).with_context(|| {
+                    format!(
+                        "error deserializing {}",
+                        std::any::type_name::<RemoteMsgT>()
+                    )
+                })?;
+                remote_msg_callback(msg, Some(header.message_id));
+            }
+            RpcMessageKind::ExpectsNoResponse => {
+                let msg: RemoteMsgT = bincode::deserialize(&body).with_context(|| {
+                    format!(
+                        "error deserializing {}",
+                        std::any::type_name::<RemoteMsgT>()
+                    )
+                })?;
+                remote_msg_callback(msg, None);
+            }
+            RpcMessageKind::IsResponse => {
+                let callback = self
+                    .registry
+                    .lock()
+                    .unwrap()
+                    .remove_request(header.message_id)?;
+                callback(&body)?;
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+    #[test]
+    fn header_serialization() {
+        // bincode has variable sized integer encoding.
+        let max_header = RpcHeader {
+            body_length: u32::MAX,
+            message_id: RpcMessageId::MAX,
+            kind: RpcMessageKind::IsResponse,
+        };
+        let serialized = bincode::serialize(&max_header).unwrap();
+
+        assert_eq!(serialized.len(), RPC_HEADER_SIZE);
+    }
+
+    async fn tcp_pair() -> (TcpStream, TcpStream) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let a = TcpStream::connect(listener.local_addr().unwrap())
+            .await
+            .unwrap();
+        let (b, _) = listener.accept().await.unwrap();
+        (a, b)
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    enum Request {
+        A,
+        B,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    struct Response {
+        message: String,
+    }
+
+    struct Fixture {
+        sender_a: RpcSender,
+        sender_b: RpcSender,
+        receiver_a: RpcReceiver,
+        receiver_b: RpcReceiver,
+    }
+
+    impl Fixture {
+        async fn new() -> Self {
+            let (a, b) = tcp_pair().await;
+            let (sender_a, receiver_a) = rpc_system(a);
+            let (sender_b, receiver_b) = rpc_system(b);
+            Self {
+                sender_a,
+                sender_b,
+                receiver_a,
+                receiver_b,
+            }
+        }
+
+        async fn ask_a<RequestT: Serialize, ResponseT: DeserializeOwned + Send + 'static>(
+            &mut self,
+            req: &RequestT,
+        ) -> UnboundedReceiver<ResponseT> {
+            let (send, recv) = unbounded_channel();
+
+            self.sender_a
+                .ask(req, move |res: ResponseT| send.send(res).unwrap())
+                .await
+                .unwrap();
+
+            recv
+        }
+
+        async fn receive_b<RequestT: DeserializeOwned + Send>(
+            &mut self,
+        ) -> Result<(RequestT, Option<RpcMessageId>)> {
+            let (send, mut recv) = unbounded_channel();
+
+            let socket_open = self
+                .receiver_b
+                .receive_one(move |req: RequestT, message_id| {
+                    send.send((req, message_id)).unwrap();
+                })
+                .await?;
+            assert!(socket_open);
+
+            Ok(recv.try_recv().unwrap())
+        }
+
+        async fn receive_b_response(&mut self) -> Result<()> {
+            let socket_open = self
+                .receiver_b
+                .receive_one(move |_: (), _| panic!())
+                .await?;
+            assert!(socket_open);
+
+            Ok(())
+        }
+
+        async fn receive_a_response(&mut self) -> Result<()> {
+            let socket_open = self
+                .receiver_a
+                .receive_one(move |_: (), _| panic!())
+                .await?;
+            assert!(socket_open);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn ask() {
+        let mut fix = Fixture::new().await;
+
+        let mut ask_recv: UnboundedReceiver<Response> = fix.ask_a(&Request::A).await;
+
+        let (req, message_id): (Request, _) = fix.receive_b().await.unwrap();
+        fix.sender_b
+            .respond(
+                &Response {
+                    message: format!("hello {req:?}"),
+                },
+                message_id.unwrap(),
+            )
+            .await
+            .unwrap();
+
+        fix.receive_a_response().await.unwrap();
+        let res = ask_recv.try_recv().unwrap();
+        assert_eq!(
+            res,
+            Response {
+                message: "hello A".into()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn tell() {
+        let mut fix = Fixture::new().await;
+
+        fix.sender_a.tell(&Request::A).await.unwrap();
+
+        let (req, message_id): (Request, _) = fix.receive_b().await.unwrap();
+        assert_eq!(req, Request::A);
+        assert!(message_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn unsolicited_response() {
+        let mut fix = Fixture::new().await;
+
+        fix.sender_a
+            .respond(
+                &Response {
+                    message: "hi".into(),
+                },
+                RpcMessageId::INITIAL,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            fix.receive_b_response().await.unwrap_err().to_string(),
+            "received response RPC which didn't have matching request"
+        );
+    }
+
+    #[tokio::test]
+    async fn socket_close() {
+        let mut fix = Fixture::new().await;
+
+        drop(fix.sender_a);
+
+        let socket_open = fix
+            .receiver_b
+            .receive_one(move |_: (), _| panic!())
+            .await
+            .unwrap();
+        assert!(!socket_open);
+    }
+}

--- a/risc0/r0vm/src/actors/rpc.rs
+++ b/risc0/r0vm/src/actors/rpc.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
@@ -74,7 +72,7 @@ impl RpcSender {
     }
 
     /// Shutdown the write side of the socket.
-    async fn shutdown(&self) -> Result<()> {
+    pub async fn shutdown(&self) -> Result<()> {
         self.stream.lock().await.shutdown().await?;
         Ok(())
     }
@@ -135,7 +133,7 @@ impl RpcMessageId {
     }
 }
 
-#[warn(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names)]
 #[derive(Serialize, Deserialize)]
 enum RpcMessageKind {
     ExpectsResponse,


### PR DESCRIPTION
This upgrades the actor system TCP communication to have multiplexing, then it uses this new feature to pipeline tasks in the worker. It grabs the next one while it is working on the current one.

I will need to merge https://github.com/risc0/risc0/pull/3191 with this one. I'm hoping to merge it on top of this probably because I think it will be easier that way, since I have to probably redo the tcp metric stuff.