### PR TITLE
Uncap bento upload limit and other fixes

### DIFF
--- a/bento/crates/api/src/lib.rs
+++ b/bento/crates/api/src/lib.rs
@@ -247,7 +247,8 @@ impl AppState {
 
 // TODO: Add authn/z to get a userID
 const USER_ID: &str = "default_user";
-const MAX_UPLOAD_SIZE: usize = 250 * 1024 * 1024; // 250 mb
+// No limit on upload size given API is trusted.
+const MAX_UPLOAD_SIZE: usize = usize::MAX;
 
 const IMAGE_UPLOAD_PATH: &str = "/images/upload/:image_id";
 async fn image_upload(

--- a/bento/crates/workflow-common/src/s3.rs
+++ b/bento/crates/workflow-common/src/s3.rs
@@ -62,7 +62,9 @@ impl S3Client {
         let client = aws_sdk_s3::Client::from_conf(s3_config);
 
         // Attempt to provision the bucket if it does not exist
-        let cfg = CreateBucketConfiguration::builder().build();
+        let cfg = CreateBucketConfiguration::builder()
+            .location_constraint(MOCK_REGION.into())
+            .build();
         let res = client
             .create_bucket()
             .create_bucket_configuration(cfg)


### PR DESCRIPTION
Uncaps bento max upload size (did not touch r0vm limit, but can if we want to do the same there), and then cherry-picks some changes @ec2 needed to get the bento cluster working