### PR TITLE
perf(hal): parallelize fri_fold in CPU HAL implementation

### DIFF
--- a/risc0/zkp/src/hal/cpu.rs
+++ b/risc0/zkp/src/hal/cpu.rs
@@ -551,8 +551,7 @@ impl<F: Field> Hal for CpuHal<F> {
         let mut output = output.as_slice_mut();
         let input = input.as_slice();
 
-        // TODO(flaub): parallelize
-        for idx in 0..count {
+        (0..count).into_par_iter().for_each(|idx| {
             let mut tot = Self::ExtElem::ZERO;
             let mut cur_mix = Self::ExtElem::ONE;
             for i in 0..FRI_FOLD {
@@ -567,7 +566,7 @@ impl<F: Field> Hal for CpuHal<F> {
             for i in 0..Self::ExtElem::EXT_SIZE {
                 output[count * i + idx] = tot.subelems()[i];
             }
-        }
+        });
     }
 
     fn hash_rows(&self, output: &Self::Buffer<Digest>, matrix: &Self::Buffer<Self::Elem>) {


### PR DESCRIPTION
### Problem
The fri_fold function in the CPU HAL uses a sequential loop despite a TODO to parallelize it. This is inconsistent with GPU implementations and other parallelized CPU HAL functions.
### Solution
Replaced the sequential loop with rayon's into_par_iter(), matching the pattern used in other CPU HAL functions. The computation logic is unchanged; only the outer loop is parallelized.