### PR TITLE
fix(wasm): correct misleading test assertion message

### DIFF
--- a/examples/wasm/src/main.rs
+++ b/examples/wasm/src/main.rs
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(
             result,
             fibonacci(fib_iters),
-            "We expect the zkVM output to be the product of the inputs"
+            "We expect the zkVM output to equal fibonacci(fib_iters)"
         )
     }
 }


### PR DESCRIPTION
This test compares the zkVM output to fibonacci(fib_iters), but the assertion message incorrectly stated it should be “the product of the inputs,” which is a copy-paste leftover from the hello-world example where multiplication is tested.
Updated the message to clearly state the expected Fibonacci result, improving test failure clarity and preventing confusion for contributors and users.