### PR TITLE
release-2.3: Backports and Version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ permissions:
 env:
   RISC0_RUST_TOOLCHAIN_VERSION: 1.85.0
   RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
-  TAG: v2.2.0
-  VERSION: "2.2.0"
+  TAG: v2.3.0
+  VERSION: 2.3.0
 
 jobs:
   release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5855,6 +5861,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "assert_matches",
  "bincode",
  "bytemuck",
  "clap 4.5.32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-risczero"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5604,7 +5604,7 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "anyhow",
  "clap 4.5.32",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5856,7 +5856,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-r0vm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ repository = "https://github.com/risc0/risc0/"
 bonsai-sdk = { version = "1.4.0", default-features = false, path = "bonsai/sdk" }
 hotbench = { path = "tools/hotbench" }
 metal = "0.29"
-risc0-bigint2 = { version = "1.4.4", default-features = false, path = "risc0/bigint2" }
+risc0-bigint2 = { version = "1.4.5", default-features = false, path = "risc0/bigint2" }
 risc0-binfmt = { version = "2.0.2", default-features = false, path = "risc0/binfmt" }
-risc0-build = { version = "2.2.0", default-features = false, path = "risc0/build" }
+risc0-build = { version = "2.3.0", default-features = false, path = "risc0/build" }
 risc0-build-kernel = { version = "2.0.0", default-features = false, path = "risc0/build_kernel" }
 risc0-circuit-keccak = { version = "3.0.0", default-features = false, path = "risc0/circuit/keccak" }
 risc0-circuit-keccak-sys = { version = "3.0.0", default-features = false, path = "risc0/circuit/keccak-sys" }
@@ -56,11 +56,11 @@ risc0-circuit-rv32im = { version = "3.0.0", default-features = false, path = "ri
 risc0-circuit-rv32im-sys = { version = "3.0.0", default-features = false, path = "risc0/circuit/rv32im-sys" }
 risc0-core = { version = "2.0.0", default-features = false, path = "risc0/core" }
 risc0-groth16 = { version = "2.0.2", default-features = false, path = "risc0/groth16" }
-risc0-r0vm = { version = "2.2.0", default-features = false, path = "risc0/r0vm" }
+risc0-r0vm = { version = "2.3.0", default-features = false, path = "risc0/r0vm" }
 risc0-sys = { version = "1.4.0", default-features = false, path = "risc0/sys" }
 risc0-zkp = { version = "2.0.2", default-features = false, path = "risc0/zkp" }
 risc0-zkos-v1compat = { version = "2.0.1", path = "risc0/zkos/v1compat" }
-risc0-zkvm = { version = "2.2.0", default-features = false, path = "risc0/zkvm" }
+risc0-zkvm = { version = "2.3.0", default-features = false, path = "risc0/zkvm" }
 risc0-zkvm-platform = { version = "2.0.3", default-features = false, path = "risc0/zkvm/platform" }
 rzup = { version = "0.4.1", default-features = false, path = "rzup" }
 sppark = "0.1.10"

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/benchmarks/methods/guest/Cargo.lock
+++ b/benchmarks/methods/guest/Cargo.lock
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/bento/crates/api/src/lib.rs
+++ b/bento/crates/api/src/lib.rs
@@ -247,7 +247,8 @@ impl AppState {
 
 // TODO: Add authn/z to get a userID
 const USER_ID: &str = "default_user";
-const MAX_UPLOAD_SIZE: usize = 250 * 1024 * 1024; // 250 mb
+// No limit on upload size given API is trusted.
+const MAX_UPLOAD_SIZE: usize = usize::MAX;
 
 const IMAGE_UPLOAD_PATH: &str = "/images/upload/:image_id";
 async fn image_upload(

--- a/bento/crates/sample-guest/methods/guest/Cargo.lock
+++ b/bento/crates/sample-guest/methods/guest/Cargo.lock
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/bento/crates/workflow-common/src/s3.rs
+++ b/bento/crates/workflow-common/src/s3.rs
@@ -62,7 +62,9 @@ impl S3Client {
         let client = aws_sdk_s3::Client::from_conf(s3_config);
 
         // Attempt to provision the bucket if it does not exist
-        let cfg = CreateBucketConfiguration::builder().build();
+        let cfg = CreateBucketConfiguration::builder()
+            .location_constraint(MOCK_REGION.into())
+            .build();
         let res = client
             .create_bucket()
             .create_bucket_configuration(cfg)

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",

--- a/examples/bevy/methods/guest/Cargo.lock
+++ b/examples/bevy/methods/guest/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/bls12_381/methods/guest/Cargo.lock
+++ b/examples/bls12_381/methods/guest/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/bn254/methods/guest/Cargo.lock
+++ b/examples/bn254/methods/guest/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/c-kzg/methods/guest/Cargo.lock
+++ b/examples/c-kzg/methods/guest/Cargo.lock
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/chess/methods/guest/Cargo.lock
+++ b/examples/chess/methods/guest/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/digital-signature/methods/guest/Cargo.lock
+++ b/examples/digital-signature/methods/guest/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/ecdsa/k256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/k256/methods/guest/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/ecdsa/p256/methods/guest/Cargo.lock
+++ b/examples/ecdsa/p256/methods/guest/Cargo.lock
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/groth16-verifier/methods/guest/Cargo.lock
+++ b/examples/groth16-verifier/methods/guest/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/hello-world/methods/guest/Cargo.lock
+++ b/examples/hello-world/methods/guest/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/json/methods/guest/Cargo.lock
+++ b/examples/json/methods/guest/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/jwt-validator/methods/guest/Cargo.lock
+++ b/examples/jwt-validator/methods/guest/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/keccak/methods/guest/Cargo.lock
+++ b/examples/keccak/methods/guest/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/password-checker/methods/guest/Cargo.lock
+++ b/examples/password-checker/methods/guest/Cargo.lock
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/profiling/methods/guest/Cargo.lock
+++ b/examples/profiling/methods/guest/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/prorata/methods/guest/Cargo.lock
+++ b/examples/prorata/methods/guest/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/sha/methods/guest/Cargo.lock
+++ b/examples/sha/methods/guest/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/smartcore-ml/methods/guest/Cargo.lock
+++ b/examples/smartcore-ml/methods/guest/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/voting-machine/methods/guest/Cargo.lock
+++ b/examples/voting-machine/methods/guest/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/waldo/methods/guest/Cargo.lock
+++ b/examples/waldo/methods/guest/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/wasm/methods/guest/Cargo.lock
+++ b/examples/wasm/methods/guest/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/wordle/methods/guest/Cargo.lock
+++ b/examples/wordle/methods/guest/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/examples/xgboost/methods/guest/Cargo.lock
+++ b/examples/xgboost/methods/guest/Cargo.lock
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-bigint2"
 description = "RISC Zero's Big Integer Accelerator"
-version = "1.4.4"
+version = "1.4.5"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/bigint2/methods/guest/Cargo.lock
+++ b/risc0/bigint2/methods/guest/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint",
@@ -1048,7 +1048,7 @@ dependencies = [
  "k256",
  "num-bigint",
  "num-bigint-dig",
- "risc0-bigint2 1.4.4",
+ "risc0-bigint2 1.4.5",
  "risc0-zkvm",
 ]
 
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-build"
 description = "RISC Zero zero-knowledge VM build tool"
-version = "2.2.0"
+version = "2.3.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -268,7 +268,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "078b0420c55e6f1d128d241e0cf20fda025c3fd1e05312703d8515e38a77ef28",
+            "5cbf3cf968de62a97e8a8d9d5127639f4ce5732411073af9790faabb1001f1b6",
         );
     }
 }

--- a/risc0/cargo-risczero/Cargo.toml
+++ b/risc0/cargo-risczero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-risczero"
-version = "2.2.0"
+version = "2.3.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/circuit/keccak/methods/guest/Cargo.lock
+++ b/risc0/circuit/keccak/methods/guest/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1.0"
 assert_cmd = "2.0"
 assert_fs = "1.0"
+assert_matches = "1.5"
 risc0-zkvm-methods = { path = "../zkvm/methods" }
 temp-env = "0.3"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-r0vm"
 description = "RISC Zero zero-knowledge VM executable"
-version = "2.2.0"
+version = "2.3.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/r0vm/tests/dev_mode.rs
+++ b/risc0/r0vm/tests/dev_mode.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ fn run_dev_mode() -> Receipt {
 
 #[test]
 #[cfg(not(feature = "disable-dev-mode"))]
-fn dev_mode() {
+fn dev_mode_env_var() {
     let receipt = run_dev_mode();
     temp_env::with_var("RISC0_DEV_MODE", Some("1"), || {
         receipt.verify(risc0_zkvm_methods::MULTI_TEST_ID).unwrap();
@@ -51,13 +51,46 @@ fn dev_mode() {
 
 #[test]
 #[cfg(not(feature = "disable-dev-mode"))]
-fn dev_mode_verify_fail() {
+fn dev_mode_verify_fail_env_var() {
     let receipt = run_dev_mode();
     temp_env::with_var("RISC0_DEV_MODE", None::<&str>, || {
         receipt
             .verify(risc0_zkvm_methods::MULTI_TEST_ID)
             .expect_err("Expecting error");
     });
+}
+
+#[test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode_programatic() {
+    use risc0_zkvm::VerifierContext;
+
+    let receipt = run_dev_mode();
+    receipt
+        .verify_with_context(
+            &VerifierContext::default().with_dev_mode(true),
+            risc0_zkvm_methods::MULTI_TEST_ID,
+        )
+        .unwrap();
+
+    match receipt.inner {
+        risc0_zkvm::InnerReceipt::Fake { .. } => {}
+        _ => panic!("expected a fake receipt"),
+    }
+}
+
+#[test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode_verify_fail_programatic() {
+    use risc0_zkvm::VerifierContext;
+
+    let receipt = run_dev_mode();
+    receipt
+        .verify_with_context(
+            &VerifierContext::default().with_dev_mode(false),
+            risc0_zkvm_methods::MULTI_TEST_ID,
+        )
+        .expect_err("Expecting error");
 }
 
 #[test]

--- a/risc0/r0vm/tests/external_prover.rs
+++ b/risc0/r0vm/tests/external_prover.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ fn prove_nothing(opt: &ProverOpts) -> Result<Receipt> {
         .unwrap();
     let r0vm_path = cargo_bin("r0vm");
     let prover = ExternalProver::new("r0vm", r0vm_path);
-    let receipt = prover.prove(env, MULTI_TEST_ELF)?.receipt;
+    let receipt = prover.prove_with_opts(env, MULTI_TEST_ELF, opt)?.receipt;
     prover.compress(opt, &receipt)
 }
 
@@ -42,4 +42,14 @@ fn compressed_proof() {
     let receipt = prove_nothing(&ProverOpts::groth16()).unwrap();
     receipt.verify(MULTI_TEST_ID).unwrap();
     receipt.inner.groth16().unwrap();
+}
+
+#[test_log::test]
+#[cfg(not(feature = "disable-dev-mode"))]
+fn dev_mode() {
+    use assert_matches::assert_matches;
+    use risc0_zkvm::InnerReceipt;
+
+    let receipt = prove_nothing(&ProverOpts::succinct().with_dev_mode(true)).unwrap();
+    assert_matches!(receipt.inner, InnerReceipt::Fake(_));
 }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-zkvm"
 description = "RISC Zero zero-knowledge VM"
-version = "2.2.0"
+version = "2.3.0"
 edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/risc0/zkvm/methods/cfg/Cargo.lock
+++ b/risc0/zkvm/methods/cfg/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/cpp-crates/Cargo.lock
+++ b/risc0/zkvm/methods/cpp-crates/Cargo.lock
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/env/Cargo.lock
+++ b/risc0/zkvm/methods/env/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/heap/Cargo.lock
+++ b/risc0/zkvm/methods/heap/Cargo.lock
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/rand/Cargo.lock
+++ b/risc0/zkvm/methods/rand/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/rand2/Cargo.lock
+++ b/risc0/zkvm/methods/rand2/Cargo.lock
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/risc0/zkvm/src/host/api/convert.rs
+++ b/risc0/zkvm/src/host/api/convert.rs
@@ -292,6 +292,7 @@ impl TryFrom<pb::api::ProverOpts> for ProverOpts {
                 .max_segment_po2
                 .try_into()
                 .map_err(|_| malformed_err("ProverOpts.max_segment_po2"))?,
+            dev_mode: opts.is_dev_mode,
         })
     }
 }
@@ -304,6 +305,7 @@ impl From<ProverOpts> for pb::api::ProverOpts {
             receipt_kind: opts.receipt_kind as i32,
             control_ids: opts.control_ids.into_iter().map(Into::into).collect(),
             max_segment_po2: opts.max_segment_po2 as u64,
+            is_dev_mode: opts.dev_mode,
         }
     }
 }

--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -429,7 +429,7 @@ impl Server {
                 .ok_or_else(|| malformed_err("ProveRequest.opts"))?
                 .try_into()?;
             let prover = get_prover_server(&opts)?;
-            let ctx = VerifierContext::default();
+            let ctx = VerifierContext::default().with_dev_mode(opts.dev_mode());
             let prove_info = prover.prove_with_ctx(env, &ctx, &bytes)?;
 
             let prove_info: pb::core::ProveInfo = prove_info.try_into()?;
@@ -480,7 +480,7 @@ impl Server {
             let segment: Segment = bincode::deserialize(&segment_bytes)?;
 
             let prover = get_prover_server(&opts)?;
-            let ctx = VerifierContext::default();
+            let ctx = VerifierContext::default().with_dev_mode(opts.dev_mode());
             let receipt = prover.prove_segment(&ctx, &segment)?;
 
             let receipt_pb: pb::core::SegmentReceipt = receipt.try_into()?;

--- a/risc0/zkvm/src/host/client/prove/bonsai.rs
+++ b/risc0/zkvm/src/host/client/prove/bonsai.rs
@@ -19,9 +19,8 @@ use bonsai_sdk::blocking::Client;
 
 use super::Prover;
 use crate::{
-    compute_image_id, is_dev_mode, AssumptionReceipt, ExecutorEnv, InnerAssumptionReceipt,
-    InnerReceipt, ProveInfo, ProverOpts, Receipt, ReceiptKind, SessionStats, VerifierContext,
-    VERSION,
+    compute_image_id, AssumptionReceipt, ExecutorEnv, InnerAssumptionReceipt, InnerReceipt,
+    ProveInfo, ProverOpts, Receipt, ReceiptKind, SessionStats, VerifierContext, VERSION,
 };
 
 /// An implementation of a [Prover] that runs proof workloads via Bonsai.
@@ -230,7 +229,7 @@ impl Prover for BonsaiProver {
             // Compression is always a no-op in dev mode
             (InnerReceipt::Fake { .. }, _) => {
                 ensure!(
-                    is_dev_mode(),
+                    opts.dev_mode(),
                     "dev mode must be enabled to compress fake receipts"
                 );
                 Ok(receipt.clone())

--- a/risc0/zkvm/src/host/client/prove/external.rs
+++ b/risc0/zkvm/src/host/client/prove/external.rs
@@ -18,8 +18,8 @@ use anyhow::{ensure, Result};
 
 use super::{Executor, Prover, ProverOpts};
 use crate::{
-    host::api::AssetRequest, is_dev_mode, ApiClient, Asset, ExecutorEnv, InnerReceipt, ProveInfo,
-    Receipt, ReceiptKind, SessionInfo, VerifierContext,
+    host::api::AssetRequest, ApiClient, Asset, ExecutorEnv, InnerReceipt, ProveInfo, Receipt,
+    ReceiptKind, SessionInfo, VerifierContext,
 };
 
 /// An implementation of a [Prover] that runs proof workloads via an external
@@ -73,7 +73,7 @@ impl Prover for ExternalProver {
             // Compression is always a no-op in dev mode
             (InnerReceipt::Fake { .. }, _) => {
                 ensure!(
-                    is_dev_mode(),
+                    opts.dev_mode(),
                     "dev mode must be enabled to compress fake receipts"
                 );
                 Ok(receipt.clone())

--- a/risc0/zkvm/src/host/protos/api.proto
+++ b/risc0/zkvm/src/host/protos/api.proto
@@ -242,6 +242,7 @@ message ProverOpts {
   ReceiptKind receipt_kind = 3;
   repeated base.Digest control_ids = 4;
   uint64 max_segment_po2 = 5;
+  bool is_dev_mode = 6;
 }
 
 enum ReceiptKind {

--- a/risc0/zkvm/src/host/protos/api.rs
+++ b/risc0/zkvm/src/host/protos/api.rs
@@ -465,6 +465,8 @@ pub struct ProverOpts {
     pub control_ids: ::prost::alloc::vec::Vec<super::base::Digest>,
     #[prost(uint64, tag = "5")]
     pub max_segment_po2: u64,
+    #[prost(bool, tag = "6")]
+    pub is_dev_mode: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/risc0/zkvm/src/host/server/prove/mod.rs
+++ b/risc0/zkvm/src/host/server/prove/mod.rs
@@ -30,7 +30,6 @@ use risc0_zkp::hal::{CircuitHal, Hal};
 use self::{dev_mode::DevModeProver, prover_impl::ProverImpl};
 use crate::{
     host::prove_info::ProveInfo,
-    is_dev_mode,
     receipt::{
         CompositeReceipt, Groth16Receipt, Groth16ReceiptVerifierParameters, InnerAssumptionReceipt,
         InnerReceipt, SegmentReceipt, SuccinctReceipt,
@@ -214,7 +213,7 @@ pub trait ProverServer: private::Sealed {
             },
             InnerReceipt::Fake(_) => {
                 ensure!(
-                    is_dev_mode(),
+                    opts.dev_mode(),
                     "dev mode must be enabled to compress fake receipts"
                 );
                 Ok(receipt.clone())
@@ -246,10 +245,9 @@ impl Session {
     }
 }
 
-/// Select a [ProverServer] based on the specified [ProverOpts] and currently
-/// compiled features.
+/// Select a [ProverServer] based on the specified [ProverOpts].
 pub fn get_prover_server(opts: &ProverOpts) -> Result<Rc<dyn ProverServer>> {
-    if is_dev_mode() {
+    if opts.dev_mode() {
         eprintln!("WARNING: proving in dev mode. This will not generate valid, secure proofs.");
         return Ok(Rc::new(DevModeProver));
     }

--- a/risc0/zkvm/src/host/server/prove/prover_impl.rs
+++ b/risc0/zkvm/src/host/server/prove/prover_impl.rs
@@ -48,7 +48,7 @@ impl ProverImpl {
 
 impl ProverServer for ProverImpl {
     fn prove(&self, env: ExecutorEnv<'_>, elf: &[u8]) -> Result<ProveInfo> {
-        let ctx = VerifierContext::default();
+        let ctx = VerifierContext::default().with_dev_mode(self.opts.dev_mode());
         self.prove_with_ctx(env, &ctx, elf)
     }
 

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -597,11 +597,17 @@ mod docker {
         );
 
         let prover = DevModeProver;
-        let receipt = prover.compress(&ProverOpts::composite(), &fake).unwrap();
+        let receipt = prover
+            .compress(&ProverOpts::composite().with_dev_mode(true), &fake)
+            .unwrap();
         ensure_fake(receipt);
-        let receipt = prover.compress(&ProverOpts::succinct(), &fake).unwrap();
+        let receipt = prover
+            .compress(&ProverOpts::succinct().with_dev_mode(true), &fake)
+            .unwrap();
         ensure_fake(receipt);
-        let receipt = prover.compress(&ProverOpts::groth16(), &fake).unwrap();
+        let receipt = prover
+            .compress(&ProverOpts::groth16().with_dev_mode(true), &fake)
+            .unwrap();
         ensure_fake(receipt);
     }
 

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -180,19 +180,40 @@ pub fn get_version() -> Result<Version, semver::Error> {
 
 /// Returns `true` if dev mode is enabled.
 #[cfg(feature = "std")]
+#[deprecated(
+    note = "dev-mode can be enabled programatically, so this function is no longer authoritative. \
+            Use `ProverOpts::is_dev_mode` or `VerifierContext::is_dev_mode`"
+)]
 pub fn is_dev_mode() -> bool {
+    is_dev_mode_enabled_via_environment()
+}
+
+/// Returns `true` if the dev mode environment variable is enabled, the `disable-dev-mode` cfg flag
+/// is not set, and we are not being compiled as a guest inside the zkvm.
+#[cfg(feature = "std")]
+fn is_dev_mode_enabled_via_environment() -> bool {
     let is_env_set = std::env::var("RISC0_DEV_MODE")
         .ok()
         .map(|x| x.to_lowercase())
         .filter(|x| x == "1" || x == "true" || x == "yes")
         .is_some();
 
-    if cfg!(feature = "disable-dev-mode") && is_env_set {
+    let dev_mode_disabled = cfg!(feature = "disable-dev-mode");
+    let inside_zkvm = cfg!(target_os = "zkvm");
+
+    if dev_mode_disabled && is_env_set {
         panic!("zkVM: Inconsistent settings -- please resolve. \
             The RISC0_DEV_MODE environment variable is set but dev mode has been disabled by feature flag.");
     }
 
-    cfg!(not(feature = "disable-dev-mode")) && is_env_set
+    !dev_mode_disabled && !inside_zkvm && is_env_set
+}
+
+/// Returns `true` if the dev mode environment variable is enabled, the `disable-dev-mode` cfg flag
+/// is not set, and we are not being compiled as a guest inside the zkvm.
+#[cfg(not(feature = "std"))]
+fn is_dev_mode_enabled_via_environment() -> bool {
+    false
 }
 
 #[cfg(feature = "metal")]

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -331,7 +331,7 @@ impl InnerReceipt {
             Self::Composite(inner) => inner.verify_integrity_with_context(ctx),
             Self::Groth16(inner) => inner.verify_integrity_with_context(ctx),
             Self::Succinct(inner) => inner.verify_integrity_with_context(ctx),
-            Self::Fake(inner) => inner.verify_integrity(),
+            Self::Fake(inner) => inner.verify_integrity_with_context(ctx),
         }
     }
 
@@ -427,15 +427,25 @@ where
         }
     }
 
-    /// Pretend to verify the integrity of this receipt. If not in dev mode (i.e. the
-    /// RISC0_DEV_MODE environment variable is not set) this will always reject. When in dev mode,
-    /// this will always pass.
+    /// Old verify function, always returns [`VerificationError::InvalidProof`].
+    #[deprecated(note = "Use verify_integrity_with_context instead")]
     pub fn verify_integrity(&self) -> Result<(), VerificationError> {
-        #[cfg(all(feature = "std", not(target_os = "zkvm")))]
-        if crate::is_dev_mode() {
-            return Ok(());
-        }
         Err(VerificationError::InvalidProof)
+    }
+
+    /// Pretend to verify the integrity of this receipt. If not in dev mode (see
+    /// [`VerifierContext::with_dev_mode`], or the `RISC0_DEV_MODE` environment variable) this will
+    /// always reject. When in dev mode, this will always pass.
+    pub fn verify_integrity_with_context(
+        &self,
+        ctx: &VerifierContext,
+    ) -> Result<(), VerificationError> {
+        if ctx.dev_mode() {
+            assert!(cfg!(not(feature = "disable-dev-mode")));
+            Ok(())
+        } else {
+            Err(VerificationError::InvalidProof)
+        }
     }
 
     /// Prunes the claim, retaining its digest, and converts into a [FakeReceipt] with an unknown
@@ -592,7 +602,7 @@ impl InnerAssumptionReceipt {
             Self::Composite(inner) => inner.verify_integrity_with_context(ctx),
             Self::Groth16(inner) => inner.verify_integrity_with_context(ctx),
             Self::Succinct(inner) => inner.verify_integrity_with_context(ctx),
-            Self::Fake(inner) => inner.verify_integrity(),
+            Self::Fake(inner) => inner.verify_integrity_with_context(ctx),
         }
     }
 
@@ -687,6 +697,9 @@ pub struct VerifierContext {
 
     /// Parameters for verification of [Groth16Receipt].
     pub groth16_verifier_parameters: Option<Groth16ReceiptVerifierParameters>,
+
+    /// Whether or not dev-mode is enabled. If enabled, fake receipts will verify successfully.
+    pub(crate) dev_mode: bool,
 }
 
 impl VerifierContext {
@@ -697,6 +710,7 @@ impl VerifierContext {
             segment_verifier_parameters: None,
             succinct_verifier_parameters: None,
             groth16_verifier_parameters: None,
+            dev_mode: crate::is_dev_mode_enabled_via_environment(),
         }
     }
 
@@ -723,6 +737,7 @@ impl VerifierContext {
             groth16_verifier_parameters: Some(Groth16ReceiptVerifierParameters::from_max_po2(
                 po2_max,
             )),
+            dev_mode: crate::is_dev_mode_enabled_via_environment(),
         }
     }
 
@@ -766,6 +781,21 @@ impl VerifierContext {
         self
     }
 
+    /// Return [VerifierContext] with is_dev_mode enabled or disabled.
+    pub fn with_dev_mode(mut self, dev_mode: bool) -> Self {
+        if cfg!(feature = "disable-dev-mode") && dev_mode {
+            panic!("zkVM: Inconsistent settings -- please resolve. \
+                The RISC0_DEV_MODE environment variable is set but dev mode has been disabled by feature flag.");
+        }
+        self.dev_mode = dev_mode;
+        self
+    }
+
+    /// Returns `true` if dev-mode is enabled.
+    pub fn dev_mode(&self) -> bool {
+        self.dev_mode
+    }
+
     /// Parameters for verification of [CompositeReceipt].
     ///
     /// Made up of the verifier parameters for each other receipt type. Returns none if any of the
@@ -786,6 +816,7 @@ impl Default for VerifierContext {
             segment_verifier_parameters: Some(Default::default()),
             succinct_verifier_parameters: Some(Default::default()),
             groth16_verifier_parameters: Some(Default::default()),
+            dev_mode: crate::is_dev_mode_enabled_via_environment(),
         }
     }
 }

--- a/tools/smoke-test/Cargo.toml
+++ b/tools/smoke-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = "2.2.0"
+risc0-zkvm = "2.3.0"
 # Use this only for testing locally before a release.
 # risc0-zkvm = { path = "../../risc0/zkvm" }
 methods = { path = "methods" }

--- a/tools/smoke-test/methods/Cargo.toml
+++ b/tools/smoke-test/methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = "2.2.0"
+risc0-build = "2.3.0"
 # Use this only for testing locally before a release.
 # risc0-build = { path = "../../../risc0/build" }
 


### PR DESCRIPTION
- Backport 8dfaac0a1daeda10e9aaf8db7d5ffad4f16880a8 to 2.3.0
- Bump versions of top-level crates to 2.3.0.