### PR TITLE
fix(rzup): remove redundant sort in show command

### DIFF
--- a/rzup/src/cli/commands.rs
+++ b/rzup/src/cli/commands.rs
@@ -145,11 +145,8 @@ impl ShowCommand {
                 let default_version = rzup.get_default_version(&component)?;
                 let current_version = rzup.settings().get_default_version(&component);
 
-                let mut sorted_versions = versions.clone();
-                sorted_versions.sort_by(|a, b| b.cmp(a)); // sort newest to oldest
-
-                for version in sorted_versions {
-                    let is_default = default_version.as_ref().is_some_and(|(v, _)| v == &version);
+                for version in &versions {
+                    let is_default = default_version.as_ref().is_some_and(|(v, _)| v == version);
                     let marker = if is_default { "* " } else { "  " };
                     rzup.print(format!("{}{version}", marker.bold()));
                 }


### PR DESCRIPTION
Rzup::list_versions already guarantees versions are returned from newest to oldest and this behavior is covered by tests. ShowCommand was cloning and resorting this list in the same order, which added extra allocations and work without changing the output. This change iterates directly over the already sorted versions, keeping the behavior identical while removing the redundant sorting.