### PR TITLE
Fix CUDA warnings

### DIFF
--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -206,7 +206,7 @@ impl KernelBuild {
             .flag("--display_error_number")
             .flag("-Xcompiler")
             .flag(
-                "-Wno-missing-braces,-Wno-unused-function,-Wno-unused-pragmas,-Wno-unused-paramter",
+                "-Wno-missing-braces,-Wno-unused-function,-Wno-unknown-pragmas,-Wno-unused-parameter",
             )
             .compile(output);
     }

--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -205,7 +205,9 @@ impl KernelBuild {
             .flag("-Xcudafe")
             .flag("--display_error_number")
             .flag("-Xcompiler")
-            .flag("-Wno-missing-braces,-Wno-unused-function")
+            .flag(
+                "-Wno-missing-braces,-Wno-unused-function,-Wno-unused-pragmas,-Wno-unused-paramter",
+            )
             .compile(output);
     }
 

--- a/risc0/circuit/keccak-sys/build.rs
+++ b/risc0/circuit/keccak-sys/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ fn build_cuda_kernels() {
         .flag("-diag-suppress=2922")
         .flag("-std=c++17")
         .flag("-Xcompiler")
-        .flag("-Wno-unused-function,-Wno-unused-parameter")
+        .flag("-Wno-missing-braces,-Wno-unused-function,-Wno-unknown-pragmas,-Wno-unused-parameter")
         .include(env::var("DEP_RISC0_SYS_CUDA_ROOT").unwrap())
         .include(env::var("DEP_SPPARK_ROOT").unwrap());
     if env::var_os("NVCC_PREPEND_FLAGS").is_none() && env::var_os("NVCC_APPEND_FLAGS").is_none() {

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -71,7 +71,7 @@ fn build_cuda_kernels() {
         .flag("-diag-suppress=2922")
         .flag("-std=c++17")
         .flag("-Xcompiler")
-        .flag("-Wno-unused-function,-Wno-unused-parameter")
+        .flag("-Wno-missing-braces,-Wno-unused-function,-Wno-unknown-pragmas,-Wno-unused-parameter")
         .flag("-Xcompiler")
         .flag("-O3")
         .flag("-Xptxas")

--- a/risc0/sys/kernels/zkp/cuda/kernels.cu
+++ b/risc0/sys/kernels/zkp/cuda/kernels.cu
@@ -20,7 +20,7 @@ constexpr size_t kFriFold = 16;
 /// Compute `ceil(log_2(in))`, i.e. find the smallest value `out` such that `2^out >= in`.
 __device__ inline constexpr size_t log2Ceil(size_t in) {
   size_t r = 0;
-  while ((1 << r) < in) {
+  while ((1uz << r) < in) {
     r++;
   }
   return r;


### PR DESCRIPTION
These were really annoying me for a while because vim's pattern matching for compilation errors would get stuck on these