### PR TITLE
fix(xtask): semver output error context to include crate name

### DIFF
--- a/xtask/src/semver_checks.rs
+++ b/xtask/src/semver_checks.rs
@@ -157,7 +157,13 @@ impl SemverOutput {
         Ok(Self {
             crate_versions: crate_versions
                 .into_iter()
-                .map(|(k, v)| Ok((k, v.try_into().context("{k} missing version")?)))
+                .map(|(k, v)| {
+                    Ok((
+                        k,
+                        v.try_into()
+                            .with_context(|| format!("{k} missing version"))?,
+                    ))
+                })
                 .collect::<Result<_>>()?,
         })
     }


### PR DESCRIPTION
Previously SemverOutput::parse used a literal "{k} missing version" as anyhow context, so the crate name was never interpolated into the error message. This made it harder to see which crate was missing current or baseline versions when parsing cargo-semver-checks output failed. Switch to with_context + format! so the crate name is included in the error context while preserving the existing inner error messages.