### PR TITLE
R0ENG-361: Add --nx to gdb invocation in gdb test

### DIFF
--- a/risc0/zkvm/src/host/server/exec/gdb.rs
+++ b/risc0/zkvm/src/host/server/exec/gdb.rs
@@ -125,6 +125,7 @@ mod tests {
         gdb_script.flush().unwrap();
 
         let gdb_output = std::process::Command::new(gdb_bin)
+            .arg("--nx") // Do not read any .gdbinit files
             .arg("-x")
             .arg(gdb_script.path())
             .arg(elf_path)


### PR DESCRIPTION
This prevents gdb from reading any .gdbinit files. Since the test runs gdb as a user would and asserts about the output, any changes to gdb's configuration can result in the test getting confused.

This flag avoids this by making gdb not read any configuration files.