### PR TITLE
Fix minor typos in xtask comments

### DIFF
--- a/xtask/src/bootstrap.rs
+++ b/xtask/src/bootstrap.rs
@@ -47,7 +47,7 @@ impl Bootstrap {
         out
     }
 
-    // Format a list of control IDs, include the names as data in a tuple of (&str, Digest)
+    // Format a list of control IDs, including the names as data in a tuple of (&str, Digest)
     fn format_control_ids_with_name(
         ids: impl IntoIterator<Item = impl Borrow<(String, Digest)>>,
     ) -> String {

--- a/xtask/src/bootstrap_poseidon.rs
+++ b/xtask/src/bootstrap_poseidon.rs
@@ -39,7 +39,7 @@ const NUM_BITS: usize = 31;
 // Smallest allowed alpha for Baby Bear
 const ALPHA: usize = 7;
 
-// A structure to hold all computed constant to eventually be exported
+// A structure to hold all computed constants to eventually be exported
 struct ComputedConstants {
     rounds_full: usize,             // The number of full rounds, always 8 in practice
     rounds_partial: usize,          // The number of partial rounds, computed based on security
@@ -62,7 +62,7 @@ impl ComputedConstants {
     }
 }
 
-// A function to turns a string of hex constants into a vector of Elems
+// A function to turn a string of hex constants into a vector of Elems
 fn to_elems(input_string: &str) -> Vec<Elem> {
     let mut out = Vec::<Elem>::new();
     for part in input_string.split(',') {

--- a/xtask/src/semver_checks.rs
+++ b/xtask/src/semver_checks.rs
@@ -76,7 +76,7 @@ impl Write for PrintStdout {
     }
 }
 
-/// Receive output from `ChannelWriter`, echos them to `eprint` calls and also saves the output and
+/// Receive output from `ChannelWriter`, echoes it to `eprint` calls and also saves the output and
 /// returns it.
 fn tee_semver_output(recv: std::sync::mpsc::Receiver<Vec<u8>>) -> Vec<u8> {
     let mut output = vec![];
@@ -222,7 +222,7 @@ fn vendor_packages(
     Ok(project_dir.join("vendor"))
 }
 
-/// Runs some command, checks for errors, and forwards output from stdout / stderr to `print and
+/// Runs some command, checks for errors, and forwards output from stdout / stderr to `print` and
 /// `eprint` which allows the test fixture to capture the output.
 fn run_command(cmd: &mut Command, error_message: &str) -> Result<()> {
     let context = format!(


### PR DESCRIPTION
xtask/src/bootstrap.rs: include → including (grammar).
xtask/src/bootstrap_poseidon.rs: constant → constants (plural); to turns → to turn (grammar).
xtask/src/semver_checks.rs: echos → echoes; echos them → echoes it; to \print and→to `print` and` (spelling/punctuation).

Why: Improves clarity and correctness of comments/docstrings.
No functional changes.