### PR TITLE
docs: Replace TODO comments with proper documentation

### DIFF
--- a/risc0/zkvm/src/lib.rs
+++ b/risc0/zkvm/src/lib.rs
@@ -136,7 +136,7 @@ pub use {
     risc0_circuit_rv32im::trace::{TraceCallback, TraceEvent},
 };
 
-/// TODO
+/// RPC protocol types for prover client-server communication.
 #[cfg(not(target_os = "zkvm"))]
 #[cfg(feature = "client")]
 pub mod rpc {


### PR DESCRIPTION
Added documentation for the RPC protocol types