### PR TITLE
Extract rzup artifacts out-of-place

### DIFF
--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -1701,9 +1701,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
@@ -1976,13 +1976,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -262,7 +262,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "8b7281e1fe0285c8d9cbb94b85c3cb5aa512672cb901e857e487cdbe677a7f0a",
+            "91d654f4e393d80f1771f70e7996e47e346bdfe011a0925279871fd25adab260",
         );
     }
 }

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1884,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
@@ -2171,11 +2171,10 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",

--- a/risc0/zkvm/methods/std-ext/Cargo.lock
+++ b/risc0/zkvm/methods/std-ext/Cargo.lock
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
@@ -2220,13 +2220,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
@@ -2220,13 +2220,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/rzup/Cargo.toml
+++ b/rzup/Cargo.toml
@@ -66,7 +66,7 @@ serde_with = "3"
 sha2 = { version = "0.10", default-features = false }
 strum = { version = "0.27.1", features = ["derive"] }
 tar = { version = "0.4.43", optional = true }
-tempfile = "3.14.0"
+tempfile = "3.20.0"
 thiserror = "2.0.6"
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "macros"], optional = true }
 toml = "0.8.19"

--- a/rzup/src/lib.rs
+++ b/rzup/src/lib.rs
@@ -575,6 +575,42 @@ mod tests {
                 .unwrap()
         }
 
+        fn bad_tar_gz_response() -> HyperResponse {
+            let mut tar_bytes = vec![];
+            let mut tar_builder = tar::Builder::new(&mut tar_bytes);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(4);
+            for i in 0..10 {
+                tar_builder
+                    .append_data(
+                        &mut header,
+                        format!("tar_contents{i}.bin"),
+                        &[0xFF, 0xFE, 0xFF, 0xFF][..],
+                    )
+                    .unwrap();
+            }
+            tar_builder.finish().unwrap();
+            drop(tar_builder);
+
+            // truncate the tar in the middle of the data to make it invalid
+            let idx = tar_bytes.iter().rposition(|b| *b == 0xFE).unwrap();
+            tar_bytes.truncate(idx);
+
+            let mut tar_gz_bytes = vec![];
+            let mut encoder =
+                flate2::write::GzEncoder::new(&mut tar_gz_bytes, flate2::Compression::default());
+            encoder.write_all(&tar_bytes).unwrap();
+            drop(encoder);
+
+            hyper::Response::builder()
+                .status(200)
+                .header("content-type", "application/octet-stream")
+                .body(http_body_util::Full::new(hyper::body::Bytes::from(
+                    tar_gz_bytes,
+                )))
+                .unwrap()
+        }
+
         fn dummy_tar_xz_response(sub_dir: &str) -> HyperResponse {
             let mut tar_bytes = vec![];
             let mut tar_builder = tar::Builder::new(&mut tar_bytes);
@@ -651,6 +687,7 @@ mod tests {
             "/github_api/repos/risc0/risc0/releases/tags/v1.0.0".into() => json_response("{}"),
             "/github_api/repos/risc0/risc0/releases/tags/v1.0.0-rc.1".into() => json_response("{}"),
             "/github_api/repos/risc0/risc0/releases/tags/v1.0.0-rc.2".into() => json_response("{}"),
+            "/github_api/repos/risc0/risc0/releases/tags/v1.0.0-rc.3".into() => json_response("{}"),
             "/github_api/repos/risc0/rust/releases/tags/r0.1.79.0".into() => json_response("{}"),
             "/risc0_github/risc0/releases/download/v1.0.0/\
                 cargo-risczero-x86_64-unknown-linux-gnu.tgz".into() => dummy_tar_gz_response(),
@@ -658,6 +695,8 @@ mod tests {
                 cargo-risczero-x86_64-unknown-linux-gnu.tgz".into() => dummy_tar_gz_response(),
             "/risc0_github/risc0/releases/download/v1.0.0-rc.2/\
                 cargo-risczero-x86_64-unknown-linux-gnu.tgz".into() => dummy_tar_gz_response(),
+            "/risc0_github/risc0/releases/download/v1.0.0-rc.3/\
+                cargo-risczero-x86_64-unknown-linux-gnu.tgz".into() => bad_tar_gz_response(),
             "/risc0_github/risc0/releases/download/v1.0.0/\
                 cargo-risczero-aarch64-apple-darwin.tgz".into() => dummy_tar_gz_response(),
             "/risc0_github/rust/releases/download/r0.1.79.0/\
@@ -1735,6 +1774,59 @@ mod tests {
             true, /* use_github_token */
             Platform::new("x86_64", Os::Linux),
         )
+    }
+
+    #[test]
+    fn install_bad_tar_gz() {
+        let server = MockDistributionServer::new();
+        let (_tmp_dir, mut rzup) = setup_test_env(
+            server.base_urls.clone(),
+            None,
+            None,
+            server.private_key.clone(),
+            Platform::new("x86_64", Os::Linux),
+        );
+
+        let base_url = &server.base_urls.risc0_github_base_url;
+        run_and_assert_events(
+            &mut rzup,
+            |rzup| {
+                let error = rzup
+                    .install_component(&Component::R0Vm, Some("1.0.0-rc.3".parse().unwrap()), false)
+                    .unwrap_err();
+                assert!(
+                    matches!(&error, RzupError::Io(msg) if msg.starts_with("failed to unpack")),
+                    "{error:?}"
+                );
+            },
+            vec![
+                RzupEvent::InstallationStarted {
+                    id: "r0vm".into(),
+                    version: "1.0.0-rc.3".into(),
+                },
+                RzupEvent::TransferStarted {
+                    kind: TransferKind::Download,
+                    id: "cargo-risczero".into(),
+                    version: Some("1.0.0-rc.3".into()),
+                    url: Some(format!(
+                        "{base_url}/risc0/releases/download/v1.0.0-rc.3/\
+                        cargo-risczero-x86_64-unknown-linux-gnu.tgz"
+                    )),
+                    len: Some(196),
+                },
+                RzupEvent::TransferProgress {
+                    id: "cargo-risczero".into(),
+                    incr: 196,
+                },
+                RzupEvent::TransferCompleted {
+                    kind: TransferKind::Download,
+                    id: "cargo-risczero".into(),
+                    version: Some("1.0.0-rc.3".into()),
+                },
+            ],
+        );
+
+        assert_eq!(rzup.list_versions(&Component::R0Vm).unwrap(), vec![]);
     }
 
     fn test_list_multiple_versions(component: Component, version1: Version, version2: Version) {


### PR DESCRIPTION
This should help ensure that components aren't ever half-installed.

The test I add doesn't fail previously because it does try to delete the directory if the extraction fails, but if rzup is killed it will leave it half extracted. I can't test the rzup being killed case, but I might as well backfill the case for regular failed extraction.

With this, I think we should be able to remove the `--force` flag from the CI invocations