### PR TITLE
fix(binfmt): handle SessionLimit in ExitCode::from_pair

### DIFF
--- a/risc0/binfmt/src/exit_code.rs
+++ b/risc0/binfmt/src/exit_code.rs
@@ -78,7 +78,11 @@ impl ExitCode {
         match sys_exit {
             0 => Ok(ExitCode::Halted(user_exit)),
             1 => Ok(ExitCode::Paused(user_exit)),
-            2 => Ok(ExitCode::SystemSplit),
+            2 => match user_exit {
+                0 => Ok(ExitCode::SystemSplit),
+                2 => Ok(ExitCode::SessionLimit),
+                _ => Err(InvalidExitCodeError(sys_exit, user_exit)),
+            },
             _ => Err(InvalidExitCodeError(sys_exit, user_exit)),
         }
     }


### PR DESCRIPTION
from_pair ignored user_exit when sys_exit == 2, always returning SystemSplit. This broke round-trip for SessionLimit: (2,2) decoded as SystemSplit instead of SessionLimit. Added match on user_exit to correctly distinguish SystemSplit (2,0) from SessionLimit (2,2).