### PR TITLE
Change unwrap to conditional return in `<LocalProver as Executor>::execute`

### DIFF
--- a/risc0/zkvm/src/host/client/prove/local.rs
+++ b/risc0/zkvm/src/host/client/prove/local.rs
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::{Executor, Prover, ProverOpts};
 use crate::{


### PR DESCRIPTION
On `main`, this line causes a panic when a conditional return is possible instead.

This issue was reported by `latara` on HackenProof
