### PR TITLE
docs: fix CompositeReceiptVerifierParameters digest comment

### DIFF
--- a/risc0/zkvm/src/receipt/composite.rs
+++ b/risc0/zkvm/src/receipt/composite.rs
@@ -279,7 +279,7 @@ impl CompositeReceiptVerifierParameters {
 }
 
 impl Digestible for CompositeReceiptVerifierParameters {
-    /// Hash the [Groth16ReceiptVerifierParameters] to get a digest of the struct.
+    /// Hash the [CompositeReceiptVerifierParameters] to get a digest of the struct.
     fn digest<S: Sha256>(&self) -> Digest {
         tagged_struct::<S>(
             "risc0.CompositeReceiptVerifierParameters",


### PR DESCRIPTION
The doc comment on `CompositeReceiptVerifierParameters::digest` incorrectly referenced `Groth16ReceiptVerifierParameters`, which was a copy-paste error and could mislead readers about what is being hashed. This change updates the comment to mention `CompositeReceiptVerifierParameters`, matching the actual type