### PR TITLE
chore: remove unused vec import from deserializer

### DIFF
--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use bytemuck::Pod;
 use risc0_zkvm_platform::WORD_SIZE;


### PR DESCRIPTION
Removed the unused vec import from serde::deserializer to satisfy lint checks and keep the module free of dead code. This import was not referenced anywhere in the file