### PR TITLE
fix: typos in executor and session comments

### DIFF
--- a/risc0/circuit/rv32im/src/execute/executor.rs
+++ b/risc0/circuit/rv32im/src/execute/executor.rs
@@ -252,7 +252,7 @@ pub struct SegmentUpdate {
     /// Record of what is read by the guest across all syscalls.
     #[debug("{}", read_record.len())]
     read_record: Vec<Vec<u8>>,
-    /// Record of writen to the host across all syscalls.
+    /// Record of written to the host across all syscalls.
     #[debug("{}", write_record.len())]
     write_record: Vec<u32>,
 

--- a/risc0/zkvm/src/host/server/session.rs
+++ b/risc0/zkvm/src/host/server/session.rs
@@ -329,7 +329,7 @@ impl Session {
     /// The populated [Output] is merged into the last segment, including journal and assumptions.
     pub fn segments(&self) -> impl Iterator<Item = Result<Segment>> {
         // NOTE: When using the default run or run_with_callback on ExecutorImpl, merging in the
-        // output is redudant. However, callers that run the ExecutorImpl iteratively and without
+        // output is redundant. However, callers that run the ExecutorImpl iteratively and without
         // the SegmentUpdateProcessor, this is where the output merging happens.
 
         // Construct the populated Output from the session's journal and assumptions.


### PR DESCRIPTION
Corrects the `write_record` comment in `SegmentUpdate`
Corrects the comment in `Session::segments`
