### PR TITLE
Avoid panicking index operations in the v2 seal decode and verify functions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
-          version: "1.10.16"
+          version: "1.17.4"
       - run: cargo binstall -y --force cargo-risczero@${{ env.VERSION }}
       - run: cargo run --bin rzup -- --verbose install --force rust $RISC0_RUST_TOOLCHAIN_VERSION
       - run: cargo run --bin rzup -- --verbose install --force cpp $RISC0_CPP_TOOLCHAIN_VERSION


### PR DESCRIPTION
Related to the issues fixed in https://github.com/risc0/risc0/pull/3637, this PR resolves a panic in code paths that did not exist on `main` at the time of that fix. Note that this PR is applied to the `release-3.0` branch, and not `main` because these code paths no longer exist there.
