### PR TITLE
fix: correct malformed error message in ProveRequest handler

### DIFF
--- a/risc0/zkvm/src/host/api/server.rs
+++ b/risc0/zkvm/src/host/api/server.rs
@@ -389,7 +389,7 @@ impl Server {
 
             let binary = env_request
                 .binary
-                .ok_or_else(|| malformed_err("ProveRequest.env_request.binary"))?;
+                .ok_or_else(|| malformed_err("ExecutorEnv.binary"))?;
             let bytes = binary.as_bytes()?;
 
             let opts: ProverOpts = request


### PR DESCRIPTION
Fix malformed error message from "ProveRequest.env_request.binary" to "ExecutorEnv.binary"

The previous error message referenced a non-existent field path. The correct path
follows the protobuf schema: ProveRequest.env.binary where env is of type ExecutorEnv.

This improves debugging by providing accurate field references.