### PR TITLE
Optimize image processing loop order for better cache locality

### DIFF
--- a/examples/waldo/core/src/image.rs
+++ b/examples/waldo/core/src/image.rs
@@ -71,8 +71,8 @@ impl ImageMask {
         assert_eq!(image.dimensions(), self.0.dimensions());
 
         let zero_pixel: Rgb<u8> = [0, 0, 0].into();
-        for x in 0..image.width() {
-            for y in 0..image.height() {
+        for y in 0..image.height() {
+            for x in 0..image.width() {
                 let m = self.0.get_pixel(x, y);
                 if m.0[0] == 0 {
                     image.put_pixel(x, y, zero_pixel);


### PR DESCRIPTION
Changed the nested loops in ImageMask.apply() method from column-major (x then y) to row-major (y then x) iteration pattern. This improves memory access patterns as images are typically stored in row-major order in memory, resulting in better cache locality and potentially significant performance improvements when processing large images. The functional behavior remains unchanged.