### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       trigger-bench: ${{ steps.filter.outputs.trigger-bench }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/paths-filter@4067d885736b84de7c414f582ac45897079b0a78
         id: filter
         with:
@@ -62,7 +62,7 @@ jobs:
       S3_BENCH_PATH: s3://risc0-ci-cache/public/bench/${{ github.base_ref || github.ref_name }}/fib/${{ matrix.os }}-${{ matrix.device }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda

--- a/.github/workflows/bench_reports.yml
+++ b/.github/workflows/bench_reports.yml
@@ -45,7 +45,7 @@ jobs:
       EXTRA: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - uses: ./.github/actions/rustup
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout gh-pages repository branch ${{ github.base_ref || github.ref_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: risc0/ghpages
           token: ${{ secrets.BENCHMARK_TOKEN }}

--- a/.github/workflows/bench_trends.yml
+++ b/.github/workflows/bench_trends.yml
@@ -50,7 +50,7 @@ jobs:
       FEATURE: ${{ matrix.feature }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda

--- a/.github/workflows/groth16_proof.yml
+++ b/.github/workflows/groth16_proof.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       check: ${{ steps.filter.outputs.check }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
@@ -35,7 +35,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Go 1.23
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       test-crates: ${{ steps.filter.outputs.test-crates }}
       web: ${{ steps.filter.outputs.web }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
@@ -134,7 +134,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history is required by license-check.py
           fetch-depth: 0
@@ -203,7 +203,7 @@ jobs:
       RISC0_SKIP_BUILD: 1
       RISC0_SKIP_BUILD_KERNELS: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - uses: ./.github/actions/rustup
@@ -256,7 +256,7 @@ jobs:
       RUST_BACKTRACE: full
       # SCCACHE_RECACHE: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - if: matrix.feature == 'cuda'
@@ -319,7 +319,7 @@ jobs:
       RUST_BACKTRACE: full
       # SCCACHE_RECACHE: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - if: matrix.feature == 'cuda'
@@ -389,7 +389,7 @@ jobs:
       RUST_BACKTRACE: full
       # SCCACHE_RECACHE: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - if: matrix.feature == 'cuda'
@@ -423,10 +423,10 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: 'risc0'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: risc0/RustCrypto-crypto-bigint
           path: 'RustCrypto-crypto-bigint'
@@ -447,7 +447,7 @@ jobs:
     needs: changes
     runs-on: [self-hosted, cluster, macOS, cpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
@@ -468,7 +468,7 @@ jobs:
       # nightly-2025-05-09 corresponds to 1.88
       NIGHTLY_RUST_TOOLCHAIN: nightly-2025-05-09
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
         with:
           toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
@@ -484,7 +484,7 @@ jobs:
     needs: changes
     runs-on: [self-hosted, cluster, macOS, cpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo check
@@ -504,7 +504,7 @@ jobs:
           - os: macOS
             arch: ARM64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/rustup
@@ -532,7 +532,7 @@ jobs:
           - os: macOS
             arch: ARM64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo install --force --path risc0/cargo-risczero --locked
@@ -565,7 +565,7 @@ jobs:
     env:
       RISC0_BUILD_LOCKED: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: browser-actions/setup-firefox@v1
       - run: firefox --version
       - uses: ./.github/actions/rustup
@@ -591,7 +591,7 @@ jobs:
     needs: changes
     runs-on: [self-hosted, cluster, Linux, X64, cpu, docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - run: git lfs pull
@@ -617,7 +617,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 🍞 Setup Bun
         uses: risc0/setup-bun@v1.2.1
         with:
@@ -647,7 +647,7 @@ jobs:
       RISC0_DEV_MODE: true
       DATABASE_URL: postgres://postgres:password@localhost:5432/postgres
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - uses: ./.github/actions/protoc
@@ -682,7 +682,7 @@ jobs:
       RISC0_SERVER_PATH: ${{ github.workspace }}/target/release/r0vm
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/cuda
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       RUST_LOG: info
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
 
       - run: cargo install --force --path risc0/cargo-risczero --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
       - run: git lfs pull

--- a/.github/workflows/risc0-ethereum.yml
+++ b/.github/workflows/risc0-ethereum.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       test: ${{ steps.filter.outputs.test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
@@ -70,7 +70,7 @@ jobs:
       # This is a workaround from: https://github.com/actions/checkout/issues/590#issuecomment-970586842
       - run: "git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :"
       # Checkout risc0
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: 'risc0'
       # Determine the branch for risc0-ethereum
@@ -83,7 +83,7 @@ jobs:
           fi
       # Checkout risc0-ethereum
       - name: Checkout risc0-ethereum
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'risc0/risc0-ethereum'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,7 +38,7 @@ jobs:
       doc-test-main: ${{ steps.filter.outputs.doc-test-main }}
       doc-test-stable: ${{ steps.filter.outputs.doc-test-stable }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
@@ -66,7 +66,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 🍞 Setup Bun
         uses: risc0/setup-bun@v1.2.1
         with:
@@ -88,7 +88,7 @@ jobs:
     needs: changes
     runs-on: [self-hosted, cluster, Linux, X64, cpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
@@ -112,7 +112,7 @@ jobs:
     needs: changes
     runs-on: [self-hosted, cluster, Linux, X64, cpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/rustup
       - uses: ./.github/actions/sccache
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0