### PR TITLE
fix: correct randomness parameter in FRI Round 3 formula

### DIFF
--- a/website/docs/proof-system/stark-by-hand.md
+++ b/website/docs/proof-system/stark-by-hand.md
@@ -318,7 +318,7 @@ At this point, $f_{2,even}=31$ and $f_{2,odd}=35$.
 Using randomness of $r_3=64$, we find:
 
 $$
-f_3(x)=f_{2,even}+r_2f_{2,odd}
+f_3(x)=f_{2,even}+r_3f_{2,odd}
 $$
 
 $$


### PR DESCRIPTION
Fixed typo in FRI protocol documentation where Round 3 formula used r_2 instead of r_3. The text correctly states r_3=64 is used, but the formula incorrectly referenced r_2. This ensures consistency with the pattern used in Rounds 1 and 2.