### PR TITLE
Handle partial-word serde byte input

### DIFF
--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -74,6 +74,10 @@ impl WordRead for &[u32] {
 /// possible, such as if `slice` is not the serialized form of an object of type
 /// `T`.
 pub fn from_slice<T: DeserializeOwned, P: Pod>(slice: &[P]) -> Result<T> {
+    if core::mem::size_of_val(slice) % WORD_SIZE != 0 {
+        return Err(Error::DeserializeUnexpectedEnd);
+    }
+
     match bytemuck::try_cast_slice(slice) {
         Ok(slice) => {
             let mut deserializer = Deserializer::new(slice);
@@ -85,7 +89,7 @@ pub fn from_slice<T: DeserializeOwned, P: Pod>(slice: &[P]) -> Result<T> {
             let mut deserializer = Deserializer::new(vec.as_slice());
             T::deserialize(&mut deserializer)
         }
-        Err(ref e) => panic!("failed to cast or read slice as [u32]: {e}"),
+        Err(_) => Err(Error::NotSupported),
     }
 }
 
@@ -572,6 +576,20 @@ mod tests {
             f64: 2.71,
         };
         assert_eq!(expected, from_slice(&words).unwrap());
+    }
+
+    #[test]
+    fn partial_word_byte_slice_returns_error() {
+        assert_eq!(
+            Err(Error::DeserializeUnexpectedEnd),
+            from_slice::<u32, u8>(&[0, 1, 2])
+        );
+    }
+
+    #[test]
+    fn unaligned_complete_byte_slice_deserializes() {
+        let bytes = [0xff, 1, 0, 0, 0];
+        assert_eq!(1u32, from_slice::<u32, u8>(&bytes[1..]).unwrap());
     }
 
     #[test]

--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -89,7 +89,7 @@ pub fn from_slice<T: DeserializeOwned, P: Pod>(slice: &[P]) -> Result<T> {
             let mut deserializer = Deserializer::new(vec.as_slice());
             T::deserialize(&mut deserializer)
         }
-        Err(_) => Err(Error::NotSupported),
+        Err(ref e) => panic!("failed to cast or read slice as [u32]: {e}"),
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #3754.

`risc0_zkvm::serde::from_slice` can currently panic when called with byte input whose length is not a complete number of `u32` words, e.g. `from_slice::<u32, u8>(&[0, 1, 2])`.

This PR adds a small pre-check that returns `Error::DeserializeUnexpectedEnd` for partial-word input before attempting the bytemuck cast. It preserves the existing unaligned-but-complete byte-slice path.

## Implementation note

This also changes the remaining bytemuck catch-all arm from a panic to `Err(Error::NotSupported)`. The partial-word length precheck is the actual fix for this issue; the catch-all change keeps `from_slice` aligned with its `Result` API. If maintainers prefer the smallest possible behavior change, I can drop that part and leave the catch-all arm unchanged.

## Tests

```text
cargo fmt --check
git diff --check
RISC0_SKIP_BUILD=1 cargo test -p risc0-zkvm --lib serde::deserializer::tests -- --nocapture
```

`RISC0_SKIP_BUILD=1` was needed in my Termux/Android environment because guest build scripts otherwise fail with `UnsupportedPlatform("unknown OS: android")`.
