### PR TITLE
Remove duplicate bounds from Elem trait in field/mod.rs

### DIFF
--- a/risc0/core/src/field/mod.rs
+++ b/risc0/core/src/field/mod.rs
@@ -41,11 +41,8 @@ pub trait Elem: 'static
     + Debug
     + Sized
     + ops::Neg<Output = Self>
-    + ops::SubAssign
     + cmp::PartialEq
     + cmp::Eq
-    + core::clone::Clone
-    + core::marker::Copy
     + bytemuck::NoUninit
     + bytemuck::CheckedBitPattern
     + core::default::Default


### PR DESCRIPTION
- Removed redundant bounds core::clone::Clone and core::marker::Copy since Clone and Copy were already specified.
- Removed the earlier ops::SubAssign bound to avoid duplication, keeping the single, clearer requirement under the “(op)=” operators section.
- Rationale: This reduces redundancy and improves readability and API clarity without changing behavior or public semantics.