### PR TITLE
Fix cargo risczero build for guests using bigint2

### DIFF
--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -23,7 +23,7 @@ clap-cargo = { version = "0.15.1", features = ["cargo_metadata"] }
 const_format = "0.2"
 hex = "0.4"
 regex = "1.11.1"
-risc0-build = { workspace = true }
+risc0-build = { workspace = true, features = ["unstable"] }
 risc0-r0vm = { workspace = true, optional = true }
 risc0-zkvm = { workspace = true, features = ["unstable"] }
 semver = "1"
@@ -58,7 +58,6 @@ experimental = [
   "dep:risc0-build",
   "dep:zip",
   "risc0-zkvm/prove",
-  "risc0-build/unstable",
 ]
 metal = ["risc0-zkvm/metal"]
 r0vm = ["dep:risc0-r0vm"]


### PR DESCRIPTION
Reported by bobafetdaor on Discord, `cargo risczero build` installed via `rzup` currently does not work to build guests that use `bigint2`. The issue is that the `unstable` flag is required on `risc0-build`, since this feature is still marked as `unstable` and a build-time env var needs to be set to enable it (see https://github.com/risc0/risc0/pull/2567).
