### PR TITLE
Half the cargo parallelism for the examples job.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,7 +370,7 @@ jobs:
             device: apple_m2_pro
             test_command: cargo nextest run
     env:
-      CARGO_BUILD_JOBS: 32
+      CARGO_BUILD_JOBS: 16
       FEATURE: ${{ matrix.feature }}
       NVCC_APPEND_FLAGS: -arch=${{ matrix.nvcc_arch }}
       RISC0_DEFAULT_PROVER_NUM_GPUS: 1


### PR DESCRIPTION
We believe the CI machines keep running out of memory, so until we can get some more memory on the CI machines, lets try to avoid the issue.