### PR TITLE
semver-checks: More fixes for release branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,6 +97,7 @@ jobs:
               - compact_proof/**
               - external/**
               - risc0/**
+              - xtask/**
             test-crates:
               - *base
               - risc0/**


### PR DESCRIPTION
Some fixes for issues with semver-checks revealed by release branch:
- One spot where we check for SemVer compatibility we compared major version numbers, this broke with .rc.x versions
- The behavior of --locked + --update didn't work as expected, it would always fail 
- Fix CI job filtering so "test" runs if there are changes in xtask/**