### PR TITLE
fix typos in the codebase

### DIFF
--- a/risc0/povw/src/tree.rs
+++ b/risc0/povw/src/tree.rs
@@ -465,15 +465,15 @@ impl Job {
         };
 
         // Check whether the requested subtree contains the boundary.
-        let boundry_level_index = index_max.checked_shr(8 + height as u32).unwrap_or(0);
-        match index.cmp(&boundry_level_index) {
+        let boundary_level_index = index_max.checked_shr(8 + height as u32).unwrap_or(0);
+        match index.cmp(&boundary_level_index) {
             Ordering::Less => FULL_SUBTREE_ROOTS[height],
-            Ordering::Equal => self.boundry_subtree_root(height),
+            Ordering::Equal => self.boundary_subtree_root(height),
             Ordering::Greater => EMPTY_SUBTREE_ROOTS[height],
         }
     }
 
-    fn boundry_subtree_root(&self, height: usize) -> Digest {
+    fn boundary_subtree_root(&self, height: usize) -> Digest {
         let mut index: u32 = self.index_max.unwrap();
 
         // Get the leaf and consume the first 8 bits.

--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/layout.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/layout.tsx
@@ -93,7 +93,7 @@ export default async function DatasheetLayout(
                   <br />
                   <br />
                   On Bonsai, calls to <CodeBadge>rv32im</CodeBadge>, <CodeBadge>lift</CodeBadge>, and{" "}
-                  <CodeBadge>join</CodeBadge> are parallellized.
+                  <CodeBadge>join</CodeBadge> are parallelized.
                 </p>
               </PopoverContent>
             </Popover>


### PR DESCRIPTION


1. **`risc0/povw/src/tree.rs`**
   - Fixed typo: `boundry` → `boundary`
     - `boundry_level_index` → `boundary_level_index`
     - `boundry_subtree_root` → `boundary_subtree_root`

2. **`web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/layout.tsx`**
   - Fixed typo: `parallellized` → `parallelized`
 

