### PR TITLE
chore(bigint2): format Cargo.toml

### DIFF
--- a/risc0/bigint2/Cargo.toml
+++ b/risc0/bigint2/Cargo.toml
@@ -3,8 +3,8 @@ name = "risc0-bigint2"
 description = "RISC Zero's Big Integer Accelerator"
 version = "1.4.12"
 edition = { workspace = true }
-license = { workspace = true }
 homepage = { workspace = true }
+license = { workspace = true }
 repository = { workspace = true }
 
 [features]
@@ -25,17 +25,16 @@ stability = "0.2"
 [dev-dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-gpu-guard = { workspace = true }
 num-bigint = { version = "0.4", default-features = false, features = ["serde"] }
-num-bigint-dig = { version = "0.8", default-features = false, features = [
-    "serde",
-] }
+num-bigint-dig = { version = "0.8", default-features = false, features = ["serde"] }
 num-traits = "0.2.18"
 puffin = "0.19"
 puffin_http = "0.16"
-risc0-bigint2-methods = { path = "methods" }
-risc0-zkvm = { workspace = true, features = ["prove"] }
 rstest = "0.25.0"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+gpu-guard = { workspace = true }
+risc0-bigint2-methods = { path = "methods" }
+risc0-zkvm = { workspace = true, features = ["prove"] }


### PR DESCRIPTION
This PR normalizes formatting of the bigint2 Cargo.toml by reordering fields and grouping workspace dependencies
