### PR TITLE
Add support for Groth16 shrink-wrapping to the actor system

### DIFF
--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -262,7 +262,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "0b25154f31ff970988c49d81539a4daaccee785b48e10775b6ee37b58112b0c6",
+            "4a038d5f7c0332ced32f114ac8c2ed1af693e8b9a638e5f9d28b75e00cef7469",
         );
     }
 }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -17,6 +17,8 @@ bytemuck = "1.12"
 clap = { version = "4.5", features = ["derive", "env"] }
 derive_more = { version = "2.0.1", default-features = false, features = [
   "debug",
+  "from",
+  "try_into",
 ] }
 dirs = "6.0.0"
 futures = "0.3.31"

--- a/risc0/r0vm/src/actors/job.rs
+++ b/risc0/r0vm/src/actors/job.rs
@@ -14,6 +14,7 @@
 
 mod proof;
 mod shrink_wrap;
+mod tracer;
 
 use derive_more::From;
 use kameo::{error::Infallible, prelude::*};

--- a/risc0/r0vm/src/actors/job.rs
+++ b/risc0/r0vm/src/actors/job.rs
@@ -12,473 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, HashMap, VecDeque},
-    sync::Arc,
-};
+mod proof;
+mod shrink_wrap;
 
+use derive_more::From;
 use kameo::{error::Infallible, prelude::*};
-use opentelemetry::{
-    global::{BoxedSpan, BoxedTracer},
-    trace::{Span, SpanKind, TraceContextExt as _, Tracer},
-    KeyValue,
-};
-use risc0_zkvm::{
-    sha::Digestible, AssumptionReceipt, InnerReceipt, ProveKeccakRequest, Receipt, ReceiptClaim,
-    Segment, SegmentReceipt, SuccinctReceipt, Unknown,
-};
-use tokio::time::Instant;
+use tokio::task::JoinSet;
 
 use super::{
     factory::FactoryActor,
-    protocol::{
-        factory::{
-            DropJob, JoinNode, ProveKeccakDone, SubmitTaskMsg, TaskDone, TaskDoneMsg, TaskUpdate,
-            TaskUpdateMsg, UnionDone,
-        },
-        ExecuteTask, GlobalId, JobId, JobInfo, JobStatus, JobStatusReply, JobStatusRequest,
-        JoinTask, LiftTask, ProofRequest, ProofResult, ProveKeccakTask, ProveSegmentTask,
-        ResolveTask, SegmentRange, Session, Task, TaskError, TaskHeader, TaskId, UnionTask,
-    },
+    protocol::{JobId, JobStatusReply, JobStatusRequest, ProofRequest, ShrinkWrapRequest},
+    TaskDoneMsg, TaskUpdateMsg,
 };
-
-#[derive(PartialEq)]
-enum KeccakPhase {
-    Build,
-    MergePeaks,
-    Done,
-}
 
 pub(crate) struct JobActor {
     job_id: JobId,
-    self_ref: Option<WeakActorRef<Self>>,
     factory: ActorRef<FactoryActor>,
-    joins: BTreeMap<SegmentRange, Arc<SuccinctReceipt<ReceiptClaim>>>,
-    next_task_id: u64,
-    session: Option<Arc<Session>>,
-    ctx: opentelemetry::Context,
-    tracer: BoxedTracer,
-    pending_spans: HashMap<TaskId, BoxedSpan>,
-    reply_sender: Option<ReplySender<JobStatusReply>>,
-    start_time: Instant,
-    status: JobStatus,
-    unions: Vec<Vec<Option<UnknownReceipt>>>,
-    keccak_phase: KeccakPhase,
-    keccak_count: usize,
-    required_keccak_layers: Vec<usize>,
-    pending_keccak_peaks: VecDeque<UnknownReceipt>,
-    keccak_root: Option<UnknownReceipt>,
-    assumptions: Option<VecDeque<UnknownReceipt>>,
-    final_receipt: Option<Arc<SuccinctReceipt<ReceiptClaim>>>,
+    join_set: JoinSet<()>,
+    inner: Option<InnerJobActor>,
 }
 
-type UnknownReceipt = Arc<SuccinctReceipt<Unknown>>;
-
-impl JobActor {
-    async fn prove_keccak_done(&mut self, done: Arc<ProveKeccakDone>) {
-        tracing::info!("ProveKeccakDone: {}", done.index);
-        let receipt = Arc::new(done.receipt.clone());
-        self.process_union(done.index, 0, receipt).await;
-    }
-
-    async fn union_done(&mut self, done: Arc<UnionDone>) {
-        let receipt = Arc::new(done.receipt.clone().into_unknown());
-        match self.keccak_phase {
-            KeccakPhase::Build => {
-                tracing::info!("UnionDone: {}/{}", done.height, done.pos);
-                self.process_union(done.pos, done.height, receipt).await;
-            }
-            KeccakPhase::MergePeaks => {
-                if let Some(rhs) = self.pending_keccak_peaks.pop_front() {
-                    self.union(0, 0, receipt, rhs).await;
-                } else {
-                    assert!(self.keccak_root.is_none());
-                    self.keccak_root = Some(receipt);
-                    self.keccak_phase = KeccakPhase::Done;
-                    tracing::info!("KeccakPhase::Done from UnionDone");
-                    self.maybe_finish().await;
-                }
-            }
-            KeccakPhase::Done => {
-                unreachable!();
-            }
-        }
-    }
-
-    async fn process_union(&mut self, pos: usize, height: usize, receipt: UnknownReceipt) {
-        if self.unions.len() < height + 1 {
-            self.unions.resize_with(height + 1, Vec::new);
-        }
-        let layer = self.unions.get_mut(height).unwrap();
-        if layer.len() < pos + 1 {
-            layer.resize(pos + 1, None);
-        }
-        layer[pos] = Some(receipt.clone());
-        let (lhs_pos, rhs_pos) = if pos % 2 == 0 {
-            (pos, pos + 1)
-        } else {
-            (pos - 1, pos)
-        };
-        if let (Some(Some(lhs)), Some(Some(rhs))) =
-            (layer.get(lhs_pos).cloned(), layer.get(rhs_pos).cloned())
-        {
-            let up_height = height + 1;
-            let up_pos = pos / 2;
-            tracing::info!("Union: {height}/({lhs_pos}, {rhs_pos}) -> {up_height}/{up_pos}");
-            self.union(up_height, up_pos, lhs, rhs).await;
-        } else {
-            self.maybe_finish().await;
-        }
-    }
-
-    async fn union(&mut self, height: usize, pos: usize, lhs: UnknownReceipt, rhs: UnknownReceipt) {
-        self.submit_task(Task::Union(Arc::new(UnionTask {
-            height,
-            pos,
-            receipts: vec![lhs, rhs],
-        })))
-        .await;
-    }
+#[derive(From)]
+enum InnerJobActor {
+    Proof(ActorRef<proof::JobActor>),
+    ShrinkWrap(ActorRef<shrink_wrap::JobActor>),
 }
 
 impl Actor for JobActor {
     type Error = Infallible;
 
-    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
-        self.self_ref = Some(actor_ref.downgrade());
-        Ok(())
-    }
-
-    async fn on_stop(
-        &mut self,
-        _actor_ref: WeakActorRef<Self>,
-        reason: ActorStopReason,
-    ) -> Result<(), Self::Error> {
-        let _ = self
-            .factory
-            .tell(DropJob {
-                job_id: self.job_id,
-            })
-            .await;
-
-        let elapsed_time = self.start_time.elapsed();
-        let span = self.ctx.span();
-
-        if let ActorStopReason::Panicked(err) = reason {
-            tracing::error!("{err}");
-            span.record_error(&err);
-            if let Some(reply_sender) = self.reply_sender.take() {
-                let info = JobInfo {
-                    status: JobStatus::Failed(TaskError::Generic(err.to_string())),
-                    elapsed_time,
-                };
-                reply_sender.send(JobStatusReply { info: Some(info) });
-            }
-        } else if let Some(reply_sender) = self.reply_sender.take() {
-            let info = JobInfo {
-                status: self.status.clone(),
-                elapsed_time,
-            };
-            reply_sender.send(JobStatusReply { info: Some(info) });
-        }
-
-        span.end();
+    async fn on_start(&mut self, _actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
 
+trait JobActorNew {
+    fn new(
+        job_id: JobId,
+        parent_ref: WeakActorRef<JobActor>,
+        factory: ActorRef<FactoryActor>,
+    ) -> Self;
+}
+
 impl JobActor {
     pub fn new(job_id: JobId, factory: ActorRef<FactoryActor>) -> Self {
-        let tracer = opentelemetry::global::tracer("job");
-        let span = tracer
-            .span_builder("job")
-            .with_kind(SpanKind::Client)
-            .with_attributes([KeyValue::new("job_id", job_id.to_string())])
-            .start(&tracer);
-        let ctx = opentelemetry::Context::current_with_span(span);
         Self {
             job_id,
-            self_ref: None,
             factory,
-            joins: BTreeMap::new(),
-            next_task_id: 0,
-            session: None,
-            ctx,
-            tracer,
-            pending_spans: HashMap::new(),
-            reply_sender: None,
-            start_time: Instant::now(),
-            status: JobStatus::Running("init".to_string()),
-            unions: Default::default(),
-            keccak_count: 0,
-            keccak_phase: KeccakPhase::Build,
-            keccak_root: None,
-            required_keccak_layers: Vec::new(),
-            pending_keccak_peaks: VecDeque::new(),
-            assumptions: None,
-            final_receipt: None,
+            join_set: JoinSet::new(),
+            inner: None,
         }
     }
 
-    fn self_ref(&self) -> ActorRef<Self> {
-        self.self_ref.as_ref().unwrap().upgrade().unwrap()
-    }
-
-    fn next_task_id(&mut self) -> u64 {
-        self.next_task_id += 1;
-        self.next_task_id
-    }
-
-    fn next_keccak_index(&mut self) -> usize {
-        let ret = self.keccak_count;
-        self.keccak_count += 1;
-        ret
-    }
-
-    fn span_start<T>(&mut self, task_id: TaskId, name: T)
-    where
-        T: Into<Cow<'static, str>>,
+    fn request<RequestT, ActorT>(
+        &mut self,
+        request: RequestT,
+        self_ref: ActorRef<Self>,
+        reply_sender: Option<ReplySender<JobStatusReply>>,
+    ) where
+        InnerJobActor: From<ActorRef<ActorT>>,
+        ActorT: Message<RequestT, Reply = DelegatedReply<JobStatusReply>> + JobActorNew,
+        RequestT: Send + 'static,
     {
-        self.pending_spans
-            .insert(task_id, self.tracer.start_with_context(name, &self.ctx));
-    }
+        let job = kameo::spawn(ActorT::new(
+            self.job_id,
+            self_ref.downgrade(),
+            self.factory.clone(),
+        ));
+        self.inner = Some(job.clone().into());
 
-    fn span_event<T>(&mut self, header: TaskHeader, name: T)
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        self.pending_spans
-            .get_mut(&header.global_id.task_id)
-            .unwrap()
-            .add_event(name, vec![]);
-    }
-
-    fn span_end(&mut self, task_id: TaskId) {
-        self.pending_spans.remove(&task_id).as_mut().unwrap().end();
-    }
-
-    fn task_start(&mut self, header: TaskHeader) {
-        let name = format!("{:?}", header.task_kind);
-        self.span_start(header.global_id.task_id, name);
-    }
-
-    async fn prove_segment(&mut self, header: TaskHeader, segment: Segment) {
-        self.span_event(header, "segment");
-        tracing::info!("ProveSegment: {}", segment.index);
-        self.submit_task(Task::ProveSegment(Arc::new(ProveSegmentTask { segment })))
-            .await;
-    }
-
-    async fn prove_keccak(&mut self, request: ProveKeccakRequest) {
-        tracing::info!("ProveKeccak: {} hashes", request.input.len());
-        let index = self.next_keccak_index();
-        self.submit_task(Task::ProveKeccak(Arc::new(ProveKeccakTask {
-            index,
-            request,
-        })))
-        .await;
-    }
-
-    async fn session_done(&mut self, session: Arc<Session>) {
-        tracing::info!("SessionDone");
-        for ref receipt in session.assumptions.iter() {
-            tracing::info!("{receipt:#?}");
-        }
-        self.session = Some(session);
-        self.required_keccak_layers = mmr_layers(self.keccak_count);
-        self.maybe_finish().await;
-    }
-
-    async fn prove_segment_done(&mut self, receipt: Box<SegmentReceipt>) {
-        tracing::info!("ProveSegmentDone: {}", receipt.index);
-        self.submit_task(Task::Lift(Arc::new(LiftTask { receipt: *receipt })))
-            .await;
-    }
-
-    async fn lift_done(&mut self, node: Box<JoinNode>) {
-        tracing::info!("LiftDone: {:?}", node.range);
-        self.joins.insert(node.range, Arc::new(node.receipt));
-        self.maybe_join().await;
-        self.maybe_finish().await;
-    }
-
-    async fn join_done(&mut self, node: Box<JoinNode>) {
-        tracing::info!("JoinDone: {:?}", node.range);
-        self.joins.insert(node.range, Arc::new(node.receipt));
-        self.maybe_join().await;
-        self.maybe_finish().await;
-    }
-
-    async fn resolve_done(&mut self, receipt: Arc<SuccinctReceipt<ReceiptClaim>>) {
-        self.final_receipt = Some(receipt);
-        self.maybe_finish().await;
-    }
-
-    async fn submit_task(&mut self, task: Task) {
-        let task_id = self.next_task_id();
-        let msg = SubmitTaskMsg {
-            job: self.self_ref(),
-            header: TaskHeader {
-                global_id: GlobalId {
-                    job_id: self.job_id,
-                    task_id,
-                },
-                task_kind: task.kind(),
-            },
-            task,
-        };
-        self.factory.tell(msg).await.unwrap();
-    }
-
-    async fn maybe_join(&mut self) {
-        if let Some(((a_range, a_receipt), (b_range, b_receipt))) = self
-            .joins
-            .iter()
-            .zip(self.joins.iter().skip(1))
-            .filter(|((a, _), (b, _))| a.end == b.start)
-            .map(|((a_range, a_receipt), (b_range, b_receipt))| {
-                ((*a_range, a_receipt.clone()), (*b_range, b_receipt.clone()))
-            })
-            .take(1)
-            .next()
-        {
-            self.joins.remove(&a_range);
-            self.joins.remove(&b_range);
-            let range = (a_range.start..b_range.end).into();
-            let receipts = vec![(*a_receipt).clone(), (*b_receipt).clone()];
-            self.submit_task(Task::Join(Arc::new(JoinTask { range, receipts })))
-                .await;
-        }
-    }
-
-    async fn maybe_finish(&mut self) {
-        if self.session.is_some() && !self.maybe_finish_keccak_mmr().await {
-            return;
-        }
-
-        if let Some(ref session) = self.session {
-            // tracing::info!("maybe_finish: session done");
-
-            if let Some(join_root) = self.join_root(session) {
-                let final_receipt = self
-                    .final_receipt
-                    .get_or_insert_with(|| join_root.clone())
-                    .clone();
-
-                if self.assumptions.is_none() {
-                    let mut assumptions = VecDeque::new();
-                    for receipt in session.assumptions.iter() {
-                        match receipt.as_ref() {
-                            AssumptionReceipt::Proven(inner) => {
-                                tracing::info!(
-                                    "Adding proven assumption: {:?}",
-                                    inner.claim_digest()
-                                );
-                                assumptions.push_back(Arc::new(inner.succinct().unwrap().clone()));
-                            }
-                            AssumptionReceipt::Unresolved(assumption) => {
-                                if let Some(keccak_root) = self.keccak_root.clone() {
-                                    if keccak_root.claim.digest() == assumption.claim {
-                                        tracing::info!("Using keccak_root");
-                                        assumptions.push_back(keccak_root);
-                                        continue;
-                                    }
-                                }
-                                panic!("Missing assumption: {assumption:?}");
-                            }
-                        }
-                    }
-                    self.assumptions = Some(assumptions);
-                }
-
-                let assumptions = self.assumptions.as_mut().unwrap();
-                if let Some(assumption) = assumptions.pop_front() {
-                    tracing::info!("Resolve: {:?}", assumption.claim.digest());
-                    self.submit_task(Task::Resolve(Arc::new(ResolveTask {
-                        conditional: final_receipt.clone(),
-                        assumption: assumption.clone(),
-                    })))
-                    .await;
-                    return;
-                }
-
-                tracing::info!("done");
-                let receipt = Receipt::new(
-                    InnerReceipt::Succinct(final_receipt.as_ref().clone()),
-                    session.journal.clone().unwrap().bytes,
-                );
-                let result = ProofResult {
-                    session: session.clone(),
-                    receipt: Arc::new(receipt),
-                };
-                self.status = JobStatus::Succeeded(result);
-                self.self_ref().stop_gracefully().await.unwrap();
+        self.join_set.spawn(async move {
+            let reply = job.ask(request).await.unwrap();
+            job.wait_for_stop().await;
+            if let Some(reply_sender) = reply_sender {
+                reply_sender.send(reply);
             }
-        }
-    }
-
-    fn join_root(&self, session: &Arc<Session>) -> Option<Arc<SuccinctReceipt<ReceiptClaim>>> {
-        if let Some((range, join_root)) = self.joins.first_key_value() {
-            if range.start == 0 && range.end == session.stats.segments {
-                return Some(join_root.clone());
-            }
-        }
-        None
-    }
-
-    async fn maybe_finish_keccak_mmr(&mut self) -> bool {
-        if self.keccak_count == 0 || self.keccak_phase == KeccakPhase::Done {
-            self.keccak_phase = KeccakPhase::Done;
-            return true;
-        }
-
-        if self.keccak_phase == KeccakPhase::Build {
-            if self.unions.is_empty() || self.unions[0].len() != self.keccak_count {
-                return false;
-            }
-
-            println!("required: {:?}", self.required_keccak_layers);
-            println!(
-                "actual:   {:?}",
-                self.unions.iter().map(|x| x.len()).collect::<Vec<_>>()
-            );
-            if self.required_keccak_layers.len() != self.unions.len()
-                || self
-                    .required_keccak_layers
-                    .iter()
-                    .zip(self.unions.iter().map(|x| x.len()))
-                    .any(|(x, y)| *x != y)
-            {
-                return false;
-            }
-
-            for layer_pos in mmr_peaks(&self.required_keccak_layers) {
-                let receipt = self.unions[layer_pos].last().unwrap().clone().unwrap();
-                self.pending_keccak_peaks.push_back(receipt);
-            }
-
-            if self.pending_keccak_peaks.len() > 1 {
-                let lhs = self.pending_keccak_peaks.pop_front().unwrap();
-                let rhs = self.pending_keccak_peaks.pop_front().unwrap();
-                self.union(0, 0, lhs, rhs).await;
-                self.keccak_phase = KeccakPhase::MergePeaks;
-            }
-        }
-
-        if self.keccak_phase == KeccakPhase::MergePeaks {
-            tracing::info!("MergePeaks");
-            return false;
-        }
-
-        if self.pending_keccak_peaks.len() == 1 {
-            assert!(self.keccak_root.is_none());
-            self.keccak_root = Some(self.pending_keccak_peaks.pop_front().unwrap());
-            self.keccak_phase = KeccakPhase::Done;
-            tracing::info!("KeccakPhase::Done from Singleton");
-        }
-
-        true
+            self_ref.stop_gracefully().await.unwrap();
+        });
     }
 }
 
@@ -490,12 +100,38 @@ impl Message<ProofRequest> for JobActor {
         request: ProofRequest,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        tracing::info!("ProofRequest");
         let (delegated_reply, reply_sender) = ctx.reply_sender();
-        self.reply_sender = reply_sender;
-        self.submit_task(Task::Execute(Arc::new(ExecuteTask { request })))
-            .await;
+        self.request::<_, proof::JobActor>(request, ctx.actor_ref(), reply_sender);
         delegated_reply
+    }
+}
+
+impl Message<ShrinkWrapRequest> for JobActor {
+    type Reply = DelegatedReply<JobStatusReply>;
+
+    async fn handle(
+        &mut self,
+        request: ShrinkWrapRequest,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        self.request::<_, shrink_wrap::JobActor>(request, ctx.actor_ref(), reply_sender);
+        delegated_reply
+    }
+}
+
+impl Message<JobStatusRequest> for JobActor {
+    type Reply = JobStatusReply;
+
+    async fn handle(
+        &mut self,
+        msg: JobStatusRequest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        match self.inner.as_mut().unwrap() {
+            InnerJobActor::Proof(job) => job.ask(msg).await.unwrap(),
+            InnerJobActor::ShrinkWrap(job) => job.ask(msg).await.unwrap(),
+        }
     }
 }
 
@@ -507,11 +143,9 @@ impl Message<TaskUpdateMsg> for JobActor {
         msg: TaskUpdateMsg,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        // tracing::info!("TaskUpdateMsg: {}", msg.header.global_id.task_id);
-        match msg.payload {
-            TaskUpdate::Start => self.task_start(msg.header),
-            TaskUpdate::Segment(segment) => self.prove_segment(msg.header, segment).await,
-            TaskUpdate::Keccak(request) => self.prove_keccak(request).await,
+        match self.inner.as_mut().unwrap() {
+            InnerJobActor::Proof(job) => job.ask(msg).await.unwrap(),
+            InnerJobActor::ShrinkWrap(job) => job.ask(msg).await.unwrap(),
         }
     }
 }
@@ -524,84 +158,9 @@ impl Message<TaskDoneMsg> for JobActor {
         msg: TaskDoneMsg,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        // tracing::info!("TaskDoneMsg: {}", msg.header.global_id.task_id);
-        let task_done = match msg.payload {
-            Ok(task_done) => task_done,
-            Err(err) => {
-                self.status = JobStatus::Failed(err);
-                let _ = _ctx.actor_ref().stop_gracefully().await;
-                return;
-            }
-        };
-        self.span_end(msg.header.global_id.task_id);
-        match task_done {
-            TaskDone::Session(session) => self.session_done(session).await,
-            TaskDone::ProveSegment(receipt) => self.prove_segment_done(receipt).await,
-            TaskDone::ProveKeccak(done) => self.prove_keccak_done(done).await,
-            TaskDone::Lift(node) => self.lift_done(node).await,
-            TaskDone::Join(node) => self.join_done(node).await,
-            TaskDone::Union(done) => self.union_done(done).await,
-            TaskDone::Resolve(receipt) => self.resolve_done(receipt).await,
+        match self.inner.as_mut().unwrap() {
+            InnerJobActor::Proof(job) => job.ask(msg).await.unwrap(),
+            InnerJobActor::ShrinkWrap(job) => job.ask(msg).await.unwrap(),
         }
     }
-}
-
-impl Message<JobStatusRequest> for JobActor {
-    type Reply = JobStatusReply;
-
-    async fn handle(
-        &mut self,
-        _msg: JobStatusRequest,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
-        JobStatusReply {
-            info: Some(JobInfo {
-                status: self.status.clone(),
-                elapsed_time: self.start_time.elapsed(),
-            }),
-        }
-    }
-}
-
-fn mmr_layers(count: usize) -> Vec<usize> {
-    let mut cur = count;
-    let mut layers = vec![cur];
-    while cur > 1 {
-        cur /= 2;
-        layers.push(cur);
-    }
-    layers
-}
-
-fn mmr_peaks(layers: &[usize]) -> VecDeque<usize> {
-    let mut peaks = VecDeque::new();
-    for (i, count) in layers.iter().enumerate().rev() {
-        if count % 2 == 1 {
-            peaks.push_back(i);
-        }
-    }
-    peaks
-}
-
-#[test]
-fn test_mmr_layers() {
-    let test = |count| {
-        let layers = mmr_layers(count);
-        println!(
-            "mmr_layers({count}) = {layers:?}, mmr_peaks = {:?}",
-            mmr_peaks(&layers)
-        );
-    };
-
-    test(0);
-    test(1);
-    test(2);
-    test(3);
-    test(4);
-    test(5);
-    test(6);
-    test(7);
-    test(8);
-    test(19);
-    test(93);
 }

--- a/risc0/r0vm/src/actors/job/proof.rs
+++ b/risc0/r0vm/src/actors/job/proof.rs
@@ -1,0 +1,618 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap, VecDeque},
+    sync::Arc,
+};
+
+use kameo::{error::Infallible, prelude::*};
+use opentelemetry::{
+    global::{BoxedSpan, BoxedTracer},
+    trace::{Span, SpanKind, TraceContextExt as _, Tracer},
+    KeyValue,
+};
+use risc0_zkvm::{
+    sha::Digestible, AssumptionReceipt, InnerReceipt, ProveKeccakRequest, Receipt, ReceiptClaim,
+    Segment, SegmentReceipt, SuccinctReceipt, Unknown,
+};
+use tokio::time::Instant;
+
+use super::JobActorNew;
+use crate::actors::{
+    factory::FactoryActor,
+    protocol::{
+        factory::{
+            DropJob, JoinNode, ProveKeccakDone, SubmitTaskMsg, TaskDone, TaskDoneMsg, TaskUpdate,
+            TaskUpdateMsg, UnionDone,
+        },
+        ExecuteTask, GlobalId, JobId, JobInfo, JobStatus, JobStatusReply, JobStatusRequest,
+        JoinTask, LiftTask, ProofRequest, ProofResult, ProveKeccakTask, ProveSegmentTask,
+        ResolveTask, SegmentRange, Session, Task, TaskError, TaskHeader, TaskId, UnionTask,
+    },
+};
+
+#[derive(PartialEq)]
+enum KeccakPhase {
+    Build,
+    MergePeaks,
+    Done,
+}
+
+pub(crate) struct JobActor {
+    job_id: JobId,
+    parent_ref: WeakActorRef<super::JobActor>,
+    self_ref: Option<WeakActorRef<Self>>,
+    factory: ActorRef<FactoryActor>,
+    joins: BTreeMap<SegmentRange, Arc<SuccinctReceipt<ReceiptClaim>>>,
+    next_task_id: u64,
+    session: Option<Arc<Session>>,
+    ctx: opentelemetry::Context,
+    tracer: BoxedTracer,
+    pending_spans: HashMap<TaskId, BoxedSpan>,
+    reply_sender: Option<ReplySender<JobStatusReply>>,
+    start_time: Instant,
+    status: JobStatus<ProofResult>,
+    unions: Vec<Vec<Option<UnknownReceipt>>>,
+    keccak_phase: KeccakPhase,
+    keccak_count: usize,
+    required_keccak_layers: Vec<usize>,
+    pending_keccak_peaks: VecDeque<UnknownReceipt>,
+    keccak_root: Option<UnknownReceipt>,
+    assumptions: Option<VecDeque<UnknownReceipt>>,
+    final_receipt: Option<Arc<SuccinctReceipt<ReceiptClaim>>>,
+}
+
+type UnknownReceipt = Arc<SuccinctReceipt<Unknown>>;
+
+impl JobActor {
+    async fn prove_keccak_done(&mut self, done: Arc<ProveKeccakDone>) {
+        tracing::info!("ProveKeccakDone: {}", done.index);
+        let receipt = Arc::new(done.receipt.clone());
+        self.process_union(done.index, 0, receipt).await;
+    }
+
+    async fn union_done(&mut self, done: Arc<UnionDone>) {
+        let receipt = Arc::new(done.receipt.clone().into_unknown());
+        match self.keccak_phase {
+            KeccakPhase::Build => {
+                tracing::info!("UnionDone: {}/{}", done.height, done.pos);
+                self.process_union(done.pos, done.height, receipt).await;
+            }
+            KeccakPhase::MergePeaks => {
+                if let Some(rhs) = self.pending_keccak_peaks.pop_front() {
+                    self.union(0, 0, receipt, rhs).await;
+                } else {
+                    assert!(self.keccak_root.is_none());
+                    self.keccak_root = Some(receipt);
+                    self.keccak_phase = KeccakPhase::Done;
+                    tracing::info!("KeccakPhase::Done from UnionDone");
+                    self.maybe_finish().await;
+                }
+            }
+            KeccakPhase::Done => {
+                unreachable!();
+            }
+        }
+    }
+
+    async fn process_union(&mut self, pos: usize, height: usize, receipt: UnknownReceipt) {
+        if self.unions.len() < height + 1 {
+            self.unions.resize_with(height + 1, Vec::new);
+        }
+        let layer = self.unions.get_mut(height).unwrap();
+        if layer.len() < pos + 1 {
+            layer.resize(pos + 1, None);
+        }
+        layer[pos] = Some(receipt.clone());
+        let (lhs_pos, rhs_pos) = if pos % 2 == 0 {
+            (pos, pos + 1)
+        } else {
+            (pos - 1, pos)
+        };
+        if let (Some(Some(lhs)), Some(Some(rhs))) =
+            (layer.get(lhs_pos).cloned(), layer.get(rhs_pos).cloned())
+        {
+            let up_height = height + 1;
+            let up_pos = pos / 2;
+            tracing::info!("Union: {height}/({lhs_pos}, {rhs_pos}) -> {up_height}/{up_pos}");
+            self.union(up_height, up_pos, lhs, rhs).await;
+        } else {
+            self.maybe_finish().await;
+        }
+    }
+
+    async fn union(&mut self, height: usize, pos: usize, lhs: UnknownReceipt, rhs: UnknownReceipt) {
+        self.submit_task(Task::Union(Arc::new(UnionTask {
+            height,
+            pos,
+            receipts: vec![lhs, rhs],
+        })))
+        .await;
+    }
+}
+
+impl Actor for JobActor {
+    type Error = Infallible;
+
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+        self.self_ref = Some(actor_ref.downgrade());
+        Ok(())
+    }
+
+    async fn on_stop(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        reason: ActorStopReason,
+    ) -> Result<(), Self::Error> {
+        let _ = self
+            .factory
+            .tell(DropJob {
+                job_id: self.job_id,
+            })
+            .await;
+
+        let elapsed_time = self.start_time.elapsed();
+        let span = self.ctx.span();
+
+        if let ActorStopReason::Panicked(err) = reason {
+            tracing::error!("{err}");
+            span.record_error(&err);
+            if let Some(reply_sender) = self.reply_sender.take() {
+                let info = JobInfo {
+                    status: JobStatus::Failed(TaskError::Generic(err.to_string())),
+                    elapsed_time,
+                };
+                reply_sender.send(JobStatusReply::Proof(info));
+            }
+        } else if let Some(reply_sender) = self.reply_sender.take() {
+            let info = JobInfo {
+                status: self.status.clone(),
+                elapsed_time,
+            };
+            reply_sender.send(JobStatusReply::Proof(info));
+        }
+
+        span.end();
+        Ok(())
+    }
+}
+
+impl JobActorNew for JobActor {
+    fn new(
+        job_id: JobId,
+        parent_ref: WeakActorRef<super::JobActor>,
+        factory: ActorRef<FactoryActor>,
+    ) -> Self {
+        let tracer = opentelemetry::global::tracer("job");
+        let span = tracer
+            .span_builder("job")
+            .with_kind(SpanKind::Client)
+            .with_attributes([KeyValue::new("job_id", job_id.to_string())])
+            .start(&tracer);
+        let ctx = opentelemetry::Context::current_with_span(span);
+        Self {
+            job_id,
+            parent_ref,
+            self_ref: None,
+            factory,
+            joins: BTreeMap::new(),
+            next_task_id: 0,
+            session: None,
+            ctx,
+            tracer,
+            pending_spans: HashMap::new(),
+            reply_sender: None,
+            start_time: Instant::now(),
+            status: JobStatus::Running("init".to_string()),
+            unions: Default::default(),
+            keccak_count: 0,
+            keccak_phase: KeccakPhase::Build,
+            keccak_root: None,
+            required_keccak_layers: Vec::new(),
+            pending_keccak_peaks: VecDeque::new(),
+            assumptions: None,
+            final_receipt: None,
+        }
+    }
+}
+
+impl JobActor {
+    fn self_ref(&self) -> ActorRef<Self> {
+        self.self_ref.as_ref().unwrap().upgrade().unwrap()
+    }
+
+    fn next_task_id(&mut self) -> u64 {
+        let id = self.next_task_id;
+        self.next_task_id += 1;
+        id
+    }
+
+    fn next_keccak_index(&mut self) -> usize {
+        let ret = self.keccak_count;
+        self.keccak_count += 1;
+        ret
+    }
+
+    fn span_start<T>(&mut self, task_id: TaskId, name: T)
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.pending_spans
+            .insert(task_id, self.tracer.start_with_context(name, &self.ctx));
+    }
+
+    fn span_event<T>(&mut self, header: TaskHeader, name: T)
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.pending_spans
+            .get_mut(&header.global_id.task_id)
+            .unwrap()
+            .add_event(name, vec![]);
+    }
+
+    fn span_end(&mut self, task_id: TaskId) {
+        self.pending_spans.remove(&task_id).as_mut().unwrap().end();
+    }
+
+    fn task_start(&mut self, header: TaskHeader) {
+        let name = format!("{:?}", header.task_kind);
+        self.span_start(header.global_id.task_id, name);
+    }
+
+    async fn prove_segment(&mut self, header: TaskHeader, segment: Segment) {
+        self.span_event(header, "segment");
+        tracing::info!("ProveSegment: {}", segment.index);
+        self.submit_task(Task::ProveSegment(Arc::new(ProveSegmentTask { segment })))
+            .await;
+    }
+
+    async fn prove_keccak(&mut self, request: ProveKeccakRequest) {
+        tracing::info!("ProveKeccak: {} hashes", request.input.len());
+        let index = self.next_keccak_index();
+        self.submit_task(Task::ProveKeccak(Arc::new(ProveKeccakTask {
+            index,
+            request,
+        })))
+        .await;
+    }
+
+    async fn session_done(&mut self, session: Arc<Session>) {
+        tracing::info!("SessionDone");
+        for ref receipt in session.assumptions.iter() {
+            tracing::info!("{receipt:#?}");
+        }
+        self.session = Some(session);
+        self.required_keccak_layers = mmr_layers(self.keccak_count);
+        self.maybe_finish().await;
+    }
+
+    async fn prove_segment_done(&mut self, receipt: Box<SegmentReceipt>) {
+        tracing::info!("ProveSegmentDone: {}", receipt.index);
+        self.submit_task(Task::Lift(Arc::new(LiftTask { receipt: *receipt })))
+            .await;
+    }
+
+    async fn lift_done(&mut self, node: Box<JoinNode>) {
+        tracing::info!("LiftDone: {:?}", node.range);
+        self.joins.insert(node.range, Arc::new(node.receipt));
+        self.maybe_join().await;
+        self.maybe_finish().await;
+    }
+
+    async fn join_done(&mut self, node: Box<JoinNode>) {
+        tracing::info!("JoinDone: {:?}", node.range);
+        self.joins.insert(node.range, Arc::new(node.receipt));
+        self.maybe_join().await;
+        self.maybe_finish().await;
+    }
+
+    async fn resolve_done(&mut self, receipt: Arc<SuccinctReceipt<ReceiptClaim>>) {
+        self.final_receipt = Some(receipt);
+        self.maybe_finish().await;
+    }
+
+    async fn submit_task(&mut self, task: Task) {
+        let task_id = self.next_task_id();
+        let msg = SubmitTaskMsg {
+            job: self.parent_ref.upgrade().unwrap(),
+            header: TaskHeader {
+                global_id: GlobalId {
+                    job_id: self.job_id,
+                    task_id,
+                },
+                task_kind: task.kind(),
+            },
+            task,
+        };
+        self.factory.tell(msg).await.unwrap();
+    }
+
+    async fn maybe_join(&mut self) {
+        if let Some(((a_range, a_receipt), (b_range, b_receipt))) = self
+            .joins
+            .iter()
+            .zip(self.joins.iter().skip(1))
+            .filter(|((a, _), (b, _))| a.end == b.start)
+            .map(|((a_range, a_receipt), (b_range, b_receipt))| {
+                ((*a_range, a_receipt.clone()), (*b_range, b_receipt.clone()))
+            })
+            .take(1)
+            .next()
+        {
+            self.joins.remove(&a_range);
+            self.joins.remove(&b_range);
+            let range = (a_range.start..b_range.end).into();
+            let receipts = vec![(*a_receipt).clone(), (*b_receipt).clone()];
+            self.submit_task(Task::Join(Arc::new(JoinTask { range, receipts })))
+                .await;
+        }
+    }
+
+    async fn maybe_finish(&mut self) {
+        if self.session.is_some() && !self.maybe_finish_keccak_mmr().await {
+            return;
+        }
+
+        if let Some(ref session) = self.session {
+            // tracing::info!("maybe_finish: session done");
+
+            if let Some(join_root) = self.join_root(session) {
+                let final_receipt = self
+                    .final_receipt
+                    .get_or_insert_with(|| join_root.clone())
+                    .clone();
+
+                if self.assumptions.is_none() {
+                    let mut assumptions = VecDeque::new();
+                    for receipt in session.assumptions.iter() {
+                        match receipt.as_ref() {
+                            AssumptionReceipt::Proven(inner) => {
+                                tracing::info!(
+                                    "Adding proven assumption: {:?}",
+                                    inner.claim_digest()
+                                );
+                                assumptions.push_back(Arc::new(inner.succinct().unwrap().clone()));
+                            }
+                            AssumptionReceipt::Unresolved(assumption) => {
+                                if let Some(keccak_root) = self.keccak_root.clone() {
+                                    if keccak_root.claim.digest() == assumption.claim {
+                                        tracing::info!("Using keccak_root");
+                                        assumptions.push_back(keccak_root);
+                                        continue;
+                                    }
+                                }
+                                panic!("Missing assumption: {assumption:?}");
+                            }
+                        }
+                    }
+                    self.assumptions = Some(assumptions);
+                }
+
+                let assumptions = self.assumptions.as_mut().unwrap();
+                if let Some(assumption) = assumptions.pop_front() {
+                    tracing::info!("Resolve: {:?}", assumption.claim.digest());
+                    self.submit_task(Task::Resolve(Arc::new(ResolveTask {
+                        conditional: final_receipt.clone(),
+                        assumption: assumption.clone(),
+                    })))
+                    .await;
+                    return;
+                }
+
+                tracing::info!("done");
+                let receipt = Receipt::new(
+                    InnerReceipt::Succinct(final_receipt.as_ref().clone()),
+                    session.journal.clone().unwrap().bytes,
+                );
+                let result = ProofResult {
+                    session: session.clone(),
+                    receipt: Arc::new(receipt),
+                };
+                self.status = JobStatus::Succeeded(result);
+                self.self_ref().stop_gracefully().await.unwrap();
+            }
+        }
+    }
+
+    fn join_root(&self, session: &Arc<Session>) -> Option<Arc<SuccinctReceipt<ReceiptClaim>>> {
+        if let Some((range, join_root)) = self.joins.first_key_value() {
+            if range.start == 0 && range.end == session.stats.segments {
+                return Some(join_root.clone());
+            }
+        }
+        None
+    }
+
+    async fn maybe_finish_keccak_mmr(&mut self) -> bool {
+        if self.keccak_count == 0 || self.keccak_phase == KeccakPhase::Done {
+            self.keccak_phase = KeccakPhase::Done;
+            return true;
+        }
+
+        if self.keccak_phase == KeccakPhase::Build {
+            if self.unions.is_empty() || self.unions[0].len() != self.keccak_count {
+                return false;
+            }
+
+            println!("required: {:?}", self.required_keccak_layers);
+            println!(
+                "actual:   {:?}",
+                self.unions.iter().map(|x| x.len()).collect::<Vec<_>>()
+            );
+            if self.required_keccak_layers.len() != self.unions.len()
+                || self
+                    .required_keccak_layers
+                    .iter()
+                    .zip(self.unions.iter().map(|x| x.len()))
+                    .any(|(x, y)| *x != y)
+            {
+                return false;
+            }
+
+            for layer_pos in mmr_peaks(&self.required_keccak_layers) {
+                let receipt = self.unions[layer_pos].last().unwrap().clone().unwrap();
+                self.pending_keccak_peaks.push_back(receipt);
+            }
+
+            if self.pending_keccak_peaks.len() > 1 {
+                let lhs = self.pending_keccak_peaks.pop_front().unwrap();
+                let rhs = self.pending_keccak_peaks.pop_front().unwrap();
+                self.union(0, 0, lhs, rhs).await;
+                self.keccak_phase = KeccakPhase::MergePeaks;
+            }
+        }
+
+        if self.keccak_phase == KeccakPhase::MergePeaks {
+            tracing::info!("MergePeaks");
+            return false;
+        }
+
+        if self.pending_keccak_peaks.len() == 1 {
+            assert!(self.keccak_root.is_none());
+            self.keccak_root = Some(self.pending_keccak_peaks.pop_front().unwrap());
+            self.keccak_phase = KeccakPhase::Done;
+            tracing::info!("KeccakPhase::Done from Singleton");
+        }
+
+        true
+    }
+}
+
+impl Message<ProofRequest> for JobActor {
+    type Reply = DelegatedReply<JobStatusReply>;
+
+    async fn handle(
+        &mut self,
+        request: ProofRequest,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::info!("ProofRequest");
+        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        self.reply_sender = reply_sender;
+        self.submit_task(Task::Execute(Arc::new(ExecuteTask { request })))
+            .await;
+        delegated_reply
+    }
+}
+
+impl Message<TaskUpdateMsg> for JobActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: TaskUpdateMsg,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        // tracing::info!("TaskUpdateMsg: {}", msg.header.global_id.task_id);
+        match msg.payload {
+            TaskUpdate::Start => self.task_start(msg.header),
+            TaskUpdate::Segment(segment) => self.prove_segment(msg.header, segment).await,
+            TaskUpdate::Keccak(request) => self.prove_keccak(request).await,
+        }
+    }
+}
+
+impl Message<TaskDoneMsg> for JobActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: TaskDoneMsg,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        // tracing::info!("TaskDoneMsg: {}", msg.header.global_id.task_id);
+        let task_done = match msg.payload {
+            Ok(task_done) => task_done,
+            Err(err) => {
+                self.status = JobStatus::Failed(err);
+                let _ = ctx.actor_ref().stop_gracefully().await;
+                return;
+            }
+        };
+        self.span_end(msg.header.global_id.task_id);
+        match task_done {
+            TaskDone::Session(session) => self.session_done(session).await,
+            TaskDone::ProveSegment(receipt) => self.prove_segment_done(receipt).await,
+            TaskDone::ProveKeccak(done) => self.prove_keccak_done(done).await,
+            TaskDone::Lift(node) => self.lift_done(node).await,
+            TaskDone::Join(node) => self.join_done(node).await,
+            TaskDone::Union(done) => self.union_done(done).await,
+            TaskDone::Resolve(receipt) => self.resolve_done(receipt).await,
+            TaskDone::ShrinkWrap(_) => {
+                panic!("Proof JobActor received unexpected TaskDone::ShrinkWrap")
+            }
+        }
+    }
+}
+
+impl Message<JobStatusRequest> for JobActor {
+    type Reply = JobStatusReply;
+
+    async fn handle(
+        &mut self,
+        _msg: JobStatusRequest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        JobStatusReply::Proof(JobInfo {
+            status: self.status.clone(),
+            elapsed_time: self.start_time.elapsed(),
+        })
+    }
+}
+
+fn mmr_layers(count: usize) -> Vec<usize> {
+    let mut cur = count;
+    let mut layers = vec![cur];
+    while cur > 1 {
+        cur /= 2;
+        layers.push(cur);
+    }
+    layers
+}
+
+fn mmr_peaks(layers: &[usize]) -> VecDeque<usize> {
+    let mut peaks = VecDeque::new();
+    for (i, count) in layers.iter().enumerate().rev() {
+        if count % 2 == 1 {
+            peaks.push_back(i);
+        }
+    }
+    peaks
+}
+
+#[test]
+fn test_mmr_layers() {
+    let test = |count| {
+        let layers = mmr_layers(count);
+        println!(
+            "mmr_layers({count}) = {layers:?}, mmr_peaks = {:?}",
+            mmr_peaks(&layers)
+        );
+    };
+
+    test(0);
+    test(1);
+    test(2);
+    test(3);
+    test(4);
+    test(5);
+    test(6);
+    test(7);
+    test(8);
+    test(19);
+    test(93);
+}

--- a/risc0/r0vm/src/actors/job/shrink_wrap.rs
+++ b/risc0/r0vm/src/actors/job/shrink_wrap.rs
@@ -1,0 +1,250 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{borrow::Cow, collections::HashMap, sync::Arc, time::Instant};
+
+use kameo::{error::Infallible, prelude::*};
+use opentelemetry::{
+    global::{BoxedSpan, BoxedTracer},
+    trace::{Span as _, SpanKind, TraceContextExt as _, Tracer},
+    KeyValue,
+};
+use risc0_zkvm::Receipt;
+
+use super::JobActorNew;
+use crate::actors::{
+    factory::FactoryActor,
+    protocol::{
+        factory::{DropJob, SubmitTaskMsg, TaskDone, TaskDoneMsg, TaskUpdate, TaskUpdateMsg},
+        GlobalId, JobId, JobStatus, JobStatusReply, JobStatusRequest, ShrinkWrapRequest,
+        ShrinkWrapResult, ShrinkWrapTask, Task, TaskError, TaskHeader, TaskId,
+    },
+    JobInfo,
+};
+
+pub(crate) struct JobActor {
+    job_id: JobId,
+    parent_ref: WeakActorRef<super::JobActor>,
+    next_task_id: u64,
+    self_ref: Option<WeakActorRef<Self>>,
+    factory: ActorRef<FactoryActor>,
+    ctx: opentelemetry::Context,
+    tracer: BoxedTracer,
+    start_time: Instant,
+    status: JobStatus<ShrinkWrapResult>,
+    reply_sender: Option<ReplySender<JobStatusReply>>,
+    pending_spans: HashMap<TaskId, BoxedSpan>,
+}
+
+impl Actor for JobActor {
+    type Error = Infallible;
+
+    async fn on_start(&mut self, actor_ref: ActorRef<Self>) -> Result<(), Self::Error> {
+        self.self_ref = Some(actor_ref.downgrade());
+        Ok(())
+    }
+
+    async fn on_stop(
+        &mut self,
+        _actor_ref: WeakActorRef<Self>,
+        reason: ActorStopReason,
+    ) -> Result<(), Self::Error> {
+        let _ = self
+            .factory
+            .tell(DropJob {
+                job_id: self.job_id,
+            })
+            .await;
+
+        let elapsed_time = self.start_time.elapsed();
+        let span = self.ctx.span();
+
+        if let ActorStopReason::Panicked(err) = reason {
+            tracing::error!("{err}");
+            span.record_error(&err);
+            if let Some(reply_sender) = self.reply_sender.take() {
+                let info = JobInfo {
+                    status: JobStatus::Failed(TaskError::Generic(err.to_string())),
+                    elapsed_time,
+                };
+                reply_sender.send(JobStatusReply::ShrinkWrap(info));
+            }
+        } else if let Some(reply_sender) = self.reply_sender.take() {
+            let info = JobInfo {
+                status: self.status.clone(),
+                elapsed_time,
+            };
+            reply_sender.send(JobStatusReply::ShrinkWrap(info));
+        }
+
+        span.end();
+        Ok(())
+    }
+}
+
+impl JobActorNew for JobActor {
+    fn new(
+        job_id: JobId,
+        parent_ref: WeakActorRef<super::JobActor>,
+        factory: ActorRef<FactoryActor>,
+    ) -> Self {
+        let tracer = opentelemetry::global::tracer("shrink_wrap_job");
+        let span = tracer
+            .span_builder("job")
+            .with_kind(SpanKind::Client)
+            .with_attributes([KeyValue::new("job_id", job_id.to_string())])
+            .start(&tracer);
+        let ctx = opentelemetry::Context::current_with_span(span);
+        Self {
+            job_id,
+            parent_ref,
+            next_task_id: 0,
+            self_ref: None,
+            factory,
+            ctx,
+            tracer,
+            start_time: Instant::now(),
+            status: JobStatus::Running("init".into()),
+            reply_sender: None,
+            pending_spans: HashMap::new(),
+        }
+    }
+}
+
+impl JobActor {
+    fn self_ref(&self) -> ActorRef<Self> {
+        self.self_ref.as_ref().unwrap().upgrade().unwrap()
+    }
+
+    fn next_task_id(&mut self) -> u64 {
+        let id = self.next_task_id;
+        self.next_task_id += 1;
+        id
+    }
+
+    async fn submit_task(&mut self, task: Task) {
+        let task_id = self.next_task_id();
+        let msg = SubmitTaskMsg {
+            job: self.parent_ref.upgrade().unwrap(),
+            header: TaskHeader {
+                global_id: GlobalId {
+                    job_id: self.job_id,
+                    task_id,
+                },
+                task_kind: task.kind(),
+            },
+            task,
+        };
+        self.factory.tell(msg).await.unwrap();
+    }
+
+    async fn shrink_wrap_done(&mut self, receipt: Arc<Receipt>) {
+        let result = ShrinkWrapResult { receipt };
+        self.status = JobStatus::Succeeded(result);
+        self.self_ref().stop_gracefully().await.unwrap();
+    }
+
+    fn span_start<T>(&mut self, task_id: TaskId, name: T)
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.pending_spans
+            .insert(task_id, self.tracer.start_with_context(name, &self.ctx));
+    }
+
+    fn span_end(&mut self, task_id: TaskId) {
+        self.pending_spans.remove(&task_id).as_mut().unwrap().end();
+    }
+
+    fn task_start(&mut self, header: TaskHeader) {
+        let name = format!("{:?}", header.task_kind);
+        self.span_start(header.global_id.task_id, name);
+    }
+}
+
+impl Message<ShrinkWrapRequest> for JobActor {
+    type Reply = DelegatedReply<JobStatusReply>;
+
+    async fn handle(
+        &mut self,
+        request: ShrinkWrapRequest,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        tracing::info!("ShrinkWrapRequest");
+        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        self.reply_sender = reply_sender;
+        self.submit_task(Task::ShrinkWrap(Arc::new(ShrinkWrapTask {
+            kind: request.kind,
+            receipt: Arc::new(request.receipt),
+        })))
+        .await;
+        delegated_reply
+    }
+}
+
+impl Message<TaskUpdateMsg> for JobActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: TaskUpdateMsg,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if matches!(msg.payload, TaskUpdate::Start) {
+            self.task_start(msg.header);
+        }
+    }
+}
+
+impl Message<TaskDoneMsg> for JobActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: TaskDoneMsg,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        // tracing::info!("TaskDoneMsg: {}", msg.header.global_id.task_id);
+        let task_done = match msg.payload {
+            Ok(task_done) => task_done,
+            Err(err) => {
+                self.status = JobStatus::Failed(err);
+                let _ = ctx.actor_ref().stop_gracefully().await;
+                return;
+            }
+        };
+        self.span_end(msg.header.global_id.task_id);
+        match task_done {
+            TaskDone::ShrinkWrap(receipt) => self.shrink_wrap_done(receipt).await,
+            _ => {
+                panic!("ShrinkWrap JobActor received unexpected task")
+            }
+        }
+    }
+}
+
+impl Message<JobStatusRequest> for JobActor {
+    type Reply = JobStatusReply;
+
+    async fn handle(
+        &mut self,
+        _msg: JobStatusRequest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        JobStatusReply::ShrinkWrap(JobInfo {
+            status: self.status.clone(),
+            elapsed_time: self.start_time.elapsed(),
+        })
+    }
+}

--- a/risc0/r0vm/src/actors/job/tracer.rs
+++ b/risc0/r0vm/src/actors/job/tracer.rs
@@ -1,0 +1,76 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{borrow::Cow, collections::HashMap};
+
+use opentelemetry::{
+    global::{BoxedSpan, BoxedTracer},
+    trace::{Span, SpanKind, TraceContextExt as _, Tracer},
+    KeyValue,
+};
+
+use crate::actors::protocol::{TaskHeader, TaskId};
+
+pub struct JobTracer {
+    ctx: opentelemetry::Context,
+    tracer: BoxedTracer,
+    pending_spans: HashMap<TaskId, BoxedSpan>,
+}
+
+impl JobTracer {
+    pub fn new(name: &'static str, job_id: impl ToString) -> Self {
+        let tracer = opentelemetry::global::tracer(name);
+        let span = tracer
+            .span_builder("job")
+            .with_kind(SpanKind::Client)
+            .with_attributes([KeyValue::new("job_id", job_id.to_string())])
+            .start(&tracer);
+        let ctx = opentelemetry::Context::current_with_span(span);
+        Self {
+            ctx,
+            tracer,
+            pending_spans: HashMap::new(),
+        }
+    }
+
+    pub fn span_start<T>(&mut self, task_id: TaskId, name: T)
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.pending_spans
+            .insert(task_id, self.tracer.start_with_context(name, &self.ctx));
+    }
+
+    pub fn span_event<T>(&mut self, header: TaskHeader, name: T)
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.pending_spans
+            .get_mut(&header.global_id.task_id)
+            .unwrap()
+            .add_event(name, vec![]);
+    }
+
+    pub fn span_end(&mut self, task_id: TaskId) {
+        self.pending_spans.remove(&task_id).as_mut().unwrap().end();
+    }
+
+    pub fn record_error(&mut self, error: &dyn std::error::Error) {
+        self.ctx.span().record_error(error);
+    }
+
+    pub fn end(&mut self) {
+        self.ctx.span().end();
+    }
+}

--- a/risc0/r0vm/src/actors/manager.rs
+++ b/risc0/r0vm/src/actors/manager.rs
@@ -14,26 +14,43 @@
 
 use std::{collections::HashMap, path::PathBuf};
 
+use derive_more::From;
 use kameo::prelude::*;
+use risc0_zkvm::Receipt;
 use tokio::task::JoinSet;
 
 use super::{
     factory::FactoryActor,
     job::JobActor,
     protocol::{
-        CreateJobReply, CreateJobRequest, JobId, JobInfo, JobStatus, JobStatusReply,
-        JobStatusRequest, ProofRequest,
+        JobId, JobInfo, JobRequestReply, JobStatus, JobStatusReply, JobStatusRequest, ProofRequest,
+        ProofResult, ShrinkWrapRequest, ShrinkWrapResult,
     },
 };
 
-enum JobEntry {
-    Active(ActorRef<JobActor>),
-    Inactive(JobInfo),
+#[derive(Clone, From)]
+enum InactiveJobEntry {
+    Proof(JobInfo<ProofResult>),
+    ShrinkWrap(JobInfo<ShrinkWrapResult>),
 }
 
-struct JobDone {
+impl From<InactiveJobEntry> for JobStatusReply {
+    fn from(e: InactiveJobEntry) -> Self {
+        match e {
+            InactiveJobEntry::Proof(info) => JobStatusReply::Proof(info),
+            InactiveJobEntry::ShrinkWrap(info) => JobStatusReply::ShrinkWrap(info),
+        }
+    }
+}
+
+enum JobEntry {
+    Active(ActorRef<JobActor>),
+    Inactive(InactiveJobEntry),
+}
+
+struct JobDone<ResultT> {
     pub job_id: JobId,
-    pub info: JobInfo,
+    pub info: JobInfo<ResultT>,
 }
 
 #[derive(Actor)]
@@ -54,12 +71,20 @@ impl ManagerActor {
         }
     }
 
-    async fn proof_request(
+    async fn job_request<RequestT, ResultT>(
         &mut self,
-        request: ProofRequest,
+        request: RequestT,
         actor_ref: ActorRef<ManagerActor>,
-        reply_sender: Option<ReplySender<JobStatusReply>>,
-    ) -> JobId {
+        reply_sender: Option<ReplySender<JobRequestReply>>,
+    ) -> JobId
+    where
+        JobActor: Message<RequestT, Reply = DelegatedReply<JobStatusReply>>,
+        RequestT: Send + 'static,
+        ResultT: HasReceipt + Send + 'static,
+        JobInfo<ResultT>: TryFrom<JobStatusReply>,
+        <JobInfo<ResultT> as TryFrom<JobStatusReply>>::Error: std::fmt::Debug,
+        InactiveJobEntry: From<JobInfo<ResultT>>,
+    {
         let job_id = JobId::new_v4();
         let actor_ref = actor_ref.clone();
         let job = kameo::spawn(JobActor::new(job_id, self.factory.clone()));
@@ -67,15 +92,18 @@ impl ManagerActor {
         self.join_set.spawn(async move {
             let reply = job.ask(request).await.unwrap();
             actor_ref
-                .tell(JobDone {
+                .tell(JobDone::<ResultT> {
                     job_id,
-                    info: reply.info.clone().unwrap(),
+                    info: reply.clone().try_into().unwrap(),
                 })
                 .await
                 .unwrap();
             job.wait_for_stop().await;
             if let Some(reply_sender) = reply_sender {
-                reply_sender.send(JobStatusReply { info: reply.info });
+                reply_sender.send(JobRequestReply {
+                    job_id,
+                    status: reply,
+                });
             }
         });
         job_id
@@ -83,7 +111,7 @@ impl ManagerActor {
 }
 
 impl Message<ProofRequest> for ManagerActor {
-    type Reply = DelegatedReply<JobStatusReply>;
+    type Reply = DelegatedReply<JobRequestReply>;
 
     async fn handle(
         &mut self,
@@ -91,39 +119,67 @@ impl Message<ProofRequest> for ManagerActor {
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let (delegated_reply, reply_sender) = ctx.reply_sender();
-        self.proof_request(msg, ctx.actor_ref(), reply_sender).await;
+        self.job_request::<_, ProofResult>(msg, ctx.actor_ref(), reply_sender)
+            .await;
         delegated_reply
     }
 }
 
-impl Message<JobDone> for ManagerActor {
+impl Message<ShrinkWrapRequest> for ManagerActor {
+    type Reply = DelegatedReply<JobRequestReply>;
+
+    async fn handle(
+        &mut self,
+        msg: ShrinkWrapRequest,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let (delegated_reply, reply_sender) = ctx.reply_sender();
+        self.job_request::<_, ShrinkWrapResult>(msg, ctx.actor_ref(), reply_sender)
+            .await;
+        delegated_reply
+    }
+}
+
+trait HasReceipt {
+    fn receipt(&self) -> &Receipt;
+}
+
+impl HasReceipt for ProofResult {
+    fn receipt(&self) -> &Receipt {
+        self.receipt.as_ref()
+    }
+}
+
+impl HasReceipt for ShrinkWrapResult {
+    fn receipt(&self) -> &Receipt {
+        self.receipt.as_ref()
+    }
+}
+
+impl<ResultT> Message<JobDone<ResultT>> for ManagerActor
+where
+    InactiveJobEntry: From<JobInfo<ResultT>>,
+    ResultT: HasReceipt + Send + 'static,
+{
     type Reply = ();
 
-    async fn handle(&mut self, msg: JobDone, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+    async fn handle(
+        &mut self,
+        msg: JobDone<ResultT>,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
         tracing::info!("JobDone: {}", msg.job_id);
         if let JobStatus::Succeeded(ref result) = msg.info.status {
             if let Some(ref storage_root) = self.storage_root {
-                let encoded = bincode::serialize(result.receipt.as_ref()).unwrap();
+                let encoded = bincode::serialize(result.receipt()).unwrap();
                 let receipts_dir = storage_root.join("receipts");
                 std::fs::create_dir_all(&receipts_dir).unwrap();
                 let receipt_path = receipts_dir.join(msg.job_id.to_string());
                 tokio::fs::write(receipt_path, encoded).await.unwrap();
             }
         }
-        self.jobs.insert(msg.job_id, JobEntry::Inactive(msg.info));
-    }
-}
-
-impl Message<CreateJobRequest> for ManagerActor {
-    type Reply = CreateJobReply;
-
-    async fn handle(
-        &mut self,
-        msg: CreateJobRequest,
-        ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
-        let job_id = self.proof_request(msg.request, ctx.actor_ref(), None).await;
-        CreateJobReply { job_id }
+        self.jobs
+            .insert(msg.job_id, JobEntry::Inactive(msg.info.into()));
     }
 }
 
@@ -136,16 +192,12 @@ impl Message<JobStatusRequest> for ManagerActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         match self.jobs.get(&msg.job_id) {
-            Some(job) => match job {
-                JobEntry::Active(job) => job
-                    .ask(JobStatusRequest { job_id: msg.job_id })
-                    .await
-                    .unwrap(),
-                JobEntry::Inactive(info) => JobStatusReply {
-                    info: Some(info.clone()),
-                },
-            },
-            None => JobStatusReply { info: None },
+            Some(JobEntry::Active(job)) => job
+                .ask(JobStatusRequest { job_id: msg.job_id })
+                .await
+                .unwrap(),
+            Some(JobEntry::Inactive(inactive)) => inactive.clone().into(),
+            None => JobStatusReply::NotFound,
         }
     }
 }

--- a/risc0/r0vm/src/actors/mod.rs
+++ b/risc0/r0vm/src/actors/mod.rs
@@ -60,7 +60,8 @@ use self::{
     manager::ManagerActor,
     protocol::{
         factory::{GetTask, TaskDoneMsg, TaskUpdateMsg},
-        JobInfo, ProofRequest, ProofResult, ShrinkWrapRequest, ShrinkWrapResult, TaskKind,
+        JobInfo, JobRequest, ProofRequest, ProofResult, ShrinkWrapRequest, ShrinkWrapResult,
+        TaskKind,
     },
     rpc::{rpc_system, RpcMessageId, RpcSender},
     worker::Worker,
@@ -142,38 +143,69 @@ pub(crate) async fn async_main(args: &Cli) -> Result<(), Box<dyn StdError>> {
     Ok(())
 }
 
-async fn relay_proof_request(app: &mut App) -> Result<(), Box<dyn StdError>> {
-    let socket: StdUnixStream = stdin().as_fd().try_clone_to_owned()?.into();
+async fn read_or_eof(socket: &mut UnixStream, buf: &mut [u8]) -> Result<bool, Box<dyn StdError>> {
+    assert!(!buf.is_empty());
 
-    socket.set_nonblocking(true)?;
-    let mut socket = UnixStream::from_std(socket)?;
+    let mut i = 0;
+    while i < buf.len() {
+        let num_read = socket
+            .read(&mut buf[i..])
+            .await
+            .context("reading RPC header")?;
+        if num_read == 0 {
+            if i > 0 {
+                Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))
+                    .context("reading RPC header")?
+            }
+            return Ok(false);
+        }
+        i += num_read;
+    }
+    Ok(true)
+}
 
+async fn relay_job_request(
+    app: &mut App,
+    socket: &mut UnixStream,
+) -> Result<bool, Box<dyn StdError>> {
     let mut buf = vec![0u8; 4];
-    socket
-        .read_exact(&mut buf)
-        .await
-        .context("error reading RPC header")?;
+    if !read_or_eof(socket, &mut buf[..]).await? {
+        return Ok(false);
+    }
+
     let body_len: u32 = bincode::deserialize(&buf).context("received invalid RPC header")?;
     let mut buf = vec![0u8; body_len as usize];
     socket
         .read_exact(&mut buf)
         .await
         .context("error reading RPC body")?;
-    let request: ProofRequest =
-        bincode::deserialize(&buf).context("error deserializing ProofRequest")?;
+    let request: JobRequest =
+        bincode::deserialize(&buf).context("error deserializing JobRequest")?;
 
-    let job_info = app
-        .proof_request(request)
-        .await
-        .context("error running ProofRequest")?;
+    let mut response_buf = vec![0u8; 4];
 
-    let mut buf = vec![0u8; 4];
-    bincode::serialize_into(&mut buf, &job_info)?;
-    let body_len = buf.len() as u32 - 4;
-    bincode::serialize_into(&mut buf[0..4], &body_len)?;
-    socket.write_all(&buf).await?;
+    match request {
+        JobRequest::Proof(request) => {
+            let job_info = app
+                .proof_request(request)
+                .await
+                .context("error running ProofRequest")?;
+            bincode::serialize_into(&mut response_buf, &job_info)?;
+        }
+        JobRequest::ShrinkWrap(request) => {
+            let job_info = app
+                .shrink_wrap_request(request)
+                .await
+                .context("error running ShrinkWrapRequest")?;
+            bincode::serialize_into(&mut response_buf, &job_info)?;
+        }
+    }
 
-    Ok(())
+    let body_len = response_buf.len() as u32 - 4;
+    bincode::serialize_into(&mut response_buf[0..4], &body_len)?;
+    socket.write_all(&response_buf).await?;
+
+    Ok(true)
 }
 
 #[tokio::main]
@@ -200,6 +232,7 @@ pub(crate) async fn rpc_main(num_gpus: Option<usize>) -> Result<(), Box<dyn StdE
             TaskKind::Join,
             TaskKind::Union,
             TaskKind::Resolve,
+            TaskKind::ShrinkWrap,
         ],
     };
 
@@ -251,7 +284,18 @@ pub(crate) async fn rpc_main(num_gpus: Option<usize>) -> Result<(), Box<dyn StdE
         children.push(child);
     }
 
-    let result = relay_proof_request(&mut app).await;
+    let socket: StdUnixStream = stdin().as_fd().try_clone_to_owned()?.into();
+
+    socket.set_nonblocking(true)?;
+    let mut socket = UnixStream::from_std(socket)?;
+
+    let result = loop {
+        match relay_job_request(&mut app, &mut socket).await {
+            Ok(true) => continue,
+            Ok(false) => break Ok(()),
+            Err(error) => break Err(error),
+        }
+    };
 
     app.stop().await;
 
@@ -441,7 +485,6 @@ impl App {
         Ok(reply.status.try_into().unwrap())
     }
 
-    #[allow(dead_code)]
     pub async fn shrink_wrap_request(
         &mut self,
         request: ShrinkWrapRequest,

--- a/risc0/r0vm/src/actors/mod.rs
+++ b/risc0/r0vm/src/actors/mod.rs
@@ -60,7 +60,7 @@ use self::{
     manager::ManagerActor,
     protocol::{
         factory::{GetTask, TaskDoneMsg, TaskUpdateMsg},
-        JobInfo, ProofRequest, TaskKind,
+        JobInfo, ProofRequest, ProofResult, ShrinkWrapRequest, ShrinkWrapResult, TaskKind,
     },
     rpc::{rpc_system, RpcMessageId, RpcSender},
     worker::Worker,
@@ -433,9 +433,21 @@ impl App {
         }
     }
 
-    pub async fn proof_request(&mut self, request: ProofRequest) -> anyhow::Result<JobInfo> {
+    pub async fn proof_request(
+        &mut self,
+        request: ProofRequest,
+    ) -> anyhow::Result<JobInfo<ProofResult>> {
         let reply = self.manager.as_ref().unwrap().ask(request).await?;
-        Ok(reply.info.unwrap())
+        Ok(reply.status.try_into().unwrap())
+    }
+
+    #[allow(dead_code)]
+    pub async fn shrink_wrap_request(
+        &mut self,
+        request: ShrinkWrapRequest,
+    ) -> anyhow::Result<JobInfo<ShrinkWrapResult>> {
+        let reply = self.manager.as_ref().unwrap().ask(request).await?;
+        Ok(reply.status.try_into().unwrap())
     }
 }
 

--- a/risc0/r0vm/src/actors/protocol.rs
+++ b/risc0/r0vm/src/actors/protocol.rs
@@ -26,8 +26,8 @@ use serde::{Deserialize, Serialize};
 use super::job::JobActor;
 
 pub use risc0_zkvm::rpc::{
-    JobInfo, JobStatus, ProofRequest, ProofResult, Session, ShrinkWrapKind, ShrinkWrapRequest,
-    ShrinkWrapResult, TaskError,
+    JobInfo, JobRequest, JobStatus, ProofRequest, ProofResult, Session, ShrinkWrapKind,
+    ShrinkWrapRequest, ShrinkWrapResult, TaskError,
 };
 
 pub(crate) type JobId = uuid::Uuid;

--- a/risc0/r0vm/src/actors/protocol.rs
+++ b/risc0/r0vm/src/actors/protocol.rs
@@ -15,39 +15,42 @@
 use std::{ops::Range, sync::Arc};
 
 use clap::ValueEnum;
-use derive_more::Debug;
+use derive_more::{Debug, TryInto};
 use kameo::{actor::ActorRef, Reply};
 use risc0_zkvm::{
-    ProveKeccakRequest, ReceiptClaim, Segment, SegmentReceipt, SuccinctReceipt, UnionClaim, Unknown,
+    ProveKeccakRequest, Receipt, ReceiptClaim, Segment, SegmentReceipt, SuccinctReceipt,
+    UnionClaim, Unknown,
 };
 use serde::{Deserialize, Serialize};
 
 use super::job::JobActor;
 
-pub use risc0_zkvm::rpc::{JobInfo, JobStatus, ProofRequest, ProofResult, Session, TaskError};
+pub use risc0_zkvm::rpc::{
+    JobInfo, JobStatus, ProofRequest, ProofResult, Session, ShrinkWrapKind, ShrinkWrapRequest,
+    ShrinkWrapResult, TaskError,
+};
 
 pub(crate) type JobId = uuid::Uuid;
 pub(crate) type TaskId = u64;
 pub(crate) type WorkerId = uuid::Uuid;
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct CreateJobRequest {
-    pub request: ProofRequest,
-}
-
-#[derive(Reply, Serialize, Deserialize)]
-pub(crate) struct CreateJobReply {
-    pub job_id: JobId,
-}
-
-#[derive(Serialize, Deserialize)]
 pub(crate) struct JobStatusRequest {
     pub job_id: JobId,
 }
 
-#[derive(Reply, Serialize, Deserialize)]
-pub(crate) struct JobStatusReply {
-    pub info: Option<JobInfo>,
+#[derive(Reply, Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct JobRequestReply {
+    pub job_id: JobId,
+    pub status: JobStatusReply,
+}
+
+#[derive(Reply, Serialize, Deserialize, TryInto, Debug, Clone)]
+pub(crate) enum JobStatusReply {
+    Proof(JobInfo<ProofResult>),
+    ShrinkWrap(JobInfo<ShrinkWrapResult>),
+    #[try_into(ignore)]
+    NotFound,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
@@ -59,6 +62,7 @@ pub(crate) enum TaskKind {
     Join,
     Union,
     Resolve,
+    ShrinkWrap,
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +86,7 @@ pub(crate) enum Task {
     Join(Arc<JoinTask>),
     Union(Arc<UnionTask>),
     Resolve(Arc<ResolveTask>),
+    ShrinkWrap(Arc<ShrinkWrapTask>),
 }
 
 #[derive(Reply, Serialize, Deserialize)]
@@ -128,6 +133,12 @@ pub(crate) struct UnionTask {
 pub(crate) struct ResolveTask {
     pub conditional: Arc<SuccinctReceipt<ReceiptClaim>>,
     pub assumption: Arc<SuccinctReceipt<Unknown>>,
+}
+
+#[derive(Reply, Serialize, Deserialize)]
+pub(crate) struct ShrinkWrapTask {
+    pub kind: ShrinkWrapKind,
+    pub receipt: Arc<Receipt>,
 }
 
 pub mod factory {
@@ -180,6 +191,7 @@ pub mod factory {
         Join(Box<JoinNode>),
         Union(Arc<UnionDone>),
         Resolve(Arc<SuccinctReceipt<ReceiptClaim>>),
+        ShrinkWrap(Arc<Receipt>),
     }
 
     #[derive(Serialize, Deserialize)]
@@ -240,6 +252,7 @@ impl Task {
             Task::Join(_) => TaskKind::Join,
             Task::Union(_) => TaskKind::Union,
             Task::Resolve(_) => TaskKind::Resolve,
+            Task::ShrinkWrap(_) => TaskKind::ShrinkWrap,
         }
     }
 }

--- a/risc0/r0vm/src/actors/tests.rs
+++ b/risc0/r0vm/src/actors/tests.rs
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::{Ipv4Addr, SocketAddrV4};
-use std::time::Duration;
+use std::{
+    net::{Ipv4Addr, SocketAddrV4},
+    time::Duration,
+};
 
+use assert_matches::assert_matches;
 use risc0_zkvm::DevModeDelay;
 use risc0_zkvm_methods::FIB_ELF;
 
 use super::{
-    protocol::{JobStatus, ProofRequest, TaskKind},
+    protocol::{JobStatus, ProofRequest, ShrinkWrapKind, ShrinkWrapRequest, TaskKind},
     App, PoolConfig, WorkerConfig,
 };
 
@@ -31,6 +34,7 @@ const PROFILE_RTX_5090: DevModeDelay = DevModeDelay {
     join: Duration::from_millis(250),
     union: Duration::from_millis(250),
     resolve: Duration::from_millis(250),
+    shrink_wrap_groth16: Duration::from_millis(3_760),
 };
 
 // const PROFILE_L40S: DevModeDelay = DevModeDelay {
@@ -48,6 +52,7 @@ async fn do_test(remote: bool) {
         TaskKind::ProveSegment,
         TaskKind::Lift,
         TaskKind::Join,
+        TaskKind::ShrinkWrap,
     ];
 
     let storage_root = assert_fs::TempDir::new().unwrap();
@@ -85,9 +90,18 @@ async fn do_test(remote: bool) {
 
     let info = app.proof_request(request).await.unwrap();
 
-    tracing::info!("{info:#?}");
+    tracing::info!("proof_request result = {info:#?}");
 
-    assert!(matches!(info.status, JobStatus::Succeeded(_result)));
+    let result = assert_matches!(info.status, JobStatus::Succeeded(r) => r);
+
+    let request = ShrinkWrapRequest {
+        kind: ShrinkWrapKind::Groth16,
+        receipt: (*result.receipt).clone(),
+    };
+
+    let info = app.shrink_wrap_request(request).await.unwrap();
+
+    tracing::info!("shrink_wrap_request result = {info:#?}");
 
     app.stop().await;
 }

--- a/risc0/r0vm/src/actors/worker.rs
+++ b/risc0/r0vm/src/actors/worker.rs
@@ -33,7 +33,7 @@ use super::{
         },
         worker::TaskMsg,
         ExecuteTask, JoinTask, LiftTask, ProveKeccakTask, ProveSegmentTask, ResolveTask, Session,
-        Task, TaskError, TaskHeader, TaskKind, UnionTask, WorkerId,
+        ShrinkWrapKind, ShrinkWrapTask, Task, TaskError, TaskHeader, TaskKind, UnionTask, WorkerId,
     },
 };
 
@@ -48,6 +48,7 @@ enum GpuTask {
     Join(Arc<JoinTask>),
     Union(Arc<UnionTask>),
     Resolve(Arc<ResolveTask>),
+    ShrinkWrap(Arc<ShrinkWrapTask>),
 }
 
 struct GpuTaskMsg {
@@ -244,6 +245,15 @@ impl Processor {
                     .await
                     .unwrap();
             }
+            Task::ShrinkWrap(task) => {
+                self.gpu_queue
+                    .send(GpuTaskMsg {
+                        header: msg.header,
+                        task: GpuTask::ShrinkWrap(task),
+                    })
+                    .await
+                    .unwrap();
+            }
         }
     }
 }
@@ -290,6 +300,7 @@ impl GpuProcessor {
             GpuTask::Join(task) => self.join(msg.header, task).await,
             GpuTask::Union(task) => self.union(msg.header, task).await,
             GpuTask::Resolve(task) => self.resolve(msg.header, task).await,
+            GpuTask::ShrinkWrap(task) => self.shrink_wrap(msg.header, task).await,
         };
 
         let result = self.send_done(header, result).await;
@@ -398,6 +409,29 @@ impl GpuProcessor {
         .await
         .context("JoinHandle error: resolve task")??;
         Ok(TaskDone::Resolve(Arc::new(receipt)))
+    }
+
+    async fn shrink_wrap(
+        &self,
+        header: TaskHeader,
+        task: Arc<ShrinkWrapTask>,
+    ) -> Result<TaskDone, TaskError> {
+        tracing::info!(
+            "ShrinkWrap({:?}): {:?}",
+            task.kind,
+            header.global_id.task_id
+        );
+        self.task_start(header.clone()).await?;
+        let prover = Prover { delay: self.delay };
+        let task_kind = task.kind;
+        let opts = match task_kind {
+            ShrinkWrapKind::Groth16 => ProverOpts::groth16(),
+        };
+        let receipt =
+            tokio::task::spawn_blocking(move || prover.get()?.compress(&opts, &task.receipt))
+                .await
+                .with_context(|| format!("JoinHandle error: shrink_wrap({task_kind:?}) task"))??;
+        Ok(TaskDone::ShrinkWrap(Arc::new(receipt)))
     }
 }
 

--- a/risc0/r0vm/src/api.rs
+++ b/risc0/r0vm/src/api.rs
@@ -46,7 +46,10 @@ use uuid::Uuid;
 
 use crate::actors::{
     manager::ManagerActor,
-    protocol::{JobInfo, JobStatus, JobStatusRequest, ProofRequest, ProofResult, TaskError},
+    protocol::{
+        JobInfo, JobStatus, JobStatusReply, JobStatusRequest, ProofRequest, ProofResult,
+        ShrinkWrapKind, ShrinkWrapRequest, ShrinkWrapResult, TaskError,
+    },
 };
 
 // TODO: Add authn/z to get a userID
@@ -416,15 +419,24 @@ async fn prove_stark(
     }))
 }
 
-async fn stark_status(
-    State(state): State<Arc<AppState>>,
-    Host(hostname): Host,
-    Path(job_id): Path<Uuid>,
-    ExtractApiKey(api_key): ExtractApiKey,
-) -> Result<Json<SessionStatusRes>, AppError> {
-    let info: JobInfo<ProofResult> = state
+struct ApiJobStatus<ResultT> {
+    state: Option<String>,
+    status: String,
+    error_msg: Option<String>,
+    elapsed_time: Option<f64>,
+    result: Option<ResultT>,
+}
+
+async fn get_job_status<ResultT>(
+    state: &AppState,
+    job_id: &Uuid,
+) -> Result<ApiJobStatus<ResultT>, AppError>
+where
+    JobInfo<ResultT>: TryFrom<JobStatusReply>,
+{
+    let info: JobInfo<ResultT> = state
         .manager
-        .ask(JobStatusRequest { job_id })
+        .ask(JobStatusRequest { job_id: *job_id })
         .await
         .context("Failed to get job status")?
         .try_into()
@@ -444,7 +456,33 @@ async fn stark_status(
         None
     };
 
-    let (stats, receipt_url) = if let JobStatus::Succeeded(ref result) = info.status {
+    let status = info.status.bonsai_status().to_string();
+    let elapsed_time = Some(info.elapsed_time.as_secs_f64());
+
+    let result = if let JobStatus::Succeeded(result) = info.status {
+        Some(result)
+    } else {
+        None
+    };
+
+    Ok(ApiJobStatus {
+        state,
+        error_msg,
+        status,
+        elapsed_time,
+        result,
+    })
+}
+
+async fn stark_status(
+    State(state): State<Arc<AppState>>,
+    Host(hostname): Host,
+    Path(job_id): Path<Uuid>,
+    ExtractApiKey(api_key): ExtractApiKey,
+) -> Result<Json<SessionStatusRes>, AppError> {
+    let status = get_job_status::<ProofResult>(&state, &job_id).await?;
+
+    let (stats, receipt_url) = if let Some(result) = status.result {
         let stats = SessionStats {
             segments: result.session.stats.segments,
             total_cycles: result.session.stats.total_cycles,
@@ -455,28 +493,31 @@ async fn stark_status(
     } else {
         (None, None)
     };
-
     Ok(Json(SessionStatusRes {
-        state,
+        state: status.state,
         receipt_url,
-        error_msg,
-        status: info.status.bonsai_status().to_string(),
-        elapsed_time: Some(info.elapsed_time.as_secs_f64()),
+        error_msg: status.error_msg,
+        status: status.status,
+        elapsed_time: status.elapsed_time,
         stats,
     }))
 }
 
-async fn stark_download(
-    State(state): State<Arc<AppState>>,
-    Path(job_id): Path<Uuid>,
-) -> Result<Vec<u8>, AppError> {
+fn get_receipt_path(state: &AppState, job_id: &Uuid) -> Result<PathBuf, AppError> {
     let job_id = job_id.to_string();
     let receipt_path = validate_path(&state.receipts_dir(), &job_id)
         .ok_or_else(|| AppError::InternalErr(anyhow!("Invalid job_id")))?;
     if !receipt_path.exists() {
         return Err(AppError::ReceiptMissing(job_id));
     }
+    Ok(receipt_path)
+}
 
+async fn stark_download(
+    State(state): State<Arc<AppState>>,
+    Path(job_id): Path<Uuid>,
+) -> Result<Vec<u8>, AppError> {
+    let receipt_path = get_receipt_path(&state, &job_id)?;
     let receipt = tokio::fs::read(receipt_path)
         .await
         .context("Failed to read receipt from object store")?;
@@ -489,13 +530,7 @@ async fn receipt_download(
     Path(job_id): Path<Uuid>,
     Host(hostname): Host,
 ) -> Result<Json<ReceiptDownload>, AppError> {
-    let job_id = job_id.to_string();
-    let receipt_path = validate_path(&state.receipts_dir(), &job_id)
-        .ok_or_else(|| AppError::InternalErr(anyhow!("Invalid job_id")))?;
-    if !receipt_path.exists() {
-        return Err(AppError::ReceiptMissing(job_id));
-    }
-
+    let _receipt_path = get_receipt_path(&state, &job_id)?;
     Ok(Json(ReceiptDownload {
         url: format!("http://{hostname}/receipts/stark/receipt/{job_id}"),
     }))
@@ -530,41 +565,31 @@ async fn preflight_journal(
 async fn prove_groth16(
     State(state): State<Arc<AppState>>,
     ExtractApiKey(api_key): ExtractApiKey,
-    Json(start_req): Json<SnarkReq>,
+    Json(snark_req): Json<SnarkReq>,
 ) -> Result<Json<CreateSessRes>, AppError> {
-    // let (
-    //     _aux_stream,
-    //     _exec_stream,
-    //     _gpu_prove_stream,
-    //     _gpu_coproc_stream,
-    //     _gpu_join_stream,
-    //     snark_stream,
-    // ) = helpers::get_or_create_streams(&state.db_pool, &api_key)
-    //     .await
-    //     .context("Failed to get / create steams")?;
+    let job_id = snark_req
+        .session_id
+        .parse()
+        .map_err(|_| AppError::InternalErr(anyhow!("Invalid job_id")))?;
+    let receipt_path = get_receipt_path(&state, &job_id)?;
+    let receipt_bytes = tokio::fs::read(receipt_path)
+        .await
+        .context("Failed to read receipt from object store")?;
+    let receipt: Receipt =
+        bincode::deserialize(&receipt_bytes).context("Failed to deserialize receipt")?;
 
-    // let task_def = serde_json::to_value(TaskType::Snark(WorkflowSnarkReq {
-    //     receipt: start_req.session_id,
-    //     compress_type: CompressType::Groth16,
-    // }))
-    // .context("Failed to serialize ExecutorReq")?;
+    let reply = state
+        .manager
+        .ask(ShrinkWrapRequest {
+            kind: ShrinkWrapKind::Groth16,
+            receipt,
+        })
+        .await
+        .context("Failed to create job")?;
 
-    // let job_id = taskdb::create_job(
-    //     &state.db_pool,
-    //     &snark_stream,
-    //     &task_def,
-    //     state.snark_retries,
-    //     state.snark_timeout,
-    //     &api_key,
-    // )
-    // .await
-    // .context("Failed to create exec / init task")?;
-
-    // Ok(Json(CreateSessRes {
-    //     uuid: job_id.to_string(),
-    // }))
-
-    todo!()
+    Ok(Json(CreateSessRes {
+        uuid: reply.job_id.to_string(),
+    }))
 }
 
 async fn groth16_status(
@@ -573,26 +598,17 @@ async fn groth16_status(
     Path(job_id): Path<Uuid>,
     Host(hostname): Host,
 ) -> Result<Json<SnarkStatusRes>, AppError> {
-    // let job_state = taskdb::get_job_state(&state.db_pool, &job_id, &api_key)
-    //     .await
-    //     .context("Failed to get job state")?;
-    // let (error_msg, output) = match job_state {
-    //     JobState::Running => (None, None),
-    //     JobState::Done => (
-    //         None,
-    //         Some(format!(
-    //             "http://{hostname}/receipts/groth16/receipt/{job_id}"
-    //         )),
-    //     ),
-    //     JobState::Failed => (None, None), // TODO error message
-    // };
-    // Ok(Json(SnarkStatusRes {
-    //     status: job_state.to_string(),
-    //     error_msg,
-    //     output,
-    // }))
+    let status = get_job_status::<ShrinkWrapResult>(&state, &job_id).await?;
 
-    todo!()
+    let output = status
+        .result
+        .is_some()
+        .then(|| format!("http://{hostname}/receipts/groth16/receipt/{job_id}"));
+    Ok(Json(SnarkStatusRes {
+        output,
+        error_msg: status.error_msg,
+        status: status.status,
+    }))
 }
 
 async fn groth16_download(

--- a/risc0/r0vm/tests/default_prover.rs
+++ b/risc0/r0vm/tests/default_prover.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use assert_cmd::cargo::cargo_bin;
-use risc0_zkvm::{DefaultProver, ExecutorEnv, Prover as _};
+use risc0_zkvm::{DefaultProver, ExecutorEnv, Prover as _, ProverOpts, VerifierContext};
 use risc0_zkvm_methods::{FIB_ELF, FIB_ID};
 
 #[test_log::test]
@@ -28,6 +28,17 @@ fn basic_proof() {
         .build()
         .unwrap();
 
-    let receipt = prover.prove(env, FIB_ELF).unwrap().receipt;
+    let ctx = VerifierContext::default();
+
+    #[cfg(feature = "cuda")]
+    let opts = ProverOpts::groth16();
+
+    #[cfg(not(feature = "cuda"))]
+    let opts = ProverOpts::default();
+
+    let receipt = prover
+        .prove_with_ctx(env, &ctx, FIB_ELF, &opts)
+        .unwrap()
+        .receipt;
     receipt.verify(FIB_ID).unwrap();
 }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -39,6 +39,7 @@ borsh = { version = "1.5", default-features = false, features = ["derive"] }
 bytemuck = { version = "1.13", features = ["extern_crate_alloc"] }
 derive_more = { version = "2.0.1", default-features = false, features = [
   "debug",
+  "from",
 ] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 risc0-binfmt = { workspace = true }

--- a/risc0/zkvm/src/host/client/prove/default.rs
+++ b/risc0/zkvm/src/host/client/prove/default.rs
@@ -20,11 +20,15 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{bail, Context as _, Result};
+use anyhow::{bail, ensure, Context as _, Result};
+use serde::de::DeserializeOwned;
 
 use crate::{
-    rpc::{JobInfo, JobStatus, ProofRequest, ProofResult},
-    ExecutorEnv, ProveInfo, Receipt, SessionInfo, VerifierContext,
+    rpc::{
+        JobInfo, JobRequest, JobStatus, ProofRequest, ProofResult, ShrinkWrapKind,
+        ShrinkWrapRequest, ShrinkWrapResult,
+    },
+    ExecutorEnv, InnerReceipt, ProveInfo, Receipt, ReceiptKind, SessionInfo, VerifierContext,
 };
 
 use super::{Executor, Prover, ProverOpts};
@@ -84,21 +88,71 @@ impl Prover for DefaultProver {
         env: ExecutorEnv<'_>,
         _ctx: &VerifierContext,
         elf: &[u8],
-        _opts: &ProverOpts,
+        opts: &ProverOpts,
     ) -> Result<ProveInfo> {
-        let proof_request = ProofRequest {
-            binary: elf.to_vec(),
-            input: env.input,
-            assumptions: env.assumptions.borrow().0.clone(),
-            segment_limit_po2: env.segment_limit_po2,
+        let result = self.prove(env, elf)?;
+
+        let mut prove_info = ProveInfo {
+            receipt: Arc::into_inner(result.receipt).unwrap(),
+            work_receipt: None, // TODO(povw): implement PoVW here
+            stats: result.session.stats.clone(),
         };
 
+        prove_info.stats.log_if_risc0_info_set();
+
+        if opts.receipt_kind == ReceiptKind::Groth16 {
+            prove_info.receipt = self.shrink_wrap_groth16(&prove_info.receipt)?;
+        }
+
+        Ok(prove_info)
+    }
+
+    fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
+        match &receipt.inner {
+            InnerReceipt::Composite(_) => match opts.receipt_kind {
+                ReceiptKind::Composite => Ok(receipt.clone()),
+                ReceiptKind::Succinct => unimplemented!("missing composite -> succinct conversion"),
+                ReceiptKind::Groth16 => self.shrink_wrap_groth16(receipt),
+            },
+            InnerReceipt::Succinct(_) => match opts.receipt_kind {
+                ReceiptKind::Composite | ReceiptKind::Succinct => Ok(receipt.clone()),
+                ReceiptKind::Groth16 => self.shrink_wrap_groth16(receipt),
+            },
+            InnerReceipt::Groth16(_) => match opts.receipt_kind {
+                ReceiptKind::Composite | ReceiptKind::Succinct | ReceiptKind::Groth16 => {
+                    Ok(receipt.clone())
+                }
+            },
+            InnerReceipt::Fake(_) => {
+                ensure!(
+                    opts.dev_mode(),
+                    "dev mode must be enabled to compress fake receipts"
+                );
+                Ok(receipt.clone())
+            }
+        }
+    }
+}
+
+impl Executor for DefaultProver {
+    fn execute(&self, _env: ExecutorEnv<'_>, _elf: &[u8]) -> Result<SessionInfo> {
+        todo!()
+    }
+}
+
+impl DefaultProver {
+    fn rpc_request<RequestT, ResultT>(&self, request: RequestT) -> Result<ResultT>
+    where
+        JobRequest: From<RequestT>,
+        ResultT: DeserializeOwned,
+    {
+        let mut socket = &self.socket;
+
         let mut buf = vec![0u8; 4];
-        bincode::serialize_into(&mut buf, &proof_request)
+        bincode::serialize_into(&mut buf, &JobRequest::from(request))
             .context("error serializing RPC header")?;
         let body_len = buf.len() as u32 - 4;
         bincode::serialize_into(&mut buf[0..4], &body_len).context("error serializing RPC body")?;
-        let mut socket = &self.socket;
 
         socket
             .write_all(&buf)
@@ -113,35 +167,37 @@ impl Prover for DefaultProver {
         socket
             .read_exact(&mut buf)
             .context("error receiving RPC body")?;
-        let job_info: JobInfo<ProofResult> =
+        let job_info: JobInfo<ResultT> =
             bincode::deserialize(&buf).context("error deserializing RPC body")?;
 
         tracing::info!("Elapsed time: {:?}", job_info.elapsed_time);
 
-        let prove_info = match job_info.status {
+        Ok(match job_info.status {
             JobStatus::Running(progress) => bail!("Job is still running: {progress}"),
-            JobStatus::Succeeded(result) => ProveInfo {
-                receipt: Arc::into_inner(result.receipt).unwrap(),
-                work_receipt: None, // TODO(povw): implement PoVW here
-                stats: result.session.stats.clone(),
-            },
+            JobStatus::Succeeded(result) => result,
             JobStatus::Failed(err) => bail!(format!("Task error: {err:?}")),
             JobStatus::TimedOut => bail!("TimedOut"),
             JobStatus::Aborted => bail!("Aborted"),
+        })
+    }
+
+    fn prove(&self, env: ExecutorEnv<'_>, elf: &[u8]) -> Result<ProofResult> {
+        let proof_request = ProofRequest {
+            binary: elf.to_vec(),
+            input: env.input,
+            assumptions: env.assumptions.borrow().0.clone(),
+            segment_limit_po2: env.segment_limit_po2,
         };
 
-        prove_info.stats.log_if_risc0_info_set();
-
-        Ok(prove_info)
+        self.rpc_request(proof_request)
     }
 
-    fn compress(&self, _opts: &ProverOpts, _receipt: &Receipt) -> Result<Receipt> {
-        unimplemented!()
-    }
-}
-
-impl Executor for DefaultProver {
-    fn execute(&self, _env: ExecutorEnv<'_>, _elf: &[u8]) -> Result<SessionInfo> {
-        todo!()
+    fn shrink_wrap_groth16(&self, receipt: &Receipt) -> Result<Receipt> {
+        let shrink_wrap_request = ShrinkWrapRequest {
+            kind: ShrinkWrapKind::Groth16,
+            receipt: receipt.clone(),
+        };
+        let result: ShrinkWrapResult = self.rpc_request(shrink_wrap_request)?;
+        Ok(Arc::into_inner(result.receipt).unwrap())
     }
 }

--- a/risc0/zkvm/src/host/client/prove/default.rs
+++ b/risc0/zkvm/src/host/client/prove/default.rs
@@ -23,7 +23,7 @@ use std::{
 use anyhow::{bail, Context as _, Result};
 
 use crate::{
-    rpc::{JobInfo, JobStatus, ProofRequest},
+    rpc::{JobInfo, JobStatus, ProofRequest, ProofResult},
     ExecutorEnv, ProveInfo, Receipt, SessionInfo, VerifierContext,
 };
 
@@ -113,7 +113,7 @@ impl Prover for DefaultProver {
         socket
             .read_exact(&mut buf)
             .context("error receiving RPC body")?;
-        let job_info: JobInfo =
+        let job_info: JobInfo<ProofResult> =
             bincode::deserialize(&buf).context("error deserializing RPC body")?;
 
         tracing::info!("Elapsed time: {:?}", job_info.elapsed_time);

--- a/risc0/zkvm/src/host/rpc.rs
+++ b/risc0/zkvm/src/host/rpc.rs
@@ -35,10 +35,26 @@ pub struct ProofRequest {
 }
 
 /// TODO
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JobInfo {
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum ShrinkWrapKind {
     /// TODO
-    pub status: JobStatus,
+    Groth16,
+}
+
+/// TODO
+#[derive(Serialize, Deserialize)]
+pub struct ShrinkWrapRequest {
+    /// TODO
+    pub kind: ShrinkWrapKind,
+    /// TODO
+    pub receipt: Receipt,
+}
+
+/// TODO
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JobInfo<JobResultT> {
+    /// TODO
+    pub status: JobStatus<JobResultT>,
 
     /// TODO
     pub elapsed_time: Duration,
@@ -46,12 +62,12 @@ pub struct JobInfo {
 
 /// TODO
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum JobStatus {
+pub enum JobStatus<JobResultT> {
     /// TODO
     Running(String),
 
     /// TODO
-    Succeeded(ProofResult),
+    Succeeded(JobResultT),
 
     /// TODO
     Failed(TaskError),
@@ -69,6 +85,13 @@ pub struct ProofResult {
     /// TODO
     pub session: Arc<Session>,
 
+    /// TODO
+    pub receipt: Arc<Receipt>,
+}
+
+/// TODO
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ShrinkWrapResult {
     /// TODO
     pub receipt: Arc<Receipt>,
 }
@@ -93,7 +116,7 @@ pub enum TaskError {
     Generic(String),
 }
 
-impl JobStatus {
+impl<JobResultT> JobStatus<JobResultT> {
     /// TODO
     pub fn bonsai_status(&self) -> &str {
         match self {

--- a/risc0/zkvm/src/host/rpc.rs
+++ b/risc0/zkvm/src/host/rpc.rs
@@ -14,6 +14,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use derive_more::From;
 use serde::{Deserialize, Serialize};
 
 use crate::{AssumptionReceipt, Journal, Receipt, SessionStats};
@@ -48,6 +49,16 @@ pub struct ShrinkWrapRequest {
     pub kind: ShrinkWrapKind,
     /// TODO
     pub receipt: Receipt,
+}
+
+/// TODO
+#[allow(clippy::large_enum_variant)]
+#[derive(Serialize, Deserialize, From)]
+pub enum JobRequest {
+    /// TODO
+    Proof(ProofRequest),
+    /// TODO
+    ShrinkWrap(ShrinkWrapRequest),
 }
 
 /// TODO


### PR DESCRIPTION
Adds new `ShrinkWrapRequest` to actor system which is fulfilled by `shrink_wrap::JobActor`. The `ShrinkWrapRequest` has a `kind` field which is `ShrinkWrapKind`, the only variant in it right now is `Groth16`.

There is a new `ShrinkWrap` task type that workers can ask for. We could split this out more in the future so that workers could subscribe to only certain kinds of shrink wrapping. The `ShrinkWrap` task always runs as a GPU task. (the workers don't have support for CPU proving right now)

Implements the `compress` method of `DefaultProver` when asking for a groth16 receipt, also add groth16 shrink-wrapping when calling `prove_with_ctx` and the `receipt_kind` is `Groth16`

Implements the snark API calls in the actor system API.