### PR TITLE
fix(blst): replace non-existent rand::rng() with rand::thread_rng()

### DIFF
--- a/risc0/zkvm/methods/cpp-crates/src/bin/blst.rs
+++ b/risc0/zkvm/methods/cpp-crates/src/bin/blst.rs
@@ -17,7 +17,7 @@ use rand::RngCore;
 use risc0_zkvm::guest::env;
 
 fn main() {
-    let mut rng = rand::rng();
+    let mut rng = rand::thread_rng();
     let mut ikm = [0u8; 32];
     rng.fill_bytes(&mut ikm);
 


### PR DESCRIPTION
The previous implementation used rand::rng(), which does not exist in the rand crate API.
This caused a compilation error and prevented the code from building.

This commit replaces rand::rng() with rand::thread_rng(), which is the standard and recommended way to obtain a random number generator in Rust for most use cases.

No other changes were made. This fix ensures compatibility with the rand crate and restores correct functionality.