### PR TITLE
Add --kernel-id mode to r0vm

### DIFF
--- a/risc0/binfmt/src/elf.rs
+++ b/risc0/binfmt/src/elf.rs
@@ -383,19 +383,31 @@ impl<'a> ProgramBinary<'a> {
         ret
     }
 
+    fn user_program(&self) -> Result<Program> {
+        Program::load_elf(self.user_elf, KERNEL_START_ADDR.0).context("Loading user ELF")
+    }
+
+    fn kernel_program(&self) -> Result<Program> {
+        Program::load_elf(self.kernel_elf, u32::MAX).context("Loading kernel ELF")
+    }
+
     /// Convert this binary into a `MemoryImage`.
     pub fn to_image(&self) -> Result<MemoryImage> {
-        let user_program =
-            Program::load_elf(self.user_elf, KERNEL_START_ADDR.0).context("Loading user ELF")?;
-        let kernel_program =
-            Program::load_elf(self.kernel_elf, u32::MAX).context("Loading kernel ELF")?;
-        Ok(MemoryImage::with_kernel(user_program, kernel_program))
+        Ok(MemoryImage::with_kernel(
+            self.user_program()?,
+            self.kernel_program()?,
+        ))
     }
 
     /// Compute and return the ImageID of this binary.
     pub fn compute_image_id(&self) -> Result<Digest> {
         let merkle_root = self.to_image()?.image_id();
         Ok(SystemState { pc: 0, merkle_root }.digest::<Impl>())
+    }
+
+    /// Compute the memory merkle root of the kernel.
+    pub fn kernel_image_id(&self) -> Result<Digest> {
+        Ok(MemoryImage::new_kernel(self.kernel_program()?).image_id())
     }
 }
 

--- a/risc0/binfmt/src/lib.rs
+++ b/risc0/binfmt/src/lib.rs
@@ -49,3 +49,8 @@ pub(crate) const PAGE_WORDS: usize = PAGE_BYTES / WORD_SIZE;
 pub fn compute_image_id(blob: &[u8]) -> Result<Digest> {
     ProgramBinary::decode(blob)?.compute_image_id()
 }
+
+/// Compute and return the kernel image ID of the specified combined user ELF + kernel ELF binary.
+pub fn compute_kernel_id(blob: &[u8]) -> Result<Digest> {
+    ProgramBinary::decode(blob)?.kernel_image_id()
+}

--- a/risc0/r0vm/src/lib.rs
+++ b/risc0/r0vm/src/lib.rs
@@ -21,7 +21,7 @@ use clap::{Args, Parser, ValueEnum};
 use risc0_circuit_rv32im::execute::Segment;
 use risc0_zkvm::{
     ApiServer, ExecutorEnv, ExecutorImpl, ProverOpts, ProverServer, VerifierContext,
-    compute_image_id, get_prover_server,
+    compute_image_id, compute_kernel_id, get_prover_server,
 };
 
 use self::actors::protocol::TaskKind;
@@ -77,6 +77,10 @@ struct Cli {
     /// Compute the image_id for the specified ELF
     #[arg(long)]
     id: bool,
+
+    /// Compute the kernel image ID for the specified binary.
+    #[arg(long, conflicts_with = "id")]
+    kernel_id: bool,
 
     #[arg(long)]
     with_debugger: bool,
@@ -175,6 +179,12 @@ pub fn main() {
     if args.id {
         let blob = std::fs::read(args.mode.elf.unwrap()).unwrap();
         let image_id = compute_image_id(&blob).unwrap();
+        println!("{image_id}");
+        return;
+    }
+    if args.kernel_id {
+        let blob = std::fs::read(args.mode.elf.unwrap()).unwrap();
+        let image_id = compute_kernel_id(&blob).unwrap();
         println!("{image_id}");
         return;
     }

--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -157,7 +157,7 @@ pub use {
         prove_info::{ProveInfo, SessionStats},
         recursion::{ALLOWED_CONTROL_IDS, ALLOWED_CONTROL_ROOT, BN254_IDENTITY_CONTROL_ID},
     },
-    risc0_binfmt::compute_image_id,
+    risc0_binfmt::{compute_image_id, compute_kernel_id},
     risc0_groth16::Seal as Groth16Seal,
 };
 


### PR DESCRIPTION
This PR adds a --kernel-id mode to `r0vm`, which may be useful in debugging.

This PR is marked as draft as I am not sure if we want to expose the API in this way, so I wanted to get feedback.
