### PR TITLE
docs: replace magic number with named constant in starter template

### DIFF
--- a/risc0/cargo-risczero/templates/rust-starter/host/src/main.rs
+++ b/risc0/cargo-risczero/templates/rust-starter/host/src/main.rs
@@ -24,7 +24,12 @@ fn main() {
     // ExecutorEnvBuilder::build().
 
     // For example:
-    let input: u32 = 15 * u32::pow(2, 27) + 1;
+    // NTT prime: 15 * 2^27 + 1 = 2013265921
+    // This is a prime number commonly used in Number Theoretic Transform (NTT) operations
+    // within cryptographic computations in the zkVM
+    const NTT_PRIME: u32 = 15 * u32::pow(2, 27) + 1;
+    
+    let input: u32 = NTT_PRIME;
     let env = ExecutorEnv::builder()
         .write(&input)
         .unwrap()


### PR DESCRIPTION
Replace the magic number 15 * 2^27 + 1 (2013265921) with a named constant NTT_PRIME in the rust-starter template. This improves code clarity for new users by:

1. Making the purpose of the number immediately clear
2. Educating users about NTT (Number Theoretic Transform) primes used in zkVM
3. Following Rust best practices of avoiding magic numbers
4. Providing educational value through descriptive comments