### PR TITLE
Add publish=false to Cargo.toml files to signal cargo publish to ignore them

### DIFF
--- a/examples/keccak/methods/Cargo.toml
+++ b/examples/keccak/methods/Cargo.toml
@@ -2,6 +2,7 @@
 name = "keccak-methods"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [build-dependencies]
 risc0-build = { path = "../../../risc0/build" }

--- a/risc0/bigint2/methods/Cargo.toml
+++ b/risc0/bigint2/methods/Cargo.toml
@@ -2,6 +2,7 @@
 name = "risc0-bigint2-methods"
 version = { workspace = true }
 edition = { workspace = true }
+publish = false
 
 [package.metadata.release]
 release = false

--- a/risc0/zkvm/methods/Cargo.toml
+++ b/risc0/zkvm/methods/Cargo.toml
@@ -2,6 +2,7 @@
 name = "risc0-zkvm-methods"
 version = { workspace = true }
 edition = { workspace = true }
+publish = false
 
 [package.metadata.release]
 release = false

--- a/risc0/zkvm/receipts/Cargo.toml
+++ b/risc0/zkvm/receipts/Cargo.toml
@@ -2,6 +2,7 @@
 name = "risc0-zkvm-receipts"
 version = { workspace = true }
 edition = { workspace = true }
+publish = false
 
 [package.metadata.release]
 release = false

--- a/tools/hotbench/Cargo.toml
+++ b/tools/hotbench/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hotbench"
 version = "0.1.0"
 edition = { workspace = true }
+publish = false
 
 [package.metadata.release]
 release = false

--- a/website/doc-test/main/Cargo.toml
+++ b/website/doc-test/main/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
+publish = false
 
 [package.metadata.release]
 release = false

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = { workspace = true }
+publish = false
 
 [package.metadata.release]
 release = false


### PR DESCRIPTION
This is a change I made locally in trying to get `cargo +nightly publish --workspace --dry-run` to work. It still doesn't work, but this is a reasonable change to make by itself and gets it _closer_ to working.