### PR TITLE
Fix sys_read reported length for short unaligned reads

### DIFF
--- a/risc0/zkvm/methods/std-ext/src/bin/standard_lib.rs
+++ b/risc0/zkvm/methods/std-ext/src/bin/standard_lib.rs
@@ -45,10 +45,16 @@ fn main() {
             risc0_zkvm::guest::env::commit(&args);
         }
         "BUF_READ" => {
-            let capacity: usize = risc0_zkvm::guest::env::read();
-            let mut reader = BufReader::with_capacity(capacity, risc0_zkvm::guest::env::stdin());
+            let capacity: u32 = risc0_zkvm::guest::env::read();
+            let mut reader =
+                BufReader::with_capacity(capacity as usize, risc0_zkvm::guest::env::stdin());
             let buf = reader.fill_buf().unwrap();
             risc0_zkvm::guest::env::commit_slice(buf)
+        }
+        "READ_TO_END" => {
+            let mut buf = Vec::new();
+            stdin().read_to_end(&mut buf).unwrap();
+            risc0_zkvm::guest::env::commit_slice(&buf)
         }
         _ => {
             panic!("Unknown test mode {test_mode}");

--- a/risc0/zkvm/platform/src/syscall.rs
+++ b/risc0/zkvm/platform/src/syscall.rs
@@ -562,13 +562,8 @@ pub unsafe extern "C" fn sys_read(fd: u32, recv_ptr: *mut u8, nread: usize) -> u
         assert!(nread_first as usize <= unaligned_at_start);
 
         // Copy the firstword provided by the host into the unaligned start bytes.
-        // NOTE: When nread_first < unaligned_at_start, we still copy unaligned_at_start bytes.
+        // NOTE: When nread_first < unaligned_at_start, we still copy unaligned_at_start. See #1557
         let main_ptr = fill_from_word(recv_ptr, firstword, unaligned_at_start);
-        // If the host returned less data than is required to align up to the word boundary, return
-        // early, as the main read cannot proceed.
-        if (nread_first as usize) < unaligned_at_start {
-            return nread_first as usize;
-        }
         // If the amount read is the full amount requested, return early.
         if nread == unaligned_at_start {
             return nread;

--- a/risc0/zkvm/platform/src/syscall.rs
+++ b/risc0/zkvm/platform/src/syscall.rs
@@ -562,6 +562,7 @@ pub unsafe extern "C" fn sys_read(fd: u32, recv_ptr: *mut u8, nread: usize) -> u
         assert!(nread_first as usize <= unaligned_at_start);
 
         // Copy the firstword provided by the host into the unaligned start bytes.
+        // NOTE: When nread_first < unaligned_at_start, we still copy unaligned_at_start bytes.
         let main_ptr = fill_from_word(recv_ptr, firstword, unaligned_at_start);
         // If the host returned less data than is required to align up to the word boundary, return
         // early, as the main read cannot proceed.
@@ -569,7 +570,7 @@ pub unsafe extern "C" fn sys_read(fd: u32, recv_ptr: *mut u8, nread: usize) -> u
             return nread_first as usize;
         }
         // If the amount read is the full amount requested, return early.
-        if nread_first as usize == nread {
+        if nread == unaligned_at_start {
             return nread;
         }
         (main_ptr, nread - unaligned_at_start, nread_first as usize)

--- a/risc0/zkvm/src/host/server/exec/tests.rs
+++ b/risc0/zkvm/src/host/server/exec/tests.rs
@@ -586,7 +586,8 @@ fn unaligned_start_short_read() {
 
     let actual: Vec<u8> = session.journal.unwrap().decode().unwrap();
     let mut expected = vec![0xff; 4];
-    expected[1..].copy_from_slice(readbuf);
+    expected[1..3].copy_from_slice(readbuf);
+    expected[3] = 0;
     assert_eq!(actual, expected, "pos and lens: {spec:?}");
 }
 


### PR DESCRIPTION
I stumbled upon this with the following guest code:

```rust
let mut buf = Vec::new();
env::stdin().read_to_end(&mut buf).unwrap()
```

When the host supplies `b"hello"`, the result is `b"hello\0\0\0"`.

With some work, I found two issues in the `sys_read` implementation:
1. On a short read with unaligned start less than `unaligned_at_start`, the function will continue as if it had read enough bytes to become aligned.
2. The host is allowed to have the `nread` value exceed the requests bytes for the read, since the checks we made are in `debug_assert` and guests are essentially always compiled in release mode.
