### PR TITLE
fix: typos in comments and documentation

### DIFF
--- a/risc0/binfmt/src/sys_state.rs
+++ b/risc0/binfmt/src/sys_state.rs
@@ -73,7 +73,7 @@ impl Digestible for SystemState {
     }
 }
 
-/// Read a SHA-256 digest as a series of half-wrods (i.e. 16-bit values).
+/// Read a SHA-256 digest as a series of half-words (i.e. 16-bit values).
 pub fn read_sha_halfs(flat: &mut VecDeque<u32>) -> Result<Digest, DecodeError> {
     let mut bytes = Vec::<u8>::new();
     if flat.len() < 16 {
@@ -103,7 +103,7 @@ fn read_u32_bytes(flat: &mut VecDeque<u32>) -> Result<u32, DecodeError> {
     ))
 }
 
-/// Write a SHA-256 digest as a series of half-wrods (i.e. 16-bit values).
+/// Write a SHA-256 digest as a series of half-words (i.e. 16-bit values).
 pub fn write_sha_halfs(flat: &mut Vec<u32>, digest: &Digest) {
     for x in digest.as_words() {
         flat.push(*x & 0xffff);

--- a/risc0/cargo-risczero/README.md
+++ b/risc0/cargo-risczero/README.md
@@ -111,7 +111,7 @@ ImageID: c7c399c25ecf26b79e987ed060efce1f0836a594ad1059b138b6ed2f123dad38 - "tar
 ImageID: a51a4b747f18b7e5f36a016bdd6f885e8293dbfca2759d6667a6df8edd5f2489 - "target/riscv-guest/riscv32im-risc0-zkvm-elf/docker/risc0_zkvm_methods_guest/slice_io"
 ```
 
-## datashet
+## datasheet
 
 The `datasheet` command performs a benchmark to evaluate zkVM performance for
 the current machine's hardware, and then prints a table (along with optional


### PR DESCRIPTION
Corrected minor spelling errors in comments and README for better readability:

- sys_state.rs – fixed half-wrods → half-words in SHA-256 digest comments.

- cargo-risczero/README.md – corrected datashet → datasheet.