### PR TITLE
fix: correct typo in error message (stdout instead of stodout)

### DIFF
--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -81,7 +81,7 @@ pub fn run_command_and_stream_output(
 
             return Err(RzupError::Other(format!(
                 "Process `{cmd_str}` failed with status {status}\n\
-                stodout: {stdout}\n\
+                stdout: {stdout}\n\
                 stderr: {stderr}",
             )));
         }


### PR DESCRIPTION
Fixed a typo in the error message within the run_command_and_stream_output function:
the output stream is now correctly labeled as stdout instead of the incorrect stodout.
This improves the clarity and accuracy of error messages when external process execution fails.