### PR TITLE
perf: avoid heap allocations in seal decoders

### DIFF
--- a/risc0/binfmt/src/povw.rs
+++ b/risc0/binfmt/src/povw.rs
@@ -204,13 +204,11 @@ impl PovwNonce {
         fn u16_from_u32(x: u32) -> Result<u16, DecodeError> {
             x.try_into().map_err(|_| DecodeError::OutOfRange)
         }
-        Ok(Self::from_u16s(
-            buf.drain(..16)
-                .map(u16_from_u32)
-                .collect::<Result<Vec<_>, _>>()?
-                .try_into()
-                .unwrap(),
-        ))
+        let mut u16s = [0u16; 16];
+        for (dst, src) in u16s.iter_mut().zip(buf.drain(..16)) {
+            *dst = u16_from_u32(src)?;
+        }
+        Ok(Self::from_u16s(u16s))
     }
 }
 

--- a/risc0/binfmt/src/sys_state.rs
+++ b/risc0/binfmt/src/sys_state.rs
@@ -95,13 +95,11 @@ fn read_u32_bytes(flat: &mut VecDeque<u32>) -> Result<u32, DecodeError> {
     if flat.len() < 4 {
         return Err(DecodeError::EndOfStream);
     }
-    Ok(u32::from_le_bytes(
-        flat.drain(0..4)
-            .map(|x| x as u8)
-            .collect::<Vec<u8>>()
-            .try_into()
-            .unwrap(),
-    ))
+    let mut bytes = [0u8; 4];
+    for (dst, src) in bytes.iter_mut().zip(flat.drain(0..4)) {
+        *dst = src as u8;
+    }
+    Ok(u32::from_le_bytes(bytes))
 }
 
 /// Write a SHA-256 digest as a series of half-words (i.e. 16-bit values).

--- a/risc0/zkvm/src/claim/work.rs
+++ b/risc0/zkvm/src/claim/work.rs
@@ -220,13 +220,11 @@ fn decode_work_value_from_seal(buf: &mut VecDeque<u32>) -> Result<u64, risc0_bin
         x.try_into()
             .map_err(|_| risc0_binfmt::DecodeError::OutOfRange)
     }
-    Ok(u64_from_u16s(
-        buf.drain(..4)
-            .map(u16_from_u32)
-            .collect::<Result<Vec<_>, _>>()?
-            .try_into()
-            .unwrap(),
-    ))
+    let mut u16s = [0u16; 4];
+    for (dst, src) in u16s.iter_mut().zip(buf.drain(..4)) {
+        *dst = u16_from_u32(src)?;
+    }
+    Ok(u64_from_u16s(u16s))
 }
 
 impl Digestible for Work {


### PR DESCRIPTION
Seal decoding helpers were allocating small temporary Vecs just to convert drained iterators into fixed-size arrays. The amount of data is always known statically (4 or 16 elements) and the callers only care about the decoded values, not the intermediate container. This change decodes directly into fixed-size arrays on the stack and preserves the existing error behavior (EndOfStream and OutOfRange) and public API, while removing a few short-lived heap allocations from hot PoVW and receipt paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal decoding operations with more explicit error handling and reduced intermediate allocations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->