### PR TITLE
Fix typos and improve documentation across risc0 modules

### DIFF
--- a/risc0/binfmt/src/addr.rs
+++ b/risc0/binfmt/src/addr.rs
@@ -112,7 +112,7 @@ impl WordAddr {
     /// Increments this address to the next word and returns its previous value
     ///
     /// This is a postfixing increment, analogous to `addr++` in C; the value
-    /// this evaluates to is the value prior to the increment.
+    /// this evaluates to the value prior to the increment.
     pub fn postfix_inc(&mut self) -> Self {
         let cur = *self;
         self.0 += 1;

--- a/risc0/binfmt/src/exit_code.rs
+++ b/risc0/binfmt/src/exit_code.rs
@@ -56,7 +56,7 @@ pub enum ExitCode {
     /// This indicates that the guest exited upon reaching the session limit set by the host.
     ///
     /// NOTE: The current version of the RISC Zero zkVM will never exit with an exit code of SessionLimit.
-    /// This is because the system cannot currently prove that the session limit as been reached.
+    /// This is because the system cannot currently prove that the session limit has been reached.
     SessionLimit,
 }
 

--- a/risc0/build/README.md
+++ b/risc0/build/README.md
@@ -27,7 +27,7 @@ fn main() {
 ```
 
 This requires including `risc0-build` as a _build_ dependency. You will also
-need add a `[package.metadata.risc0]` section to your cargo file. In this
+need to add a `[package.metadata.risc0]` section to your cargo file. In this
 section, put a `methods` field with a list of relative paths containing the
 guest code. For example, if your guest code is in the `guest` directory,
 then `Cargo.toml` might include:

--- a/risc0/cargo-risczero/src/lib.rs
+++ b/risc0/cargo-risczero/src/lib.rs
@@ -48,7 +48,7 @@ pub struct RisczeroArgs {
 
 #[derive(Subcommand)]
 #[non_exhaustive]
-/// Primary commands  of `cargo risczero`.
+/// Primary commands of `cargo risczero`.
 pub enum Commands {
     /// Bake guest code.
     Bake(BakeCommand),

--- a/risc0/core/src/field/baby_bear.rs
+++ b/risc0/core/src/field/baby_bear.rs
@@ -118,7 +118,7 @@ impl field::Elem for Elem {
         // Even if we imagined that this failure to reject totally destroys soundness,
         // the probability of it occurring even once during proving is vanishingly low
         // (for the about 50 samples our current verifier pulls and at a probability of
-        // less than2^-161 per sample, this is less than 2^-155).  Even if we target
+        // less than 2^-161 per sample, this is less than 2^-155).  Even if we target
         // a soundness of 128 bits, we are millions of times more likely to let an
         // invalid proof by due to normal low probability events which are part of
         // soundness analysis than due to imperfect sampling.


### PR DESCRIPTION
Corrected typos and improved clarity in comments and documentation:

- **binfmt/addr.rs**: Removed redundant wording in postfix increment doc.
- **binfmt/exit_code.rs**: Fixed "as been reached" → "has been reached".
- **build/README.md**: Fixed grammar: "need add" → "need to add".
- **cargo-risczero/lib.rs**: Fixed spacing in comment: "commands  of" → "commands of".
- **core/field/baby_bear.rs**: Fixed formatting in probability expression ("less than2^-161" → "less than 2^-161").

