### PR TITLE
docs: fix misleading to_po2 function documentation

### DIFF
--- a/risc0/zkp/src/core/mod.rs
+++ b/risc0/zkp/src/core/mod.rs
@@ -26,13 +26,16 @@ pub mod poly;
 
 use rand_core::RngCore;
 
-/// For x = (1 << po2), given x, find po2.
+/// Compute `floor(log_2(x))`.
+///
+/// Returns the position of the highest set bit (0-indexed).
+/// Equivalent to finding the largest `po2` such that `(1 << po2) <= x`.
 /// # Example
 /// ```rust
 /// # use risc0_zkp::core::to_po2;
 /// #
-/// assert_eq!(to_po2(7), 2);
-/// assert_eq!(to_po2(10), 3);
+/// assert_eq!(to_po2(7), 2);  // floor(log2(7)) = 2
+/// assert_eq!(to_po2(10), 3); // floor(log2(10)) = 3
 /// ```
 pub fn to_po2(x: usize) -> usize {
     (31 - (x as u32).leading_zeros()) as usize


### PR DESCRIPTION

The doc comment said "For x = (1 << po2), given x, find po2" which implies the function only works for powers of two. But the examples right below show to_po2(7) and to_po2(10) - neither of which are powers of two.

Updated the comment to correctly describe what the function actually does: floor(log2(x)).