### PR TITLE
fix: correct formatting issues in documentation

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -256,7 +256,7 @@
     How can we use the ImageID to determine if an application is altered before execution?
   </summary>
 
-  A: The ImageID is determined from an application's compiled binary (ELF),  explained in detail <a href="https://dev.risczero.com/faq#image-id">above.</a>
+  A: The ImageID is determined from an application's compiled binary (ELF), explained in detail <a href="https://dev.risczero.com/faq#image-id">above.</a>
 
   Someone wishing to confirm that a receipt corresponds to specific Rust source code can locally reproduce a binary targeting the RISC Zero zkVM using our reproducible build tool and verify that the resulting ImageID matches the ImageID in the receipt.
 

--- a/website/docs/reference-docs/about-finite-fields.md
+++ b/website/docs/reference-docs/about-finite-fields.md
@@ -25,7 +25,7 @@ We say $3$ is a **multiplicative generator** for the integers modulo 5. For any 
 
 Most of your Algebra II knowledge about polynomials still holds in finite fields.
 
-`Example: Consider` $f(x)=x^2-1\text{ mod }5$`.  Observe that ` $f(1)=f(4)=0.$
+`Example: Consider` $f(x)=x^2-1\text{ mod }5$`. Observe that ` $f(1)=f(4)=0.$
 `We say ` $f$ `has roots at 1 and 4, and we can factor in the familiar way:` $f(x)=(x-1)(x-4)$`.`
 
 `Example:

--- a/website/docs/reference-docs/about-fri.md
+++ b/website/docs/reference-docs/about-fri.md
@@ -8,7 +8,7 @@ The FRI protocol finishes the argument by proving the assertion about block prox
 
 ## Basic Function
 
-Given a Merkle root, the _FRI protocol_ is a recursive technique for proving that the associated Merkle leaves are associated with a low-degree polynomial.
+Given a Merkle root, the _FRI protocol_ is a recursive technique for proving that the associated Merkle leaves correspond to a low-degree polynomial.
 
 ## Background
 


### PR DESCRIPTION
- Fix double spacing in faq.md between "ELF)," and "explained"
- Replace repeated "associated" with "correspond to" in about-fri.md  
- Fix double spacing in about-finite-fields.md between "5$." and "Observe"