### PR TITLE
fix: add explicit size_of import in hello-m3 circuit

### DIFF
--- a/risc0/circuit/hello-m3/src/lib.rs
+++ b/risc0/circuit/hello-m3/src/lib.rs
@@ -15,6 +15,8 @@
 
 #[cfg(test)]
 mod test {
+    use std::mem::size_of;
+
     use anyhow::Result;
     use risc0_circuit_recursion::{CircuitImpl, prove::Program};
     use risc0_core::field::baby_bear::{BabyBear, BabyBearElem, BabyBearExtElem};


### PR DESCRIPTION
## What

Add explicit `use std::mem::size_of;` import in `hello-m3` circuit test module.

## Why

The code uses `size_of::<u32>()` without an explicit import, which works but doesn't match project conventions. Other files use full paths (`core::mem::size_of`) or explicit imports. This change ensures consistency and avoids potential compatibility issues with future Rust versions.