### PR TITLE
security: prevent filesystem path disclosure in help messages

### DIFF
--- a/groth16_proof/circom-compat/cmd/converter/main.go
+++ b/groth16_proof/circom-compat/cmd/converter/main.go
@@ -7,12 +7,14 @@ import (
 	"compress/gzip"
 	"flag"
 	"fmt"
-	"github.com/consensys/gnark/backend/groth16"
-	"github.com/consensys/gnark/constraint"
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
+
+	"github.com/consensys/gnark/backend/groth16"
+	"github.com/consensys/gnark/constraint"
 )
 
 var dumpPK = flag.Bool("dump", false, "use very unsafe memory dump to serialize the proving key")
@@ -32,7 +34,8 @@ func main() {
 }
 
 func help() {
-	fmt.Printf("Usage of %s:\n", os.Args[0])
+	programName := filepath.Base(os.Args[0])
+	fmt.Printf("Usage of %s:\n", programName)
 	fmt.Printf("\t<r1cs file> <zkey file>\n")
 	os.Exit(2)
 }

--- a/groth16_proof/circom-compat/cmd/prover/main.go
+++ b/groth16_proof/circom-compat/cmd/prover/main.go
@@ -8,6 +8,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark/backend/groth16"
@@ -15,9 +20,6 @@ import (
 	"github.com/consensys/gnark/constraint"
 	bn254r1cs "github.com/consensys/gnark/constraint/bn254"
 	"github.com/consensys/gnark/logger"
-	"os"
-	"path"
-	"time"
 )
 
 func main() {
@@ -35,7 +37,8 @@ func main() {
 }
 
 func help() {
-	fmt.Printf("Usage of %s:\n", os.Args[0])
+	programName := filepath.Base(os.Args[0])
+	fmt.Printf("Usage of %s:\n", programName)
 	fmt.Printf("\t<constraint file> <proving key file> <witness file> <output proof> [output public]\n")
 	os.Exit(2)
 }


### PR DESCRIPTION
Replace os.Args[0] with filepath.Base(os.Args[0]) in help functions to prevent filesystem path disclosure vulnerability. 

This change ensures that only the program name is displayed in usage messages instead of the full executable path, which could reveal sensitive information about the system's directory structure and user environment. 

This is particularly important for cryptographic tools that handle sensitive data and should follow security best practices for minimal information disclosure.

Files modified:
- groth16_proof/circom-compat/cmd/converter/main.go
- groth16_proof/circom-compat/cmd/prover/main.go

Security impact: Prevents potential information leakage that could aid attackers 
in reconnaissance and system mapping.