### PR TITLE
ZKVM-1406: Remove mentions of Metal from 2.0 and main docs

### DIFF
--- a/website/api/generating-proofs/local-proving.md
+++ b/website/api/generating-proofs/local-proving.md
@@ -24,7 +24,7 @@ You can find out more info in the relevant issues [#1520] and [#1749].
 > TIP: In cases where memory is constrained (i.e. less than 10 GB is available), it may be necessary to change the [segment size limit][segment-limit-docs].
 > You can find information about expected memory consumption on our [benchmarks page][datasheet].
 
-> NOTE: When run for the first time, the GPU (e.g. Metal or CUDA) kernels may need to be JIT compiled.
+> NOTE: When run for the first time, the GPU (e.g. CUDA) kernels may need to be JIT compiled.
 > This can take a few minutes, but should only happen once.
 
 ### CPU
@@ -65,14 +65,8 @@ cargo run --bin rzup install
 RUSTFLAGS="-C target-cpu=native" cargo run -F cuda -r --example datasheet
 ```
 
-### Apple Metal
-
-On MacOS, when using a machine with Apple Silicon (such as the M-series MacBooks), RISC Zero will use the integrated [Metal][apple-metal] compute cores.
-No options need to be configured to take advantage of acceleration through the use of Metal.
-
 [#1520]: https://github.com/risc0/risc0/issues/1520
 [#1749]: https://github.com/risc0/risc0/issues/1749
-[apple-metal]: https://developer.apple.com/metal
 [Bonsai]: ./remote-proving.md
 [datasheet]: https://benchmarks.risczero.com/main/datasheet
 [feature flags]: https://github.com/risc0/risc0#feature-flags

--- a/website/api/use-cases.md
+++ b/website/api/use-cases.md
@@ -41,7 +41,7 @@ for the ZK software world: projects that would take months or years to build on
 other platforms can be solved trivially on our platform.
 
 In addition to being far easier to build on, we're also delivering on
-[performance]. The zkVM has GPU acceleration for CUDA and Metal, and with
+[performance]. The zkVM has GPU acceleration for CUDA, and with
 [continuations] we've enabled parallel proving of large programs.
 
 **Ready to start building?** <br />

--- a/website/api/zkvm/benchmarks.md
+++ b/website/api/zkvm/benchmarks.md
@@ -26,18 +26,12 @@ cargo run --release --example datasheet
 This will produce the benchmark data shown in the [datasheet] for your system
 (using the CPU) on the checked out version of the RISC Zero zkVM.
 
-If you want to benchmark a GPU, you will need to build with the `cuda` or
-`metal` feature enabled (whichever is appropriate for your hardware). To do
-this, use the following commands:
+If you want to benchmark a GPU, you will need to build with the `cuda` feature
+enabled. To do this, use the following command:
 
-- **Metal**
-  ```bash
-  cargo run --release -F metal --example datasheet
-  ```
-- **CUDA**
-  ```bash
-  cargo run --release -F cuda --example datasheet
-  ```
+```bash
+cargo run --release -F cuda --example datasheet
+```
 
 We also have a benchmark based on running a simple Fibonacci guest program,
 which you can run with:
@@ -50,7 +44,7 @@ This will compute the 100th, 1000th, and 10000th Fibonacci numbers modulo 2^64
 (ten times for each). It will report both time and throughput (how many numbers
 were added per second) with separate statistics for [execution] and
 [proving][prover]. As with the loop benchmark, the Fibonacci benchmark will use
-the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
+the CPU by default, and you can benchmark a CUDA GPU by setting the
 appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles

--- a/website/api_versioned_docs/version-2.0.0/generating-proofs/local-proving.md
+++ b/website/api_versioned_docs/version-2.0.0/generating-proofs/local-proving.md
@@ -24,7 +24,7 @@ You can find out more info in the relevant issues [#1520] and [#1749].
 > TIP: In cases where memory is constrained (i.e. less than 10 GB is available), it may be necessary to change the [segment size limit][segment-limit-docs].
 > You can find information about expected memory consumption on our [benchmarks page][datasheet].
 
-> NOTE: When run for the first time, the GPU (e.g. Metal or CUDA) kernels may need to be JIT compiled.
+> NOTE: When run for the first time, the GPU (e.g. CUDA) kernels may need to be JIT compiled.
 > This can take a few minutes, but should only happen once.
 
 ### CPU
@@ -65,14 +65,8 @@ cargo run --bin rzup install
 RUSTFLAGS="-C target-cpu=native" cargo run -F cuda -r --example datasheet
 ```
 
-### Apple Metal
-
-On MacOS, when using a machine with Apple Silicon (such as the M-series MacBooks), RISC Zero will use the integrated [Metal][apple-metal] compute cores.
-No options need to be configured to take advantage of acceleration through the use of Metal.
-
 [#1520]: https://github.com/risc0/risc0/issues/1520
 [#1749]: https://github.com/risc0/risc0/issues/1749
-[apple-metal]: https://developer.apple.com/metal
 [Bonsai]: ./remote-proving.md
 [datasheet]: https://benchmarks.risczero.com/main/datasheet
 [feature flags]: https://github.com/risc0/risc0#feature-flags

--- a/website/api_versioned_docs/version-2.0.0/use-cases.md
+++ b/website/api_versioned_docs/version-2.0.0/use-cases.md
@@ -41,7 +41,7 @@ for the ZK software world: projects that would take months or years to build on
 other platforms can be solved trivially on our platform.
 
 In addition to being far easier to build on, we're also delivering on
-[performance]. The zkVM has GPU acceleration for CUDA and Metal, and with
+[performance]. The zkVM has GPU acceleration for CUDA, and with
 [continuations] we've enabled parallel proving of large programs.
 
 **Ready to start building?** <br />

--- a/website/api_versioned_docs/version-2.0.0/zkvm/benchmarks.md
+++ b/website/api_versioned_docs/version-2.0.0/zkvm/benchmarks.md
@@ -26,18 +26,12 @@ cargo run --release --example datasheet
 This will produce the benchmark data shown in the [datasheet] for your system
 (using the CPU) on the checked out version of the RISC Zero zkVM.
 
-If you want to benchmark a GPU, you will need to build with the `cuda` or
-`metal` feature enabled (whichever is appropriate for your hardware). To do
-this, use the following commands:
+If you want to benchmark a GPU, you will need to build with the `cuda` feature
+enabled. To do this, use the following command:
 
-- **Metal**
-  ```bash
-  cargo run --release -F metal --example datasheet
-  ```
-- **CUDA**
-  ```bash
-  cargo run --release -F cuda --example datasheet
-  ```
+```bash
+cargo run --release -F cuda --example datasheet
+```
 
 We also have a benchmark based on running a simple Fibonacci guest program,
 which you can run with:
@@ -50,7 +44,7 @@ This will compute the 100th, 1000th, and 10000th Fibonacci numbers modulo 2^64
 (ten times for each). It will report both time and throughput (how many numbers
 were added per second) with separate statistics for [execution] and
 [proving][prover]. As with the loop benchmark, the Fibonacci benchmark will use
-the CPU by default, and you can benchmark a CUDA or Metal GPU by setting the
+the CPU by default, and you can benchmark a CUDA GPU by setting the
 appropriate feature flag.
 
 [cycle count]: /terminology#clock-cycles


### PR DESCRIPTION
Metal support is not yet implemented for 2.0. We've had a few folks get confused recently about why proving on Mac is slower than they expected.

This PR is to remove the mention of Metal as a supported accelerator target from the 2.0 and `main` docs
