### PR TITLE
fix: correct randomness parameter in FRI Round 3 formula

### DIFF
--- a/website/docs/proof-system/stark-by-hand.md
+++ b/website/docs/proof-system/stark-by-hand.md
@@ -318,7 +318,7 @@ At this point, $f_{2,even}=31$ and $f_{2,odd}=35$.
 Using randomness of $r_3=64$, we find:
 
 $$
-f_3(x)=f_{2,even}+r_2f_{2,odd}
+f_3(x)=f_{2,even}+r_3f_{2,odd}
 $$
 
 $$


### PR DESCRIPTION
Replace r_2 with r_3 in the Round 3 FRI folding formula to match the declared randomness parameter. The formula now correctly uses r_3=64 as stated in the text, fixing a typo that could confuse readers following the FRI protocol explanation.