### PR TITLE
fix: add platform-specific compilation for symlink function

### DIFF
--- a/rzup/src/components.rs
+++ b/rzup/src/components.rs
@@ -299,7 +299,7 @@ pub fn install(
     Ok(())
 }
 
-#[cfg(feature = "install")]
+#[cfg(all(feature = "install", unix))]
 fn symlink(original: &Path, link: &Path) -> Result<()> {
     if let Ok(metadata) = std::fs::symlink_metadata(link) {
         if metadata.is_dir() {
@@ -321,6 +321,13 @@ fn symlink(original: &Path, link: &Path) -> Result<()> {
     }
     std::os::unix::fs::symlink(original, link)
         .map_err(|e| RzupError::Other(format!("Failed to create symlink: {e}")))
+}
+
+#[cfg(all(feature = "install", windows))]
+fn symlink(_original: &Path, _link: &Path) -> Result<()> {
+    Err(RzupError::UnsupportedPlatform(
+        "Windows platform is not supported".into(),
+    ))
 }
 
 #[cfg(not(feature = "install"))]


### PR DESCRIPTION
Add #[cfg(unix)] to symlink so it compiles on Windows. Windows version just returns UnsupportedPlatform error for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for symlink operations on Windows. Users now receive explicit messaging indicating symlink functionality is unsupported on their platform, improving transparency during the installation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->