### PR TITLE
fix(v1compat): replace todo!() with unimplemented!() for ProveZkr syscall

### DIFF
--- a/risc0/zkos/v1compat/src/main.rs
+++ b/risc0/zkos/v1compat/src/main.rs
@@ -413,7 +413,8 @@ mod zkvm {
             Syscall::VerifyIntegrity2 => sys_verify_integrity2(fd),
             Syscall::Write => sys_write(fd),
             Syscall::Unknown(_) => unimplemented!(),
-            Syscall::ProveZkr => todo!(),
+            // ProveZkr is deprecated and not supported in v1compat
+            Syscall::ProveZkr => unimplemented!(),
         }
     }
 


### PR DESCRIPTION
Replace todo!() with unimplemented!() for the deprecated ProveZkr syscall handler to maintain consistency with Unknown syscall handling. 
Added a comment noting that ProveZkr is deprecated and not supported in v1compat.