### PR TITLE
docs(reference): mention finite field extensions F_{p^k} and their use

### DIFF
--- a/website/docs/reference-docs/about-finite-fields.md
+++ b/website/docs/reference-docs/about-finite-fields.md
@@ -15,6 +15,7 @@ We call $x^{-1}$ the _reciprocal_ of $x$ or the _multiplicative inverse_ of $x$.
 `Example: The integers modulo 5 are a field. In this field, the reciprocal of 2 is 3. 4 is its own reciprocal.`
 
 If $p$ is prime, the integers modulo $p$ are a field.
+More generally, finite fields of order $p^k$ (written as $\mathbb{F}_{p^k}$) exist for any prime $p$ and integer $k\ge 1$, and they are widely used in modern cryptographic protocols and proof systems.
 Moreover, I can find some element $g$ and write all the integers modulo $p$ as powers of $g$.
 
 `Example: The integers modulo 5 can all be written as a power of 3.`


### PR DESCRIPTION
This change adds a brief mention of finite field extensions F_{p^k} to the introductory section, clarifying that beyond prime fields F_p there exist finite fields of size p^k that are widely used in modern cryptographic protocols and zero-knowledge proof systems. Including this context helps readers bridge from basic modular arithmetic to the broader field theory used in practice, aligns expectations with typical zk tooling that relies on extension fields for operations like NTTs and polynomial commitments, and improves the pedagogical flow without increasing complexity or scope.