### PR TITLE
fix(ui): remove duplicate line break in datasheet layout

### DIFF
--- a/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/layout.tsx
+++ b/web/apps/benchmarks-and-reports/src/app/(benchmarks-and-reports)/[version]/datasheet/layout.tsx
@@ -91,7 +91,6 @@ export default async function DatasheetLayout(
                   <CodeBadge>rv32im</CodeBadge> + <CodeBadge>lift</CodeBadge> + <CodeBadge>identity_p254</CodeBadge> +
                   <CodeBadge>stark2snark</CodeBadge>.
                   <br />
-                  <br />
                   On Bonsai, calls to <CodeBadge>rv32im</CodeBadge>, <CodeBadge>lift</CodeBadge>, and{" "}
                   <CodeBadge>join</CodeBadge> are parallelized.
                 </p>


### PR DESCRIPTION
Removed duplicate line break tag on line 94 that was causing unnecessary extra spacing.