### PR TITLE
Remove implementaions of host_write

### DIFF
--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -672,10 +672,8 @@ impl<S: Syscall> Risc0Context for Executor<'_, '_, S> {
         Ok(rlen)
     }
 
-    fn host_write(&mut self, fd: u32, buf: &[u8]) -> Result<u32> {
-        let rlen = self.syscall_handler.host_write(self, fd, buf)?;
-        self.write_record.push(rlen);
-        Ok(rlen)
+    fn host_write(&mut self, _fd: u32, _buf: &[u8]) -> Result<u32> {
+        unimplemented!()
     }
 
     fn on_sha2_cycle(&mut self, _cur_state: CycleState, _sha2: &Sha2State) {

--- a/risc0/circuit/rv32im/src/execute/segment.rs
+++ b/risc0/circuit/rv32im/src/execute/segment.rs
@@ -102,6 +102,7 @@ impl Segment {
 struct SegmentSyscallHandler<'a> {
     segment: &'a Segment,
     read_pos: Cell<usize>,
+    #[expect(dead_code)]
     write_pos: Cell<usize>,
 }
 
@@ -114,7 +115,6 @@ impl Syscall for SegmentSyscallHandler<'_> {
     }
 
     fn host_write(&self, _ctx: &mut dyn SyscallContext, _fd: u32, _buf: &[u8]) -> Result<u32> {
-        let pos = self.write_pos.replace(self.read_pos.get() + 1);
-        Ok(self.segment.write_record[pos])
+        unimplemented!()
     }
 }

--- a/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
@@ -77,6 +77,7 @@ pub(crate) struct Preflight<'a> {
     pager: PagedMemory,
     pc: ByteAddr,
     machine_mode: u32,
+    #[expect(dead_code)]
     cur_write: usize,
     cur_read: usize,
     user_cycle: u32,
@@ -672,11 +673,7 @@ impl Risc0Context for Preflight<'_> {
     }
 
     fn host_write(&mut self, _fd: u32, _buf: &[u8]) -> Result<u32> {
-        if self.cur_write >= self.segment.write_record.len() {
-            bail!("Invalid segment: unexpected write record");
-        }
-        self.cur_write += 1;
-        Ok(self.segment.write_record[self.cur_write])
+        unimplemented!();
     }
 
     fn on_sha2_cycle(&mut self, cur_state: CycleState, sha2: &Sha2State) {

--- a/risc0/zkvm/src/host/server/exec/executor.rs
+++ b/risc0/zkvm/src/host/server/exec/executor.rs
@@ -407,10 +407,13 @@ impl CircuitSyscall for ExecutorImpl<'_> {
         Ok(rlen as u32)
     }
 
-    fn host_write(&self, ctx: &mut dyn CircuitSyscallContext, _fd: u32, buf: &[u8]) -> Result<u32> {
-        let str = String::from_utf8(buf.to_vec())?;
-        tracing::debug!("R0VM[{}] {str}", ctx.get_cycle());
-        Ok(buf.len() as u32)
+    fn host_write(
+        &self,
+        _ctx: &mut dyn CircuitSyscallContext,
+        _fd: u32,
+        _buf: &[u8],
+    ) -> Result<u32> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
Running tests locally, I could not find any failures created by simply removing all implementations of the `host_write`. I also could not confidently determine whether it is intended to be used somewhere. Opening this draft PR to run the full suite of tests in CI and get a second opinion.