### PR TITLE
Replace size_t literal syntax with more portable static_cast

### DIFF
--- a/risc0/sys/kernels/zkp/cuda/kernels.cu
+++ b/risc0/sys/kernels/zkp/cuda/kernels.cu
@@ -20,7 +20,7 @@ constexpr size_t kFriFold = 16;
 /// Compute `ceil(log_2(in))`, i.e. find the smallest value `out` such that `2^out >= in`.
 __device__ inline constexpr size_t log2Ceil(size_t in) {
   size_t r = 0;
-  while ((1uz << r) < in) {
+  while ((static_cast<size_t>(1) << r) < in) {
     r++;
   }
   return r;


### PR DESCRIPTION
I used a size_t literal here to fix an implicit cast warning, but the syntax I used is only available in a newer C++ standard. To maximize portability use the older syntax.