### PR TITLE
docs: fix typos in log-builder tests

### DIFF
--- a/risc0/povw/guests/tests/log-builder.rs
+++ b/risc0/povw/guests/tests/log-builder.rs
@@ -74,7 +74,7 @@ fn rand_claim() -> MaybePruned<Unknown> {
     MaybePruned::Pruned(Digest::new(rand::random()))
 }
 
-/// Proves the busy loop test utility, using default_prover, which is guarenteed to run for at
+/// Proves the busy loop test utility, using default_prover, which is guaranteed to run for at
 /// least as many user cycles as is given in the cycles argument.
 fn prove_busy_loop(job_id: PovwJobId, cycles: u64) -> anyhow::Result<ProveInfo> {
     let env = ExecutorEnv::builder()
@@ -339,7 +339,7 @@ fn prove_three_sequential_updates() -> anyhow::Result<()> {
 
     // Prove another update, this time rebuilding the prover with provided work log and receipt to
     // resume the previous state, like what might be done if the state is being deserialized from
-    // peristent storage.
+    // persistent storage.
 
     let work_info = prove_busy_loop(
         PovwJobId {


### PR DESCRIPTION

This PR corrects minor documentation issues in `log-builder.rs`:  
- Fixed spelling error (`persitent` → `persistent`).  
- Fixed spelling error (`guarenteed` → `guaranteed`).  
