### PR TITLE
test(recursion): remove unused out_stream in identity sha-256 test

### DIFF
--- a/risc0/zkvm/src/host/recursion/tests.rs
+++ b/risc0/zkvm/src/host/recursion/tests.rs
@@ -348,8 +348,6 @@ fn test_recursion_identity_sha256() {
 
     let mut prover = Prover::new_identity(&default_receipt, opts.clone()).unwrap();
     let sha256_recursion_receipt = prover.run().unwrap();
-    let mut out_stream = VecDeque::<u32>::new();
-    out_stream.extend(sha256_recursion_receipt.output.iter());
 
     // Include an inclusion proof for control_id to allow verification against a root.
     let hashfn = opts.hash_suite().unwrap().hashfn;


### PR DESCRIPTION
Deletes unused out_stream allocation in test_recursion_identity_sha256.
No behavioral changes; test logic remains the same.
Keeps test clean and avoids dead code.