### PR TITLE
bonsai-sdk: compare response status to StatusCode::NO_CONTENT

### DIFF
--- a/bonsai/sdk/src/lib.rs
+++ b/bonsai/sdk/src/lib.rs
@@ -622,7 +622,7 @@ bonsai_sdk::non_blocking::Client::from_env(risc0_zkvm::VERSION)
                 .send()
                 .await?;
 
-            if res.status() == 204 {
+            if res.status() == reqwest::StatusCode::NO_CONTENT {
                 return Ok(ImageExistsOpt::Exists);
             }
 


### PR DESCRIPTION
Switched the check in get_image_upload_url() from a numeric literal (204) to reqwest::StatusCode::NO_CONTENT for clarity and consistency with other status checks (e.g., NOT_FOUND in receipt_download). The previous code was correct due to PartialEq on StatusCode, but the typed constant is more readable and less error-prone.