### PR TITLE
Speed up tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,4 +5,4 @@ xtask = "run --package xtask --release --"
 xtask-groth16 = "run --package xtask --no-default-features -F setup-groth16 -- setup-groth16"
 
 [build]
-rustflags = ["-Dclippy::all", "-Dwarnings", "--check-cfg=cfg(ci)"]
+rustflags = ["-Dclippy::all", "-Dwarnings"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,4 +5,4 @@ xtask = "run --package xtask --release --"
 xtask-groth16 = "run --package xtask --no-default-features -F setup-groth16 -- setup-groth16"
 
 [build]
-rustflags = ["-Dclippy::all", "-Dwarnings"]
+rustflags = ["-Dclippy::all", "-Dwarnings", "--check-cfg=cfg(ci)"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,7 +242,6 @@ jobs:
       RISC0_DEFAULT_PROVER_NUM_GPUS: 1
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
-      RUSTFLAGS: --cfg=ci
       # SCCACHE_RECACHE: 1
     steps:
       - uses: actions/checkout@v4
@@ -273,7 +272,7 @@ jobs:
         run: brew install zstd gettext lz4 mpfr gmp
         if: matrix.os == 'macOS'
       - name: test workspace
-        run: ${{ matrix.test_command }} -F $FEATURE -F prove -F redis -F unstable --workspace --timings --exclude doc-test
+        run: ${{ matrix.test_command }} --release -F $FEATURE -F prove -F redis -F unstable --workspace --timings --exclude doc-test
       - uses: actions/upload-artifact@v4
         with:
           name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}-${{ matrix.partition }}
@@ -324,7 +323,7 @@ jobs:
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force risc0-groth16 $RISC0_GROTH16_VERSION
       - name: test risc0-r0vm
-        run: ${{ matrix.test_command }} -p risc0-r0vm -F $FEATURE
+        run: ${{ matrix.test_command }} --release -p risc0-r0vm -F $FEATURE
       - name: test risc0-r0vm (disable-dev-mode)
         run: ${{ matrix.test_command }} -p risc0-r0vm -F $FEATURE -F disable-dev-mode
       - run: ${{ matrix.test_command }} -p cargo-risczero -F experimental
@@ -391,10 +390,10 @@ jobs:
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo build --release -p risc0-r0vm -F $FEATURE
       - name: test in dev mode
-        run: RISC0_DEV_MODE=1 ${{ matrix.test_command }} --locked -F $FEATURE --workspace --exclude prover-example
+        run: RISC0_DEV_MODE=1 ${{ matrix.test_command }} --release --locked -F $FEATURE --workspace --exclude prover-example
         working-directory: examples
       - name: test prover example
-        run: ${{ matrix.test_command }} --locked -F $FEATURE -p prover-example
+        run: ${{ matrix.test_command }} --release --locked -F $FEATURE -p prover-example
         working-directory: examples
       - run: cargo run --locked -F $FEATURE
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,7 @@ jobs:
       RISC0_DEFAULT_PROVER_NUM_GPUS: 1
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
-      RUSTFLAGS: --cfg=ci=\"${{ matrix.ci_profile }}\"
+      RUSTFLAGS: --cfg ci="${{ matrix.ci_profile }}"
       # SCCACHE_RECACHE: 1
     steps:
       - uses: actions/checkout@v4
@@ -311,7 +311,7 @@ jobs:
       RISC0_DEFAULT_PROVER_NUM_GPUS: 1
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
-      RUSTFLAGS: --cfg=ci=\"${{ matrix.ci_profile }}\"
+      RUSTFLAGS: --cfg ci="${{ matrix.ci_profile }}"
       # SCCACHE_RECACHE: 1
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,24 +224,28 @@ jobs:
             nvcc_arch: sm_89
             test_command: cargo test
             partition: 1
+            ci_profile: slow
           - os: macOS
             arch: ARM64
             feature: default
             device: apple_m2_pro
             test_command: cargo nextest run --partition hash:1/2
             partition: 1
+            ci_profile: fast
           - os: macOS
             arch: ARM64
             feature: default
             device: apple_m2_pro
             test_command: cargo nextest run --partition hash:2/2
             partition: 2
+            ci_profile: fast
     env:
       FEATURE: ${{ matrix.feature }}
       NVCC_APPEND_FLAGS: -arch=${{ matrix.nvcc_arch }}
       RISC0_DEFAULT_PROVER_NUM_GPUS: 1
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
+      RUSTFLAGS: --cfg=ci=\"${{ matrix.ci_profile }}\"
       # SCCACHE_RECACHE: 1
     steps:
       - uses: actions/checkout@v4
@@ -294,17 +298,20 @@ jobs:
             device: nvidia_rtx_4000_ada
             nvcc_arch: sm_89
             test_command: cargo test
+            ci_profile: slow
           - os: macOS
             arch: ARM64
             feature: default
             device: apple_m2_pro
             test_command: cargo nextest run
+            ci_profile: fast
     env:
       FEATURE: ${{ matrix.feature }}
       NVCC_APPEND_FLAGS: -arch=${{ matrix.nvcc_arch }}
       RISC0_DEFAULT_PROVER_NUM_GPUS: 1
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
+      RUSTFLAGS: --cfg=ci=\"${{ matrix.ci_profile }}\"
       # SCCACHE_RECACHE: 1
     steps:
       - uses: actions/checkout@v4
@@ -325,7 +332,7 @@ jobs:
       - name: test risc0-r0vm
         run: ${{ matrix.test_command }} --release -p risc0-r0vm -F $FEATURE
       - name: test risc0-r0vm (disable-dev-mode)
-        run: ${{ matrix.test_command }} -p risc0-r0vm -F $FEATURE -F disable-dev-mode
+        run: ${{ matrix.test_command }} --release -p risc0-r0vm -F $FEATURE -F disable-dev-mode
       - run: ${{ matrix.test_command }} -p cargo-risczero -F experimental
       - name: run datasheet generator (smoke test)
         run: cargo run --locked -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,6 +242,7 @@ jobs:
       RISC0_DEFAULT_PROVER_NUM_GPUS: 1
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
+      RUSTFLAGS: --cfg=ci
       # SCCACHE_RECACHE: 1
     steps:
       - uses: actions/checkout@v4
@@ -272,7 +273,7 @@ jobs:
         run: brew install zstd gettext lz4 mpfr gmp
         if: matrix.os == 'macOS'
       - name: test workspace
-        run: ${{ matrix.test_command }} --release -F $FEATURE -F prove -F redis -F unstable --workspace --timings --exclude doc-test
+        run: ${{ matrix.test_command }} -F $FEATURE -F prove -F redis -F unstable --workspace --timings --exclude doc-test
       - uses: actions/upload-artifact@v4
         with:
           name: cargo-timings-${{ matrix.os }}-${{ matrix.device }}-${{ matrix.partition }}
@@ -323,18 +324,15 @@ jobs:
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force risc0-groth16 $RISC0_GROTH16_VERSION
       - name: test risc0-r0vm
-        run: ${{ matrix.test_command }} --release -p risc0-r0vm -F $FEATURE
+        run: ${{ matrix.test_command }} -p risc0-r0vm -F $FEATURE
       - name: test risc0-r0vm (disable-dev-mode)
-        run: ${{ matrix.test_command }} --release -p risc0-r0vm -F $FEATURE -F disable-dev-mode
-      - run: ${{ matrix.test_command }} --release -p cargo-risczero -F experimental
-      - name: run fibonacci benchmark
-        run: cargo run --release --locked -F $FEATURE -- fibonacci
-        working-directory: benchmarks
+        run: ${{ matrix.test_command }} -p risc0-r0vm -F $FEATURE -F disable-dev-mode
+      - run: ${{ matrix.test_command }} -p cargo-risczero -F experimental
       - name: run datasheet generator (smoke test)
-        run: cargo run --release --locked -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift
+        run: cargo run --locked -F $FEATURE -F prove --example datasheet -- --json tmp/datasheet.json lift
       - name: run datasheet generator (CUDA full)
         if: matrix.feature == 'cuda'
-        run: cargo run --release --locked -F $FEATURE -F prove --example datasheet
+        run: cargo run --locked -F $FEATURE -F prove --example datasheet
       - name: check benches
         run: cargo check -F $FEATURE --benches --workspace --exclude doc-test
       - run: cargo check -p risc0-build
@@ -393,10 +391,10 @@ jobs:
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION
       - run: cargo build --release -p risc0-r0vm -F $FEATURE
       - name: test in dev mode
-        run: RISC0_DEV_MODE=1 ${{ matrix.test_command }} --release --locked -F $FEATURE --workspace --exclude prover-example
+        run: RISC0_DEV_MODE=1 ${{ matrix.test_command }} --locked -F $FEATURE --workspace --exclude prover-example
         working-directory: examples
       - name: test prover example
-        run: ${{ matrix.test_command }} --release --locked -F $FEATURE -p prover-example
+        run: ${{ matrix.test_command }} --locked -F $FEATURE -p prover-example
         working-directory: examples
       - run: cargo run --locked -F $FEATURE
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6590,9 +6590,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -6600,9 +6600,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -6796,7 +6796,7 @@ dependencies = [
  "puffin_http",
  "risc0-bigint2-methods",
  "risc0-zkvm",
- "rstest 0.25.0",
+ "rstest",
  "stability",
  "test-log",
  "tracing",
@@ -6843,6 +6843,7 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
+ "rayon",
  "risc0-binfmt",
  "risc0-zkos-v1compat",
  "risc0-zkp",
@@ -7244,7 +7245,7 @@ dependencies = [
  "risc0-zkvm-platform",
  "rmp-serde",
  "rrs-lib",
- "rstest 0.25.0",
+ "rstest",
  "ruint",
  "rustc-demangle",
  "rzup",
@@ -7263,22 +7264,6 @@ dependencies = [
  "tracing-forest",
  "tracing-subscriber 0.3.19",
  "typetag",
-]
-
-[[package]]
-name = "risc0-zkvm-compat-tests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "risc0-binfmt",
- "risc0-r0vm",
- "risc0-zkp",
- "risc0-zkvm",
- "risc0-zkvm-methods",
- "rstest 0.24.0",
- "semver 1.0.26",
- "test-log",
- "tokio",
 ]
 
 [[package]]
@@ -7412,44 +7397,14 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros 0.24.0",
- "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros 0.25.0",
+ "rstest_macros",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version 0.4.1",
- "syn 2.0.100",
- "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ incremental = true
 [profile.release]
 lto = true
 
-[lints.rust]
+[workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(ci)',
   'cfg(ci, values("fast", "medium", "slow"))',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,9 @@ incremental = true
 
 [profile.release]
 lto = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(ci)',
+  'cfg(ci, values("fast", "medium", "slow"))',
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,5 +76,12 @@ lto = true
 [profile.dev]
 opt-level = 3
 
+[profile.test]
+opt-level = 0
+codegen-units = 256
+debug = 1
+lto = "off"
+incremental = true
+
 [profile.release]
 lto = true

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1590,7 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3287,8 +3287,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3386,7 +3386,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3480,9 +3480,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -3490,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3705,6 +3705,7 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
+ "rayon",
  "risc0-binfmt",
  "risc0-zkos-v1compat",
  "risc0-zkp",
@@ -4121,7 +4122,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4134,7 +4135,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4602,7 +4603,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1890,7 +1890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3034,7 +3034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3968,7 +3968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4111,7 +4111,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4205,9 +4205,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -4215,9 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -4431,6 +4431,7 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
+ "rayon",
  "risc0-binfmt",
  "risc0-zkos-v1compat",
  "risc0-zkp",
@@ -4963,7 +4964,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4976,7 +4977,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5610,7 +5611,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6474,7 +6475,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/examples/composition/methods/guest/Cargo.lock
+++ b/examples/composition/methods/guest/Cargo.lock
@@ -498,6 +498,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1413,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1493,7 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
+ "rayon",
  "risc0-binfmt",
  "risc0-zkos-v1compat",
  "risc0-zkp",

--- a/risc0/build/Cargo.toml
+++ b/risc0/build/Cargo.toml
@@ -14,6 +14,7 @@ derive_builder = "0.20.2"
 dirs = "6.0.0"
 docker-generate = "0.1"
 hex = "0.4"
+rayon = "1.11"
 risc0-binfmt = { workspace = true, features = ["std"] }
 risc0-zkos-v1compat = { workspace = true }
 risc0-zkp = { workspace = true, features = ["std"] }

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -262,7 +262,7 @@ mod test {
         compare_image_id(
             &guest_list,
             "hello_commit",
-            "91d654f4e393d80f1771f70e7996e47e346bdfe011a0925279871fd25adab260",
+            "8b7281e1fe0285c8d9cbb94b85c3cb5aa512672cb901e857e487cdbe677a7f0a",
         );
     }
 }

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -38,6 +38,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use cargo_metadata::{Message, MetadataCommand, Package};
 use config::GuestMetadata;
+use rayon::prelude::*;
 use risc0_binfmt::{KERNEL_START_ADDR, ProgramBinary};
 use risc0_zkp::core::digest::Digest;
 use risc0_zkvm_platform::memory;
@@ -68,7 +69,7 @@ impl Risc0Metadata {
     }
 }
 
-trait GuestBuilder: Sized {
+trait GuestBuilder: Sized + Send {
     fn build(guest_info: &GuestInfo, name: &str, elf_path: &str) -> Result<Self>;
 
     fn codegen_consts(&self) -> String;
@@ -762,58 +763,37 @@ fn build_methods<G: GuestBuilder>(guest_packages: &[GuestPackageWithOptions]) ->
     let methods_path = out_dir.join("methods.rs");
     let mut methods_file = File::create(&methods_path).unwrap();
 
-    // NOTE: Codegen of the guest list is gated behind the "guest-list" feature flag,
-    // although the data structure are not, because when the `GuestListEntry` type
-    // is referenced in the generated code, this requires `risc0-build` be declared
-    // as a dependency of the methods crate.
-    #[cfg(feature = "guest-list")]
-    let mut guest_list_codegen = Vec::new();
-    #[cfg(feature = "guest-list")]
-    methods_file
-        .write_all(b"use risc0_build::GuestListEntry;\n")
-        .unwrap();
-
     let profile = if is_debug() { "debug" } else { "release" };
 
-    let mut guest_list = vec![];
-    for guest in guest_packages {
-        println!("Building guest package: {}", guest.name);
+    let guest_list: Vec<G> = guest_packages
+        .par_iter()
+        .flat_map(|guest| {
+            println!("Building guest package: {}", guest.name);
 
-        let guest_info = GuestInfo {
-            options: guest.opts.clone(),
-            metadata: (&guest.pkg).into(),
-        };
+            let guest_info = GuestInfo {
+                options: guest.opts.clone(),
+                metadata: (&guest.pkg).into(),
+            };
 
-        let methods: Vec<G> = if guest.opts.use_docker.is_some() {
-            build_guest_package_docker(&guest.pkg, &guest.target_dir, &guest_info).unwrap();
-            guest_methods(&guest.pkg, &guest.target_dir, &guest_info, "docker")
-        } else {
-            build_guest_package(&guest.pkg, &guest.target_dir, &guest_info);
-            guest_methods(&guest.pkg, &guest.target_dir, &guest_info, profile)
-        };
+            if guest.opts.use_docker.is_some() {
+                build_guest_package_docker(&guest.pkg, &guest.target_dir, &guest_info).unwrap();
+                guest_methods(&guest.pkg, &guest.target_dir, &guest_info, "docker")
+            } else {
+                build_guest_package(&guest.pkg, &guest.target_dir, &guest_info);
+                guest_methods(&guest.pkg, &guest.target_dir, &guest_info, profile)
+            }
+        })
+        .collect();
 
-        for method in methods {
-            methods_file
-                .write_all(method.codegen_consts().as_bytes())
-                .unwrap();
-
-            #[cfg(feature = "guest-list")]
-            guest_list_codegen.push(method.codegen_list_entry());
-            guest_list.push(method);
-        }
+    #[cfg(not(feature = "guest-list"))]
+    for guest in guest_list.iter() {
+        methods_file
+            .write_all(guest.codegen_consts().as_bytes())
+            .unwrap();
     }
 
     #[cfg(feature = "guest-list")]
-    methods_file
-        .write_all(
-            format!(
-                "\npub const GUEST_LIST: &[{}] = &[{}];\n",
-                std::any::type_name::<G>(),
-                guest_list_codegen.join(",")
-            )
-            .as_bytes(),
-        )
-        .unwrap();
+    build_guest_list(&guest_list, methods_file);
 
     // HACK: It's not particularly practical to figure out all the
     // files that all the guest crates transitively depend on.  So, we
@@ -825,6 +805,40 @@ fn build_methods<G: GuestBuilder>(guest_packages: &[GuestPackageWithOptions]) ->
     println!("cargo:rerun-if-env-changed=RISC0_GUEST_LOGFILE");
 
     guest_list
+}
+
+#[cfg(feature = "guest-list")]
+fn build_guest_list<G: GuestBuilder>(guest_list: &[G], mut methods_file: File) {
+    // NOTE: Codegen of the guest list is gated behind the "guest-list" feature flag,
+    // although the data structure are not, because when the `GuestListEntry` type
+    // is referenced in the generated code, this requires `risc0-build` be declared
+    // as a dependency of the methods crate.
+
+    // prefix
+    methods_file
+        .write_all(b"use risc0_build::GuestListEntry;\n")
+        .unwrap();
+
+    // body
+    let mut guest_list_codegen = Vec::new();
+    for method in guest_list.iter() {
+        methods_file
+            .write_all(method.codegen_consts().as_bytes())
+            .unwrap();
+        guest_list_codegen.push(method.codegen_list_entry());
+    }
+
+    // suffix
+    methods_file
+        .write_all(
+            format!(
+                "\npub const GUEST_LIST: &[{}] = &[{}];\n",
+                std::any::type_name::<G>(),
+                guest_list_codegen.join(",")
+            )
+            .as_bytes(),
+        )
+        .unwrap();
 }
 
 /// Embeds methods built for RISC-V for use by host-side dependencies.

--- a/risc0/povw/Cargo.toml
+++ b/risc0/povw/Cargo.toml
@@ -33,6 +33,6 @@ guest = ["dep:derive_builder"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-  "cfg(ci)",
-  "cfg(ci, values('fast', 'medium', 'slow')",
+  'cfg(ci)',
+  'cfg(ci, values("fast", "medium", "slow")',
 ] }

--- a/risc0/povw/Cargo.toml
+++ b/risc0/povw/Cargo.toml
@@ -30,9 +30,3 @@ ruint = { version = "1.15", features = ["proptest"] }
 default = ["guest", "prover"]
 prover = ["guest", "risc0-zkvm/client", "dep:derive_builder", "dep:anyhow"]
 guest = ["dep:derive_builder"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(ci)',
-  'cfg(ci, values("fast", "medium", "slow"))',
-] }

--- a/risc0/povw/Cargo.toml
+++ b/risc0/povw/Cargo.toml
@@ -34,5 +34,5 @@ guest = ["dep:derive_builder"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(ci)",
-  "cfg(ci, values('fast', 'medium' slow')",
+  "cfg(ci, values('fast', 'medium', 'slow')",
 ] }

--- a/risc0/povw/Cargo.toml
+++ b/risc0/povw/Cargo.toml
@@ -34,5 +34,5 @@ guest = ["dep:derive_builder"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(ci)',
-  'cfg(ci, values("fast", "medium", "slow")',
+  'cfg(ci, values("fast", "medium", "slow"))',
 ] }

--- a/risc0/povw/Cargo.toml
+++ b/risc0/povw/Cargo.toml
@@ -9,7 +9,10 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = { version = "1.0", optional = true }
-borsh = { version = "1.5", default-features = false, features = ["derive", "std"] }
+borsh = { version = "1.5", default-features = false, features = [
+  "derive",
+  "std",
+] }
 bytemuck = "1.22"
 derive_builder = { version = "0.20.2", optional = true }
 hybrid-array = { version = "0.3.0", features = ["serde"] }
@@ -27,3 +30,9 @@ ruint = { version = "1.15", features = ["proptest"] }
 default = ["guest", "prover"]
 prover = ["guest", "risc0-zkvm/client", "dep:derive_builder", "dep:anyhow"]
 guest = ["dep:derive_builder"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(ci)",
+  "cfg(ci, values('fast', 'medium' slow')",
+] }

--- a/risc0/povw/guests/Cargo.toml
+++ b/risc0/povw/guests/Cargo.toml
@@ -26,3 +26,6 @@ risc0-build = { workspace = true }
 
 [package.metadata.risc0]
 methods = ["log-builder"]
+
+[lints]
+workspace = true

--- a/risc0/povw/guests/tests/log-builder.rs
+++ b/risc0/povw/guests/tests/log-builder.rs
@@ -261,7 +261,7 @@ fn two_batched_updates() -> anyhow::Result<()> {
 }
 
 #[test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn prove_three_sequential_updates() -> anyhow::Result<()> {
     let work_log_id = uint!(0xdeafbee7_U160);
 

--- a/risc0/povw/guests/tests/log-builder.rs
+++ b/risc0/povw/guests/tests/log-builder.rs
@@ -261,6 +261,7 @@ fn two_batched_updates() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn prove_three_sequential_updates() -> anyhow::Result<()> {
     let work_log_id = uint!(0xdeafbee7_U160);
 

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -70,5 +70,5 @@ r0vm-ver-compat = ["risc0-zkvm/r0vm-ver-compat"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(ci)",
-  "cfg(ci, values('fast', 'medium' slow')",
+  "cfg(ci, values('fast', 'medium', 'slow')",
 ] }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -70,5 +70,5 @@ r0vm-ver-compat = ["risc0-zkvm/r0vm-ver-compat"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(ci)',
-  'cfg(ci, values("fast", "medium", "slow")',
+  'cfg(ci, values("fast", "medium", "slow"))',
 ] }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -69,6 +69,6 @@ r0vm-ver-compat = ["risc0-zkvm/r0vm-ver-compat"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-  "cfg(ci)",
-  "cfg(ci, values('fast', 'medium', 'slow')",
+  'cfg(ci)',
+  'cfg(ci, values("fast", "medium", "slow")',
 ] }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -66,3 +66,9 @@ dual = ["risc0-zkvm/dual"]
 metal = ["risc0-zkvm/metal"]
 redis = ["risc0-zkvm/redis"]
 r0vm-ver-compat = ["risc0-zkvm/r0vm-ver-compat"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(ci)",
+  "cfg(ci, values('fast', 'medium' slow')",
+] }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -66,9 +66,3 @@ dual = ["risc0-zkvm/dual"]
 metal = ["risc0-zkvm/metal"]
 redis = ["risc0-zkvm/redis"]
 r0vm-ver-compat = ["risc0-zkvm/r0vm-ver-compat"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(ci)',
-  'cfg(ci, values("fast", "medium", "slow"))',
-] }

--- a/risc0/r0vm/Cargo.toml
+++ b/risc0/r0vm/Cargo.toml
@@ -66,3 +66,6 @@ dual = ["risc0-zkvm/dual"]
 metal = ["risc0-zkvm/metal"]
 redis = ["risc0-zkvm/redis"]
 r0vm-ver-compat = ["risc0-zkvm/r0vm-ver-compat"]
+
+[lints]
+workspace = true

--- a/risc0/r0vm/tests/default_prover.rs
+++ b/risc0/r0vm/tests/default_prover.rs
@@ -17,7 +17,6 @@ use risc0_zkvm::{DefaultProver, ExecutorEnv, Prover as _, ProverOpts, VerifierCo
 use risc0_zkvm_methods::{FIB_ELF, FIB_ID};
 
 #[test_log::test]
-#[cfg_attr(all(not(feature = "cuda"), ci), ignore = "slow on CPU")]
 fn basic_proof() {
     let r0vm_path = cargo_bin("r0vm");
     let prover = DefaultProver::new(r0vm_path).unwrap();

--- a/risc0/r0vm/tests/default_prover.rs
+++ b/risc0/r0vm/tests/default_prover.rs
@@ -17,6 +17,7 @@ use risc0_zkvm::{DefaultProver, ExecutorEnv, Prover as _, ProverOpts, VerifierCo
 use risc0_zkvm_methods::{FIB_ELF, FIB_ID};
 
 #[test_log::test]
+#[cfg_attr(all(not(feature = "cuda"), ci), ignore = "slow on CPU")]
 fn basic_proof() {
     let r0vm_path = cargo_bin("r0vm");
     let prover = DefaultProver::new(r0vm_path).unwrap();

--- a/risc0/r0vm/tests/default_prover.rs
+++ b/risc0/r0vm/tests/default_prover.rs
@@ -17,6 +17,7 @@ use risc0_zkvm::{DefaultProver, ExecutorEnv, Prover as _, ProverOpts, VerifierCo
 use risc0_zkvm_methods::{FIB_ELF, FIB_ID};
 
 #[test_log::test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn basic_proof() {
     let r0vm_path = cargo_bin("r0vm");
     let prover = DefaultProver::new(r0vm_path).unwrap();

--- a/risc0/r0vm/tests/default_prover.rs
+++ b/risc0/r0vm/tests/default_prover.rs
@@ -17,7 +17,7 @@ use risc0_zkvm::{DefaultProver, ExecutorEnv, Prover as _, ProverOpts, VerifierCo
 use risc0_zkvm_methods::{FIB_ELF, FIB_ID};
 
 #[test_log::test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn basic_proof() {
     let r0vm_path = cargo_bin("r0vm");
     let prover = DefaultProver::new(r0vm_path).unwrap();

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -223,5 +223,5 @@ witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(ci)",
-  "cfg(ci, values('fast', 'medium' slow')",
+  "cfg(ci, values('fast', 'medium', 'slow')",
 ] }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -219,9 +219,3 @@ std = [
 ]
 unstable = ["risc0-zkvm-platform/unstable"]
 witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(ci)',
-  'cfg(ci, values("fast", "medium", "slow"))',
-] }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -222,6 +222,6 @@ witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-  "cfg(ci)",
-  "cfg(ci, values('fast', 'medium', 'slow')",
+  'cfg(ci)',
+  'cfg(ci, values("fast", "medium", "slow")',
 ] }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -219,3 +219,9 @@ std = [
 ]
 unstable = ["risc0-zkvm-platform/unstable"]
 witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(ci)",
+  "cfg(ci, values('fast', 'medium' slow')",
+] }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -223,5 +223,5 @@ witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(ci)',
-  'cfg(ci, values("fast", "medium", "slow")',
+  'cfg(ci, values("fast", "medium", "slow"))',
 ] }

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -219,3 +219,6 @@ std = [
 ]
 unstable = ["risc0-zkvm-platform/unstable"]
 witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
+
+[lints]
+workspace = true

--- a/risc0/zkvm/methods/guest/Cargo.lock
+++ b/risc0/zkvm/methods/guest/Cargo.lock
@@ -548,6 +548,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1491,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1615,7 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
+ "rayon",
  "risc0-binfmt",
  "risc0-zkos-v1compat",
  "risc0-zkp",

--- a/risc0/zkvm/methods/std-ext/Cargo.lock
+++ b/risc0/zkvm/methods/std-ext/Cargo.lock
@@ -558,6 +558,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1533,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1657,7 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
+ "rayon",
  "risc0-binfmt",
  "risc0-zkos-v1compat",
  "risc0-zkp",

--- a/risc0/zkvm/methods/std/Cargo.lock
+++ b/risc0/zkvm/methods/std/Cargo.lock
@@ -558,6 +558,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1533,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1657,7 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
+ "rayon",
  "risc0-binfmt",
  "risc0-zkos-v1compat",
  "risc0-zkp",

--- a/risc0/zkvm/src/host/api/tests.rs
+++ b/risc0/zkvm/src/host/api/tests.rs
@@ -233,6 +233,7 @@ fn prove_segment_elf() {
 }
 
 #[test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn lift_join_identity() {
     let segment_limit_po2 = 16; // 64k cycles
     let cycles = 1 << segment_limit_po2;

--- a/risc0/zkvm/src/host/api/tests.rs
+++ b/risc0/zkvm/src/host/api/tests.rs
@@ -233,7 +233,7 @@ fn prove_segment_elf() {
 }
 
 #[test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn lift_join_identity() {
     let segment_limit_po2 = 16; // 64k cycles
     let cycles = 1 << segment_limit_po2;

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -233,6 +233,7 @@ fn test_recursion_lift_then_unwrap_povw() {
 }
 
 #[test_log::test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn test_recursion_lift_join_unwrap_povw() -> anyhow::Result<()> {
     // Prove the base case
     let (journal, segments) = BUSY_LOOP_SEGMENTS.clone();
@@ -304,6 +305,7 @@ fn test_recursion_lift_join_unwrap_povw() -> anyhow::Result<()> {
 }
 
 #[test_log::test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn test_recursion_lift_join_identity_p254_e2e() {
     // Prove the base case
     let (journal, segments) = BUSY_LOOP_SEGMENTS.clone();

--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -233,7 +233,7 @@ fn test_recursion_lift_then_unwrap_povw() {
 }
 
 #[test_log::test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn test_recursion_lift_join_unwrap_povw() -> anyhow::Result<()> {
     // Prove the base case
     let (journal, segments) = BUSY_LOOP_SEGMENTS.clone();
@@ -305,7 +305,7 @@ fn test_recursion_lift_join_unwrap_povw() -> anyhow::Result<()> {
 }
 
 #[test_log::test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn test_recursion_lift_join_identity_p254_e2e() {
     // Prove the base case
     let (journal, segments) = BUSY_LOOP_SEGMENTS.clone();

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -96,6 +96,7 @@ fn prove_elf_succinct(env: ExecutorEnv, elf: &[u8]) -> Result<Receipt> {
 }
 
 #[test_log::test]
+#[cfg_attr(all(not(feature = "cuda"), ci), ignore = "slow on CPU")]
 fn keccak_union() {
     let env = ExecutorEnv::builder()
         .write(&MultiTestSpec::KeccakUnion(3))

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -96,6 +96,7 @@ fn prove_elf_succinct(env: ExecutorEnv, elf: &[u8]) -> Result<Receipt> {
 }
 
 #[test_log::test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn keccak_union() {
     let env = ExecutorEnv::builder()
         .write(&MultiTestSpec::KeccakUnion(3))
@@ -222,6 +223,7 @@ fn sha_basics() {
 }
 
 #[test_log::test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn sha_iter() {
     let input = MultiTestSpec::ShaDigestIter {
         data: Vec::from([0u8; 32]),
@@ -241,6 +243,7 @@ fn sha_iter() {
 }
 
 #[test_log::test]
+#[cfg(any(not(ci), ci = "slow"))]
 fn bigint_accel() {
     let cases = testutils::generate_bigint_test_cases(10);
     for case in cases {

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -96,7 +96,7 @@ fn prove_elf_succinct(env: ExecutorEnv, elf: &[u8]) -> Result<Receipt> {
 }
 
 #[test_log::test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn keccak_union() {
     let env = ExecutorEnv::builder()
         .write(&MultiTestSpec::KeccakUnion(3))
@@ -223,7 +223,7 @@ fn sha_basics() {
 }
 
 #[test_log::test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn sha_iter() {
     let input = MultiTestSpec::ShaDigestIter {
         data: Vec::from([0u8; 32]),
@@ -243,7 +243,7 @@ fn sha_iter() {
 }
 
 #[test_log::test]
-#[cfg(any(not(ci), ci = "slow"))]
+#[cfg_attr(not(ci = "slow"), ignore = "slow test")]
 fn bigint_accel() {
     let cases = testutils::generate_bigint_test_cases(10);
     for case in cases {

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -96,7 +96,6 @@ fn prove_elf_succinct(env: ExecutorEnv, elf: &[u8]) -> Result<Receipt> {
 }
 
 #[test_log::test]
-#[cfg_attr(all(not(feature = "cuda"), ci), ignore = "slow on CPU")]
 fn keccak_union() {
     let env = ExecutorEnv::builder()
         .write(&MultiTestSpec::KeccakUnion(3))


### PR DESCRIPTION
* Build methods crates in parallel
* Adjust test profile to favor building faster at the cost of slower tests
* CI can select a `fast` or `slow` profile. `fast` causes slow tests to be ignored. `fast` is selected for GPU, while `slow` for CPU.