### PR TITLE
fix guest allocator alignment in c-kzg example to prevent UB

### DIFF
--- a/examples/c-kzg/methods/guest/src/main.rs
+++ b/examples/c-kzg/methods/guest/src/main.rs
@@ -18,7 +18,7 @@ use c_kzg_core::Proof;
 use risc0_zkvm::guest::env;
 use sha2::{Digest as _, Sha256};
 use std::alloc::{alloc, handle_alloc_error};
-use std::{alloc::Layout, ffi::c_void};
+use std::{alloc::Layout, ffi::c_void, mem};
 
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;
 
@@ -31,8 +31,8 @@ pub fn kzg_to_versioned_hash(commitment: &KzgCommitment) -> [u8; 32] {
 #[unsafe(no_mangle)]
 // TODO ideally this is c_size_t, but not stabilized (not guaranteed to be usize on all archs)
 unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
-    let layout = Layout::from_size_align(size, 4).expect("unable to allocate more memory");
-    let ptr = unsafe { alloc(layout) };
+    let align = mem::align_of::<usize>().max(16);
+    let layout = Layout::from_size_align(size, align).expect("unable to allocate more memory");
 
     if ptr.is_null() {
         handle_alloc_error(layout);


### PR DESCRIPTION


### Description
- Summary: Use a safe alignment for the guest `malloc` in `examples/c-kzg/methods/guest/src/main.rs`.
- Motivation: Fixed 4-byte alignment could misalign types requiring 8/16 bytes, risking undefined behavior.
- Changes: `Layout::from_size_align(size, align_of::<usize>().max(16))` instead of `4`.
- Impact: Safer memory allocations; no behavioral change expected for correct callers.
