### PR TITLE
fix: typos in Cargo.toml descriptions and zkVM docs

### DIFF
--- a/risc0/circuit/keccak-sys/Cargo.toml
+++ b/risc0/circuit/keccak-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-circuit-keccak-sys"
-description = "Generated HAL code for keccak cicuit"
+description = "Generated HAL code for keccak circuit"
 version = "4.0.2"
 edition = { workspace = true }
 license = { workspace = true }

--- a/risc0/circuit/recursion-sys/Cargo.toml
+++ b/risc0/circuit/recursion-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-circuit-recursion-sys"
-description = "Generated HAL code for recursion cicuit"
+description = "Generated HAL code for recursion circuit"
 version = "4.0.2"
 edition = { workspace = true }
 license = { workspace = true }

--- a/risc0/circuit/rv32im-sys/Cargo.toml
+++ b/risc0/circuit/rv32im-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risc0-circuit-rv32im-sys"
-description = "Generated HAL code for rv32im cicuit"
+description = "Generated HAL code for rv32im circuit"
 version = "4.0.2"
 edition = { workspace = true }
 license = { workspace = true }

--- a/risc0/zkvm/src/host/client/env.rs
+++ b/risc0/zkvm/src/host/client/env.rs
@@ -180,7 +180,7 @@ impl<'a> ExecutorEnvBuilder<'a> {
     ///
     /// Lowering this value will reduce the memory consumption of the prover. Memory consumption is
     /// roughly linear with the segment size, so lowering this value by 1 will cut memory
-    /// consumpton by about half.
+    /// consumption by about half.
     ///
     /// The default value is chosen to be performant on commonly used hardware. Tuning this value,
     /// either up or down, may result in better proving performance.
@@ -196,7 +196,7 @@ impl<'a> ExecutorEnvBuilder<'a> {
     ///
     /// Lowering this value will reduce the memory consumption of the prover. Memory consumption is
     /// roughly linear with the segment size, so lowering this value by 1 will cut memory
-    /// consumpton by about half.
+    /// consumption by about half.
     ///
     /// The default value is chosen to be performant on commonly used hardware. Tuning this value,
     /// either up or down, may result in better proving performance.

--- a/risc0/zkvm/src/receipt.rs
+++ b/risc0/zkvm/src/receipt.rs
@@ -309,10 +309,10 @@ pub enum InnerReceipt {
     /// A non-succinct [CompositeReceipt], made up of one inner receipt per segment.
     Composite(CompositeReceipt),
 
-    /// A [SuccinctReceipt], proving arbitrarily long zkVM computions with a single STARK.
+    /// A [SuccinctReceipt], proving arbitrarily long zkVM computations with a single STARK.
     Succinct(SuccinctReceipt<ReceiptClaim>),
 
-    /// A [Groth16Receipt], proving arbitrarily long zkVM computions with a single Groth16 SNARK.
+    /// A [Groth16Receipt], proving arbitrarily long zkVM computations with a single Groth16 SNARK.
     Groth16(Groth16Receipt<ReceiptClaim>),
 
     /// A [FakeReceipt], with no cryptographic integrity, used only for development.


### PR DESCRIPTION
- Corrected cicuit → circuit in multiple Cargo.toml package descriptions.

- Fixed typos in env.rs doc comments (consumpton → consumption).

- Fixed typos in receipt.rs doc comments (computions → computations).