### PR TITLE
Update README.md

### DIFF
--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -9,7 +9,7 @@ First, follow the [examples guide] to install dependencies and check out the cor
 Then, run the example with:
 
 ```bash
-cargo run --release
+cargo run --release --bin json-example
 ```
 
 ## Video Tutorial


### PR DESCRIPTION
Instruction to just run 

```
cargo run --release
``` 
For me resulted in : 
```
Error: `cargo run` could not determine which binary to run. Use the `--bin` opti
on to specify a binary, or 
the `default-run` manifest key.
                           available binaries: json-example, search_json
```

The following command though more specifically specifies which binary and actually works: 

```
cargo run --release --bin json-example
```