### PR TITLE
ZKVM-1407: Disable bento-run CI job.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
   main-status-check:
     if: always()
     needs:
-      - bento-run
+      # - bento-run
       - bento-test
       - browser
       - check
@@ -740,52 +740,52 @@ jobs:
       - run: cargo test --manifest-path bento/Cargo.toml --locked --workspace --all-targets -- --ignored
       - run: sccache --show-stats
 
-  bento-run:
-    if: needs.changes.outputs.bento == 'true'
-    needs: changes
-    runs-on: [ self-hosted, prod, Linux, X64, cuda, g6e.xlarge, bench ]
-    env:
-      FEATURE: cuda
-      RISC0_BUILD_LOCKED: 1
-      RISC0_EXECUTOR: ipc
-      RISC0_PROVER: ipc
-      RISC0_SERVER_PATH: ${{ github.workspace }}/target/release/r0vm
-      RUST_BACKTRACE: full
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/cuda
-      - uses: ./.github/actions/rustup
-      - uses: ./.github/actions/sccache
-        with:
-          key: Linux-cuda
-      - uses: risc0/cargo-install@9f6037ed331dcf7da101461a20656273fa72abf0
-        with:
-          crate: cargo-binstall
-          version: "1.10.16"
-      - name: Install cargo-nextest
-        run: cargo binstall cargo-nextest
-      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
-      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
-      - run: cargo build --release -p risc0-r0vm -F $FEATURE
-      - uses: aws-actions/configure-aws-credentials@v4
-        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-        id: aws-creds
-        with:
-          aws-region: 'us-west-2'
-          role-to-assume: 'arn:aws:iam::083632199359:role/gha_oidc_risc0_cache_public_access'
-          output-credentials: true
-      - name: create ci creds file
-        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-        run: |
-          echo "[default]" > bento/dockerfiles/ci-cache-creds.txt
-          echo "aws_access_key_id=${{ steps.aws-creds.outputs.aws-access-key-id }}" >> bento/dockerfiles/ci-cache-creds.txt && \
-          echo "aws_secret_access_key=${{ steps.aws-creds.outputs.aws-secret-access-key }}" >> bento/dockerfiles/ci-cache-creds.txt && \
-          echo "aws_session_token=${{ steps.aws-creds.outputs.aws-session-token }}" >> bento/dockerfiles/ci-cache-creds.txt
-      - uses: docker/login-action@v3
-        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-        with:
-          username: ${{ secrets.DOCKERHUB_CI_USER }}
-          password: ${{ secrets.DOCKERHUB_CI_PAT }}
-      - uses: docker/setup-buildx-action@v3
-      - run: COMPOSE_BAKE=true docker compose --env-file bento/dockerfiles/sample.env -f compose.yml up -d
-      - run: RUST_LOG=info cargo run --manifest-path bento/Cargo.toml --bin bento_cli -- -c 32 -s
+#  bento-run:
+#    if: needs.changes.outputs.bento == 'true'
+#    needs: changes
+#    runs-on: [ self-hosted, prod, Linux, X64, cuda, g6e.xlarge, bench ]
+#    env:
+#      FEATURE: cuda
+#      RISC0_BUILD_LOCKED: 1
+#      RISC0_EXECUTOR: ipc
+#      RISC0_PROVER: ipc
+#      RISC0_SERVER_PATH: ${{ github.workspace }}/target/release/r0vm
+#      RUST_BACKTRACE: full
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: ./.github/actions/cuda
+#      - uses: ./.github/actions/rustup
+#      - uses: ./.github/actions/sccache
+#        with:
+#          key: Linux-cuda
+#      - uses: risc0/cargo-install@9f6037ed331dcf7da101461a20656273fa72abf0
+#        with:
+#          crate: cargo-binstall
+#          version: "1.10.16"
+#      - name: Install cargo-nextest
+#        run: cargo binstall cargo-nextest
+#      - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
+#      - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
+#      - run: cargo build --release -p risc0-r0vm -F $FEATURE
+#      - uses: aws-actions/configure-aws-credentials@v4
+#        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+#        id: aws-creds
+#        with:
+#          aws-region: 'us-west-2'
+#          role-to-assume: 'arn:aws:iam::083632199359:role/gha_oidc_risc0_cache_public_access'
+#          output-credentials: true
+#      - name: create ci creds file
+#        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+#        run: |
+#          echo "[default]" > bento/dockerfiles/ci-cache-creds.txt
+#          echo "aws_access_key_id=${{ steps.aws-creds.outputs.aws-access-key-id }}" >> bento/dockerfiles/ci-cache-creds.txt && \
+#          echo "aws_secret_access_key=${{ steps.aws-creds.outputs.aws-secret-access-key }}" >> bento/dockerfiles/ci-cache-creds.txt && \
+#          echo "aws_session_token=${{ steps.aws-creds.outputs.aws-session-token }}" >> bento/dockerfiles/ci-cache-creds.txt
+#      - uses: docker/login-action@v3
+#        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+#        with:
+#          username: ${{ secrets.DOCKERHUB_CI_USER }}
+#          password: ${{ secrets.DOCKERHUB_CI_PAT }}
+#      - uses: docker/setup-buildx-action@v3
+#      - run: COMPOSE_BAKE=true docker compose --env-file bento/dockerfiles/sample.env -f compose.yml up -d
+#      - run: RUST_LOG=info cargo run --manifest-path bento/Cargo.toml --bin bento_cli -- -c 32 -s


### PR DESCRIPTION
It seems to be having issues compiling the docker image and we don't want to focus on fixing it at the moment, especially since we are working on a rewrite.