### PR TITLE
test: fix session_logs test to use body instead of json_body_obj

### DIFF
--- a/bonsai/sdk/src/lib.rs
+++ b/bonsai/sdk/src/lib.rs
@@ -1338,7 +1338,7 @@ mod tests {
                 .header(VERSION_HEADER, TEST_VERSION);
             then.status(200)
                 .header("content-type", "text/plain")
-                .json_body_obj(&response);
+                .body(response);
         });
 
         let server_url = format!("http://{}", server.address());
@@ -1346,7 +1346,7 @@ mod tests {
 
         let logs = session_id.logs(&client).unwrap();
 
-        assert_eq!(logs, "\"Hello\\nWorld\"");
+        assert_eq!(logs, "Hello\nWorld");
 
         create_mock.assert();
     }


### PR DESCRIPTION
The session_logs test was incorrectly using json_body_obj for a plain text response. Changed to use body() method to match the actual API behavior that returns text/plain content. Updated assertion to expect unescaped text instead of JSON-serialized string.