### PR TITLE
fix: correct FRI rounds capacity assert to allow exact-capacity

### DIFF
--- a/risc0/zkp/src/verify/fri.rs
+++ b/risc0/zkp/src/verify/fri.rs
@@ -114,7 +114,7 @@ where
         // We want to minimize reallocation in verify, so make sure we
         // didn't have to reallocate.
         assert!(
-            rounds.len() < rounds_capacity,
+            rounds.len() <= rounds_capacity,
             "Did not allocate enough rounds; needed {} for degree {} but only allocated {}",
             rounds.len(),
             degree,


### PR DESCRIPTION
This change updates the FRI rounds capacity assertion in risc0/zkp/src/verify/fri.rs from < to <= so it accurately reflects the intent that no reallocation occurred. A Vec with capacity N can hold exactly N elements without reallocating, so asserting < could spuriously panic when capacity is fully utilized. This minimal change preserves behavior, avoids false failures, and keeps the diagnostic unchanged.