### PR TITLE
fix: misleading expect message in RpcDispatchOps::ask

### DIFF
--- a/risc0/r0vm/src/actors/mod.rs
+++ b/risc0/r0vm/src/actors/mod.rs
@@ -938,7 +938,7 @@ impl RpcDispatchOps {
         MessageT: Send + 'static,
         <ReceiverT as Message<MessageT>>::Reply: serde::Serialize + Sync,
     {
-        let message_id = self.message_id.expect("request should not have a response");
+        let message_id = self.message_id.expect("request should have a response");
         let rpc_sender = self
             .rpc_sender
             .expect("ask should not be called on one-way RPC actor");


### PR DESCRIPTION
Correct the expect text in RpcDispatchOps::ask() in risc0/r0vm/src/actors/mod.rs.
The previous message claimed “request should not have a response” for the ask path, which is incorrect. For ask, the RPC protocol requires a message_id because the request expects a response. This change clarifies the invariant for better diagnostics.