### PR TITLE
fix: Use correct stream IDs for cpu_stream and gpu_stream in stress test job definition

### DIFF
--- a/bento/crates/taskdb/examples/stress.rs
+++ b/bento/crates/taskdb/examples/stress.rs
@@ -60,7 +60,7 @@ async fn spawner(shutdown: Arc<AtomicBool>, pool: PgPool, args: Args) -> Result<
         let ((cpu_stream, gpu_stream), user_id) = customers.choose(&mut r).unwrap();
         let segment_count = r.random_range(1..args.max_job_size);
         let task_def = serde_json::json!({
-            "cpu_stream": gpu_stream.to_string(),
+            "cpu_stream": cpu_stream.to_string(),
             "gpu_stream": gpu_stream.to_string(),
             "segments": segment_count,
             "user_id": user_id,


### PR DESCRIPTION
Previously, both the "cpu_stream" and "gpu_stream" fields in the generated task definition were set to the GPU stream ID, which was incorrect. This commit updates the code so that "cpu_stream" is set to the CPU stream ID and "gpu_stream" is set to the GPU stream ID as intended. This ensures that downstream logic receives the correct stream assignments for each job in the stress test.