### PR TITLE
Fix operator precedence issue in check_bigint_addr

### DIFF
--- a/risc0/circuit/rv32im/src/execute/bigint.rs
+++ b/risc0/circuit/rv32im/src/execute/bigint.rs
@@ -317,8 +317,7 @@ mod tests {
 
         test_context.store_region(base_addr, &input)?;
 
-        let mode = if machine_mode { 1 } else { 0 };
-        let mut io = BigIntIOImpl::new(&mut test_context, mode);
+        let mut io = BigIntIOImpl::new(&mut test_context, machine_mode as u32);
         let natural_out = io.load(ARENA_REG as u32, 0, count).unwrap();
         assert_eq!(natural_out.to_limbs_asc(), expected);
         Ok(())
@@ -332,8 +331,7 @@ mod tests {
         let mut test_context = TestRisc0Context::default();
         test_context.store_register(MACHINE_REGS_ADDR.waddr(), ARENA_REG, base_addr.0)?;
 
-        let mode = if machine_mode { 1 } else { 0 };
-        let mut io = BigIntIOImpl::new(&mut test_context, mode);
+        let mut io = BigIntIOImpl::new(&mut test_context, machine_mode as u32);
         let error = io
             .load(ARENA_REG as u32, 0, count)
             .err()


### PR DESCRIPTION
In the executor, there is a bug in the implementation of the check for whether a bigint2 memory op is withing the allowed address range. This PR fixes this issue.

The issue was reported to us by ChainSentry on Hackenproof
