### PR TITLE
Fix article usage in documentation

### DIFF
--- a/website/api/recursion.md
+++ b/website/api/recursion.md
@@ -39,7 +39,7 @@ RISC Zero's zkVM consists of three circuits.
 2. The Recursion Circuit is a separate STARK circuit, that's designed to efficiently generate proofs for the verification of STARK proofs and to support the integration of custom accelerator circuits into the zkVM.
    This circuit has a similar architecture to the RISC-V Circuit, but with fewer columns and an instruction set optimized for cryptography.
    The same [proof system] is used for both the RISC-V Circuit and the Recursion Circuit.
-3. The STARK-to-SNARK Circuit is an R1CS circuit that verifies proofs from the Recursion Circuit.
+3. The STARK-to-SNARK Circuit is a R1CS circuit that verifies proofs from the Recursion Circuit.
 
 ## Recursion Programs
 

--- a/website/api/zkvm/optimization.md
+++ b/website/api/zkvm/optimization.md
@@ -379,7 +379,7 @@ proving times, to reduce compute costs, or both. RISC Zero can leverage hardware
 accelerators, the ones made of real silicon this time, to accomplish both of
 these objectives.
 
-With an NVIDIA graphics card, proving can be accelerated through the [CUDA]
+With a NVIDIA graphics card, proving can be accelerated through the [CUDA]
 implementation. When running a zkVM application, a compatible version of the
 CUDA runtime needs to be installed. When building the zkVM from source, a
 compatible version of the CUDA toolkit needs to be installed on the build

--- a/website/api_versioned_docs/version-0.20/zkvm/optimization.md
+++ b/website/api_versioned_docs/version-0.20/zkvm/optimization.md
@@ -376,7 +376,7 @@ proving times, to reduce compute costs, or both. RISC Zero can leverage hardware
 accelerators, the ones made of real silicon this time, to accomplish both of
 these objectives.
 
-With an NVIDIA graphics card, proving can be accelerated through the [CUDA]
+With a NVIDIA graphics card, proving can be accelerated through the [CUDA]
 implementation. When running a zkVM application, a compatible version of the
 CUDA runtime needs to be installed. When building the zkVM from source, a
 compatible version of the CUDA toolkit needs to be installed on the build

--- a/website/api_versioned_docs/version-0.21/zkvm/optimization.md
+++ b/website/api_versioned_docs/version-0.21/zkvm/optimization.md
@@ -376,7 +376,7 @@ proving times, to reduce compute costs, or both. RISC Zero can leverage hardware
 accelerators, the ones made of real silicon this time, to accomplish both of
 these objectives.
 
-With an NVIDIA graphics card, proving can be accelerated through the [CUDA]
+With a NVIDIA graphics card, proving can be accelerated through the [CUDA]
 implementation. When running a zkVM application, a compatible version of the
 CUDA runtime needs to be installed. When building the zkVM from source, a
 compatible version of the CUDA toolkit needs to be installed on the build

--- a/website/api_versioned_docs/version-1.0/recursion.md
+++ b/website/api_versioned_docs/version-1.0/recursion.md
@@ -39,7 +39,7 @@ RISC Zero's zkVM consists of three circuits.
 2. The Recursion Circuit is a separate STARK circuit, that's designed to efficiently generate proofs for the verification of STARK proofs and to support the integration of custom accelerator circuits into the zkVM.
    This circuit has a similar architecture to the RISC-V Circuit, but with fewer columns and an instruction set optimized for cryptography.
    The same [proof system] is used for both the RISC-V Circuit and the Recursion Circuit.
-3. The STARK-to-SNARK Circuit is an R1CS circuit that verifies proofs from the Recursion Circuit.
+3. The STARK-to-SNARK Circuit is a R1CS circuit that verifies proofs from the Recursion Circuit.
 
 ## Recursion Programs
 


### PR DESCRIPTION
Corrects grammatical errors in article usage throughout documentation files. 
Changes "an honest" to "a honest", "an R1CS" to "a R1CS", and "an NVIDIA" to "a NVIDIA" based on phonetic pronunciation rules where articles should match the sound rather than spelling.


