### PR TITLE
fix: correct guest command documentation in cargo-risczero

### DIFF
--- a/risc0/cargo-risczero/src/commands/guest.rs
+++ b/risc0/cargo-risczero/src/commands/guest.rs
@@ -33,10 +33,10 @@ pub struct GuestCommand {
 /// Subcommands of cargo that are supported by this cargo risczero command.
 #[derive(Debug, Subcommand)]
 pub enum GuestSubCommands {
-    /// Invocation of `cargo risczero build` which calls `cargo build`.
+    /// Invocation of `cargo risczero guest build` which calls `cargo build`.
     Build(CommonArgs),
 
-    /// Invocation of `cargo risczero build` which calls `cargo test --no-run`.
+    /// Invocation of `cargo risczero guest test` which calls `cargo test --no-run`.
     Test(CommonArgs),
 }
 


### PR DESCRIPTION
Fix documentation comments for guest subcommands in cargo-risczero.

- Change "cargo risczero build" to "cargo risczero guest build" for Build subcommand
- Change "cargo risczero build" to "cargo risczero guest test" for Test subcommand

The guest command is an experimental feature that provides local alternatives to the main build command, and the documentation should accurately reflect the correct command structure.