### PR TITLE
chore: cleaned up build script

### DIFF
--- a/xtask/src/bootstrap_protos.rs
+++ b/xtask/src/bootstrap_protos.rs
@@ -20,12 +20,11 @@ pub struct BootstrapProtos;
 
 impl BootstrapProtos {
     pub fn run(&self) {
-        unsafe {
-            std::env::set_var("PROTOC", protobuf_src::protoc());
-        }
+        std::env::set_var("PROTOC", protobuf_src::protoc());
 
+        let out_dir = std::env::var("OUT_DIR").unwrap();
         prost_build::Config::new()
-            .out_dir("risc0/zkvm/src/host/server/exec")
+            .out_dir(&out_dir)
             .compile_protos(
                 &["risc0/zkvm/src/host/server/exec/profile.proto"],
                 &["risc0/zkvm/src/host/server/exec"],


### PR DESCRIPTION
got rid of the pointless `unsafe` - `std::env::set_var` doesn’t need it anyway.
now grabbing `OUT_DIR` with `std::env::var("OUT_DIR")` so the generated files land where Cargo expects them.
also ditched the hardcoded `risc0/...` path in favor of using the dynamic `out_dir(&out_dir)`.

build’s cleaner, safer, and plays nicely with the Rust build process.
