### PR TITLE
`downloader` Removes explicit `rustls-tls` feature

### DIFF
--- a/risc0/circuit/recursion/Cargo.toml
+++ b/risc0/circuit/recursion/Cargo.toml
@@ -66,6 +66,7 @@ metal = ["prove"]
 prove = [
   "dep:cfg-if",
   "dep:downloader",
+  "downloader/rustls-tls",
   "dep:lazy-regex",
   "dep:liblzma",
   "dep:rand",


### PR DESCRIPTION
Allowing for feature unification to take care of it.

The issue is that even though it is build dependency, it goes in to feature unification, which might be not desirable in some cases.