### PR TITLE
chore: fix link to risc0 docs

### DIFF
--- a/risc0/bigint2/README.md
+++ b/risc0/bigint2/README.md
@@ -22,4 +22,4 @@ BigInt2 precompiles are automatically available in the RISC Zero zkVM environmen
 
 ## Documentation
 
-For detailed API documentation and examples, see the [RISC Zero documentation](https://docs.risczero.com).
+For detailed API documentation and examples, see the [RISC Zero documentation](https://dev.risczero.com).


### PR DESCRIPTION
previous one is not working any more so we need to update it. 