### PR TITLE
Refactor: reuse cached benchmark names when building dataset

### DIFF
--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/benchmarks/_components/benchmarks.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/benchmarks/_components/benchmarks.tsx
@@ -49,7 +49,7 @@ export function Benchmarks() {
     };
 
     // Prepare data points for charts
-    const dataset = Object.keys(data.entries).map((name) => ({
+    const dataset = names.map((name) => ({
       name,
       dataSet: collectBenchesPerTestCase(data.entries[name]),
     }));


### PR DESCRIPTION
Reuse the cached `names` array to map benchmark entries eliminate an extra Object.keys traversal and keep tab names and datasets in lockstep