### PR TITLE
fix: typo in util.h comment

### DIFF
--- a/risc0/circuit/rv32im-sys/cxx/core/util.h
+++ b/risc0/circuit/rv32im-sys/cxx/core/util.h
@@ -33,7 +33,7 @@ inline size_t constexpr ceilDiv(size_t a, size_t b) {
   return (a + (b - 1)) / b;
 }
 
-/// Round `a` up to the nearest multipe of `b`.
+/// Round `a` up to the nearest multiple of `b`.
 inline size_t constexpr roundUp(size_t a, size_t b) {
   return ceilDiv(a, b) * b;
 }


### PR DESCRIPTION
Fix typo: "multipe" -> "multiple" in roundUp function comment.