### PR TITLE
Add s3 region to Bento

### DIFF
--- a/bento/crates/api/src/lib.rs
+++ b/bento/crates/api/src/lib.rs
@@ -191,6 +191,10 @@ pub struct Args {
     #[clap(env)]
     s3_url: String,
 
+    /// S3 region, can be anything is using minio
+    #[clap(env, default_value = "us-west-2")]
+    s3_region: String,
+
     /// Executor timeout in seconds
     #[clap(long, default_value_t = 4 * 60 * 60)]
     exec_timeout: i32,
@@ -230,6 +234,7 @@ impl AppState {
             &args.s3_bucket,
             &args.s3_access_key,
             &args.s3_secret_key,
+            &args.s3_region,
         )
         .await
         .context("Failed to initialize s3 client / bucket")?;

--- a/bento/crates/workflow-common/src/s3.rs
+++ b/bento/crates/workflow-common/src/s3.rs
@@ -33,8 +33,6 @@ pub const STARK_BUCKET_DIR: &str = "stark";
 /// Object store receipts groth15 dir
 pub const GROTH16_BUCKET_DIR: &str = "groth16";
 
-const MOCK_REGION: &str = "us-west-2";
-
 /// S3 client object
 pub struct S3Client {
     bucket: String,
@@ -48,6 +46,7 @@ impl S3Client {
         bucket: &str,
         access_key: &str,
         secret_key: &str,
+        region: &str,
     ) -> Result<Self> {
         let cred = Credentials::new(access_key, secret_key, None, None, "loaded-from-custom-env");
 
@@ -55,7 +54,7 @@ impl S3Client {
             .endpoint_url(url)
             .credentials_provider(cred)
             .behavior_version_latest()
-            .region(Region::new(MOCK_REGION))
+            .region(Region::new(region.to_string()))
             .force_path_style(true)
             .build();
 
@@ -63,7 +62,7 @@ impl S3Client {
 
         // Attempt to provision the bucket if it does not exist
         let cfg = CreateBucketConfiguration::builder()
-            .location_constraint(MOCK_REGION.into())
+            .location_constraint(region.into())
             .build();
         let res = client
             .create_bucket()

--- a/bento/crates/workflow/src/lib.rs
+++ b/bento/crates/workflow/src/lib.rs
@@ -90,6 +90,10 @@ pub struct Args {
     #[clap(env)]
     pub s3_url: String,
 
+    /// S3 region, can be anything is using minio
+    #[clap(env, default_value = "us-west-2")]
+    pub s3_region: String,
+
     /// Enables a background thread to monitor for tasks that need to be retried / timed-out
     #[clap(long, default_value_t = false)]
     monitor_requeue: bool,
@@ -172,6 +176,7 @@ impl Agent {
             &args.s3_bucket,
             &args.s3_access_key,
             &args.s3_secret_key,
+            &args.s3_region,
         )
         .await
         .context("Failed to initialize s3 client / bucket")?;


### PR DESCRIPTION
Bento works with minio, but fails when using S3 in any other region besides us-west-2. This allows the region to be set. 