### PR TITLE
Backport: Update cargo-binstall to 1.17.4 in release workflow (#3700)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
-          version: "1.10.16"
+          version: "1.17.4"
       - run: cargo binstall -y --force cargo-risczero@${{ env.VERSION }}
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION


### PR DESCRIPTION
The release workflow is currently failing to build `cargo-binstall` [1].
Updating to the latest version is one way to resolve this issue. This PR
updates to `1.17.4`.

[1]
https://github.com/risc0/risc0/actions/runs/21611440327/job/62280880824