### PR TITLE
Fix broken documentation links in comments

### DIFF
--- a/risc0/sys/cxx/vendor/poolstl.hpp
+++ b/risc0/sys/cxx/vendor/poolstl.hpp
@@ -2111,7 +2111,7 @@ namespace std {
 
     /**
      * NOTE: Iterators are expected to be random access.
-     * See std::count_if https://en.cppreference.com/w/cpp/algorithm/count_if
+     * See std::count_if https://en.cppreference.com/w/cpp/algorithm/count.html
      */
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
     poolstl::internal::enable_if_poolstl_policy<ExecPolicy, typename iterator_traits<RandIt>::difference_type>

--- a/risc0/sys/cxx/vendor/poolstl.hpp
+++ b/risc0/sys/cxx/vendor/poolstl.hpp
@@ -2175,7 +2175,7 @@ namespace std {
 
     /**
      * NOTE: Iterators are expected to be random access.
-     * See std::find_if https://en.cppreference.com/w/cpp/algorithm/find_if
+     * See std::find_if https://en.cppreference.com/w/cpp/algorithm/find.html
      */
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
     poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>
@@ -2211,7 +2211,7 @@ namespace std {
 
     /**
      * NOTE: Iterators are expected to be random access.
-     * See std::find_if_not https://en.cppreference.com/w/cpp/algorithm/find_if_not
+     * See std::find_if_not https://en.cppreference.com/w/cpp/algorithm/find.html
      */
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
     poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>

--- a/risc0/zkp/src/prove/mod.rs
+++ b/risc0/zkp/src/prove/mod.rs
@@ -15,9 +15,9 @@
 //! Cryptographic algorithms for producing a ZK proof of compute
 //!
 //! This module is not typically used directly. Instead, we recommend the
-//! higher-level tools offered in [`risc0_zkvm::prove`].
+//! higher-level tools offered in [the risc0_zkvm documentation].
 //!
-//! [`risc0_zkvm::prove`]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/prove/index.html
+//! [the risc0_zkvm documentation]: https://docs.rs/risc0-zkvm/latest/risc0_zkvm/
 
 mod fri;
 mod merkle;


### PR DESCRIPTION
Updated outdated or incorrect std and crate documentation URLs in comments to point to the correct references:
- Replaced `count_if`, `find_if`, and `find_if_not` links with the accurate `count.html` and `find.html` references from cppreference.
- Updated the link in `prove/mod.rs` to refer to the main risc0_zkvm documentation page instead of a specific module.

These changes improve developer experience by ensuring that reference links are valid and point to the intended content.
