### PR TITLE
docs: fix misleading link

### DIFF
--- a/website/docs/reference-docs/about-rs-codes.md
+++ b/website/docs/reference-docs/about-rs-codes.md
@@ -4,7 +4,7 @@
 
 ## Documentation
 
-Implementation and documentation for Reed-Solomon encoding is in the `risc0-zkp-core` [Rust crate](https://github.com/risc0/risc0#rust-crates).
+Implementation and documentation for Reed-Solomon encoding is in the `risc0-zkp-core` [Rust crate](https://docs.rs/risc0-zkp-core/latest/risc0_zkp_core/).
 
 ## Basic Function
 


### PR DESCRIPTION
https://github.com/risc0/risc0#rust-crates - this link works but it leads just to main risc0 repository
https://docs.rs/risc0-zkp-core/latest/risc0_zkp_core/ - and this link leads correctly to Implementation and documentation for Reed-Solomon encoding is in the `risc0-zkp-core`