### PR TITLE
fix: add missing PFLAG_IS_ELEM flag in Poseidon2Short test case

### DIFF
--- a/risc0/zkvm/methods/guest/src/bin/multi_test.rs
+++ b/risc0/zkvm/methods/guest/src/bin/multi_test.rs
@@ -586,7 +586,7 @@ fn main() {
             ];
             let mut actual: [u32; DIGEST_WORDS] = [0u32; 8];
             unsafe {
-                sys_poseidon2(null_mut(), input.as_ptr() as *const u8, &mut actual, 1u32);
+                sys_poseidon2(null_mut(), input.as_ptr() as *const u8, &mut actual, PFLAG_IS_ELEM | 1u32);
             }
             assert_eq!(expected, actual);
         }


### PR DESCRIPTION
## Problem
The `Poseidon2Short` test was calling `sys_poseidon2` without the `PFLAG_IS_ELEM` flag, causing witness generation to fail with "rx len failed" error during proving.

## Solution
Added `PFLAG_IS_ELEM` flag to the `bits_count` parameter in `MultiTestSpec::Poseidon2Short` test case.

## Changes
- Modified `sys_poseidon2` call in `risc0/zkvm/methods/guest/src/bin/multi_test.rs`
- Changed `bits_count` from `1u32` to `PFLAG_IS_ELEM | 1u32`

Fixes #3427