### PR TITLE
fix: add missing semicolon in bail! macro call

### DIFF
--- a/risc0/cargo-risczero/src/commands/guest.rs
+++ b/risc0/cargo-risczero/src/commands/guest.rs
@@ -196,7 +196,7 @@ impl GuestCommand {
             .wait()
             .with_context(|| "couldn't get cargo's exit status")?;
         if !output.success() {
-            bail!("failed to build crate")
+            bail!("failed to build crate");
         }
 
         // If we are running `cargo risczero test`, load each test binary into the


### PR DESCRIPTION
Fix syntax error in guest.rs where bail! macro call was missing
a semicolon at the end of the expression on line 199.

