### PR TITLE
fix duplicate in Update ceremony.Dockerfile

### DIFF
--- a/groth16_proof/docker/ceremony.Dockerfile
+++ b/groth16_proof/docker/ceremony.Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /src/
 RUN apt -qq update && \
   apt install -y -q apt-transport-https build-essential clang cmake curl gnupg libgmp-dev libsodium-dev m4 nasm nlohmann-json3-dev npm
 
-WORKDIR /src/
-
 # Build and install circom
 RUN git clone https://github.com/iden3/circom.git && \
   cd circom && \
@@ -21,7 +19,6 @@ ENV CXX=clang++
 # Cache ahead of the larger build process
 FROM dependencies AS builder
 
-WORKDIR /src/
 COPY groth16/risc0.circom ./groth16/risc0.circom
 COPY groth16/stark_verify.circom ./groth16/stark_verify.circom
 


### PR DESCRIPTION
Repeating WORKDIR /src/ multiple times in a Dockerfile is not technically an error — Docker allows multiple WORKDIR instructions and will simply change the working directory each time.

However:

Repeating the same WORKDIR instruction consecutively is unnecessary and redundant.

It clutters the Dockerfile and may confuse readers, making it seem like something is being overridden or forgotten.

For clarity and maintainability, it’s better to set WORKDIR /src/ once and avoid repeating it.

So, while having it three times won’t break your build, it’s cleaner and more efficient to keep only one WORKDIR /src/ and remove the duplicates.