### PR TITLE
fix: remove duplicate unwrap in allocator

### DIFF
--- a/risc0/r0vm/src/actors/allocator.rs
+++ b/risc0/r0vm/src/actors/allocator.rs
@@ -1438,7 +1438,6 @@ mod allocation_tests {
                     )
                     .await
                     .unwrap()
-                    .unwrap();
                 worker_addresses.insert(*worker_id, worker_addr);
             }
 


### PR DESCRIPTION
The second .unwrap() would cause a compilation error or runtime panic.