### PR TITLE
fix(serde): use DeserializeBadUtf8 for invalid UTF-8 strings

### DIFF
--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -343,7 +343,7 @@ impl<'de, R: WordRead + 'de> serde::Deserializer<'de> for &'_ mut Deserializer<'
         // safe; is there another way to not do double writes here?
         let mut bytes = vec![0u8; len_bytes];
         self.reader.read_padded_bytes(&mut bytes)?;
-        visitor.visit_string(String::from_utf8(bytes).map_err(|_| Error::DeserializeBadChar)?)
+        visitor.visit_string(String::from_utf8(bytes).map_err(|_| Error::DeserializeBadUtf8)?)
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>


### PR DESCRIPTION
Map String::from_utf8 failures in deserialize_str to Error::DeserializeBadUtf8 instead of DeserializeBadChar. This makes the actual behavior match the documented meaning of the error variants and ensures that UTF-8 decoding errors are reported through the dedicated DeserializeBadUtf8 variant while keeping the rest of the serialization/deserialization logic unchanged.