### PR TITLE
Prepare for guest code upgrade to Rust 1.88.0

### DIFF
--- a/risc0/zkvm/methods/guest/src/bin/multi_test/profiler.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test/profiler.rs
@@ -15,7 +15,6 @@
 use core::arch::asm;
 
 #[inline(never)]
-#[no_mangle]
 pub fn profile_test_func1() {
     // Two functions inlined one after the other to test we get the bounds correct.
     profile_test_func2();
@@ -28,27 +27,23 @@ pub fn profile_test_func1() {
 }
 
 #[inline(always)]
-#[no_mangle]
 fn profile_test_func2() {
     unsafe { asm!("nop") }
 }
 
 #[inline(always)]
-#[no_mangle]
 fn profile_test_func3() {
     unsafe { asm!("nop") }
 }
 
 /// This contains a jump in the middle that shouldn't be interpreted as a "call" by the profiler.
 #[inline(always)]
-#[no_mangle]
 fn profile_test_func4() {
     unsafe { asm!("la a0, 1f", "jr a0", "1:", "nop") }
 }
 
 /// Inline the same function many times in different locations
 #[inline(never)]
-#[no_mangle]
 fn profile_test_func5() {
     profile_test_func3();
     profile_test_func3();

--- a/risc0/zkvm/platform/src/syscall.rs
+++ b/risc0/zkvm/platform/src/syscall.rs
@@ -381,8 +381,8 @@ pub extern "C" fn sys_input(index: u32) -> u32 {
 ///
 /// `out_state`, `in_state`, `block1_ptr`, and `block2_ptr` must be aligned and
 /// dereferenceable.
-#[inline(always)]
 #[cfg_attr(feature = "export-syscalls", no_mangle)]
+#[cfg_attr(not(feature = "export-syscalls"), inline(always))]
 pub unsafe extern "C" fn sys_sha_compress(
     out_state: *mut [u32; DIGEST_WORDS],
     in_state: *const [u32; DIGEST_WORDS],
@@ -402,8 +402,8 @@ pub unsafe extern "C" fn sys_sha_compress(
 /// # Safety
 ///
 /// `out_state`, `in_state`, and `buf` must be aligned and dereferenceable.
-#[inline(always)]
 #[cfg_attr(feature = "export-syscalls", no_mangle)]
+#[cfg_attr(not(feature = "export-syscalls"), inline(always))]
 pub unsafe extern "C" fn sys_sha_buffer(
     out_state: *mut [u32; DIGEST_WORDS],
     in_state: *const [u32; DIGEST_WORDS],
@@ -433,8 +433,8 @@ pub unsafe extern "C" fn sys_sha_buffer(
 ///
 /// `state_addr`, `in_buf_addr`, and `out_buf_addr` must be word-aligned and
 /// dereferenceable.
-#[inline(always)]
 #[cfg_attr(feature = "export-syscalls", no_mangle)]
+#[cfg_attr(not(feature = "export-syscalls"), inline(always))]
 pub unsafe extern "C" fn sys_poseidon2(
     state_addr: *mut [u32; DIGEST_WORDS],
     in_buf_addr: *const u8,
@@ -457,8 +457,8 @@ pub unsafe extern "C" fn sys_poseidon2(
 /// # Safety
 ///
 /// `result`, `x`, `y`, and `modulus` must be aligned and dereferenceable.
-#[inline(always)]
 #[cfg_attr(feature = "export-syscalls", no_mangle)]
+#[cfg_attr(not(feature = "export-syscalls"), inline(always))]
 pub unsafe extern "C" fn sys_bigint(
     result: *mut [u32; bigint::WIDTH_WORDS],
     op: u32,

--- a/risc0/zkvm/src/host/server/exec/gdb.rs
+++ b/risc0/zkvm/src/host/server/exec/gdb.rs
@@ -159,14 +159,14 @@ mod tests {
             "\
             Reading symbols from .*\\.elf\\.\\.\\.\n\
             0xc0000000 in \\?\\? \\(\\)\n\
-            Breakpoint 1 at 0x[0-9a-f]*: file src/bin/multi_test/profiler.rs, line 33\\.\n\n\
+            Breakpoint 1 at 0x[0-9a-f]*: file src/bin/multi_test/profiler.rs, line [0-9]+\\.\n\n\
             Breakpoint 1, multi_test::profiler::profile_test_func1 \\(\\)\n\
-            \\s+at src/bin/multi_test/profiler.rs:21\n\
-            21\t    profile_test_func2\\(\\);\n\
+            \\s+at src/bin/multi_test/profiler.rs:[0-9]+\n\
+            [0-9]+\t    profile_test_func2\\(\\);\n\
             #0  multi_test::profiler::profile_test_func1 \\(\\)\n\
-            \\s+at src/bin/multi_test/profiler.rs:21\n.*\
-            #1  0x002[0-9a-f]* in multi_test::main \\(\\) at src/bin/multi_test.rs:127\n\
-            #2  0x002[0-9a-f]* in risc0_zkvm::guest::__start \\(\\) at src/guest/mod.rs:159\n\
+            \\s+at src/bin/multi_test/profiler.rs:[0-9]+\n.*\
+            #1  0x002[0-9a-f]* in multi_test::main \\(\\) at src/bin/multi_test.rs:[0-9]+\n\
+            #2  0x002[0-9a-f]* in risc0_zkvm::guest::__start \\(\\) at src/guest/mod.rs:[0-9]+\n\
             #3  0x002[0-9a-f]* in _start \\(\\)\n\
             Backtrace stopped: frame did not save the PC\n\
             \\(gdb\\) A debugging session is active.\n\n\

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -1021,7 +1021,7 @@ fn profiler() {
         vec![
             (
                 vec![
-                    "profile_test_func1".into(),
+                    "multi_test::profiler::profile_test_func1".into(),
                     "multi_test::main".into(),
                     "main".into(),
                     "__start".into()
@@ -1030,8 +1030,8 @@ fn profiler() {
             ),
             (
                 vec![
-                    "profile_test_func2".into(),
-                    "profile_test_func1".into(),
+                    "multi_test::profiler::profile_test_func2".into(),
+                    "multi_test::profiler::profile_test_func1".into(),
                     "multi_test::main".into(),
                     "main".into(),
                     "__start".into(),
@@ -1040,8 +1040,8 @@ fn profiler() {
             ),
             (
                 vec![
-                    "profile_test_func3".into(),
-                    "profile_test_func1".into(),
+                    "multi_test::profiler::profile_test_func3".into(),
+                    "multi_test::profiler::profile_test_func1".into(),
                     "multi_test::main".into(),
                     "main".into(),
                     "__start".into(),
@@ -1050,9 +1050,9 @@ fn profiler() {
             ),
             (
                 vec![
-                    "profile_test_func3".into(),
-                    "profile_test_func5".into(),
-                    "profile_test_func1".into(),
+                    "multi_test::profiler::profile_test_func3".into(),
+                    "multi_test::profiler::profile_test_func5".into(),
+                    "multi_test::profiler::profile_test_func1".into(),
                     "multi_test::main".into(),
                     "main".into(),
                     "__start".into(),
@@ -1061,8 +1061,8 @@ fn profiler() {
             ),
             (
                 vec![
-                    "profile_test_func4".into(),
-                    "profile_test_func1".into(),
+                    "multi_test::profiler::profile_test_func4".into(),
+                    "multi_test::profiler::profile_test_func1".into(),
                     "multi_test::main".into(),
                     "main".into(),
                     "__start".into(),
@@ -1071,8 +1071,8 @@ fn profiler() {
             ),
             (
                 vec![
-                    "profile_test_func5".into(),
-                    "profile_test_func1".into(),
+                    "multi_test::profiler::profile_test_func5".into(),
+                    "multi_test::profiler::profile_test_func1".into(),
                     "multi_test::main".into(),
                     "main".into(),
                     "__start".into(),
@@ -1102,7 +1102,10 @@ fn profiler() {
     let program = Program::load_elf(binary.user_elf, u32::MAX).unwrap();
 
     // Check that the addresses for these two functions point to the right place
-    for func_name in ["profile_test_func2", "profile_test_func3"] {
+    for func_name in [
+        "multi_test::profiler::profile_test_func2",
+        "multi_test::profiler::profile_test_func3",
+    ] {
         let test_func = test_samples
             .iter()
             .find(|sample| sample.frames[0].frame.name == func_name)

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -147,7 +147,7 @@ pub fn git_short_rev_parse(path: &Path, tag: &str) -> Result<String> {
     )
 }
 
-fn find_build_directories(build_dir: &Path) -> Result<(PathBuf, PathBuf)> {
+fn find_build_directories(build_dir: &Path) -> Result<(PathBuf, PathBuf, PathBuf)> {
     if !build_dir.exists() {
         return Err(RzupError::Other(
             "failed to find Rust toolchain build directory".into(),
@@ -156,14 +156,15 @@ fn find_build_directories(build_dir: &Path) -> Result<(PathBuf, PathBuf)> {
 
     for entry in std::fs::read_dir(build_dir)? {
         let entry = entry?;
-        let dir1 = entry.path().join("stage2");
-        let dir2 = entry.path().join("stage2-tools-bin");
-        if dir1.is_dir() && dir2.is_dir() && dir1.join("bin").is_dir() {
-            return Ok((dir1, dir2));
+        let stage2 = entry.path().join("stage2");
+        let stage2_tools_bin = entry.path().join("stage2-tools-bin");
+        let stage3 = entry.path().join("stage3");
+        if stage2.is_dir() && stage2_tools_bin.is_dir() && stage3.is_dir() {
+            return Ok((stage2, stage2_tools_bin, stage3));
         }
     }
     Err(RzupError::Other(
-        "failed to find Rust toolchain stage2 build directories".into(),
+        "failed to find Rust toolchain stage2/stage3 build directories".into(),
     ))
 }
 
@@ -215,10 +216,6 @@ pub fn build_rust_toolchain(
 
     std::fs::write(repo_dir.join("config.toml"), CONFIG_TOML)?;
 
-    env.emit(RzupEvent::BuildingRustToolchainUpdate {
-        message: "./x build".into(),
-    });
-
     let req = semver::VersionReq::parse(">=1.82.0")?;
     let lower_atomic = if req.matches(&version) {
         "-Cpasses=lower-atomic"
@@ -226,41 +223,37 @@ pub fn build_rust_toolchain(
         "-Cpasses=loweratomic"
     };
 
-    run_command_and_stream_output(
-        "./x",
-        &["build"],
-        Some(&repo_dir),
-        &[(
-            "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",
-            lower_atomic,
-        )],
-        |line| {
-            env.emit(RzupEvent::BuildingRustToolchainUpdate {
-                message: line.into(),
-            });
-        },
-    )
-    .map_err(|e| RzupError::Other(format!("failed to run Rust toolchain build: {e}")))?;
+    for stage in [None, Some(2), Some(3)] {
+        let mut args = vec!["build".into()];
+        if let Some(stage) = stage {
+            args.push("--stage".into());
+            args.push(stage.to_string());
+        }
 
-    env.emit(RzupEvent::BuildingRustToolchainUpdate {
-        message: "./x build --stage 2".into(),
-    });
+        env.emit(RzupEvent::BuildingRustToolchainUpdate {
+            message: format!("./x {}", args.join(" ")),
+        });
 
-    run_command_and_stream_output(
-        "./x",
-        &["build", "--stage", "2"],
-        Some(&repo_dir),
-        &[(
-            "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",
-            lower_atomic,
-        )],
-        |line| {
-            env.emit(RzupEvent::BuildingRustToolchainUpdate {
-                message: line.into(),
-            });
-        },
-    )
-    .map_err(|e| RzupError::Other(format!("failed to run Rust toolchain build --stage 2: {e}")))?;
+        run_command_and_stream_output(
+            "./x",
+            &args.iter().map(|a| a.as_ref()).collect::<Vec<_>>(),
+            Some(&repo_dir),
+            &[(
+                "CARGO_TARGET_RISCV32IM_RISC0_ZKVM_ELF_RUSTFLAGS",
+                lower_atomic,
+            )],
+            |line| {
+                env.emit(RzupEvent::BuildingRustToolchainUpdate {
+                    message: line.into(),
+                });
+            },
+        )
+        .map_err(|e| {
+            RzupError::Other(format!(
+                "failed to run Rust toolchain build stage={stage:?}: {e}"
+            ))
+        })?;
+    }
 
     env.emit(RzupEvent::BuildingRustToolchainUpdate {
         message: "installing".into(),
@@ -270,8 +263,17 @@ pub fn build_rust_toolchain(
         std::fs::create_dir_all(parent)?;
     }
 
-    let (stage2, stage2_tools) = find_build_directories(&repo_dir.join("build"))?;
+    let (stage2, stage2_tools, stage3) = find_build_directories(&repo_dir.join("build"))?;
     std::fs::rename(stage2, &dest_dir)?;
+
+    let riscv_libs = "lib/rustlib/riscv32im-risc0-zkvm-elf";
+
+    let riscv_libs_dest = dest_dir.join(riscv_libs);
+    if let Some(parent) = riscv_libs_dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    std::fs::rename(stage3.join(riscv_libs), riscv_libs_dest)?;
 
     for tool in std::fs::read_dir(stage2_tools)? {
         let tool = tool?;

--- a/rzup/src/lib.rs
+++ b/rzup/src/lib.rs
@@ -2438,6 +2438,7 @@ mod tests {
             #!/bin/bash
             mkdir -p build/foo/stage2/bin
             mkdir -p build/foo/stage2-tools-bin
+            mkdir -p build/foo/stage3/lib/rustlib/riscv32im-risc0-zkvm-elf
             touch build/foo/stage2/bin/rustc
             touch build/foo/stage2-tools-bin/cargo-fmt
             echo 'build output line 1'
@@ -2472,6 +2473,7 @@ mod tests {
             #!/bin/bash
             mkdir -p build/foo/stage2/bin
             mkdir -p build/foo/stage2-tools-bin
+            mkdir -p build/foo/stage3/lib/rustlib/riscv32im-risc0-zkvm-elf
             touch build/foo/stage2/bin/rustc
             touch build/foo/stage2-tools-bin/cargo-fmt
             touch build/foo/stage2-tools-bin/bar-fmt
@@ -2544,6 +2546,15 @@ mod tests {
                 },
                 RzupEvent::BuildingRustToolchainUpdate {
                     message: "./x build --stage 2".into(),
+                },
+                RzupEvent::BuildingRustToolchainUpdate {
+                    message: "build output line 1".into(),
+                },
+                RzupEvent::BuildingRustToolchainUpdate {
+                    message: "build output line 2".into(),
+                },
+                RzupEvent::BuildingRustToolchainUpdate {
+                    message: "./x build --stage 3".into(),
                 },
                 RzupEvent::BuildingRustToolchainUpdate {
                     message: "build output line 1".into(),
@@ -2662,8 +2673,8 @@ mod tests {
             .unwrap();
             let env = parse_env_output(&env_raw);
 
-            // two ./x invocations
-            assert_eq!(env.len(), 2);
+            // three ./x invocations
+            assert_eq!(env.len(), 3);
 
             for e in env {
                 assert_eq!(


### PR DESCRIPTION
This updates rzup to compile toolchains of a later Rust version.

This also fixes a warning seen from compiling guest code with Rust 1.88.0