### PR TITLE
Fix bounds checking issue in zkp eltwise code

### DIFF
--- a/risc0/sys/kernels/zkp/cuda/eltwise.cu
+++ b/risc0/sys/kernels/zkp/cuda/eltwise.cu
@@ -69,14 +69,18 @@ eltwise_sum_fpext(Fp* out, const FpExt* in, const uint32_t to_add, const uint32_
   }
 }
 
-__global__ void eltwise_zeroize_fp(Fp* elems) {
+__global__ void eltwise_zeroize_fp(Fp* elems, uint32_t count) {
   uint idx = blockIdx.x * blockDim.x + threadIdx.x;
-  Fp val = elems[idx];
-  elems[idx] = val.zeroize();
+  if (idx < count) {
+      Fp val = elems[idx];
+      elems[idx] = val.zeroize();
+  }
 }
 
-__global__ void eltwise_zeroize_fpext(FpExt* elems) {
+__global__ void eltwise_zeroize_fpext(FpExt* elems, uint32_t count) {
   uint idx = blockIdx.x * blockDim.x + threadIdx.x;
-  FpExt val = elems[idx];
-  elems[idx] = val.zeroize();
+  if (idx < count) {
+      FpExt val = elems[idx];
+      elems[idx] = val.zeroize();
+  }
 }

--- a/risc0/sys/kernels/zkp/cuda/ffi.cu
+++ b/risc0/sys/kernels/zkp/cuda/ffi.cu
@@ -65,11 +65,11 @@ const char* risc0_zkp_cuda_eltwise_sum_fpext(Fp* out,
 }
 
 const char* risc0_zkp_cuda_eltwise_zeroize_fp(Fp* elems, const uint32_t count) {
-  return launchKernel(eltwise_zeroize_fp, count, 0, elems);
+  return launchKernel(eltwise_zeroize_fp, count, 0, elems, count);
 }
 
 const char* risc0_zkp_cuda_eltwise_zeroize_fpext(FpExt* elems, const uint32_t count) {
-  return launchKernel(eltwise_zeroize_fpext, count, 0, elems);
+  return launchKernel(eltwise_zeroize_fpext, count, 0, elems, count);
 }
 
 const char* risc0_zkp_cuda_fri_fold(Fp* out, const Fp* in, const FpExt* mix, const uint32_t count) {

--- a/risc0/sys/kernels/zkp/cuda/kernels.h
+++ b/risc0/sys/kernels/zkp/cuda/kernels.h
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,9 +37,9 @@ __global__ void eltwise_copy_fp_region(Fp* into,
 __global__ void
 eltwise_sum_fpext(Fp* out, const FpExt* in, const uint32_t to_add, const uint32_t count);
 
-__global__ void eltwise_zeroize_fp(Fp* elems);
+__global__ void eltwise_zeroize_fp(Fp* elems, uint32_t count);
 
-__global__ void eltwise_zeroize_fpext(FpExt* elems);
+__global__ void eltwise_zeroize_fpext(FpExt* elems, uint32_t count);
 
 __global__ void fri_fold(Fp* out, const Fp* in, const FpExt* mix, const uint32_t count);
 


### PR DESCRIPTION
We would write past the end of the buffer.