### PR TITLE
docs: reference correct risc0-zkp crate for RS codes

### DIFF
--- a/website/docs/reference-docs/about-rs-codes.md
+++ b/website/docs/reference-docs/about-rs-codes.md
@@ -4,7 +4,7 @@
 
 ## Documentation
 
-Implementation and documentation for Reed-Solomon encoding is in the `risc0-zkp-core` [Rust crate](https://github.com/risc0/risc0#rust-crates).
+Implementation and documentation for Reed-Solomon encoding is in the `risc0-zkp` [Rust crate](https://github.com/risc0/risc0/tree/main/risc0/zkp).
 
 ## Basic Function
 


### PR DESCRIPTION
fixed risc0-zkp crate instead of the old risc0-zkp-core name.
and also fixed link which lead just to main https://github.com/risc0/risc0#rust-crates
instead now it correctly leads to https://github.com/risc0/risc0/tree/main/risc0/zkp