### PR TITLE
fix(zkvm): implement missing delay simulations in DevModeProver

### DIFF
--- a/risc0/zkvm/src/host/server/prove/dev_mode.rs
+++ b/risc0/zkvm/src/host/server/prove/dev_mode.rs
@@ -329,16 +329,14 @@ impl ProverServer for DevModeProver {
         &self,
         _a: &SuccinctReceipt<WorkClaim<ReceiptClaim>>,
     ) -> Result<SuccinctReceipt<ReceiptClaim>> {
-        // TODO: Apply a delay here. Should be a little smaller than a join.
-        fake_recursion(None)
+        fake_recursion(self.delay.map(|d| d.join))
     }
 
     fn identity_p254(
         &self,
         _a: &SuccinctReceipt<ReceiptClaim>,
     ) -> Result<SuccinctReceipt<ReceiptClaim>> {
-        // TODO: Apply a delay here.
-        fake_recursion(None)
+        fake_recursion(self.delay.map(|d| d.join))
     }
 
     fn compress(&self, opts: &ProverOpts, receipt: &Receipt) -> Result<Receipt> {
@@ -348,10 +346,10 @@ impl ProverServer for DevModeProver {
         if let Some(delay) = &self.delay {
             match opts.receipt_kind {
                 ReceiptKind::Composite => {
-                    // TODO: Apply a delay here.
+                    std::thread::sleep(delay.lift);
                 }
                 ReceiptKind::Succinct => {
-                    // TODO: Apply a delay here.
+                    std::thread::sleep(delay.join);
                 }
                 ReceiptKind::Groth16 => {
                     std::thread::sleep(delay.shrink_wrap_groth16);


### PR DESCRIPTION
Added missing delay simulations for unwrap_povw, identity_p254, and compress methods that were marked as TODO. All methods now consistently apply delays when configured, matching the behavior of other recursion operations in the prover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dev mode proving server to support configurable per-operation delays that simulate realistic proving timelines. Replaced deterministic stubs with actual timing behavior across multiple proof generation paths: standard proofs, identity verification, proof unwrapping, and composite flows. Delays now vary based on proof type and compression method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->