### PR TITLE
Use file_type() to avoid unwrap and ignore symlinked dirs in version scan

### DIFF
--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -34,7 +34,12 @@ impl Paths {
 
         let matching_path = std::fs::read_dir(component_dir)?
             .filter_map(|entry| entry.ok())
-            .filter(|entry| entry.path().is_dir() && !entry.metadata().unwrap().is_symlink())
+            .filter_map(|entry| {
+                match entry.file_type() {
+                    Ok(ft) if ft.is_dir() && !ft.is_symlink() => Some(entry),
+                    _ => None,
+                }
+            })
             .find_map(|entry| {
                 let dir_name = entry.file_name().to_string_lossy().to_string();
                 let parsed_version = Self::parse_version_from_path(&dir_name, component)?;


### PR DESCRIPTION
- Replace path().is_dir() and metadata().unwrap().is_symlink() with a single file_type() check.
- Now we only consider entries where file_type.is_dir() and not file_type.is_symlink().
- Removes potential panic on metadata().unwrap() and ensures symlinks are excluded without following them.