### PR TITLE
Add a way to programmatically enable dev-mode.

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -262,7 +262,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "b9ba64266d85ed36df1811e5af90d84645286ad6f476853678cde15acea282fd",
+            "f079f261fa0e4e5b750edf0e2c2239572c42e075b24cba0fca04400850a4f406",
         );
     }
 }

--- a/risc0/r0vm/src/actors/worker.rs
+++ b/risc0/r0vm/src/actors/worker.rs
@@ -319,7 +319,7 @@ impl GpuProcessor {
         self.task_start(header.clone()).await?;
         let prover = Prover { delay: self.delay };
         let receipt = tokio::task::spawn_blocking(move || {
-            let ctx = VerifierContext::default();
+            let ctx = VerifierContext::default().with_dev_mode(prover.delay.is_some());
             prover
                 .get()?
                 .prove_segment_core(&ctx, *task.preflight_results)

--- a/risc0/r0vm/tests/dev_mode.rs
+++ b/risc0/r0vm/tests/dev_mode.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ fn run_dev_mode() -> Receipt {
 
 #[test]
 #[cfg(not(feature = "disable-dev-mode"))]
-fn dev_mode() {
+fn dev_mode_env_var() {
     let receipt = run_dev_mode();
     temp_env::with_var("RISC0_DEV_MODE", Some("1"), || {
         receipt.verify(risc0_zkvm_methods::MULTI_TEST_ID).unwrap();
@@ -51,13 +51,46 @@ fn dev_mode() {
 
 #[test]
 #[cfg(not(feature = "disable-dev-mode"))]
-fn dev_mode_verify_fail() {
+fn dev_mode_verify_fail_env_var() {
     let receipt = run_dev_mode();
     temp_env::with_var("RISC0_DEV_MODE", None::<&str>, || {
         receipt
             .verify(risc0_zkvm_methods::MULTI_TEST_ID)
             .expect_err("Expecting error");
     });
+}
+
+#[test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode_programatic() {
+    use risc0_zkvm::VerifierContext;
+
+    let receipt = run_dev_mode();
+    receipt
+        .verify_with_context(
+            &VerifierContext::default().with_dev_mode(true),
+            risc0_zkvm_methods::MULTI_TEST_ID,
+        )
+        .unwrap();
+
+    match receipt.inner {
+        risc0_zkvm::InnerReceipt::Fake { .. } => {}
+        _ => panic!("expected a fake receipt"),
+    }
+}
+
+#[test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode_verify_fail_programatic() {
+    use risc0_zkvm::VerifierContext;
+
+    let receipt = run_dev_mode();
+    receipt
+        .verify_with_context(
+            &VerifierContext::default().with_dev_mode(false),
+            risc0_zkvm_methods::MULTI_TEST_ID,
+        )
+        .expect_err("Expecting error");
 }
 
 #[test]

--- a/risc0/r0vm/tests/external_prover.rs
+++ b/risc0/r0vm/tests/external_prover.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ fn prove_nothing(opt: &ProverOpts) -> Result<Receipt> {
         .unwrap();
     let r0vm_path = cargo_bin("r0vm");
     let prover = ExternalProver::new("r0vm", r0vm_path);
-    let receipt = prover.prove(env, MULTI_TEST_ELF)?.receipt;
+    let receipt = prover.prove_with_opts(env, MULTI_TEST_ELF, opt)?.receipt;
     prover.compress(opt, &receipt)
 }
 
@@ -42,4 +42,14 @@ fn compressed_proof() {
     let receipt = prove_nothing(&ProverOpts::groth16()).unwrap();
     receipt.verify(MULTI_TEST_ID).unwrap();
     receipt.inner.groth16().unwrap();
+}
+
+#[test_log::test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode() {
+    use assert_matches::assert_matches;
+    use risc0_zkvm::InnerReceipt;
+
+    let receipt = prove_nothing(&ProverOpts::succinct().with_dev_mode(true)).unwrap();
+    assert_matches!(receipt.inner, InnerReceipt::Fake(_));
 }

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -292,6 +292,7 @@ impl TryFrom<pb::api::ProverOpts> for ProverOpts {
                 .max_segment_po2
                 .try_into()
                 .map_err(|_| malformed_err("ProverOpts.max_segment_po2"))?,
+            dev_mode: opts.is_dev_mode,
         })
     }
 }
@@ -304,6 +305,7 @@ impl From<ProverOpts> for pb::api::ProverOpts {
             receipt_kind: opts.receipt_kind as i32,
             control_ids: opts.control_ids.into_iter().map(Into::into).collect(),
             max_segment_po2: opts.max_segment_po2 as u64,
+            is_dev_mode: opts.dev_mode,
         }
     }
 }

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -429,7 +429,7 @@ impl Server {
                 .ok_or_else(|| malformed_err("ProveRequest.opts"))?
                 .try_into()?;
             let prover = get_prover_server(&opts)?;
-            let ctx = VerifierContext::default();
+            let ctx = VerifierContext::default().with_dev_mode(opts.dev_mode());
             let prove_info = prover.prove_with_ctx(env, &ctx, &bytes)?;
 
             let prove_info: pb::core::ProveInfo = prove_info.try_into()?;
@@ -480,7 +480,7 @@ impl Server {
             let segment: Segment = bincode::deserialize(&segment_bytes)?;
 
             let prover = get_prover_server(&opts)?;
-            let ctx = VerifierContext::default();
+            let ctx = VerifierContext::default().with_dev_mode(opts.dev_mode());
             let receipt = prover.prove_segment(&ctx, &segment)?;
 
             let receipt_pb: pb::core::SegmentReceipt = receipt.try_into()?;

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -19,9 +19,8 @@ use bonsai_sdk::blocking::Client;
 
 use super::Prover;
 use crate::{
-    compute_image_id, is_dev_mode, AssumptionReceipt, ExecutorEnv, InnerAssumptionReceipt,
-    InnerReceipt, ProveInfo, ProverOpts, Receipt, ReceiptKind, SessionStats, VerifierContext,
-    VERSION,
+    compute_image_id, AssumptionReceipt, ExecutorEnv, InnerAssumptionReceipt, InnerReceipt,
+    ProveInfo, ProverOpts, Receipt, ReceiptKind, SessionStats, VerifierContext, VERSION,
 };
 
 /// An implementation of a [Prover] that runs proof workloads via Bonsai.
@@ -230,7 +229,7 @@ impl Prover for BonsaiProver {
             // Compression is always a no-op in dev mode
             (InnerReceipt::Fake { .. }, _) => {
                 ensure!(
-                    is_dev_mode(),
+                    opts.dev_mode(),
                     "dev mode must be enabled to compress fake receipts"
                 );
                 Ok(receipt.clone())

--- a/risc0/zkvm/src/host/client/prove/external.rs
+++ b/risc0/zkvm/src/host/client/prove/external.rs
@@ -18,8 +18,8 @@ use anyhow::{ensure, Result};
 
 use super::{Executor, Prover, ProverOpts};
 use crate::{
-    host::api::AssetRequest, is_dev_mode, ApiClient, Asset, ExecutorEnv, InnerReceipt, ProveInfo,
-    Receipt, ReceiptKind, SessionInfo, VerifierContext,
+    host::api::AssetRequest, ApiClient, Asset, ExecutorEnv, InnerReceipt, ProveInfo, Receipt,
+    ReceiptKind, SessionInfo, VerifierContext,
 };
 
 /// An implementation of a [Prover] that runs proof workloads via an external
@@ -73,7 +73,7 @@ impl Prover for ExternalProver {
             // Compression is always a no-op in dev mode
             (InnerReceipt::Fake { .. }, _) => {
                 ensure!(
-                    is_dev_mode(),
+                    opts.dev_mode(),
                     "dev mode must be enabled to compress fake receipts"
                 );
                 Ok(receipt.clone())

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -242,6 +242,7 @@ message ProverOpts {
   ReceiptKind receipt_kind = 3;
   repeated base.Digest control_ids = 4;
   uint64 max_segment_po2 = 5;
+  bool is_dev_mode = 6;
 }
 
 enum ReceiptKind {

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -465,6 +465,8 @@ pub struct ProverOpts {
     pub control_ids: ::prost::alloc::vec::Vec<super::base::Digest>,
     #[prost(uint64, tag = "5")]
     pub max_segment_po2: u64,
+    #[prost(bool, tag = "6")]
+    pub is_dev_mode: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/risc0/zkvm/src/host/server/prove/dev_mode.rs
+++ b/risc0/zkvm/src/host/server/prove/dev_mode.rs
@@ -112,11 +112,18 @@ impl Default for DevModeProver {
 }
 
 impl ProverServer for DevModeProver {
-    fn prove_session(&self, _ctx: &VerifierContext, session: &Session) -> Result<ProveInfo> {
+    fn prove(&self, env: ExecutorEnv<'_>, elf: &[u8]) -> Result<ProveInfo> {
+        let ctx = VerifierContext::default().with_dev_mode(true);
+        self.prove_with_ctx(env, &ctx, elf)
+    }
+
+    fn prove_session(&self, ctx: &VerifierContext, session: &Session) -> Result<ProveInfo> {
         eprintln!(
             "WARNING: Proving in dev mode does not generate a valid receipt. \
             Receipts generated from this process are invalid and should never be used in production."
         );
+
+        ensure!(ctx.dev_mode(), ERR_DEV_MODE_DISABLED);
 
         ensure!(
             cfg!(not(feature = "disable-dev-mode")),
@@ -217,9 +224,10 @@ impl ProverServer for DevModeProver {
 
     fn prove_segment_core(
         &self,
-        _ctx: &VerifierContext,
+        ctx: &VerifierContext,
         preflight_results: PreflightResults,
     ) -> Result<SegmentReceipt> {
+        ensure!(ctx.dev_mode(), ERR_DEV_MODE_DISABLED);
         ensure!(
             cfg!(not(feature = "disable-dev-mode")),
             ERR_DEV_MODE_DISABLED
@@ -338,7 +346,8 @@ impl ProverServer for DevModeProver {
         Ok(fake_succinct_receipt())
     }
 
-    fn compress(&self, _opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
+    fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
+        ensure!(opts.dev_mode(), ERR_DEV_MODE_DISABLED);
         ensure!(
             cfg!(not(feature = "disable-dev-mode")),
             ERR_DEV_MODE_DISABLED

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -30,7 +30,6 @@ use risc0_zkp::hal::{CircuitHal, Hal};
 use self::{dev_mode::DevModeProver, prover_impl::ProverImpl};
 use crate::{
     host::prove_info::ProveInfo,
-    is_dev_mode,
     receipt::{
         CompositeReceipt, Groth16Receipt, Groth16ReceiptVerifierParameters, InnerAssumptionReceipt,
         InnerReceipt, SegmentReceipt, SuccinctReceipt,
@@ -227,7 +226,7 @@ pub trait ProverServer: private::Sealed {
             },
             InnerReceipt::Fake(_) => {
                 ensure!(
-                    is_dev_mode(),
+                    opts.dev_mode(),
                     "dev mode must be enabled to compress fake receipts"
                 );
                 Ok(receipt.clone())
@@ -259,10 +258,9 @@ impl Session {
     }
 }
 
-/// Select a [ProverServer] based on the specified [ProverOpts] and currently
-/// compiled features.
+/// Select a [ProverServer] based on the specified [ProverOpts].
 pub fn get_prover_server(opts: &ProverOpts) -> Result<Rc<dyn ProverServer>> {
-    if is_dev_mode() {
+    if opts.dev_mode() {
         eprintln!("WARNING: proving in dev mode. This will not generate valid, secure proofs.");
         return Ok(Rc::new(DevModeProver::new()));
     }

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -48,7 +48,7 @@ impl ProverImpl {
 
 impl ProverServer for ProverImpl {
     fn prove(&self, env: ExecutorEnv<'_>, elf: &[u8]) -> Result<ProveInfo> {
-        let ctx = VerifierContext::default();
+        let ctx = VerifierContext::default().with_dev_mode(self.opts.dev_mode());
         self.prove_with_ctx(env, &ctx, elf)
     }
 

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -625,11 +625,17 @@ mod docker {
         );
 
         let prover = DevModeProver::new();
-        let receipt = prover.compress(&ProverOpts::composite(), &fake).unwrap();
+        let receipt = prover
+            .compress(&ProverOpts::composite().with_dev_mode(true), &fake)
+            .unwrap();
         ensure_fake(receipt);
-        let receipt = prover.compress(&ProverOpts::succinct(), &fake).unwrap();
+        let receipt = prover
+            .compress(&ProverOpts::succinct().with_dev_mode(true), &fake)
+            .unwrap();
         ensure_fake(receipt);
-        let receipt = prover.compress(&ProverOpts::groth16(), &fake).unwrap();
+        let receipt = prover
+            .compress(&ProverOpts::groth16().with_dev_mode(true), &fake)
+            .unwrap();
         ensure_fake(receipt);
     }
 

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -183,19 +183,40 @@ pub fn get_version() -> Result<Version, semver::Error> {
 
 /// Returns `true` if dev mode is enabled.
 #[cfg(feature = "std")]
+#[deprecated(
+    note = "dev-mode can be enabled programatically, so this function is no longer authoritative. \
+            Use `ProverOpts::is_dev_mode` or `VerifierContext::is_dev_mode`"
+)]
 pub fn is_dev_mode() -> bool {
+    is_dev_mode_enabled_via_environment()
+}
+
+/// Returns `true` if the dev mode environment variable is enabled, the `disable-dev-mode` cfg flag
+/// is not set, and we are not being compiled as a guest inside the zkvm.
+#[cfg(feature = "std")]
+fn is_dev_mode_enabled_via_environment() -> bool {
     let is_env_set = std::env::var("RISC0_DEV_MODE")
         .ok()
         .map(|x| x.to_lowercase())
         .filter(|x| x == "1" || x == "true" || x == "yes")
         .is_some();
 
-    if cfg!(feature = "disable-dev-mode") && is_env_set {
+    let dev_mode_disabled = cfg!(feature = "disable-dev-mode");
+    let inside_zkvm = cfg!(target_os = "zkvm");
+
+    if dev_mode_disabled && is_env_set {
         panic!("zkVM: Inconsistent settings -- please resolve. \
             The RISC0_DEV_MODE environment variable is set but dev mode has been disabled by feature flag.");
     }
 
-    cfg!(not(feature = "disable-dev-mode")) && is_env_set
+    !dev_mode_disabled && !inside_zkvm && is_env_set
+}
+
+/// Returns `true` if the dev mode environment variable is enabled, the `disable-dev-mode` cfg flag
+/// is not set, and we are not being compiled as a guest inside the zkvm.
+#[cfg(not(feature = "std"))]
+fn is_dev_mode_enabled_via_environment() -> bool {
+    false
 }
 
 #[cfg(feature = "metal")]

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -330,7 +330,7 @@ impl InnerReceipt {
             Self::Composite(inner) => inner.verify_integrity_with_context(ctx),
             Self::Groth16(inner) => inner.verify_integrity_with_context(ctx),
             Self::Succinct(inner) => inner.verify_integrity_with_context(ctx),
-            Self::Fake(inner) => inner.verify_integrity(),
+            Self::Fake(inner) => inner.verify_integrity_with_context(ctx),
         }
     }
 
@@ -426,15 +426,25 @@ where
         }
     }
 
-    /// Pretend to verify the integrity of this receipt. If not in dev mode (i.e. the
-    /// RISC0_DEV_MODE environment variable is not set) this will always reject. When in dev mode,
-    /// this will always pass.
+    /// Old verify function, always returns [`VerificationError::InvalidProof`].
+    #[deprecated(note = "Use verify_integrity_with_context instead")]
     pub fn verify_integrity(&self) -> Result<(), VerificationError> {
-        #[cfg(all(feature = "std", not(target_os = "zkvm")))]
-        if crate::is_dev_mode() {
-            return Ok(());
-        }
         Err(VerificationError::InvalidProof)
+    }
+
+    /// Pretend to verify the integrity of this receipt. If not in dev mode (see
+    /// [`VerifierContext::with_dev_mode`], or the `RISC0_DEV_MODE` environment variable) this will
+    /// always reject. When in dev mode, this will always pass.
+    pub fn verify_integrity_with_context(
+        &self,
+        ctx: &VerifierContext,
+    ) -> Result<(), VerificationError> {
+        if ctx.dev_mode() {
+            assert!(cfg!(not(feature = "disable-dev-mode")));
+            Ok(())
+        } else {
+            Err(VerificationError::InvalidProof)
+        }
     }
 
     /// Prunes the claim, retaining its digest, and converts into a [FakeReceipt] with an unknown
@@ -591,7 +601,7 @@ impl InnerAssumptionReceipt {
             Self::Composite(inner) => inner.verify_integrity_with_context(ctx),
             Self::Groth16(inner) => inner.verify_integrity_with_context(ctx),
             Self::Succinct(inner) => inner.verify_integrity_with_context(ctx),
-            Self::Fake(inner) => inner.verify_integrity(),
+            Self::Fake(inner) => inner.verify_integrity_with_context(ctx),
         }
     }
 
@@ -686,6 +696,9 @@ pub struct VerifierContext {
 
     /// Parameters for verification of [Groth16Receipt].
     pub groth16_verifier_parameters: Option<Groth16ReceiptVerifierParameters>,
+
+    /// Whether or not dev-mode is enabled. If enabled, fake receipts will verify successfully.
+    pub(crate) dev_mode: bool,
 }
 
 impl VerifierContext {
@@ -696,6 +709,7 @@ impl VerifierContext {
             segment_verifier_parameters: None,
             succinct_verifier_parameters: None,
             groth16_verifier_parameters: None,
+            dev_mode: crate::is_dev_mode_enabled_via_environment(),
         }
     }
 
@@ -722,6 +736,7 @@ impl VerifierContext {
             groth16_verifier_parameters: Some(Groth16ReceiptVerifierParameters::from_max_po2(
                 po2_max,
             )),
+            dev_mode: crate::is_dev_mode_enabled_via_environment(),
         }
     }
 
@@ -765,6 +780,21 @@ impl VerifierContext {
         self
     }
 
+    /// Return [VerifierContext] with is_dev_mode enabled or disabled.
+    pub fn with_dev_mode(mut self, dev_mode: bool) -> Self {
+        if cfg!(feature = "disable-dev-mode") && dev_mode {
+            panic!("zkVM: Inconsistent settings -- please resolve. \
+                The RISC0_DEV_MODE environment variable is set but dev mode has been disabled by feature flag.");
+        }
+        self.dev_mode = dev_mode;
+        self
+    }
+
+    /// Returns `true` if dev-mode is enabled.
+    pub fn dev_mode(&self) -> bool {
+        self.dev_mode
+    }
+
     /// Parameters for verification of [CompositeReceipt].
     ///
     /// Made up of the verifier parameters for each other receipt type. Returns none if any of the
@@ -785,6 +815,7 @@ impl Default for VerifierContext {
             segment_verifier_parameters: Some(Default::default()),
             succinct_verifier_parameters: Some(Default::default()),
             groth16_verifier_parameters: Some(Default::default()),
+            dev_mode: crate::is_dev_mode_enabled_via_environment(),
         }
     }
 }


### PR DESCRIPTION
This PR adds a way to programmatically enable dev-mode. It does this with the following changes

- Add new `with_dev_mode` builder function to `ProverOpts` and `VerifierContext`
    - controls new `dev_mode` state in respective structs
- New `dev_mode` (private) state in `ProverOpts`
    - defaults to previous value determination about dev-mode (env-var + cfg flags)
    - allows the dev-mode prover to be selected
    - forwards on to `dev_mode` state in `VerifierContext`
- New `dev_mode` (private) state in `VerifierContext`
    - defaults to previous value determination about dev-mode (env-var + cfg flags)
    - allows fake receipts to verify successfully
- New `dev_mode` field in proto-buf `ProverOpts` for client/server
    - Allows `dev_mode` selection to flow into the `r0vm` server
- `risc0_zkvm::is_dev_mode` deprecated in favor of new `ProverOpts::dev_mode` and `VerifierContext::dev_mode`
    - Programatic enabling now means there is no global way to know if dev-mode is enabled
- `FakeRecipt::verifty_integrity` is deprecated and now always errors
    - New `FakeReceipt::verify_integrity_with_context` must be used so it can read the dev-mode state