### PR TITLE
docs: clarify Merkle matrix layout indexing

### DIFF
--- a/risc0/zkp/src/prove/merkle.rs
+++ b/risc0/zkp/src/prove/merkle.rs
@@ -43,7 +43,9 @@ impl<H: Hal + ?Sized> MerkleTreeProver<H> {
     /// Generate a merkle tree from a matrix of values.
     ///
     /// The proofs will prove a single 'column' of values in the tree at a
-    /// certain row. Layout is presumed to be packed row-major.
+    /// certain row. The matrix buffer has length `rows * cols` and is indexed
+    /// as `matrix[row + col * rows]`, so for a fixed `row` the `cols` values
+    /// are stored at stride `rows`.
     /// The number of queries represents the expected # of queries and
     /// determines the size of the 'top' layer. It is important that the
     /// verifier is constructed with identical size parameters, including # of


### PR DESCRIPTION
The Merkle tree prover already uses a consistent column-oriented indexing scheme where elements are accessed as `matrix[row + col * rows]`, and this matches the HAL and verifier logic. However, the comment in MerkleTreeProver::new incorrectly referred to the layout as row-major, which could mislead readers about how `rows` and `cols` map to the underlying buffer. This change updates the comment to explicitly describe the actual indexing and stride without changing any behavior.