### PR TITLE
fix invalid usage in Update testutil.rs

### DIFF
--- a/risc0/circuit/keccak/src/prove/testutil.rs
+++ b/risc0/circuit/keccak/src/prove/testutil.rs
@@ -47,7 +47,7 @@ pub struct EvalCheckParams {
 
 impl EvalCheckParams {
     pub fn new(po2: usize) -> Self {
-        let mut rng = rand::rng();
+        let mut rng = rand::thread_rng();
         let steps = 1 << po2;
         let domain = steps * INV_RATE;
         let code_size = TAPSET.group_size(REGISTER_GROUP_CODE);


### PR DESCRIPTION
This PR fixes a compilation error caused by the use of the invalid API rand::rng(). In EvalCheckParams::new, the following line is used: let mut rng = rand::rng();

However, rand::rng() is not a valid API in any version of the rand crate, including 0.8.x and 0.9.x.

This causes a compile-time error: error[E0433]: failed to resolve: use of undeclared crate or module `rng`

Need fix it replaced with the correct standard API: let mut rng = rand::thread_rng(); This is the idiomatic and documented way to obtain a default RNG instance.

Impact:
Fixes a compilation failure.

No behavioral changes.

Fully backward-compatible with existing logic.