### PR TITLE
rzup: Add publish command to upload to S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,353 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd9b83179adf8998576317ce47785948bcff399ec5b15f4dfbdedd44ddf5b92"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.3.1",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08b5d4e069cbc868041a64bd68dc8cb39a0d79585cd6c5a24caa8c2d622121be"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bf26698dd6d238ef1486bdda46f22a589dc813368ba868dc3d94c8d27b56ba"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cd07ed1edd939fae854a22054299ae3576500f4e0fadc560ca44f9c6ea1664"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f7766d2344f56d10d12f3c32993da36d78217f32594fe4fb8e57a538c1cdea"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852b9226cb60b78ce9369022c0df678af1cac231c882d5da97a0c4e03be6e67"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.3.1",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +1217,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "basic-cookies"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1244,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.100",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1100,6 +1480,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bzip2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1645,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1713,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1399,6 +1809,15 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -1511,6 +1930,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,7 +1952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -2353,6 +2782,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3723,6 +4158,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4249,6 +4685,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "levenshtein"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4259,6 +4701,16 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.53.0",
+]
 
 [[package]]
 name = "libm"
@@ -4537,6 +4989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4569,7 +5027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2921dd3396771d28d081e93dbb62dc62e14ee4fe63978c6528e177ad0c6bfe"
 dependencies = [
  "multi_index_map_derive",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "slab",
 ]
 
@@ -4604,7 +5062,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4636,6 +5094,16 @@ name = "no_std_strings"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "ntapi"
@@ -4968,6 +5436,12 @@ dependencies = [
  "serde",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "overload"
@@ -5498,7 +5972,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.12",
@@ -5517,7 +5991,7 @@ dependencies = [
  "getrandom 0.3.2",
  "rand 0.9.1",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5726,6 +6200,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -6418,6 +6898,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -6437,7 +6923,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd5cb7a0c0a5a4f6bc429274fc1073d395237c83ef13d0ac728e0f95f5499ca"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -6447,7 +6933,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33060dbec9e1d13d285c4cddc150a431569be97f33bf0b6c1ec6eea934c31ca"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -6457,7 +6943,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf583db9958b3161d7980a56a8ee3c25e1a40708b81259be72584b7e0ea07c95"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -6467,7 +6953,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b61d5673c3f4b49d35be6a58c49210596f61b8db580bc3b6d9dee5e9dc5458"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -6477,7 +6963,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79f6e675de57460d306a273321d3799b010b23713144caffe00b4a4fde83620e"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -6513,12 +6999,25 @@ version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -6545,6 +7044,7 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6575,20 +7075,26 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 name = "rzup"
 version = "0.5.0"
 dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
  "clap 4.5.37",
  "colored",
  "flate2",
  "fs2",
+ "http 1.3.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
  "indicatif",
  "is-terminal",
+ "maplit",
  "paste",
  "reqwest",
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "strum",
  "tar",
  "tempfile",
@@ -6640,7 +7146,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -7081,7 +7600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -7689,7 +8208,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustdoc-types 0.32.2",
  "trustfall",
 ]
@@ -7703,7 +8222,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustdoc-types 0.33.0",
  "trustfall",
 ]
@@ -7717,7 +8236,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustdoc-types 0.35.0",
  "trustfall",
 ]
@@ -7731,7 +8250,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustdoc-types 0.39.0",
  "trustfall",
 ]
@@ -7745,7 +8264,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustdoc-types 0.41.0",
  "trustfall",
 ]
@@ -8013,6 +8532,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -8576,6 +9101,12 @@ dependencies = [
  "libc",
  "rustix 1.0.5",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xshell"

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -12,15 +12,29 @@ name = "rzup"
 path = "src/bin/rzup.rs"
 
 [features]
-default = ["cli", "install"]
+default = ["cli", "install", "publish"]
 cli = ["dep:clap", "dep:indicatif", "dep:colored", "dep:is-terminal"]
 install = ["dep:reqwest", "dep:tar", "dep:xz", "dep:flate2", "dep:fs2"]
+publish = [
+    "dep:aws-config",
+    "dep:aws-credential-types",
+    "dep:aws-sigv4",
+    "dep:http",
+    "dep:reqwest",
+    "dep:serde_json",
+    "dep:sha2",
+    "dep:tokio",
+]
 
 [dependencies]
+aws-config = { version = "1.8", optional = true, features = ["behavior-version-latest"] }
+aws-credential-types = { version = "1.2", optional = true }
+aws-sigv4 = { version = "1.3", optional = true }
 clap = { version = "4.5.23", features = ["derive"], optional = true }
 colored = { version = "3.0.0", optional = true }
 flate2 = { version = "1.0.35", optional = true }
 fs2 = { version = "0.4.3", optional = true }
+http = { version = "1", optional = true }
 indicatif = { version = "0.17.9", optional = true }
 is-terminal = { version = "0.4.15", optional = true }
 reqwest = { version = "0.12.15", default-features = false, features = [
@@ -30,10 +44,13 @@ reqwest = { version = "0.12.15", default-features = false, features = [
 ], optional = true }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.215", features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
+sha2 = { version = "0.10", optional = true }
 strum = { version = "0.27.1", features = ["derive"] }
 tar = { version = "0.4.43", optional = true }
 tempfile = "3.14.0"
 thiserror = "2.0.6"
+tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "macros"], optional = true }
 toml = "0.8.19"
 xz = { version = "0.1.0", optional = true }
 yaml-rust2 = "0.10.1"
@@ -42,6 +59,7 @@ yaml-rust2 = "0.10.1"
 http-body-util = "0.1.3"
 hyper = { version = "1.5.1", features = ["server"] }
 hyper-util = "0.1.10"
+maplit = "1"
 paste = "1.0.15"
 serde_json = "1.0"
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "macros"] }

--- a/rzup/src/cli/commands.rs
+++ b/rzup/src/cli/commands.rs
@@ -16,9 +16,11 @@ use crate::error::Result;
 use crate::events::RzupEvent;
 use crate::{Rzup, RzupError};
 
-use clap::{ArgGroup, Parser};
+use clap::{ArgGroup, Args, Parser, Subcommand};
 use colored::Colorize;
 use semver::Version;
+
+use std::path::PathBuf;
 
 fn parser(cmd: &str) -> Vec<&'static str> {
     match cmd {
@@ -68,24 +70,27 @@ fn parse_cpp_version(v: &str) -> Result<Version> {
     })
 }
 
+fn parse_version(name: Option<&str>, v: &str) -> Result<Version> {
+    // special handling for cpp date-based versions
+    // TODO: Move away from date version tags to semver
+    if name.is_some_and(|n| n == "cpp" || n == "gdb") {
+        return parse_cpp_version(v);
+    }
+
+    Version::parse(v).map_err(|_| {
+        RzupError::InvalidVersion(format!(
+            "{v}\n\n  {}: use semantic version (e.g. 1.0.0)",
+            "tip".green()
+        ))
+    })
+}
+
 impl InstallCommand {
     fn parse_version(&self) -> Result<Option<Version>> {
         let Some(v) = &self.version else {
             return Ok(None);
         };
-
-        // special handling for cpp date-based versions
-        // TODO: Move away from date version tags to semver
-        if self.name.as_ref().is_some_and(|n| n == "cpp" || n == "gdb") {
-            return Ok(Some(parse_cpp_version(v)?));
-        }
-
-        Ok(Some(Version::parse(v).map_err(|_| {
-            RzupError::InvalidVersion(format!(
-                "{v}\n\n  {}: use semantic version (e.g. 1.0.0)",
-                "tip".green()
-            ))
-        })?))
+        Ok(Some(parse_version(self.name.as_deref(), v)?))
     }
 
     pub(crate) fn execute(self, rzup: &mut Rzup) -> Result<()> {
@@ -301,5 +306,99 @@ impl BuildCommand {
             &self.tag_or_commit,
             &self.path,
         )
+    }
+}
+
+pub const PUBLISH_HELP: &str = "Discussion:
+    Publishes a component to S3 at a particular version, or updates the current latest version.
+
+    Requires that AWS credentials be available in the environment.
+
+    Each version of a component is either tagged with a target, or is target agnostic. A particular
+    version can only have one target-agnostic artifact, or many target specific artifacts, but each
+    target may only have one artifact each.";
+
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct TargetGroup {
+    /// Is the component the same for all targets
+    #[arg(long, conflicts_with = "target_triple")]
+    target_agnostic: bool,
+    /// The target triple of the component
+    #[arg(long, conflicts_with = "target_agnostic")]
+    target_triple: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct PublishUploadCommand {
+    /// Name of component to publish (e.g. rust).
+    #[arg(value_parser=parser("publish"))]
+    name: String,
+    /// Version of the component to publish (e.g. 1.0.0).
+    version: String,
+    #[command(flatten)]
+    target_group: TargetGroup,
+    /// If the component at the given target / version already exists, replace it
+    #[arg(long)]
+    force: bool,
+    /// The path to the archive
+    payload: PathBuf,
+}
+
+#[derive(Parser)]
+pub struct PublishSetLatestCommand {
+    /// Name of component to update the latest version of (e.g. rust).
+    #[arg(value_parser=parser("publish"))]
+    name: String,
+    /// Version to set (e.g. 1.0.0).
+    version: String,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum PublishCommand {
+    Upload(PublishUploadCommand),
+    SetLatest(PublishSetLatestCommand),
+}
+
+impl PublishCommand {
+    fn parse_version(&self) -> Result<Version> {
+        match self {
+            Self::Upload(cmd) => parse_version(Some(&cmd.name), &cmd.version),
+            Self::SetLatest(cmd) => parse_version(Some(&cmd.name), &cmd.version),
+        }
+    }
+
+    #[cfg_attr(not(feature = "publish"), allow(unused_variables))]
+    pub(crate) fn execute(self, rzup: &mut Rzup) -> Result<()> {
+        let version = self.parse_version()?;
+
+        #[cfg(feature = "publish")]
+        match self {
+            Self::Upload(cmd) => {
+                let platform = cmd
+                    .target_group
+                    .target_triple
+                    .map(|tt| {
+                        crate::Platform::from_target_triple(&tt).ok_or_else(|| {
+                            RzupError::Other("unsupported target-triple {tt}".into())
+                        })
+                    })
+                    .transpose()?;
+
+                let name = cmd.name.parse()?;
+                rzup.publish_upload(&name, &version, platform, &cmd.payload, cmd.force)?;
+
+                Ok(())
+            }
+            Self::SetLatest(cmd) => {
+                let name = cmd.name.parse()?;
+                rzup.publish_set_latest(&name, &version)?;
+
+                Ok(())
+            }
+        }
+
+        #[cfg(not(feature = "publish"))]
+        Err(RzupError::Other("publish feature not enabled".into()))
     }
 }

--- a/rzup/src/cli/mod.rs
+++ b/rzup/src/cli/mod.rs
@@ -21,7 +21,9 @@ use crate::Rzup;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use commands::UninstallCommand;
-use commands::{BuildCommand, CheckCommand, DefaultCommand, InstallCommand, ShowCommand};
+use commands::{
+    BuildCommand, CheckCommand, DefaultCommand, InstallCommand, PublishCommand, ShowCommand,
+};
 use ui::{TerminalUi, TextUi};
 
 #[derive(Subcommand)]
@@ -44,6 +46,9 @@ enum Commands {
     /// Build a component
     #[command(after_help = commands::BUILD_HELP)]
     Build(BuildCommand),
+    /// Publish a component on S3
+    #[command(after_help = commands::PUBLISH_HELP, subcommand)]
+    Publish(PublishCommand),
 }
 
 pub const RZUP_HELP: &str = "Discussion:
@@ -118,6 +123,7 @@ impl Cli {
                 Commands::Check(cmd) => cmd.execute(&rzup),
                 Commands::Uninstall(cmd) => cmd.execute(&mut rzup),
                 Commands::Build(cmd) => cmd.execute(&mut rzup),
+                Commands::Publish(cmd) => cmd.execute(&mut rzup),
             }
         });
 

--- a/rzup/src/components.rs
+++ b/rzup/src/components.rs
@@ -375,7 +375,7 @@ mod tests {
             tmp_dir.path().join(".rustup"),
             tmp_dir.path().join(".cargo"),
             None,
-            None,
+            || None,
             Platform::detect().unwrap(),
             |_| {},
         )

--- a/rzup/src/components.rs
+++ b/rzup/src/components.rs
@@ -370,10 +370,11 @@ mod tests {
 
     fn test_env() -> (TempDir, Environment) {
         let tmp_dir = tempfile::tempdir().unwrap();
-        let env = Environment::with_paths_token_platform_and_event_handler(
+        let env = Environment::with_paths_creds_platform_and_event_handler(
             tmp_dir.path().join(".risc0"),
             tmp_dir.path().join(".rustup"),
             tmp_dir.path().join(".cargo"),
+            None,
             None,
             Platform::detect().unwrap(),
             |_| {},

--- a/rzup/src/distribution/github.rs
+++ b/rzup/src/distribution/github.rs
@@ -18,7 +18,7 @@ use crate::distribution::{
     Platform, ProgressWriter,
 };
 use crate::env::Environment;
-use crate::{BaseUrls, Result, RzupError, RzupEvent};
+use crate::{BaseUrls, Result, RzupError, RzupEvent, TransferDirection};
 
 use semver::Version;
 use serde::Deserialize;
@@ -166,7 +166,8 @@ impl<'a> DistributionPlatform for GithubRelease<'a> {
         let download_url = self.download_url(component, version, platform)?;
         let mut resp = download_bytes(&download_url, env.github_token())?;
 
-        env.emit(RzupEvent::DownloadStarted {
+        env.emit(RzupEvent::TransferStarted {
+            direction: TransferDirection::Download,
             id: component.to_string(),
             version: version.to_string(),
             url: download_url.clone(),
@@ -180,7 +181,8 @@ impl<'a> DistributionPlatform for GithubRelease<'a> {
         ))
         .map_err(|e| RzupError::Other(format!("Failed to download file: {e}")))?;
 
-        env.emit(RzupEvent::DownloadCompleted {
+        env.emit(RzupEvent::TransferCompleted {
+            direction: TransferDirection::Download,
             id: component.to_string(),
             version: version.to_string(),
         });

--- a/rzup/src/distribution/http.rs
+++ b/rzup/src/distribution/http.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 use crate::error::{Result, RzupError};
 use reqwest::{blocking::Client, IntoUrl, Url};
-use serde::Deserialize;
 use std::time::Duration;
 
 fn http_client_get(
@@ -33,12 +32,7 @@ fn http_client_get(
 
     builder
         .send()
-        .map_err(|e| RzupError::Other(format!("{e}: {url}")))
-}
-
-#[derive(Deserialize)]
-struct RemoteResponse {
-    message: String,
+        .map_err(|e| RzupError::Other(format!("{e:?}: {url}")))
 }
 
 fn error_on_status(
@@ -50,15 +44,11 @@ fn error_on_status(
     if !status.is_success() {
         let host = response.url().host_str().expect("URL has a host");
         let host = host.to_owned();
-        if let Ok(RemoteResponse { message }) = response.json() {
-            Err(RzupError::Other(format!(
-                "Remote error: {host}: {message}: {url}"
-            )))
-        } else {
-            Err(RzupError::Other(format!(
-                "Unexpected response: {host}: {status}: {url}"
-            )))
-        }
+        let body = response.text().ok();
+
+        Err(RzupError::Other(format!(
+            "Remote error: {host}: {body:?}: {url}"
+        )))
     } else {
         Ok(response)
     }
@@ -88,7 +78,7 @@ pub fn download_json<RetT: serde::de::DeserializeOwned>(
     let response = error_on_status(response, &url)?;
     response
         .json()
-        .map_err(|e| RzupError::Other(format!("{e}: {url}")))
+        .map_err(|e| RzupError::Other(format!("{e:?}: {url}")))
 }
 
 pub fn download_text(url: impl IntoUrl, bearer_token: &Option<String>) -> Result<String> {
@@ -99,7 +89,7 @@ pub fn download_text(url: impl IntoUrl, bearer_token: &Option<String>) -> Result
     let response = error_on_status(response, &url)?;
     response
         .text()
-        .map_err(|e| RzupError::Other(format!("{e}: {url}")))
+        .map_err(|e| RzupError::Other(format!("{e:?}: {url}")))
 }
 
 pub fn download_bytes(
@@ -112,4 +102,44 @@ pub fn download_bytes(
     let response = http_client_get(&url, bearer_token)?;
     let response = error_on_status(response, &url)?;
     Ok(response)
+}
+
+pub fn upload_bytes<BodyT: std::io::Read + Send + 'static>(
+    url: impl IntoUrl,
+    signer: impl FnOnce(&mut http::Request<reqwest::blocking::Body>) -> Result<()>,
+    body_stream: BodyT,
+    content_length: u64,
+) -> Result<()> {
+    let url = url
+        .into_url()
+        .map_err(|e| RzupError::Other(e.to_string()))?;
+
+    let client = Client::builder()
+        .build()
+        .map_err(|e| RzupError::Other(format!("Failed to create HTTP client: {e:?}")))?;
+
+    let mut request = http::Request::builder()
+        .method("PUT")
+        .uri(url.as_str())
+        .header("user-agent", "rzup")
+        .header("content-type", "application/octet-stream")
+        .header("content-length", content_length.to_string())
+        .body(reqwest::blocking::Body::sized(body_stream, content_length))
+        .map_err(|e| RzupError::Other(format!("failed to build HTTP request: {e:?}")))?;
+
+    signer(&mut request)?;
+
+    let request = reqwest::blocking::Request::try_from(request).map_err(|e| {
+        RzupError::Other(format!(
+            "failed to convert to reqwest::blocking::Request: {e:?}"
+        ))
+    })?;
+
+    let response = client
+        .execute(request)
+        .map_err(|e| RzupError::Other(format!("{e:?}: {url}")))?;
+
+    error_on_status(response, &url)?;
+
+    Ok(())
 }

--- a/rzup/src/distribution/s3.rs
+++ b/rzup/src/distribution/s3.rs
@@ -14,15 +14,23 @@
 
 use crate::components::Component;
 use crate::distribution::{download_bytes, download_json, DistributionPlatform, ProgressWriter};
+#[cfg(feature = "publish")]
+use crate::distribution::{upload_bytes, ProgressReader};
 use crate::env::Environment;
-use crate::{BaseUrls, Result, RzupError, RzupEvent};
+#[cfg(feature = "publish")]
+use crate::{AwsCredentials, Platform};
+use crate::{BaseUrls, Result, RzupError, RzupEvent, TransferDirection};
 
 use semver::Version;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
+#[cfg(feature = "publish")]
+use std::{
+    collections::hash_map::Entry, fs::File, io::Read as _, io::Seek as _, io::SeekFrom, path::Path,
+};
 
-#[derive(Deserialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(transparent)]
 struct TargetTriple(String);
 
@@ -32,32 +40,120 @@ impl fmt::Display for TargetTriple {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct Artifact {
     sha256: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 struct TargetSpecificRelease {
     artifacts: HashMap<TargetTriple, Artifact>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct TargetAgnosticRelease {
     artifact: Artifact,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Release {
     TargetSpecific(TargetSpecificRelease),
     TargetAgnostic(TargetAgnosticRelease),
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct DistributionManifest {
     releases: HashMap<semver::Version, Release>,
     latest_version: semver::Version,
+}
+
+#[cfg(feature = "publish")]
+fn sha256_for_file(file: &mut File) -> Result<String> {
+    use sha2::Digest as _;
+
+    let mut hasher = sha2::Sha256::new();
+
+    let mut chunk = vec![0u8; 1024 * 1024];
+    loop {
+        let bytes_read = file.read(&mut chunk)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&chunk[..bytes_read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(feature = "publish")]
+fn validate_tar_xz(file: &mut File) -> Result<()> {
+    use std::io::BufReader;
+    use tar::Archive;
+    use xz::bufread::XzDecoder;
+
+    let mut ar = Archive::new(XzDecoder::new(BufReader::new(file)));
+    let entries = ar
+        .entries()
+        .map_err(|e| RzupError::Other(format!("invalid tar.xz file: {e}")))?
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|e| RzupError::Other(format!("invalid tar.xz file: {e}")))?;
+    if entries.is_empty() {
+        return Err(RzupError::Other("invalid tar.xz file: empty".into()));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "publish")]
+const S3_REGION: &str = "us-west-2";
+
+#[cfg(feature = "publish")]
+fn sign_s3_request(
+    creds: &AwsCredentials,
+    req: &mut http::Request<reqwest::blocking::Body>,
+) -> Result<()> {
+    use aws_sigv4::http_request::{sign, SignableBody, SignableRequest, SigningSettings};
+    use aws_sigv4::sign::v4;
+
+    let identity = creds.clone().into();
+    let signing_settings = SigningSettings::default();
+    let signing_params = v4::SigningParams::builder()
+        .identity(&identity)
+        .region(S3_REGION)
+        .name("s3")
+        .time(std::time::SystemTime::now())
+        .settings(signing_settings)
+        .build()
+        .unwrap()
+        .into();
+
+    let mut headers = vec![];
+    for (k, v) in req.headers() {
+        headers.push((
+            k.as_str(),
+            v.to_str()
+                .map_err(|e| RzupError::Other(format!("unsignable request header {k}: {e}")))?,
+        ));
+    }
+
+    let signable_request = SignableRequest::new(
+        req.method().as_str(),
+        req.uri().to_string(),
+        headers.into_iter(),
+        SignableBody::UnsignedPayload,
+    )
+    .map_err(|e| RzupError::Other(format!("error signing HTTP request: {e}")))?;
+
+    let (signing_instructions, _signature) = sign(signable_request, &signing_params)
+        .map_err(|e| RzupError::Other(format!("error signing HTTP request: {e}")))?
+        .into_parts();
+    signing_instructions.apply_to_request_http1x(req);
+
+    req.headers_mut().insert(
+        "x-amz-content-sha256",
+        http::HeaderValue::from_static("UNSIGNED-PAYLOAD"),
+    );
+
+    Ok(())
 }
 
 pub struct S3Bucket<'a> {
@@ -81,6 +177,256 @@ impl<'a> S3Bucket<'a> {
         let base_url = &self.base_urls.s3_base_url;
         let url = format!("{base_url}/rzup/components/{component}/distribution_manifest.json");
         download_json(&url, &None)
+    }
+
+    #[cfg(feature = "publish")]
+    fn validate_upload(
+        &self,
+        version: &Version,
+        platform: Option<Platform>,
+        manifest: &DistributionManifest,
+    ) -> Result<()> {
+        if let Some(release) = manifest.releases.get(version) {
+            match (release, platform) {
+                (Release::TargetAgnostic(_), Some(_)) => {
+                    return Err(RzupError::Other(
+                        "target-agnostic artifact already exists for this release version, \
+                                add --force flag to overwrite"
+                            .into(),
+                    ));
+                }
+                (Release::TargetSpecific(_), None) => {
+                    return Err(RzupError::Other(
+                        "target-specific artifact already exists for this release version, \
+                                add --force flag to overwrite"
+                            .into(),
+                    ));
+                }
+                (Release::TargetAgnostic(_), None) => {
+                    return Err(RzupError::Other(
+                        "artifact already exists for this release, add --force flag to \
+                                overwrite"
+                            .into(),
+                    ));
+                }
+                (Release::TargetSpecific(TargetSpecificRelease { artifacts }), Some(platform))
+                    if artifacts.contains_key(&TargetTriple(platform.target_triple())) =>
+                {
+                    return Err(RzupError::Other(
+                        "artifact already exists for this release and target, \
+                                add --force flag to overwrite"
+                            .into(),
+                    ));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "publish")]
+    fn update_manifest_with_artifact(
+        &self,
+        version: &Version,
+        platform: Option<Platform>,
+        sha256: String,
+        manifest: &mut DistributionManifest,
+    ) {
+        let artifact = Artifact { sha256 };
+        match manifest.releases.entry(version.clone()) {
+            Entry::Occupied(mut entry) => {
+                let existing_release = entry.get_mut();
+                match (existing_release, platform) {
+                    (
+                        Release::TargetSpecific(TargetSpecificRelease { artifacts }),
+                        Some(platform),
+                    ) => {
+                        artifacts.insert(TargetTriple(platform.target_triple()), artifact);
+                    }
+                    (existing_release @ Release::TargetAgnostic(_), Some(platform)) => {
+                        let mut artifacts = HashMap::new();
+                        artifacts.insert(TargetTriple(platform.target_triple()), artifact);
+                        *existing_release =
+                            Release::TargetSpecific(TargetSpecificRelease { artifacts });
+                    }
+                    (existing_release @ Release::TargetSpecific(_), None)
+                    | (existing_release @ Release::TargetAgnostic(_), None) => {
+                        *existing_release =
+                            Release::TargetAgnostic(TargetAgnosticRelease { artifact });
+                    }
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(if let Some(platform) = platform {
+                    let mut artifacts = HashMap::new();
+                    artifacts.insert(TargetTriple(platform.target_triple()), artifact);
+                    Release::TargetSpecific(TargetSpecificRelease { artifacts })
+                } else {
+                    Release::TargetAgnostic(TargetAgnosticRelease { artifact })
+                });
+            }
+        }
+    }
+
+    #[cfg(feature = "publish")]
+    fn upload_manifest(
+        &self,
+        component: &Component,
+        creds: &AwsCredentials,
+        manifest: DistributionManifest,
+    ) -> Result<()> {
+        let manifest_json = serde_json::to_vec(&manifest)
+            .expect("serde_json should serialize successfully to memory");
+        let manifest_json_len = manifest_json.len() as u64;
+        let base_url = &self.base_urls.s3_base_url;
+        let upload_url =
+            format!("{base_url}/rzup/components/{component}/distribution_manifest.json");
+        upload_bytes(
+            &upload_url,
+            |req| sign_s3_request(creds, req),
+            std::io::Cursor::new(manifest_json),
+            manifest_json_len,
+        )?;
+        Ok(())
+    }
+
+    #[cfg(feature = "publish")]
+    #[allow(clippy::too_many_arguments)]
+    fn upload_artifact(
+        &self,
+        env: &Environment,
+        component: &Component,
+        version: &Version,
+        creds: &AwsCredentials,
+        data_stream: File,
+        data_length: u64,
+        sha256: &String,
+    ) -> Result<()> {
+        let base_url = &self.base_urls.s3_base_url;
+        let upload_url = format!("{base_url}/rzup/components/{component}/sha256/{sha256}");
+        let upload_id = format!("{component}/{sha256}");
+
+        env.emit(RzupEvent::TransferStarted {
+            direction: TransferDirection::Upload,
+            id: upload_id.clone(),
+            version: version.to_string(),
+            url: upload_url.clone(),
+            len: Some(data_length),
+        });
+        let (send, recv) = std::sync::mpsc::channel();
+        let data_stream = ProgressReader::new(upload_id.clone(), send, data_stream);
+        std::thread::scope(move |scope| -> Result<()> {
+            scope.spawn(move || {
+                while let Ok(r) = recv.recv() {
+                    env.emit(r);
+                }
+            });
+
+            upload_bytes(
+                &upload_url,
+                |req| sign_s3_request(creds, req),
+                data_stream,
+                data_length,
+            )?;
+
+            Ok(())
+        })?;
+
+        env.emit(RzupEvent::TransferCompleted {
+            direction: TransferDirection::Upload,
+            id: upload_id,
+            version: version.to_string(),
+        });
+
+        Ok(())
+    }
+
+    #[cfg(feature = "publish")]
+    pub fn publish_upload(
+        &self,
+        env: &Environment,
+        component: &Component,
+        version: &Version,
+        platform: Option<Platform>,
+        payload: &Path,
+        force: bool,
+    ) -> Result<()> {
+        let creds = env
+            .aws_creds()
+            .as_ref()
+            .ok_or_else(|| RzupError::Other("missing AWS S3 credentials".into()))?;
+
+        let mut manifest = self.get_distribution_manifest(env, component)?;
+
+        // Check if we are going to replace something by uploading
+        if !force {
+            self.validate_upload(version, platform, &manifest)?;
+        }
+
+        let mut data_stream = File::open(payload)?;
+        validate_tar_xz(&mut data_stream)?;
+        data_stream.seek(SeekFrom::Start(0))?;
+
+        // Calculate the sha256
+        env.emit(RzupEvent::Print {
+            message: format!("Calculating sha256 for {component} {version}"),
+        });
+
+        let data_length = data_stream.metadata()?.len();
+        let sha256 = sha256_for_file(&mut data_stream)?;
+        data_stream.seek(SeekFrom::Start(0))?;
+
+        // Upload the artifact to S3
+        self.upload_artifact(
+            env,
+            component,
+            version,
+            creds,
+            data_stream,
+            data_length,
+            &sha256,
+        )?;
+
+        // Update the manifest
+        self.update_manifest_with_artifact(version, platform, sha256, &mut manifest);
+
+        env.emit(RzupEvent::Print {
+            message: format!("Updating distribution_manifest.json for {component} {version}"),
+        });
+        self.upload_manifest(component, creds, manifest)?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "publish")]
+    pub fn publish_set_latest(
+        &self,
+        env: &Environment,
+        component: &Component,
+        version: &Version,
+    ) -> Result<()> {
+        let creds = env
+            .aws_creds()
+            .as_ref()
+            .ok_or_else(|| RzupError::Other("missing AWS S3 credentials".into()))?;
+
+        let mut manifest = self.get_distribution_manifest(env, component)?;
+        if !manifest.releases.contains_key(version) {
+            return Err(RzupError::Other(format!(
+                "release for {component} at version {version} not found"
+            )));
+        }
+        manifest.latest_version = version.clone();
+
+        env.emit(RzupEvent::Print {
+            message: format!(
+                "Updating distribution_manifest.json for {component}, \
+                setting latest-version to {version}"
+            ),
+        });
+        self.upload_manifest(component, creds, manifest)?;
+
+        Ok(())
     }
 }
 
@@ -146,7 +492,8 @@ impl<'a> DistributionPlatform for S3Bucket<'a> {
         let download_url = format!("{base_url}/rzup/components/{component}/sha256/{sha256}");
         let mut resp = download_bytes(&download_url, &None)?;
 
-        env.emit(RzupEvent::DownloadStarted {
+        env.emit(RzupEvent::TransferStarted {
+            direction: TransferDirection::Download,
             id: component.to_string(),
             version: version.to_string(),
             url: download_url.clone(),
@@ -160,7 +507,8 @@ impl<'a> DistributionPlatform for S3Bucket<'a> {
         ))
         .map_err(|e| RzupError::Other(format!("Failed to download file: {e}")))?;
 
-        env.emit(RzupEvent::DownloadCompleted {
+        env.emit(RzupEvent::TransferCompleted {
+            direction: TransferDirection::Download,
             id: component.to_string(),
             version: version.to_string(),
         });

--- a/rzup/src/distribution/s3.rs
+++ b/rzup/src/distribution/s3.rs
@@ -352,8 +352,7 @@ impl<'a> S3Bucket<'a> {
         force: bool,
     ) -> Result<()> {
         let creds = env
-            .aws_creds()
-            .as_ref()
+            .get_aws_creds()
             .ok_or_else(|| RzupError::Other("missing AWS S3 credentials".into()))?;
 
         let mut manifest = self.get_distribution_manifest(env, component)?;
@@ -381,7 +380,7 @@ impl<'a> S3Bucket<'a> {
             env,
             component,
             version,
-            creds,
+            &creds,
             data_stream,
             data_length,
             &sha256,
@@ -393,7 +392,7 @@ impl<'a> S3Bucket<'a> {
         env.emit(RzupEvent::Print {
             message: format!("Updating distribution_manifest.json for {component} {version}"),
         });
-        self.upload_manifest(component, creds, manifest)?;
+        self.upload_manifest(component, &creds, manifest)?;
 
         Ok(())
     }
@@ -406,8 +405,7 @@ impl<'a> S3Bucket<'a> {
         version: &Version,
     ) -> Result<()> {
         let creds = env
-            .aws_creds()
-            .as_ref()
+            .get_aws_creds()
             .ok_or_else(|| RzupError::Other("missing AWS S3 credentials".into()))?;
 
         let mut manifest = self.get_distribution_manifest(env, component)?;
@@ -424,7 +422,7 @@ impl<'a> S3Bucket<'a> {
                 setting latest-version to {version}"
             ),
         });
-        self.upload_manifest(component, creds, manifest)?;
+        self.upload_manifest(component, &creds, manifest)?;
 
         Ok(())
     }

--- a/rzup/src/env.rs
+++ b/rzup/src/env.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 use crate::distribution::Platform;
 use crate::error::Result;
-use crate::RzupError;
-use crate::RzupEvent;
+use crate::{AwsCredentials, RzupError, RzupEvent};
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -36,6 +35,7 @@ pub struct Environment {
     event_handler: Option<Box<dyn Fn(RzupEvent) + Send + Sync>>,
     platform: Platform,
     github_token: Option<String>,
+    aws_creds: Option<AwsCredentials>,
 }
 
 fn get_github_token_from_hosts_yml(home_dir: &Path) -> Result<String> {
@@ -94,6 +94,25 @@ fn get_github_token_from_hosts_yml_test() {
     assert_eq!(token, "mysecret");
 }
 
+#[cfg(feature = "publish")]
+#[tokio::main]
+async fn get_aws_creds() -> Result<AwsCredentials> {
+    use aws_credential_types::provider::ProvideCredentials as _;
+
+    let config = aws_config::load_from_env().await;
+    config
+        .credentials_provider()
+        .ok_or_else(|| RzupError::Other("no AWS credentials provider".into()))?
+        .provide_credentials()
+        .await
+        .map_err(|err| RzupError::Other(format!("failed to get AWS credentials: {err}")))
+}
+
+#[cfg(not(feature = "publish"))]
+fn get_aws_creds() -> Result<AwsCredentials> {
+    Err(RzupError::Other("publish feature not enabled".into()))
+}
+
 impl Environment {
     fn ensure_directories(&self) -> Result<()> {
         if !self.risc0_dir.exists() {
@@ -114,11 +133,12 @@ impl Environment {
         Ok(())
     }
 
-    pub fn with_paths_token_platform_and_event_handler(
+    pub fn with_paths_creds_platform_and_event_handler(
         risc0_dir: impl Into<PathBuf>,
         rustup_dir: impl AsRef<Path>,
         cargo_dir: impl AsRef<Path>,
         github_token: Option<String>,
+        aws_creds: Option<AwsCredentials>,
         platform: Platform,
         event_handler: impl Fn(RzupEvent) + Send + Sync + 'static,
     ) -> Result<Self> {
@@ -137,6 +157,7 @@ impl Environment {
             event_handler: None,
             platform,
             github_token,
+            aws_creds,
         };
         env.set_event_handler(event_handler);
 
@@ -170,11 +191,14 @@ impl Environment {
             .or_else(|_| get_github_token_from_hosts_yml(&home_dir))
             .ok();
 
-        let env = Self::with_paths_token_platform_and_event_handler(
+        let aws_creds = get_aws_creds().ok();
+
+        let env = Self::with_paths_creds_platform_and_event_handler(
             risc0_dir,
             rustup_dir,
             cargo_dir,
             github_token,
+            aws_creds,
             platform,
             event_handler,
         )?;
@@ -220,6 +244,10 @@ impl Environment {
 
     pub fn github_token(&self) -> &Option<String> {
         &self.github_token
+    }
+
+    pub fn aws_creds(&self) -> &Option<AwsCredentials> {
+        &self.aws_creds
     }
 
     #[cfg(feature = "install")]
@@ -277,11 +305,12 @@ mod tests {
     #[test]
     fn test_custom_root() {
         let tmp_dir = tempfile::tempdir().unwrap();
-        let env = Environment::with_paths_token_platform_and_event_handler(
+        let env = Environment::with_paths_creds_platform_and_event_handler(
             tmp_dir.path().join(".risc0"),
             tmp_dir.path().join(".rustup"),
             tmp_dir.path().join(".cargo"),
             Some("foo".into()),
+            None,
             Platform::new("x86_64", Os::Linux),
             |_| {},
         )

--- a/rzup/src/events.rs
+++ b/rzup/src/events.rs
@@ -11,19 +11,28 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum TransferDirection {
+    Upload,
+    Download,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum RzupEvent {
-    DownloadStarted {
+    TransferStarted {
+        direction: TransferDirection,
         id: String,
         version: String,
         url: String,
         len: Option<u64>,
     },
-    DownloadProgress {
+    TransferProgress {
         id: String,
         incr: u64,
     },
-    DownloadCompleted {
+    TransferCompleted {
+        direction: TransferDirection,
         id: String,
         version: String,
     },

--- a/rzup/src/lib.rs
+++ b/rzup/src/lib.rs
@@ -102,7 +102,7 @@ impl Rzup {
     /// * `cargo_dir` - The path to cargo's home directory (usually ~/.cargo)
     /// * `base_urls` - The base URLs used to communicate with GitHub
     /// * `github_token` - The token to use when communicating with GitHub
-    /// * `aws_creds` - Credentials for communicating with S3
+    /// * `aws_creds_factory` - Function which gets credentials for communicating with S3
     #[allow(clippy::too_many_arguments)]
     pub fn with_paths_urls_creds_platform_and_event_handler(
         risc0_dir: impl Into<PathBuf>,
@@ -110,7 +110,7 @@ impl Rzup {
         cargo_dir: impl AsRef<Path>,
         base_urls: BaseUrls,
         github_token: Option<String>,
-        aws_creds: Option<AwsCredentials>,
+        aws_creds_factory: impl Fn() -> Option<AwsCredentials> + Send + Sync + 'static,
         platform: Platform,
         event_handler: impl Fn(RzupEvent) + Send + Sync + 'static,
     ) -> Result<Self> {
@@ -119,7 +119,7 @@ impl Rzup {
             rustup_dir,
             cargo_dir,
             github_token,
-            aws_creds,
+            aws_creds_factory,
             platform,
             event_handler,
         )?;
@@ -700,7 +700,7 @@ mod tests {
             tmp_dir.path().join(".cargo"),
             base_urls,
             github_token,
-            aws_creds,
+            move || aws_creds.clone(),
             platform,
             |_| {},
         )

--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -134,10 +134,11 @@ mod tests {
 
     fn setup_test_env() -> (TempDir, Environment) {
         let tmp_dir = TempDir::new().unwrap();
-        let env = Environment::with_paths_token_platform_and_event_handler(
+        let env = Environment::with_paths_creds_platform_and_event_handler(
             tmp_dir.path().join(".risc0"),
             tmp_dir.path().join(".rustup"),
             tmp_dir.path().join(".cargo"),
+            None,
             None,
             Platform::new("x86_64", Os::Linux),
             |_| {},

--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -139,7 +139,7 @@ mod tests {
             tmp_dir.path().join(".rustup"),
             tmp_dir.path().join(".cargo"),
             None,
-            None,
+            || None,
             Platform::new("x86_64", Os::Linux),
             |_| {},
         )

--- a/rzup/src/settings.rs
+++ b/rzup/src/settings.rs
@@ -116,7 +116,7 @@ mod tests {
             tmp_dir.path().join(".rustup"),
             tmp_dir.path().join(".cargo"),
             None,
-            None,
+            || None,
             Platform::new("x86_64", Os::Linux),
             |_| {},
         )

--- a/rzup/src/settings.rs
+++ b/rzup/src/settings.rs
@@ -111,10 +111,11 @@ mod tests {
 
     fn test_env() -> (TempDir, Environment) {
         let tmp_dir = TempDir::new().unwrap();
-        let env = Environment::with_paths_token_platform_and_event_handler(
+        let env = Environment::with_paths_creds_platform_and_event_handler(
             tmp_dir.path().join(".risc0"),
             tmp_dir.path().join(".rustup"),
             tmp_dir.path().join(".cargo"),
+            None,
             None,
             Platform::new("x86_64", Os::Linux),
             |_| {},


### PR DESCRIPTION
This PR adds two new commands to the `rzup` CLI.
- `publish upload` uploads a `.tar.xz` file to S3 under `rzup/components/<component>/sha265` and updates the `rzup/components/<component>/distribution_manifest.json` to mention the artifact
- `publish set-latest` which updates the `latest_version` field fo the `distribution_manifest.json`

`publish` help text
```
Publish a component on S3

Usage: rzup publish [OPTIONS] <COMMAND>

Commands:
  upload
  set-latest
  help        Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose  Enable verbose output
  -q, --quiet    Suppress output
  -h, --help     Print help

Discussion:
    Publishes a component to S3 at a particular version, or updates the current latest version.

    Requires that AWS credentials be available in the environment.

    Each version of a component is either tagged with a target, or is target agnostic. A particular
    version can only have one target-agnostic artifact, or many target specific artifacts, but each
    target may only have one artifact each.
```
`publish upload` help text
```
Usage: rzup publish upload [OPTIONS] <--target-agnostic|--target-triple <TARGET_TRIPLE>> <NAME> <VERSION> <PAYLOAD>

Arguments:
  <NAME>     Name of component to publish (e.g. rust) [possible values: cargo-risczero, cpp, gdb, r0vm, rust, risc0-groth16, self]
  <VERSION>  Version of the component to publish (e.g. 1.0.0)
  <PAYLOAD>  The path to the archive

Options:
      --target-agnostic                Is the component the same for all targets
      --target-triple <TARGET_TRIPLE>  The target triple of the component
      --force                          If the component at the given target / version already exists, replace it
  -v, --verbose                        Enable verbose output
  -q, --quiet                          Suppress output
  -h, --help                           Print help
```

`publish set-latest` help text
```
Usage: rzup publish set-latest [OPTIONS] <NAME> <VERSION>

Arguments:
  <NAME>     Name of component to update the latest version of (e.g. rust) [possible values: cargo-risczero, cpp, gdb, r0vm, rust, risc0-groth16, self]
  <VERSION>  Version to set (e.g. 1.0.0)

Options:
  -v, --verbose  Enable verbose output
  -q, --quiet    Suppress output
  -h, --help     Print help
```