### PR TITLE
docs(zkvm): Add documentation for RPC types

### DIFF
--- a/risc0/zkvm/src/host/rpc.rs
+++ b/risc0/zkvm/src/host/rpc.rs
@@ -89,7 +89,7 @@ pub struct JobInfo<JobResultT> {
 /// Status of an RPC job.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum JobStatus<JobResultT> {
-    /// The job is still running; includes an optional progress message.
+    /// The job is still running; includes a progress message (may be empty)
     Running(String),
 
     /// The job completed successfully and produced a result.


### PR DESCRIPTION
Replace placeholder `/// TODO` comments with proper documentation