### PR TITLE
docs(circuit): fix spelling in rv32im decode verification

### DIFF
--- a/risc0/circuit/rv32im-sys/cxx/rv32im/circuit/decode.ipp
+++ b/risc0/circuit/rv32im-sys/cxx/rv32im/circuit/decode.ipp
@@ -199,7 +199,7 @@ template <typename C> FDEV void DecodeBlock<C>::verify(CTX) DEV {
   Val<C> f7 = getFunct7();
   Val<C> f3 = getFunct3();
 
-  // Compute the multiple verisons of the immediate
+  // Compute the multiple versions of the immediate
   ValU32<C> immR(0, 0);
   ValU32<C> immI = getImmI();
   ValU32<C> immIL = getImmIL();


### PR DESCRIPTION
Correct `verisons` to `versions` in immediate computation comment within decode.ipp