### PR TITLE
Fix two issues with the semver-checks

### DIFF
--- a/xtask/src/semver_checks.rs
+++ b/xtask/src/semver_checks.rs
@@ -605,6 +605,9 @@ fn write_semver_lock_file(workspace_root: &Path, baselines: &SemverBaselines) ->
 }
 
 fn semver_compatible(a: &semver::Version, b: &semver::Version) -> bool {
+    if a == b {
+        return true;
+    }
     if !a.pre.is_empty() || !b.pre.is_empty() {
         return false;
     }
@@ -634,7 +637,7 @@ fn semver_compatible_test() {
         &semver::Version::new(0, 1, 1)
     ));
 
-    assert!(!semver_compatible(
+    assert!(semver_compatible(
         &"1.2.3-rc.1".parse().unwrap(),
         &"1.2.3-rc.1".parse().unwrap()
     ));


### PR DESCRIPTION
This fixes two issues with the semver checks that I ran into on the release branch.

- If we are publishing a new crate and are passing `--update`, don't error if it has no baseline, instead set its baseline to "none" in the lock file.
- Count exact .rc versions as semver compatible so that they get vendor'd properly. Later we need them vendored locally to compare with the local version.