### PR TITLE
fix: add digest validity assertions in poseidon254 hash_pair

### DIFF
--- a/risc0/zkp/src/core/hash/poseidon_254/mod.rs
+++ b/risc0/zkp/src/core/hash/poseidon_254/mod.rs
@@ -140,6 +140,8 @@ where
 
 impl HashFn<BabyBear> for Poseidon254HashFn {
     fn hash_pair(&self, a: &Digest, b: &Digest) -> Box<Digest> {
+        assert!(self.is_digest_valid(a));
+        assert!(self.is_digest_valid(b));
         let mut cells = [Fr::ZERO; CELLS];
         cells[1] = digest_to_fr(a);
         cells[2] = digest_to_fr(b);


### PR DESCRIPTION
## Fix

Adds explicit digest validity assertions in `poseidon254::hash_pair()` to match the error handling style used in `poseidon2` implementation.

## Changes

- Added `assert!` checks for digest validity before converting to field elements in `hash_pair()`
- Ensures consistent behavior across hash function implementations
- Helps catch invalid digests early during development