### PR TITLE
Parallelize Merkle tree operations in risc0-povw 0.4.0

### DIFF
--- a/risc0/povw/Cargo.toml
+++ b/risc0/povw/Cargo.toml
@@ -25,5 +25,9 @@ ruint = { version = "1.15", features = ["proptest"] }
 
 [features]
 default = ["guest", "prover"]
-prover = ["guest", "risc0-zkvm/client", "dep:derive_builder", "dep:anyhow"]
+prover = ["guest", "risc0-zkvm/client", "dep:derive_builder", "dep:anyhow", "dep:rayon"]
 guest = ["dep:derive_builder"]
+
+[dependencies.rayon]
+version = "1.10"
+optional = true


### PR DESCRIPTION
## Summary
Optimize Merkle tree operations in risc0-povw using Rayon parallelization.
Based on risc0-povw 0.4.0 version.

## Changes
Three parallelizations in `tree.rs`:

1. **prove_job_opening**: Parallelize subtree_root computations across tree heights
2. **subtree_root**: Parallelize jobs filtering and commit calculations  
3. **Merkle layer construction**: Parallelize hash operations for sibling nodes

Adds `rayon` as a dependency for parallel processing.
Automatically uses parallel processing for large workloads (jobs > 20) and sequential processing for small workloads.
