### PR TITLE
docs: fix typos and grammar in risc0 zkp/zkvm docs and comments

### DIFF
--- a/risc0/zkp/src/core/digest.rs
+++ b/risc0/zkp/src/core/digest.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/risc0/zkp/src/core/digest.rs
+++ b/risc0/zkp/src/core/digest.rs
@@ -70,7 +70,7 @@ impl Digest {
         Self(data)
     }
 
-    /// Construct a digest from a array of bytes in a const context.
+    /// Construct a digest from an array of bytes in a const context.
     /// Outside of const context, `Digest::from` is recommended.
     pub const fn from_bytes(bytes: [u8; DIGEST_BYTES]) -> Self {
         let mut digest: Digest = Digest::ZERO;

--- a/risc0/zkp/src/core/hash/mod.rs
+++ b/risc0/zkp/src/core/hash/mod.rs
@@ -32,11 +32,11 @@ pub trait HashFn<F: Field>: Send + Sync {
     fn hash_pair(&self, a: &Digest, b: &Digest) -> Box<Digest>;
 
     /// Generate a hash from a slice of field elements.  This may be unpadded so
-    /// this is only safe to used when the size is known.
+    /// this is only safe to be used when the size is known.
     fn hash_elem_slice(&self, slice: &[F::Elem]) -> Box<Digest>;
 
     /// Generate a hash from a slice of extension field element.  This may be
-    /// unpadded so this is only safe to used when the size is known.
+    /// unpadded so this is only safe to be used when the size is known.
     fn hash_ext_elem_slice(&self, slice: &[F::ExtElem]) -> Box<Digest>;
 }
 

--- a/risc0/zkp/src/core/hash/poseidon2/consts.rs
+++ b/risc0/zkp/src/core/hash/poseidon2/consts.rs
@@ -169,7 +169,7 @@ pub const _M_EXT: &[Elem] = &baby_bear_array![
 /// Standardizing on the same coefficients as <https://github.com/HorizenLabs/poseidon2.git>
 /// (as used in its plain implementation of Poseidon2 for BabyBear)
 ///
-/// These parameters are have been confirmed to pass the algorithms given in Grassi, Rechberger, and
+/// These parameters have been confirmed to pass the algorithms given in Grassi, Rechberger, and
 /// Schofnegger's paper "Proving Resistance Against Infinitely Long Subspace Trails: How to Choose
 /// the Linear Layer" by running a version of the code provided with the paper adapted to include
 /// these parameters in what's tested.

--- a/risc0/zkvm/src/claim/maybe_pruned.rs
+++ b/risc0/zkvm/src/claim/maybe_pruned.rs
@@ -95,7 +95,7 @@ where
 }
 
 impl<T> MaybePruned<Option<T>> {
-    /// Returns true is the value is None, or the value is pruned as the zero
+    /// Returns true if the value is None, or the value is pruned as the zero
     /// digest.
     pub fn is_none(&self) -> bool {
         match self {
@@ -105,7 +105,7 @@ impl<T> MaybePruned<Option<T>> {
         }
     }
 
-    /// Returns true is the value is Some(_), or the value is pruned as a
+    /// Returns true if the value is Some(_), or the value is pruned as a
     /// non-zero digest.
     pub fn is_some(&self) -> bool {
         !self.is_none()

--- a/risc0/zkvm/src/claim/merge.rs
+++ b/risc0/zkvm/src/claim/merge.rs
@@ -47,7 +47,7 @@ pub(crate) trait Merge: Digestible + Sized {
     }
 }
 
-/// Error returned when a merge it attempted with two values with unequal digests.
+/// Error returned when a merge is attempted with two values with unequal digests.
 #[derive(Debug, Clone)]
 pub(crate) struct MergeInequalityError(pub Digest, pub Digest);
 

--- a/risc0/zkvm/src/guest/env/verify.rs
+++ b/risc0/zkvm/src/guest/env/verify.rs
@@ -27,7 +27,7 @@ use super::ASSUMPTIONS_DIGEST;
 /// Calling this function in the guest is logically equivalent to verifying a receipt with the same
 /// image ID and journal. Any party verifying the receipt produced by this execution can then be
 /// sure that the receipt verified by this call is also valid. In this way, multiple receipts from
-/// potentially distinct guests can be combined into one. This feature is know as [composition].
+/// potentially distinct guests can be combined into one. This feature is known as [composition].
 ///
 /// In order to be valid, the [crate::Receipt] must have [ExitCode::Halted(0)][crate::ExitCode] or
 /// [ExitCode::Paused(0)][crate::ExitCode], an empty assumptions list, and an all-zeroes input
@@ -71,7 +71,7 @@ pub fn verify(image_id: impl Into<Digest>, journal: &[impl Pod]) -> Result<(), I
 /// Calling this function in the guest is logically equivalent to verifying a receipt with the same
 /// [ReceiptClaim][crate::ReceiptClaim]. Any party verifying the receipt produced by this execution
 /// can then be sure that the receipt verified by this call is also valid. In this way, multiple
-/// receipts from  potentially distinct guests can be combined into one. This feature is known as
+/// receipts from potentially distinct guests can be combined into one. This feature is known as
 /// [composition].
 ///
 /// In order for a receipt to be valid, it must have a verifying cryptographic seal and

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -125,7 +125,7 @@ pub struct Receipt {
     /// Metadata providing context on the receipt, about the proving system, SDK versions, and other
     /// information to help with interoperability. It is not cryptographically bound to the receipt,
     /// and should not be used for security-relevant decisions, such as choosing whether or not to
-    /// accept a receipt based on it's stated version.
+    /// accept a receipt based on its stated version.
     pub metadata: ReceiptMetadata,
 }
 
@@ -228,8 +228,8 @@ impl Receipt {
             journal: MaybePruned::Pruned(self.journal.digest()),
             // TODO(#982): It would be reasonable for this method to allow integrity verification
             // for receipts that have a non-empty assumptions list, but it is not supported here
-            // because we don't have a enough information to open the assumptions list unless we
-            // require it be empty.
+            // because we don't have enough information to open the assumptions list unless we
+            // require it to be empty.
             assumptions: Assumptions(vec![]).into(),
         });
 

--- a/risc0/zkvm/src/receipt/composite.rs
+++ b/risc0/zkvm/src/receipt/composite.rs
@@ -56,7 +56,7 @@ pub struct CompositeReceipt {
 
     /// A digest of the verifier parameters that can be used to verify this receipt.
     ///
-    /// Acts as a fingerprint to identity differing proof system or circuit versions between a
+    /// Acts as a fingerprint to identify differing proof system or circuit versions between a
     /// prover and a verifier. Is not intended to contain the full verifier parameters, which must
     /// be provided by a trusted source (e.g. packaged with the verifier code).
     pub verifier_parameters: Digest,

--- a/risc0/zkvm/src/receipt/groth16.rs
+++ b/risc0/zkvm/src/receipt/groth16.rs
@@ -47,7 +47,7 @@ pub struct Groth16Receipt<Claim> {
 
     /// A digest of the verifier parameters that can be used to verify this receipt.
     ///
-    /// Acts as a fingerprint to identity differing proof system or circuit versions between a
+    /// Acts as a fingerprint to identify differing proof system or circuit versions between a
     /// prover and a verifier. Is not intended to contain the full verifier parameters, which must
     /// be provided by a trusted source (e.g. packaged with the verifier code).
     pub verifier_parameters: Digest,

--- a/risc0/zkvm/src/receipt/segment.rs
+++ b/risc0/zkvm/src/receipt/segment.rs
@@ -54,7 +54,7 @@ pub struct SegmentReceipt {
 
     /// A digest of the verifier parameters that can be used to verify this receipt.
     ///
-    /// Acts as a fingerprint to identity differing proof system or circuit versions between a
+    /// Acts as a fingerprint to identify differing proof system or circuit versions between a
     /// prover and a verifier. Is not intended to contain the full verifier parameters, which must
     /// be provided by a trusted source (e.g. packaged with the verifier code).
     pub verifier_parameters: Digest,

--- a/risc0/zkvm/src/receipt/succinct.rs
+++ b/risc0/zkvm/src/receipt/succinct.rs
@@ -121,7 +121,7 @@ impl<Claim> SuccinctReceipt<Claim> {
 
         // Check that the proof system and circuit info strings match what is implemented by this
         // function. Info strings are used a version identifiers, and this verify implementation
-        // supports exactly one proof systema and circuit version at a time.
+        // supports exactly one proof system and circuit version at a time.
         if params.proof_system_info != PROOF_SYSTEM_INFO {
             return Err(VerificationError::ProofSystemInfoMismatch {
                 expected: PROOF_SYSTEM_INFO,


### PR DESCRIPTION
Fixed a lot of typos in code comments
"are have been → have been"
"it attempted" → "is attempted"
"know → known"

and many others