### PR TITLE
rzup: Implement installation of risc0-groth16 component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6588,6 +6588,7 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "serde_json",
  "strum",
  "tar",
  "tempfile",

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "0.12.15", default-features = false, features = [
   "blocking",
   "json",
 ], optional = true }
-semver = "1.0.23"
+semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.215", features = ["derive"] }
 strum = { version = "0.27.1", features = ["derive"] }
 tar = { version = "0.4.43", optional = true }
@@ -43,5 +43,6 @@ http-body-util = "0.1.3"
 hyper = { version = "1.5.1", features = ["server"] }
 hyper-util = "0.1.10"
 paste = "1.0.15"
+serde_json = "1.0"
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "macros"] }
 walkdir = "2.5.0"

--- a/rzup/src/build.rs
+++ b/rzup/src/build.rs
@@ -16,7 +16,6 @@ use crate::components::Component;
 use crate::env::Environment;
 use crate::error::{Result, RzupError};
 use crate::events::RzupEvent;
-use crate::paths::Paths;
 
 use semver::Version;
 use std::io::{BufRead, BufReader};
@@ -207,7 +206,7 @@ pub fn build_rust_toolchain(
     let mut version = Version::parse(version_str.trim())?;
     version.build = semver::BuildMetadata::new(&commit).unwrap();
 
-    let dest_dir = Paths::get_version_dir(env, &Component::RustToolchain, &version);
+    let dest_dir = Component::RustToolchain.get_version_dir(env, &version);
     if dest_dir.exists() {
         return Err(RzupError::Other(format!(
             "Rust toolchain version {version} already installed"

--- a/rzup/src/components.rs
+++ b/rzup/src/components.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::distribution::{github::GithubRelease, Os, Platform};
+use crate::distribution::{
+    github::GithubRelease, s3::S3Bucket, DistributionPlatform, Os, Platform,
+};
 use crate::env::Environment;
 use crate::error::{Result, RzupError};
 use crate::paths::Paths;
@@ -69,13 +71,15 @@ impl Component {
         )
     }
 
-    pub fn repo_name(&self) -> &'static str {
+    pub fn repo_name(&self) -> Result<&'static str> {
         match self {
-            Component::CargoRiscZero | Component::R0Vm => "risc0",
-            Component::RustToolchain => "rust",
-            Component::CppToolchain => "toolchain",
-            Component::Gdb => "toolchain",
-            Component::Risc0Groth16 => unimplemented!(),
+            Component::CargoRiscZero | Component::R0Vm => Ok("risc0"),
+            Component::RustToolchain => Ok("rust"),
+            Component::CppToolchain => Ok("toolchain"),
+            Component::Gdb => Ok("toolchain"),
+            Component::Risc0Groth16 => Err(RzupError::UnsupportedDistributionPlatform(
+                "github download not supported for risc0-groth16".into(),
+            )),
         }
     }
 
@@ -106,6 +110,11 @@ impl Component {
         })
     }
 
+    pub fn archive_name(&self, platform: &Platform) -> Result<String> {
+        let (asset_name, ext) = self.asset_name(platform)?;
+        Ok(format!("{asset_name}.{ext}"))
+    }
+
     pub fn version_str(&self, version: &Version) -> String {
         match self {
             // rust toolchain uses date-based versions with r0. prefix
@@ -133,6 +142,20 @@ impl Component {
             | Component::R0Vm
             | Component::Gdb
             | Component::Risc0Groth16 => env.risc0_dir().join("extensions"),
+        }
+    }
+
+    pub fn get_version_dir(&self, env: &Environment, version: &Version) -> PathBuf {
+        let base_path = self.get_dir(env);
+        match self {
+            Component::Gdb
+            | Component::CargoRiscZero
+            | Component::CppToolchain
+            | Component::R0Vm
+            | Component::RustToolchain => {
+                base_path.join(format!("v{version}-{self}-{}", env.platform()))
+            }
+            Component::Risc0Groth16 => base_path.join(format!("v{version}-{self}")),
         }
     }
 }
@@ -194,6 +217,25 @@ fn extract_archive(_env: &Environment, _archive_path: &Path, _target_dir: &Path)
     Err(RzupError::Other("not built with install support".into()))
 }
 
+/// This function selects where to download a particular component from.
+fn distribution<'a>(
+    base_urls: &'a BaseUrls,
+    component: &Component,
+) -> Box<dyn DistributionPlatform + 'a> {
+    match component {
+        // These components are grandfathered into using GitHub, at some point we should move them
+        // to S3.
+        Component::CargoRiscZero
+        | Component::CppToolchain
+        | Component::Gdb
+        | Component::R0Vm
+        | Component::RustToolchain => Box::new(GithubRelease::new(base_urls)),
+
+        // Any new components should be using S3
+        _ => Box::new(S3Bucket::new(base_urls)),
+    }
+}
+
 pub fn install(
     component: &Component,
     env: &Environment,
@@ -203,15 +245,16 @@ pub fn install(
 ) -> Result<()> {
     let component_to_install = component.parent_component().unwrap_or(*component);
 
-    let distribution = GithubRelease::new(base_urls);
+    let distribution = distribution(base_urls, &component_to_install);
 
     env.emit(RzupEvent::InstallationStarted {
         id: component.to_string(),
         version: version.to_string(),
     });
 
-    let archive_name = distribution.get_archive_name(&component_to_install, env.platform())?;
-    let downloaded_file = env.tmp_dir().join(archive_name);
+    let downloaded_file = env
+        .tmp_dir()
+        .join(component_to_install.archive_name(env.platform())?);
 
     if force {
         Paths::cleanup_version(env, &component_to_install, version)?;
@@ -219,7 +262,7 @@ pub fn install(
 
     // Download and extract
     distribution.download_version(env, &component_to_install, version)?;
-    let version_dir = Paths::get_version_dir(env, &component_to_install, version);
+    let version_dir = component_to_install.get_version_dir(env, version);
 
     if let Err(e) = extract_archive(env, &downloaded_file, &version_dir) {
         Paths::cleanup_version(env, &component_to_install, version)?;
@@ -297,7 +340,7 @@ pub fn set_default(env: &Environment, component: &Component, version: &Version) 
             &version_dir.join("riscv32im-gdb"),
             &env.risc0_dir().join("bin/riscv32im-gdb"),
         )?,
-        Component::Risc0Groth16 => unimplemented!(),
+        Component::Risc0Groth16 => {}
     };
     Ok(())
 }
@@ -312,7 +355,7 @@ pub fn get_latest_version(
     env: &Environment,
     base_urls: &BaseUrls,
 ) -> Result<Version> {
-    let distribution = GithubRelease::new(base_urls);
+    let distribution = distribution(base_urls, component);
     distribution.latest_version(env, component)
 }
 

--- a/rzup/src/distribution/mod.rs
+++ b/rzup/src/distribution/mod.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 pub mod github;
+pub mod s3;
 
 #[cfg_attr(not(feature = "install"), path = "erroring_http.rs")]
 mod http;
 
 pub use self::http::*;
 use crate::error::{Result, RzupError};
-use crate::{Environment, RzupEvent};
+use crate::{Component, Environment, RzupEvent};
 use semver::Version;
 use std::{fmt, io};
 
@@ -130,4 +131,15 @@ impl<WriterT: io::Write> io::Write for ProgressWriter<'_, WriterT> {
     fn flush(&mut self) -> io::Result<()> {
         self.writer.flush()
     }
+}
+
+pub trait DistributionPlatform {
+    fn download_version(
+        &self,
+        env: &Environment,
+        component: &Component,
+        version: &Version,
+    ) -> Result<()>;
+
+    fn latest_version(&self, env: &Environment, component: &Component) -> Result<Version>;
 }

--- a/rzup/src/distribution/s3.rs
+++ b/rzup/src/distribution/s3.rs
@@ -1,0 +1,170 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::components::Component;
+use crate::distribution::{download_bytes, download_json, DistributionPlatform, ProgressWriter};
+use crate::env::Environment;
+use crate::{BaseUrls, Result, RzupError, RzupEvent};
+
+use semver::Version;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Deserialize, Clone, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct TargetTriple(String);
+
+impl fmt::Display for TargetTriple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Deserialize)]
+struct Artifact {
+    sha256: String,
+}
+
+#[derive(Deserialize)]
+struct TargetSpecificRelease {
+    artifacts: HashMap<TargetTriple, Artifact>,
+}
+
+#[derive(Deserialize)]
+struct TargetAgnosticRelease {
+    artifact: Artifact,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Release {
+    TargetSpecific(TargetSpecificRelease),
+    TargetAgnostic(TargetAgnosticRelease),
+}
+
+#[derive(Deserialize)]
+struct DistributionManifest {
+    releases: HashMap<semver::Version, Release>,
+    latest_version: semver::Version,
+}
+
+pub struct S3Bucket<'a> {
+    base_urls: &'a BaseUrls,
+}
+
+impl<'a> S3Bucket<'a> {
+    pub fn new(base_urls: &'a BaseUrls) -> Self {
+        Self { base_urls }
+    }
+
+    fn get_distribution_manifest(
+        &self,
+        env: &Environment,
+        component: &Component,
+    ) -> Result<DistributionManifest> {
+        env.emit(RzupEvent::Debug {
+            message: format!("Fetching distribution information for {component}"),
+        });
+
+        let base_url = &self.base_urls.s3_base_url;
+        let url = format!("{base_url}/rzup/components/{component}/distribution_manifest.json");
+        download_json(&url, &None)
+    }
+}
+
+impl<'a> DistributionPlatform for S3Bucket<'a> {
+    fn latest_version(&self, env: &Environment, component: &Component) -> Result<Version> {
+        env.emit(RzupEvent::Debug {
+            message: format!("Fetching latest version for {component}"),
+        });
+
+        let manifest = self.get_distribution_manifest(env, component)?;
+
+        Ok(manifest.latest_version)
+    }
+
+    fn download_version(
+        &self,
+        env: &Environment,
+        component: &Component,
+        version: &Version,
+    ) -> Result<()> {
+        let manifest = self.get_distribution_manifest(env, component)?;
+
+        let Some(release) = manifest.releases.get(version) else {
+            env.emit(RzupEvent::InstallationFailed {
+                id: component.to_string(),
+                version: version.to_string(),
+            });
+            return Err(RzupError::InvalidVersion(format!(
+                "{version} is not available for {component}",
+            )));
+        };
+
+        let platform = env.platform();
+        let artifact = match release {
+            Release::TargetSpecific(release) => {
+                let target_triple = TargetTriple(platform.target_triple());
+
+                let Some(artifact) = release.artifacts.get(&target_triple) else {
+                    env.emit(RzupEvent::InstallationFailed {
+                        id: component.to_string(),
+                        version: version.to_string(),
+                    });
+                    return Err(RzupError::UnsupportedPlatform(format!(
+                        "{component} is not available for platform {target_triple}",
+                    )));
+                };
+                artifact
+            }
+            Release::TargetAgnostic(release) => &release.artifact,
+        };
+
+        let archive_name = component.archive_name(platform)?;
+
+        let download_path = env.tmp_dir().join(archive_name);
+        let mut download_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&download_path)?;
+
+        let base_url = &self.base_urls.s3_base_url;
+        let sha256 = &artifact.sha256;
+        let download_url = format!("{base_url}/rzup/components/{component}/sha256/{sha256}");
+        let mut resp = download_bytes(&download_url, &None)?;
+
+        env.emit(RzupEvent::DownloadStarted {
+            id: component.to_string(),
+            version: version.to_string(),
+            url: download_url.clone(),
+            len: resp.content_length(),
+        });
+
+        resp.copy_to(&mut ProgressWriter::new(
+            component.to_string(),
+            env,
+            &mut download_file,
+        ))
+        .map_err(|e| RzupError::Other(format!("Failed to download file: {e}")))?;
+
+        env.emit(RzupEvent::DownloadCompleted {
+            id: component.to_string(),
+            version: version.to_string(),
+        });
+
+        Ok(())
+    }
+}

--- a/rzup/src/error.rs
+++ b/rzup/src/error.rs
@@ -41,6 +41,9 @@ pub enum RzupError {
 
     #[error("Unsupported platform: {0}")]
     UnsupportedPlatform(String),
+
+    #[error("Unsupported distribution platform: {0}")]
+    UnsupportedDistributionPlatform(String),
 }
 
 impl From<std::io::Error> for RzupError {

--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -22,11 +22,6 @@ use std::path::PathBuf;
 pub struct Paths;
 
 impl Paths {
-    pub fn get_version_dir(env: &Environment, component: &Component, version: &Version) -> PathBuf {
-        let base_path = component.get_dir(env);
-        base_path.join(format!("v{version}-{component}-{}", env.platform()))
-    }
-
     fn find_version_dir_inner(
         env: &Environment,
         component: &Component,
@@ -247,7 +242,7 @@ mod tests {
         let version = Version::new(1, 0, 0);
         let component = Component::RustToolchain;
 
-        let version_dir = Paths::get_version_dir(&env, &component, &version);
+        let version_dir = component.get_version_dir(&env, &version);
         std::fs::create_dir_all(&version_dir).unwrap();
         assert!(Paths::find_version_dir(&env, &component, &version)
             .unwrap()


### PR DESCRIPTION
This implements downloading and installing the new `risc0-groth16` component.

### The `risc0-groth16` component

This new component uses S3 to store its metadata and tar.xz files. This is the first component to do this, and a new S3 distribution has been added to support this. If this works out well we can transition existing components to S3 and not have to deal with downloading from GitHub anymore.

The risc0-groth16 component is implemented as "target agnostic" meaning the same bits are used on all platforms. The code for a target specific S3 component has been added but nothing is using it yet.

When this component is selected as default, no symlinks are created, only the `rzup` metadata is changed. Unclear that this default version for this component will be used for anything, if not it is fine.

I uploaded to S3 a dummy tar.xz for now under the version 1.0.0-beta1. We can edit the bucket to add the real files.

### S3 backed `rzup` components

The S3 distribution stores a `distribution_manifest.json` per component that contains a list of releases keyed by version and shasums for the artifacts. The artifacts are intended to be stored as objects at a "sha256" prefix keyed off of their base64-encoded sha256 sum. This should allow for releases to be obtained by the client atomically. Also it should allow for verification of the artifacts contents later in the client by verifying the sha256 sum.

I wish to add in a later PR a new `publish` subcommand to `rzup` which will upload artifacts to S3 and update the manifest accordingly. We can hopefully use this in our release GitHub action to store future releases on S3 automatically.