### PR TITLE
perf: avoid unnecessary Arc clone in maybe_finish

### DIFF
--- a/risc0/r0vm/src/actors/job/proof.rs
+++ b/risc0/r0vm/src/actors/job/proof.rs
@@ -467,11 +467,11 @@ impl JobActor {
             return Ok(());
         }
 
-        let Some(session) = self.session.clone() else {
+        let Some(session) = self.session.as_ref() else {
             return Ok(());
         };
 
-        let Some(join_root) = self.join_root(&session)? else {
+        let Some(join_root) = self.join_root(session)? else {
             return Ok(());
         };
 
@@ -480,11 +480,11 @@ impl JobActor {
             .get_or_insert_with(|| join_root.clone())
             .clone();
 
-        if !self.resolve_assumptions(&session, &final_receipt).await? {
+        if !self.resolve_assumptions(session, &final_receipt).await? {
             return Ok(());
         }
 
-        self.finish(&session, final_receipt, self_ref).await?;
+        self.finish(session, final_receipt, self_ref).await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Problem

The `maybe_finish` method was unnecessarily cloning `Arc<Session>` before passing it to methods that already accept `&Arc<Session>`. While `Arc::clone()` is cheap (just increments a reference counter), it's still redundant when a reference would suffice.

## Solution

Replace `self.session.clone()` with `self.session.as_ref()` in `maybe_finish`. Remove redundant `&` operators when passing `session` to `join_root`, `resolve_assumptions`, and `finish` methods, since `session` is already `&Arc<Session>`. This eliminates an unnecessary reference count increment without changing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory handling by improving reference management patterns, resulting in more efficient resource utilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->