### PR TITLE
docs: fix broken links

### DIFF
--- a/website/api_versioned_docs/version-2.0.0/zkvm/tutorials/io.md
+++ b/website/api_versioned_docs/version-2.0.0/zkvm/tutorials/io.md
@@ -315,7 +315,7 @@ Happy coding!
 [source-executor-env]: https://docs.rs/risc0-zkvm/2.0/struct.ExecutorEnv.html
 [source-ExecutorEnvBuilder::stderr]: https://docs.rs/risc0-zkvm/2.0/struct.ExecutorEnvBuilder.html#method.stderr
 [source-ExecutorEnvBuilder::stdout]: https://docs.rs/risc0-zkvm/2.0/struct.ExecutorEnvBuilder.html#method.stdout
-[source-ExecutorEnvBuilder::write]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/struct.ExecutorEnvBuilder.html
+[source-ExecutorEnvBuilder::write]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/struct.ExecutorEnvBuilder.html#method.write
 [source-ExecutorEnvBuilder::write_slice]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/struct.ExecutorEnvBuilder.html#method.write_slice
 [source-fileno]: https://docs.rs/risc0-zkvm-platform/2.0/fileno/index.html
 [source-from_slice]: https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/serde/fn.from_slice.html


### PR DESCRIPTION
https://docs.rs/risc0-zkvm/2.0/struct.ExecutorEnvBuilder.html#method.write and
https://docs.rs/risc0-zkvm/2.0/struct.ExecutorEnvBuilder.html#method.write_slice are broken


https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/struct.ExecutorEnvBuilder.html#method.write
and 
https://docs.rs/risc0-zkvm/2.0/risc0_zkvm/struct.ExecutorEnvBuilder.html#method.write_slice - are working, these links are redirecting to 2.3.2 bersion, like all the other links in the file