### PR TITLE
fix: use core::fmt instead of alloc::fmt in baby_bear.rs

### DIFF
--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -18,8 +18,9 @@
 //! extension field. This field choice allows for 32-bit addition without
 //! overflow.
 
-use alloc::{fmt, vec::Vec};
+use alloc::vec::Vec;
 use core::{
+    fmt,
     cmp::{Ordering, PartialEq},
     ops,
 };


### PR DESCRIPTION
Replace incorrect import of fmt from alloc with core::fmt while keeping Vec from alloc for no_std compatibility. Rust’s fmt lives in core (and std), not in alloc, so the previous import would not compile. This aligns the file with the project-wide pattern (use alloc::vec::Vec; use core::fmt)