### PR TITLE
fix: point sccache URL to actual release tag

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
 
     - env:
-        SCCACHE_URL: https://github.com/mozilla/sccache/releases/download
+        SCCACHE_URL: https://github.com/mozilla/sccache/releases/tag/v0.10.0
         SCCACHE_VERSION: v0.10.0
       run: |
         SCCACHE_FILE=sccache-$SCCACHE_VERSION-$SCCACHE_ARCH

--- a/bento/dockerfiles/sccache-setup.sh
+++ b/bento/dockerfiles/sccache-setup.sh
@@ -4,6 +4,6 @@ set -e -u -o pipefail
 SCCACHE_ARCH=$1
 SCCACHE_VERSION=$2
 SCCACHE_FILE=sccache-$SCCACHE_VERSION-$SCCACHE_ARCH
-SCCACHE_URL=https://github.com/mozilla/sccache/releases/download
+SCCACHE_URL=https://github.com/mozilla/sccache/releases/tag/v0.10.0
 curl -L "$SCCACHE_URL/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
 mv -f $SCCACHE_FILE/sccache /usr/local/bin


### PR DESCRIPTION
Previous link hit a 404 — switched to the tag URL so devs can grab the right binary manually. Quick patch to unblock CI & local setup.