### PR TITLE
fix(groth16): include docker stderr/stdout in error messages

### DIFF
--- a/risc0/groth16/src/docker.rs
+++ b/risc0/groth16/src/docker.rs
@@ -59,10 +59,23 @@ pub fn stark_to_snark(identity_p254_seal_bytes: &[u8]) -> Result<Seal> {
         .stderr(Stdio::piped())
         .output()?;
     if !output.status.success() {
-        bail!(
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        
+        let mut error_msg = format!(
             "docker returned failure exit code: {:?}",
             output.status.code()
         );
+        
+        if !stderr.is_empty() {
+            error_msg.push_str(&format!("\nstderr: {}", stderr));
+        }
+        
+        if !stdout.is_empty() {
+            error_msg.push_str(&format!("\nstdout: {}", stdout));
+        }
+        
+        bail!("{}", error_msg);
     }
 
     tracing::debug!("Parsing proof");


### PR DESCRIPTION
## Description

Fixes #3275 - Makes error messages from the groth16 prover docker image more informative by including the actual stderr/stdout output instead of just the exit code.

## Changes

- Modified error handling in `risc0/groth16/src/docker.rs` to capture and display docker stderr/stdout when the process fails
- Users now see actual error messages instead of just "docker returned failure exit code: Some(1)"

## Benefits

- Better debugging experience for users
- Self-service troubleshooting capabilities 
- No impact on successful execution paths
- Backward compatible

## Testing

The change only affects error paths when docker commands fail. No changes to successful execution flows.