### PR TITLE
Export BN254_IDENTITY_CONTROL_ID from risc0-zkvm

### DIFF
--- a/risc0/zkvm/src/host/recursion/mod.rs
+++ b/risc0/zkvm/src/host/recursion/mod.rs
@@ -29,7 +29,9 @@ mod tests;
 // of SuccinctReceipt, but is logically part of the recursion system.
 #[cfg(feature = "prove")]
 pub use crate::receipt::merkle::{MerkleGroup, MerkleProof};
-pub use risc0_circuit_recursion::control_id::{ALLOWED_CONTROL_IDS, ALLOWED_CONTROL_ROOT};
+pub use risc0_circuit_recursion::control_id::{
+    ALLOWED_CONTROL_IDS, ALLOWED_CONTROL_ROOT, BN254_IDENTITY_CONTROL_ID,
+};
 
 #[cfg(test)]
 #[cfg(feature = "prove")]

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -155,7 +155,7 @@ pub use self::host::client::env::{CoprocessorCallback, ProveKeccakRequest};
 pub use {
     self::host::{
         prove_info::{ProveInfo, SessionStats},
-        recursion::{ALLOWED_CONTROL_IDS, ALLOWED_CONTROL_ROOT},
+        recursion::{ALLOWED_CONTROL_IDS, ALLOWED_CONTROL_ROOT, BN254_IDENTITY_CONTROL_ID},
     },
     risc0_binfmt::compute_image_id,
     risc0_groth16::Seal as Groth16Seal,


### PR DESCRIPTION
We currently export `ALLOWED_CONTROL_ROOT` and `ALLOWED_CONTROL_IDS` from `risc0-zkvm`, but we do not export `BN254_IDENTITY_CONTROL_ID`. This is a required field to build `Groth16ReceiptVerifierParameters`, and to deploy the Groth16 verifier smart contract. As a result, when we want to use Rust to deploy that contract (e.g. in tests) we currently need to import `risc0-circuit-recursion` [2].

This PR exports `BN254_IDENTITY_CONTROL_ID` from `risc0-zkvm`, which will allow code that depends on it to drop the direct dep on `risc0-circuit-recursion`.

[1] https://github.com/risc0/risc0/blob/b81b1f9175df9cadb3675caebc993c7b1e9d8082/risc0/zkvm/src/receipt/groth16.rs#L135-L137
[2] https://github.com/boundless-xyz/boundless/blob/main/crates/boundless-market/test-utils/src/lib.rs#L42
