### PR TITLE
fix: remove unused `loadFFI` function from rv32im load_elf

### DIFF
--- a/risc0/circuit/rv32im-sys/cxx/rv32im/emu/load_elf.h
+++ b/risc0/circuit/rv32im-sys/cxx/rv32im/emu/load_elf.h
@@ -27,9 +27,6 @@ namespace risc0::rv32im {
 // Adds exansion table for compressed instructions
 void fillExpandTable(std::map<uint32_t, uint32_t>& words);
 
-// Loads for FFI test (TODO: remove?)
-void loadFFI(std::map<uint32_t, uint32_t>& words, const ArrayRef<uint8_t>& elfBytes);
-
 // Loads as only a machine mode kernel for machine mode test
 void loadKernelV2(std::map<uint32_t, uint32_t>& words, const std::string& elf);
 


### PR DESCRIPTION
Removes the unused `loadFFI` function which was marked with "TODO: remove?" comment.