### PR TITLE
Re-enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ debug = 1
 lto = "off"
 incremental = true
 
+[profile.release]
+lto = true
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(ci)',


### PR DESCRIPTION
This seems to work again on Rust 1.90 for some reason.