### PR TITLE
docs: update copyright year in LICENSE

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 RISC Zero
+Copyright (c) 2026 RISC Zero
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the copyright year from 2025 to 2026.

Keeping license files current for the new year.