### PR TITLE
docs(guest/env): define [risc0-r0vm] link in write and write_slice docs

### DIFF
--- a/risc0/zkvm/src/guest/env/mod.rs
+++ b/risc0/zkvm/src/guest/env/mod.rs
@@ -266,6 +266,7 @@ pub fn read_slice<T: Pod>(slice: &mut [T]) {
 ///
 /// [example page]: https://dev.risczero.com/api/zkvm/examples
 /// [I/O documentation]: https://dev.risczero.com/api/zkvm/tutorials/io
+/// [risc0-r0vm]: https://crates.io/crates/risc0-r0vm
 pub fn write<T: Serialize>(data: &T) {
     stdout().write(data)
 }
@@ -297,6 +298,7 @@ pub fn write<T: Serialize>(data: &T) {
 /// [example page]: https://dev.risczero.com/api/zkvm/examples
 /// [I/O documentation]: https://dev.risczero.com/api/zkvm/tutorials/io
 /// [instructions on guest optimization]: https://dev.risczero.com/api/zkvm/optimization#when-reading-data-as-raw-bytes-use-envread_slice
+/// [risc0-r0vm]: https://crates.io/crates/risc0-r0vm
 pub fn write_slice<T: Pod>(slice: &[T]) {
     stdout().write_slice(slice);
 }


### PR DESCRIPTION
The guest env docs referenced [risc0-r0vm] in both write() and write_slice() without defining the link label, which results in a broken rendered link. This change adds the link label pointing to the crates.io page for the r0vm binary (https://crates.io/crates/risc0-r0vm). The target is chosen to be stable and consistent with the crate name declared in risc0/r0vm/Cargo.toml and the existing reference in the workspace README. No behavior is changed; this strictly fixes documentation rendering by aligning with the file’s established link-label style.