### PR TITLE
Update GitHub Actions: Bump checkout action to v5

### DIFF
--- a/.github/workflows/groth16_proof.yml
+++ b/.github/workflows/groth16_proof.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       check: ${{ steps.filter.outputs.check }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
@@ -35,7 +35,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Go 1.23
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION


---



**Description:**  
- Upgraded `actions/checkout` from v4 to v5 in the `.github/workflows/groth16_proof.yml` workflow.
- Ensures compatibility with the latest features and security updates.


---

