### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/risc0/povw/guests/log-builder/src/main.rs
+++ b/risc0/povw/guests/log-builder/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
     let mut update_value = 0u64;
     for update in input.updates {
         // Verify the WorkClaim and extract the Work struct.
-        // NOTE: env::verify_assumption is used here instead of env::verify, becuase the claim type
+        // NOTE: env::verify_assumption is used here instead of env::verify, because the claim type
         // is WorkClaim<Unknown> rather than ReceiptClaim.
         env::verify_assumption(update.claim.digest(), Digest::ZERO).unwrap();
         let work = update.claim.work.value().expect("work value is pruned");

--- a/risc0/zkvm/src/claim/receipt.rs
+++ b/risc0/zkvm/src/claim/receipt.rs
@@ -219,7 +219,7 @@ impl ReceiptClaim {
             .context("conditional receipt has pruned assumptions")?;
 
         // Use the control root from the head of the assumptions list to form an Assumption from
-        // the given claim. This is a simplifying assumption but connot guarantee that the claim
+        // the given claim. This is a simplifying assumption but cannot guarantee that the claim
         // actually resolves the assumption if it was produced with an incompatible control root.
         let head_control_root = assumptions
             .first()

--- a/risc0/zkvm/src/host/client/env.rs
+++ b/risc0/zkvm/src/host/client/env.rs
@@ -462,7 +462,7 @@ impl<'a> ExecutorEnvBuilder<'a> {
     }
 
     /// Return [ProverOpts][crate::ProverOpts] with proof of verifiable work (PoVW) enabled, and the specified work
-    /// log identifer and job number as the base for PoVW nonces assigned to each segment.
+    /// log identifier and job number as the base for PoVW nonces assigned to each segment.
     ///
     /// ```
     /// # use risc0_zkvm::ExecutorEnv;

--- a/risc0/zkvm/src/host/server/prove/tests.rs
+++ b/risc0/zkvm/src/host/server/prove/tests.rs
@@ -927,7 +927,7 @@ mod sys_verify {
         work_receipt.verify_integrity()?;
 
         // NOTE: The work claim will only contain value for the conditional receipt.
-        // PoVW value for the assumption receipts is considered seperately, instead of in the take
+        // PoVW value for the assumption receipts is considered separately, instead of in the take
         // WorkClaim (i.e. the same compact range representation).
         let work_claim = work_receipt.claim().as_value()?.clone();
         assert_eq!(


### PR DESCRIPTION
### Changes
Corrected `becuase` → `because`
Corrected `connot` → `cannot`
Corrected `identifer` → `identifier`
Corrected `seperately` → `separately`

### Files Modified
- `risc0/povw/guests/log-builder/src/main.rs`
- `risc0/zkvm/src/claim/receipt.rs`
- `risc0/zkvm/src/host/client/env.rs`
- `risc0/zkvm/src/host/server/prove/tests.rs`