### PR TITLE
fix(jwt-validator): correct guest/host code links to local files

### DIFF
--- a/examples/jwt-validator/README.md
+++ b/examples/jwt-validator/README.md
@@ -46,10 +46,10 @@ The [guest code] confirms the JWT's integrity using the public key and records t
 [Bonsai Pay Demonstration Application]: https://github.com/risc0/demos/tree/main/bonsai-pay
 [developer docs]: https://dev.risczero.com
 [examples guide]: https://dev.risczero.com/api/zkvm/examples/#running-the-examples
-[guest code]: https://github.com/risc0/risc0-rust-examples/blob/main/chess/methods/guest/src/bin/checkmate.rs
+[guest code]: https://github.com/risc0/risc0/blob/main/examples/jwt-validator/methods/guest/src/main.rs
 [guest program]: https://dev.risczero.com/terminology#guest-program
 [host]: https://dev.risczero.com/terminology#host
-[host code]: https://github.com/risc0/risc0/blob/main/examples/chess/methods/guest/src/main.rs
+[host code]: https://github.com/risc0/risc0/blob/main/examples/jwt-validator/src/main.rs
 [host program]: https://dev.risczero.com/terminology#host-program
 [journal]: https://dev.risczero.com/terminology#journal
 [jwt-compact]: https://github.com/slowli/jwt-compact


### PR DESCRIPTION
- Replace incorrect cross-example links copied from the chess example with local paths to this example’s guest and host sources.
- Ensures README references are accurate and consistent with the project structure, preventing confusion for users navigating the code.