### PR TITLE
fix Update prover.Dockerfile

### DIFF
--- a/groth16_proof/docker/prover.Dockerfile
+++ b/groth16_proof/docker/prover.Dockerfile
@@ -7,7 +7,10 @@ FROM rust:1.84-bookworm AS circom
 WORKDIR /usr/src/
 
 # Clone and build Circom version 2.2.2 from a specific commit
-ADD https://github.com/iden3/circom.git#e410b0d5cd2948a15931df0bc50d79ce56fa8c32 circom
+RUN git clone https://github.com/iden3/circom.git && \
+    cd circom && \
+    git checkout e410b0d5cd2948a15931df0bc50d79ce56fa8c32 && \
+    cargo install --path circom
 RUN (cd circom; cargo install --path circom)
 
 # Add the required circuit files


### PR DESCRIPTION
ADD https://github.com/iden3/circom.git#e410b0d5cd2948a15931df0bc50d79ce56fa8c32 circom

 This doesn't clone the Git repository as expected. Instead, it fetches the raw content (likely an HTML page or archive), which results in a broken circom directory. Consequently, the following cargo install --path circom fails due to missing Cargo.toml.

Replaced the ADD line with a proper git clone and git checkout: RUN git clone https://github.com/iden3/circom.git && \
    cd circom && \
    git checkout e410b0d5cd2948a15931df0bc50d79ce56fa8c32 && \
    cargo install --path circom

This ensures:

The correct commit is checked out

The Circom Rust project is valid and contains the necessary files

cargo install works as expected