### PR TITLE
fix(cargo-risczero): correct CLI command in guest.rs comment

### DIFF
--- a/risc0/cargo-risczero/src/commands/guest.rs
+++ b/risc0/cargo-risczero/src/commands/guest.rs
@@ -200,7 +200,7 @@ impl GuestCommand {
             bail!("failed to build crate")
         }
 
-        // If we are running `cargo risczero test`, load each test binary into the
+        // If we are running `cargo risczero guest test`, load each test binary into the
         // executor and run them.
         if matches!(self.command, GuestSubCommands::Test(_)) && !no_run_flag {
             eprintln!("Running tests: {tests:?}");


### PR DESCRIPTION
The comment was using the shortened command name which could be confusing to developers reading the code. The actual command users run is `cargo risczero guest test`