### PR TITLE
Draft: validate Metal rv32im eval-check on Apple Silicon

### DIFF
--- a/.github/workflows/metal_p0_validation.yml
+++ b/.github/workflows/metal_p0_validation.yml
@@ -1,0 +1,117 @@
+name: Metal P0 Validation
+
+on:
+  pull_request:
+    branches: [main, "release-*"]
+    paths:
+      - ".github/workflows/metal_p0_validation.yml"
+      - "docs/metal-optimization-progress.md"
+      - "risc0/circuit/rv32im/**"
+      - "risc0/circuit/rv32im-sys/**"
+      - "risc0/circuit/keccak/**"
+      - "risc0/circuit/keccak-sys/**"
+      - "risc0/zkvm/**"
+      - "examples/keccak/**"
+      - "examples/voting-machine/**"
+  workflow_dispatch:
+    inputs:
+      run_benchmarks:
+        description: "Run the longer benchmark gates"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  RISC0_BUILD_LOCKED: 1
+  RISC0_DEFAULT_PROVER_NUM_GPUS: 1
+  RISC0_RUST_TOOLCHAIN_VERSION: 1.94.1
+  RISC0_CPP_TOOLCHAIN_VERSION: 2024.01.05
+  RUST_BACKTRACE: full
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  apple-silicon:
+    name: Apple Silicon Metal P0
+    runs-on: [self-hosted, cluster, macOS, ARM64, apple_m2_pro]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - run: git lfs pull
+      - uses: ./.github/actions/rustup
+      - uses: ./.github/actions/sccache
+      - uses: ./.github/actions/protoc
+
+      - run: cargo run --bin rzup -- --verbose install rust $RISC0_RUST_TOOLCHAIN_VERSION
+      - run: cargo run --bin rzup -- --verbose install cpp $RISC0_CPP_TOOLCHAIN_VERSION
+
+      - name: Capture environment
+        run: |
+          git rev-parse --short HEAD
+          git branch --show-current
+          xcode-select -p
+          xcodebuild -version
+          xcrun --sdk macosx metal -v
+          uname -a
+          sysctl -n machdep.cpu.brand_string
+
+      - name: Format
+        run: cargo fmt --check
+
+      - name: rv32im Metal prove suite
+        run: cargo test -p risc0-circuit-rv32im --features prove prove::tests --release -- --nocapture
+
+      - name: rv32im Metal prove suite with eval-check verification
+        run: |
+          RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
+            cargo test -p risc0-circuit-rv32im --features prove prove::tests --release -- --nocapture
+
+      - name: rv32im focused eval-check regression
+        run: |
+          RISC0_RV32IM_METAL_EVAL_CHECK=1 \
+          RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
+            cargo test -p risc0-circuit-rv32im --features prove \
+              prove::tests::metal_eval_check_sltiu_repeated --release -- \
+              --ignored --nocapture --test-threads=1
+
+      - name: zkVM basic proof
+        run: cargo test -p risc0-zkvm --features prove host::server::prove::tests::basic -- --nocapture
+
+      - name: zkVM Keccak assumption proof
+        run: cargo test -p risc0-zkvm --features prove host::server::prove::tests::keccak::basic -- --nocapture
+
+      - name: Keccak example proof
+        run: cargo test --manifest-path examples/keccak/Cargo.toml --features prove hash_abc -- --nocapture
+
+      - name: Voting-machine protocol proof workload
+        run: |
+          RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
+            cargo test --manifest-path examples/voting-machine/Cargo.toml \
+              --features prove protocol -- --nocapture
+
+      - name: Segment benchmark
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        run: cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2
+
+      - name: Datasheet composite benchmark
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        run: cargo run --release -p risc0-zkvm --features prove,metal --example datasheet -- --max-po2 20 composite
+
+      - name: Datasheet succinct benchmark
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        run: cargo run --release -p risc0-zkvm --features prove,metal --example datasheet -- --max-po2 18 succinct
+
+      - name: CPU eval-check fallback benchmark
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        run: |
+          RISC0_RV32IM_METAL_EVAL_CHECK=0 \
+            cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2
+
+      - run: sccache --show-stats

--- a/.github/workflows/metal_p0_validation.yml
+++ b/.github/workflows/metal_p0_validation.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/metal_p0_validation.yml"
       - "docs/metal-optimization-progress.md"
+      - "risc0/build_kernel/**"
       - "risc0/circuit/rv32im/**"
       - "risc0/circuit/rv32im-sys/**"
       - "risc0/circuit/keccak/**"
@@ -65,6 +66,9 @@ jobs:
       - name: Format
         run: cargo fmt --check
 
+      - name: build-kernel tests
+        run: cargo test -p risc0-build-kernel
+
       - name: rv32im Metal prove suite
         run: cargo test -p risc0-circuit-rv32im --features prove prove::tests --release -- --nocapture
 
@@ -113,5 +117,25 @@ jobs:
         run: |
           RISC0_RV32IM_METAL_EVAL_CHECK=0 \
             cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2
+
+      - name: Exact po2 candidate segment benchmark
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks == 'true' }}
+        run: |
+          RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14,20 \
+            cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2
+
+      - name: Exact po2 candidate Keccak long proof
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks == 'true' }}
+        run: |
+          RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14,20 \
+            cargo test --manifest-path examples/keccak/Cargo.toml \
+              --features prove,risc0-zkvm/metal hash_long --release -- --nocapture
+
+      - name: Exact po2 candidate voting-machine proof
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks == 'true' }}
+        run: |
+          RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14,20 \
+            cargo test --manifest-path examples/voting-machine/Cargo.toml \
+              --features prove,risc0-zkvm/metal protocol --release -- --nocapture
 
       - run: sccache --show-stats

--- a/.github/workflows/metal_p0_validation.yml
+++ b/.github/workflows/metal_p0_validation.yml
@@ -97,19 +97,19 @@ jobs:
               --features prove protocol -- --nocapture
 
       - name: Segment benchmark
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks == 'true' }}
         run: cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2
 
       - name: Datasheet composite benchmark
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks == 'true' }}
         run: cargo run --release -p risc0-zkvm --features prove,metal --example datasheet -- --max-po2 20 composite
 
       - name: Datasheet succinct benchmark
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks == 'true' }}
         run: cargo run --release -p risc0-zkvm --features prove,metal --example datasheet -- --max-po2 18 succinct
 
       - name: CPU eval-check fallback benchmark
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmarks == 'true' }}
         run: |
           RISC0_RV32IM_METAL_EVAL_CHECK=0 \
             cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -24,9 +24,10 @@ The best current experimental full-Metal rv32im candidate is:
 RISC0_RV32IM_METAL_EVAL_CHECK=1`
 
 On the M5 Max this passes the current serial rv32im suite with eval-check CPU
-verification and is faster than the CPU-eval-check safety fallback on the
-filtered `fib prove/poseidon2` benchmark. The non-serial test harness also
-passes, but this still needs longer stress testing before becoming the default.
+verification, the non-serial rv32im harness, and small-to-medium composite and
+succinct datasheet runs. It is faster than the CPU-eval-check safety fallback on
+the filtered `fib prove/poseidon2` benchmark, but this still needs longer stress
+testing before becoming the default.
 
 For the best local proving throughput, start with `ProverOpts::fast()` or
 `ProverOpts::composite()`. This produces a composite STARK receipt: fastest,
@@ -261,6 +262,12 @@ Metal-focused validation on the M5 Max:
   `datasheet --max-po2 16 composite`: 658.9ms for 16K rows and 2.04s for 64K
   rows. This improves on the current safety-path baseline of 897.8ms and 4.56s,
   so the candidate is meaningful beyond the isolated `fib` segment benchmark.
+- The candidate also passed `datasheet --max-po2 18 composite`: 658.7ms for 16K
+  rows, 1.85s for 64K rows, 5.96s for 128K rows, and 9.04s for 256K rows. The
+  larger 256K-row case reached about 28.3K rows/sec.
+- The same candidate passed `datasheet --max-po2 18 succinct`: 2.57s for the
+  64K-row succinct case, about 24.9K rows/sec, with about 930MB max RAM and a
+  217.4KB seal.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
@@ -348,7 +355,9 @@ than at stale C++ header bindings alone.
   - warm `hello-world` proof: present, but too small to distinguish safe
     CPU-eval-check and forced full-Metal eval-check.
   - small Metal-enabled `datasheet execute`, `composite`, `lift`, `join`, and
-    `succinct`: present at `--max-po2 16`.
+    `succinct`: present at `--max-po2 16`; the `-fno-inline-functions`
+    full-Metal candidate also has `composite` and `succinct` coverage at
+    `--max-po2 18`.
   - filtered `fib execute`: present.
   - rv32im segment-only benchmark: present through filtered `fib
     prove/poseidon2`; currently slow because the safety path keeps rv32im

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -299,6 +299,8 @@ Metal-focused validation on the M5 Max:
   prove::tests::metal_eval_check_sltiu_repeated --release -- --ignored
   --nocapture --test-threads=1`. After narrowing the scoped compiler flag to
   `-fno-inline`, this ignored regression passed 20 `sltiu` proofs in 14.55s.
+  After reverting the rejected `EvalCheckReg<po2>::get()` noinline experiment,
+  the same focused regression recheck passed in 13.81s.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -165,13 +165,14 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_COMPARE_CPU=1 RISC0_RV32IM_METAL_EVAL_CHECK=1`, a serial
   suite run failed in `beq` with `DualHal matrix verify mismatch after
   evalCheck`. A later serial run failed in `sltiu` after `evalCheck` at row
-  8288 col 0. Running only `prove::tests::sltiu` can also fail after
-  `evalCheck`, but not every run; one observed loop failed after 19 repeats.
-  Use this as the current compact repro shape:
-  `for i in {1..20}; do RISC0_RV32IM_METAL_COMPARE_CPU=1
-  RISC0_RV32IM_METAL_EVAL_CHECK=1 cargo test -p risc0-circuit-rv32im --features
-  prove prove::tests::sltiu --release -- --nocapture --test-threads=1 || exit
-  $?; done`.
+  8288 col 0. Running only `prove::tests::sltiu` has reproduced the problem in
+  older local runs, but it is not a stable current-head canary: a current
+  `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1
+  RISC0_RV32IM_METAL_EVAL_CHECK=1
+  RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` 20-iteration `sltiu` loop passed
+  20/20. The current compact current-head repro is the serial full prove suite
+  with the same unsafe inline env; it failed in `xori` with `Metal evalCheck CPU
+  verify mismatch at row 6720 col 0, 1336042307 vs 806756744`.
 - Bypassing only the Metal `eval_check_metal_*` kernels restores correctness.
   The branch now keeps the rest of the Metal HAL active but computes the rv32im
   validity polynomial on CPU by default:
@@ -300,7 +301,9 @@ Metal-focused validation on the M5 Max:
   --nocapture --test-threads=1`. After narrowing the scoped compiler flag to
   `-fno-inline`, this ignored regression passed 20 `sltiu` proofs in 14.55s.
   After reverting the rejected `EvalCheckReg<po2>::get()` noinline experiment,
-  the same focused regression recheck passed in 13.81s.
+  the same focused regression recheck passed in 13.81s. After the current-head
+  unsafe-inline full-suite repro, rebuilding the mitigated default and rerunning
+  the same focused regression passed in 13.65s.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
@@ -536,8 +539,8 @@ Prompt-to-artifact checklist:
   uses eval-check on Metal by default unless `RISC0_RV32IM_METAL_EVAL_CHECK=0`
   is set.
 - Unsafe original repro path: present. `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`
-  removes the scoped noinline mitigation, and prior inline full-suite testing
-  reproduced a direct eval-check mismatch.
+  removes the scoped noinline mitigation, and current-head inline full-suite
+  testing reproduced a direct eval-check mismatch in `xori` at row 6720 col 0.
 - Direct correctness diagnostic: present.
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` compares Metal eval-check output
   against CPU eval-check output from the same inputs.
@@ -644,8 +647,9 @@ Failure triage:
 
 ```sh
 RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1 \
+  RISC0_RV32IM_METAL_EVAL_CHECK=1 \
   RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
-  cargo test -p risc0-circuit-rv32im --features prove prove::tests::sltiu --release -- --nocapture --test-threads=1
+  cargo test -p risc0-circuit-rv32im --features prove prove::tests --release -- --nocapture --test-threads=1
 RISC0_RV32IM_METAL_KERNEL_O0=1 \
   RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
   cargo test -p risc0-circuit-rv32im --features prove prove::tests::sltiu --release -- --nocapture --test-threads=1

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -198,6 +198,11 @@ than at stale C++ header bindings alone.
   `metal-cpp_26.4.zip`, whose README mentions bugfixing and other improvements.
   A first trial suggests this is not the root cause. Keep the check open only as
   a binding-health task, not as the leading correctness hypothesis.
+- Do not treat the Rust `metal = "0.29"` dependency as a normal bump target.
+  Upstream `metal-rs` is deprecated and recommends `objc2` / `objc2-metal` for
+  new development. That dependency still matters for the Rust ZKP and recursion
+  Metal HALs, but replacing it is a migration task rather than a quick P0
+  correctness fix for rv32im's C++ Metal-cpp path.
 - Compare `.metallib` output and runtime behavior across Apple Metal Toolchain
   versions if possible. A CI Apple Silicon runner passing with a different Xcode
   or Metal Toolchain would be a strong signal that this is toolchain-sensitive.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -267,6 +267,12 @@ Metal-focused validation on the M5 Max:
   - `cargo test -p risc0-zkvm --features prove
     host::server::prove::tests::basic -- --nocapture` passed, producing a
     succinct receipt for the `DoNothing` multi-test guest.
+  - `cargo test -p risc0-zkvm --features prove
+    host::server::prove::tests::sha_basics -- --nocapture` passed, proving SHA
+    digest test vectors with four rv32im segment proofs.
+  - `cargo test -p risc0-zkvm --features prove
+    host::server::prove::tests::continuation -- --nocapture` passed, proving a
+    two-segment continuation session and checking segment indices.
 - Before flipping the runtime default, the scoped full-Metal path passed five
   consecutive non-serial full-suite verifier runs with
   `RISC0_RV32IM_METAL_EVAL_CHECK=1
@@ -537,10 +543,10 @@ Remaining gaps before marking P0 complete:
 - The mitigation is still a compiler-flag workaround, not a real Zirgen/M3
   code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
   slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
-- The default path has strong local smoke, benchmark, 10-pass verifier-loop, and
-  Keccak example coverage, including a 100KB input proof, but not a broad
-  non-example application workload beyond the current datasheet/examples/zkVM
-  tests.
+- The default path has strong local smoke, benchmark, 10-pass verifier-loop,
+  SHA, continuation, and Keccak example coverage, including a 100KB Keccak input
+  proof, but not a broad product-style application workload beyond the current
+  datasheet/examples/zkVM tests.
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -16,7 +16,7 @@ MetalToolchain`; `xcrun --sdk macosx metal -v` reports Apple metal version
 
 Use the M3 rv32im segment prover on Apple Silicon with Metal enabled by target
 selection. On this branch, rv32im eval-check also uses Metal by default after
-compiling generated `eval_check_*.metal` files with `-fno-inline-functions`.
+compiling generated `eval_check_*.metal` files with `-fno-inline`.
 
 Use this env var only to force the old CPU eval-check safety fallback:
 
@@ -232,13 +232,20 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_APPEND_FLAGS`. The same filtered suite also passed 46/46
   without `--test-threads=1`. This points at inlining pressure in the generated
   `verifyCircuit` / eval-check path as the most actionable current hypothesis.
-- The branch now applies `-fno-inline-functions` only to generated
+- The branch first applied `-fno-inline-functions` only to generated
   `eval_check_*.metal` files by default. With no global append flags, forced
   Metal eval-check plus CPU verification passed the focused `sltiu` loop 20/20
   and the full rv32im prove suite 46/46. This preserves the original repro path
   behind `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`: a focused inline `sltiu`
   loop passed 25/25, but the inline full rv32im prove suite failed in `sltiu`
   with a direct eval-check verifier mismatch at row 31840 col 0.
+- The scoped default was then narrowed from `-fno-inline-functions` to
+  `-fno-inline` on generated `eval_check_*.metal` files. Apple Metal accepts
+  `-fno-inline`, but ignores narrower candidates such as
+  `-fno-inline-functions-called-once` and `-fno-inline-small-functions`. With
+  scoped `-fno-inline`, the focused `sltiu` eval-check verifier passed and the
+  full rv32im prove suite with `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`
+  passed 46/46 with one ignored regression test.
 - Full Metal eval-check is now the runtime default in this branch. The default
   full rv32im prove suite passed 46/46 with one ignored Metal regression test,
   and a default full-suite run with
@@ -314,11 +321,14 @@ Metal-focused validation on the M5 Max:
   benchmark without any rv32im eval-check env flags passed with a 4.73s to 4.84s
   range, about 105.8K to 108.3K rows/sec. This is the best current default
   segment-proving measurement.
+- After narrowing the scoped eval-check flag to `-fno-inline`, the default
+  no-env benchmark stayed in the same range: 4.77s to 4.93s, about 103.9K to
+  107.4K rows/sec.
 - A source-level Metal `__attribute__((noinline))` experiment on
   `computeRow<po2>` compiled and passed the focused default
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity
   test, but the single proof took 63.38s. That is not a viable replacement for
-  the scoped `-fno-inline-functions` compiler flag.
+  the scoped compiler-flag mitigation.
 - The same `-fno-inline-functions` full-Metal eval-check candidate passed
   `datasheet --max-po2 16 composite`: 658.9ms for 16K rows and 2.04s for 64K
   rows. This improves on the current safety-path baseline of 897.8ms and 4.56s,
@@ -403,11 +413,11 @@ than at stale C++ header bindings alone.
   mishandling the generated rv32im eval-check shape. Initial measurement shows
   the `-O0` full-Metal path is slower than the CPU-eval-check safety path.
 - Use `RISC0_RV32IM_METAL_APPEND_FLAGS` for targeted compiler-flag experiments.
-  The first strong candidate, `-fno-inline-functions`, is now applied only to
-  generated `eval_check_*.metal` files by default, and full Metal eval-check is
-  now the runtime default in this branch. Keep stressing this scoped default
-  with longer proof loops and larger real workloads before treating it as
-  upstream-production evidence.
+  The first strong candidate was `-fno-inline-functions`, but the current
+  narrower default is `-fno-inline` applied only to generated
+  `eval_check_*.metal` files. Full Metal eval-check is now the runtime default
+  in this branch. Keep stressing this scoped default with longer proof loops and
+  larger real workloads before treating it as upstream-production evidence.
 - Investigate a Zirgen/M3 code-shape fix for `eval_check` rather than treating
   Metal bindings alone as the root issue. Promising directions are reducing
   inlining/register pressure in `verifyCircuit`, avoiding the giant

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -164,6 +164,15 @@ Metal-focused validation on the M5 Max:
   runs; one filtered run averaged about 73MHz. The full `fib` benchmark suite is
   still not part of the default quick gate because each selected hotbench entry
   runs for roughly 10s plus setup.
+- `cargo bench -p risc0-zkvm --features prove,metal --bench fib
+  prove/poseidon2` now runs as a segment-only benchmark. On the current safety
+  path it completed one timed iteration in 28.31s, about 18.1K rows/sec. This is
+  intentionally recorded as the CPU-eval-check safety-path baseline, not a
+  full-Metal result.
+- `cargo run --release -p risc0-circuit-keccak --features prove --example
+  keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
+  Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
+  fallback baseline and not evidence of Metal Keccak coverage.
 - The `datasheet composite` harness had a sparse-`po2` bug: it used `.take(...)`
   over a table that intentionally omits too-small powers of two, so `--max-po2
   16` could still run `po2=17` and panic. The harness now filters by the actual
@@ -232,8 +241,11 @@ than at stale C++ header bindings alone.
   - small Metal-enabled `datasheet execute`, `composite`, `lift`, `join`, and
     `succinct`: present at `--max-po2 16`.
   - filtered `fib execute`: present.
-  - rv32im segment-only benchmark
-  - Keccak-heavy workload
+  - rv32im segment-only benchmark: present through filtered `fib
+    prove/poseidon2`; currently slow because the safety path keeps rv32im
+    eval-check on CPU.
+  - Keccak-heavy workload: CPU fallback baseline present; Metal Keccak remains
+    disabled.
 
 ### P1: Optimize Transparent Local Proving
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -652,6 +652,11 @@ Prompt-to-artifact checklist:
   and common Xcode selection inputs are build-script rerun signals. This reduces
   the chance that local or CI validation accidentally tests stale kernels after
   source, flag, or toolchain changes.
+- Exact Metal file-flag coverage: present. `risc0-build-kernel` now unit-tests
+  the per-file flag selection used by the
+  `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S` diagnostic, including the case
+  where `eval_check_20.metal` must not accidentally match
+  `eval_check_200.metal`.
 
 Remaining gaps before marking P0 complete:
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -257,6 +257,10 @@ Metal-focused validation on the M5 Max:
   RISC0_RV32IM_METAL_EVAL_CHECK=1`, the filtered `fib prove/poseidon2`
   benchmark completed in 15.94s, about 32.1K rows/sec. This is faster than both
   the CPU-eval-check safety path and the `-O0` diagnostic path.
+- The same `-fno-inline-functions` full-Metal eval-check candidate passed
+  `datasheet --max-po2 16 composite`: 658.9ms for 16K rows and 2.04s for 64K
+  rows. This improves on the current safety-path baseline of 897.8ms and 4.56s,
+  so the candidate is meaningful beyond the isolated `fib` segment benchmark.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -315,6 +315,17 @@ Metal-focused validation on the M5 Max:
   `RISC0_USE_DOCKER=1 cargo test -p risc0-zkvm --features prove,docker
   host::server::exec::tests::cpp_test -- --nocapture` rebuilt the guest Docker
   artifacts and executed the `blst` guest successfully.
+- The Metal build cache now hashes `KernelBuild::generated_files` contents in
+  addition to manifest/static files. This matters for rv32im because
+  `eval_check_*.metal`, `data_witgen_*.metal`, and `accum_witgen_*.metal` are
+  generated into `OUT_DIR`; without hashing those generated sources, local cache
+  reuse could hide a changed generated kernel and weaken Metal validation.
+  After this cache-key fix, the focused rv32im Metal eval-check regression
+  rebuilt through `risc0-build-kernel` and passed in 14.23s. Package-level
+  checks also pass, including the direct
+  `generated_files_are_part_of_kernel_source_hash` regression test:
+  `cargo test -p risc0-build-kernel` and
+  `cargo clippy -p risc0-build-kernel --all-targets -- -D warnings`.
 - The small Metal-enabled release datasheet matrix is now runnable with
   `--max-po2 16`. Refreshed under the current default scoped `-fno-inline`
   rv32im eval-check path:

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -15,24 +15,23 @@ MetalToolchain`; `xcrun --sdk macosx metal -v` reports Apple metal version
 ## Current Recommendation
 
 Use the M3 rv32im segment prover on Apple Silicon with Metal enabled by target
-selection, but keep the current rv32im eval-check safety fallback enabled. Do
-not force full Metal rv32im eval-check for production proofs yet.
+selection. On this branch, rv32im eval-check also uses Metal by default after
+compiling generated `eval_check_*.metal` files with `-fno-inline-functions`.
 
-The best current experimental full-Metal rv32im candidate is:
+Use this env var only to force the old CPU eval-check safety fallback:
 
-`RISC0_RV32IM_METAL_EVAL_CHECK=1`
+`RISC0_RV32IM_METAL_EVAL_CHECK=0`
 
-On this branch, generated `eval_check_*.metal` files are compiled with
-`-fno-inline-functions` by default while the other rv32im Metal kernels keep the
-normal optimization pipeline. Set `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1` when
-comparing against or reproducing the original fully optimized eval-check failure
-mode.
+The other rv32im Metal kernels keep the normal optimization pipeline. Set
+`RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1` when comparing against or reproducing
+the original fully optimized eval-check failure mode.
 
 On the M5 Max this passes the current serial rv32im suite with eval-check CPU
 verification, the non-serial rv32im harness, and 1M-row composite plus 64K-row
 succinct datasheet runs. It is much faster than the CPU-eval-check safety
-fallback on the filtered `fib prove/poseidon2` benchmark, but this still needs
-longer stress testing before full Metal eval-check becomes the runtime default.
+fallback on the filtered `fib prove/poseidon2` benchmark. This still needs
+broader cross-machine and cross-toolchain validation before treating it as
+upstream-production evidence.
 
 For the best local proving throughput, start with `ProverOpts::fast()` or
 `ProverOpts::composite()`. This produces a composite STARK receipt: fastest,
@@ -240,6 +239,17 @@ Metal-focused validation on the M5 Max:
   behind `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`: a focused inline `sltiu`
   loop passed 25/25, but the inline full rv32im prove suite failed in `sltiu`
   with a direct eval-check verifier mismatch at row 31840 col 0.
+- Full Metal eval-check is now the runtime default in this branch. The default
+  full rv32im prove suite passed 46/46 with one ignored Metal regression test,
+  and a default full-suite run with
+  `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` also passed 46/46. The old CPU
+  eval-check fallback remains available with `RISC0_RV32IM_METAL_EVAL_CHECK=0`;
+  a focused `sltiu` fallback sanity run passed with that env set.
+- Before flipping the runtime default, the scoped full-Metal path passed five
+  consecutive non-serial full-suite verifier runs with
+  `RISC0_RV32IM_METAL_EVAL_CHECK=1
+  RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`: each run passed 46/46, with the
+  ignored Metal regression test skipped unless `--ignored` is provided.
 - The branch also has an ignored focused regression test for the scoped
   eval-check mitigation:
   `RISC0_RV32IM_METAL_EVAL_CHECK=1
@@ -367,9 +377,9 @@ than at stale C++ header bindings alone.
   inlining/register pressure in `verifyCircuit`, avoiding the giant
   `EvalCheckReg<po2>` reinterpret-cast access pattern, or splitting the validity
   polynomial into smaller Metal functions/kernels.
-- Benchmark the default CPU eval-check safety path against full Metal eval-check
-  once full Metal is reliable enough to compare. The branch can force full Metal
-  eval-check with `RISC0_RV32IM_METAL_EVAL_CHECK=1`.
+- Keep benchmarking the default full-Metal eval-check path against the CPU
+  eval-check safety fallback. The branch can force the fallback with
+  `RISC0_RV32IM_METAL_EVAL_CHECK=0`.
 - Keep the ignored `metal_eval_check_sltiu_repeated` test as the focused
   regression command for the scoped eval-check mitigation. Broaden it only if a
   smaller deterministic repro is found for the original inline failure.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -273,6 +273,9 @@ Metal-focused validation on the M5 Max:
   - `cargo test -p risc0-zkvm --features prove
     host::server::prove::tests::continuation -- --nocapture` passed, proving a
     two-segment continuation session and checking segment indices.
+  - `cargo test -p risc0-zkvm --features prove
+    host::server::prove::tests::bigint_accel -- --nocapture` passed the BigInt
+    accelerator proof workload across 15 generated test cases.
 - Before flipping the runtime default, the scoped full-Metal path passed five
   consecutive non-serial full-suite verifier runs with
   `RISC0_RV32IM_METAL_EVAL_CHECK=1
@@ -544,9 +547,9 @@ Remaining gaps before marking P0 complete:
   code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
   slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
 - The default path has strong local smoke, benchmark, 10-pass verifier-loop,
-  SHA, continuation, and Keccak example coverage, including a 100KB Keccak input
-  proof, but not a broad product-style application workload beyond the current
-  datasheet/examples/zkVM tests.
+  SHA, continuation, BigInt, and Keccak example coverage, including a 100KB
+  Keccak input proof, but not a broad product-style application workload beyond
+  the current datasheet/examples/zkVM tests.
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -108,6 +108,25 @@ The practical optimization boundary is:
 For M3 rv32im, main already has a hand-integrated Metal HAL and generated
 per-`po2` kernels for `data_witgen`, `accum_witgen`, and `eval_check`.
 
+The RISC0 checkout pins Bazel `@zirgen` to
+`df6fb9dda1c20209058d6ee90a8912351b741081`, which is current
+`risc0/zirgen` `main` as of this investigation. So the external Zirgen pin is
+not stale. The checked-in rv32im M3 `eval_check` implementation is still from
+the M3 circuit integration lineage, though: it entered with `cbcc6f79e`
+(`Initial commit for rv32im-m3 circuit`, PR #3430), was moved into the merged
+rv32im crates by `ccc793fc9` (PR #3600), and has not had a substantive
+`eval_check` code-shape change since. The generic Zirgen Metal
+`eval_check.tmpl.metal` template dates back to the initial Zirgen import and is
+not the exact code path used by the rv32im M3 C++/Metal HAL.
+
+Historical RISC Zero issue #999 is relevant context: old Metal support was
+deprecated because `eval_check` codegen could exceed Apple temporary-register
+limits, and the issue explicitly pointed at needing more structured Zirgen
+output. The current M5 Max failure is different in symptom (`Poly check failed`
+rather than compile-time register exhaustion), but the successful `-O0`
+experiment makes generated eval-check code shape and Metal optimizer pressure a
+leading hypothesis.
+
 ## Validation Snapshot
 
 Metal-focused validation on the M5 Max:
@@ -177,6 +196,14 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_EVAL_CHECK=1`, the 20-run focused `sltiu` loop failed at
   row 5568 col 0 with `1869206222 vs 201529409`. This confirms the bug is in
   the Metal eval-check output itself, not only in later proof verification.
+- Compiling the rv32im Metal kernels with `-O0` is a strong diagnostic. With a
+  temporary hardcoded `-O0`, the focused direct verifier loop
+  (`RISC0_RV32IM_METAL_EVAL_CHECK=1
+  RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu`) passed
+  20/20, and the full serial rv32im prove suite passed 46/46 under forced Metal
+  eval-check plus CPU verification. The branch now exposes this as
+  `RISC0_RV32IM_METAL_KERNEL_O0=1` when rebuilding rv32im Metal kernels instead
+  of hardcoding it globally.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
@@ -247,6 +274,15 @@ than at stale C++ header bindings alone.
   full-Metal eval-check path.
 - Use `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` for lower-overhead direct
   eval-check mismatch localization before falling back to full DualHal runs.
+- Use `RISC0_RV32IM_METAL_KERNEL_O0=1` as the current strongest compiler/codegen
+  diagnostic. It should not become the default without performance measurement,
+  but it is the best available evidence that optimized Metal compilation is
+  mishandling the generated rv32im eval-check shape.
+- Investigate a Zirgen/M3 code-shape fix for `eval_check` rather than treating
+  Metal bindings alone as the root issue. Promising directions are reducing
+  inlining/register pressure in `verifyCircuit`, avoiding the giant
+  `EvalCheckReg<po2>` reinterpret-cast access pattern, or splitting the validity
+  polynomial into smaller Metal functions/kernels.
 - Benchmark the default CPU eval-check safety path against full Metal eval-check
   once full Metal is reliable enough to compare. The branch can force full Metal
   eval-check with `RISC0_RV32IM_METAL_EVAL_CHECK=1`.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -123,13 +123,15 @@ per-`po2` kernels for `data_witgen`, `accum_witgen`, and `eval_check`.
 The RISC0 checkout pins Bazel `@zirgen` to
 `df6fb9dda1c20209058d6ee90a8912351b741081`, which is current
 `risc0/zirgen` `main` as of this investigation. So the external Zirgen pin is
-not stale. The checked-in rv32im M3 `eval_check` implementation is still from
-the M3 circuit integration lineage, though: it entered with `cbcc6f79e`
-(`Initial commit for rv32im-m3 circuit`, PR #3430), was moved into the merged
-rv32im crates by `ccc793fc9` (PR #3600), and has not had a substantive
-`eval_check` code-shape change since. The generic Zirgen Metal
-`eval_check.tmpl.metal` template dates back to the initial Zirgen import and is
-not the exact code path used by the rv32im M3 C++/Metal HAL.
+not stale. The recent Zirgen `main` commits checked here are out-of-tree build
+support, V3/PoVW predicate work, and a CUDA `poly_mix` codegen change; they do
+not change the generic Metal `eval_check` template. The checked-in rv32im M3
+`eval_check` implementation is still from the M3 circuit integration lineage,
+though: it entered with `cbcc6f79e` (`Initial commit for rv32im-m3 circuit`, PR
+#3430), was moved into the merged rv32im crates by `ccc793fc9` (PR #3600), and
+has not had a substantive `eval_check` code-shape change since. The generic
+Zirgen Metal `eval_check.tmpl.metal` template dates back to the initial Zirgen
+import and is not the exact code path used by the rv32im M3 C++/Metal HAL.
 
 Historical RISC Zero issue #999 is relevant context: old Metal support was
 deprecated because `eval_check` codegen could exceed Apple temporary-register

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -465,6 +465,59 @@ than at stale C++ header bindings alone.
   - Keccak-heavy workload: CPU fallback baseline present; Metal Keccak remains
     disabled.
 
+### P0 Exit Audit
+
+Current status: not complete for upstream-production confidence, but the branch
+has a usable local M5 Max default path.
+
+Prompt-to-artifact checklist:
+
+- Branch and commits: present. Work is on `metal-p0-m5-validation` with focused
+  code and documentation commits.
+- Living progress document: present in this file. It records prover selection,
+  Keccak, Groth16/trusted setup, Zirgen, Metal bindings, validation results, and
+  remaining work.
+- M3 rv32im Metal eval-check default: present. `rv32im-sys` applies scoped
+  `-fno-inline` only to generated `eval_check_*.metal` files, and the Metal HAL
+  uses eval-check on Metal by default unless `RISC0_RV32IM_METAL_EVAL_CHECK=0`
+  is set.
+- Unsafe original repro path: present. `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`
+  removes the scoped noinline mitigation, and prior inline full-suite testing
+  reproduced a direct eval-check mismatch.
+- Direct correctness diagnostic: present.
+  `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` compares Metal eval-check output
+  against CPU eval-check output from the same inputs.
+- Focused regression: present as ignored test
+  `prove::tests::metal_eval_check_sltiu_repeated`.
+- Native and Docker guest C/C++ archiver fix: present. Both native
+  `cpp_test`/`--no-run` and Docker `RISC0_USE_DOCKER=1 ... cpp_test` passed.
+- Benchmark matrix: present for default segment proving, CPU eval-check
+  fallback, composite up to 1M rows, succinct at 64K rows, and Keccak CPU
+  fallback.
+- M5 Max and modern Apple toolchain context: present. Validation records Xcode
+  26.5 build `17F42`, Metal `32023.883`, and that no alternate Xcode is locally
+  installed.
+- Zirgen freshness check: present. The local RISC0 pin matches current
+  `risc0/zirgen` `main`; recent Zirgen work does not contain a Metal eval-check
+  fix for this path.
+- Metal binding check: present. Newer Metal-cpp headers did not fix correctness,
+  and the deprecated Rust `metal` crate is tracked as a separate maintenance
+  risk rather than the rv32im P0 root cause.
+
+Remaining gaps before marking P0 complete:
+
+- Cross-machine or cross-toolchain validation is still missing. This machine has
+  only Xcode 26.5, so the branch needs CI or another Apple Silicon host to
+  separate an M5 Max/Metal Toolchain sensitivity from a general Metal issue.
+- The mitigation is still a compiler-flag workaround, not a real Zirgen/M3
+  code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
+  slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
+- The default path has strong local smoke and benchmark coverage, but not a
+  long-duration stress run or broad application workload beyond the current
+  datasheet/hello-world/zkVM tests.
+- Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
+  but it is still a major gap for best local proving on Keccak-heavy workloads.
+
 ### P1: Optimize Transparent Local Proving
 
 - Treat `ProverOpts::composite()` as the throughput baseline.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -310,6 +310,11 @@ Metal-focused validation on the M5 Max:
   benchmark without any rv32im eval-check env flags passed with a 4.73s to 4.84s
   range, about 105.8K to 108.3K rows/sec. This is the best current default
   segment-proving measurement.
+- A source-level Metal `__attribute__((noinline))` experiment on
+  `computeRow<po2>` compiled and passed the focused default
+  `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity
+  test, but the single proof took 63.38s. That is not a viable replacement for
+  the scoped `-fno-inline-functions` compiler flag.
 - The same `-fno-inline-functions` full-Metal eval-check candidate passed
   `datasheet --max-po2 16 composite`: 658.9ms for 16K rows and 2.04s for 64K
   rows. This improves on the current safety-path baseline of 897.8ms and 4.56s,

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -583,6 +583,13 @@ Remaining gaps before marking P0 complete:
 Run this packet on any other Apple Silicon host or CI runner before treating the
 branch as more than M5 Max/Xcode 26.5 evidence.
 
+Existing GitHub workflow context: `.github/workflows/main.yml` already has
+`macOS`/`ARM64` jobs on `apple_m2_pro` runners for clippy, workspace tests,
+extra tests, and Bazel checks, and `.github/workflows/bench_pr.yml` has an
+Apple Silicon benchmark runner. Those jobs are useful cross-machine signal once
+the branch is pushed as a PR or manually dispatched, but they do not by
+themselves run the explicit eval-check CPU-verifier packet below.
+
 Environment capture:
 
 ```sh

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -385,6 +385,9 @@ Metal-focused validation on the M5 Max:
     receipts and receipt verification.
   - `cargo test --manifest-path examples/keccak/Cargo.toml --features prove
     hash_abc -- --nocapture` passed the public tiny-keccak accelerator example.
+  - `cargo test --manifest-path examples/keccak/Cargo.toml --features prove
+    hash_long -- --nocapture` passed the same public example with a 100KB input
+    in 72.79s.
 - The `datasheet composite` harness had a sparse-`po2` bug: it used `.take(...)`
   over a table that intentionally omits too-small powers of two, so `--max-po2
   16` could still run `po2=17` and panic. The harness now filters by the actual
@@ -531,8 +534,9 @@ Remaining gaps before marking P0 complete:
   code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
   slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
 - The default path has strong local smoke, benchmark, short repeat-loop, and
-  Keccak example coverage, but not a long-duration stress run or a broad
-  real-application workload beyond the current datasheet/examples/zkVM tests.
+  Keccak example coverage, including a 100KB input proof, but not a
+  long-duration stress run or a broad non-example application workload beyond
+  the current datasheet/examples/zkVM tests.
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -170,6 +170,13 @@ Metal-focused validation on the M5 Max:
   stabilize non-dual full Metal. The serial suite still failed with `Poly check
   failed` in `div`, `divu`, and `lh`, so command-buffer batching is unlikely to
   be the only root cause.
+- The branch now has a narrower opt-in eval-check verifier:
+  `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`. It runs the Metal eval-check
+  kernel, computes the same check buffer with `evalCheckCpu` from the same
+  pinned inputs, and reports the first mismatch. With
+  `RISC0_RV32IM_METAL_EVAL_CHECK=1`, the 20-run focused `sltiu` loop failed at
+  row 5568 col 0 with `1869206222 vs 201529409`. This confirms the bug is in
+  the Metal eval-check output itself, not only in later proof verification.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
@@ -238,6 +245,8 @@ than at stale C++ header bindings alone.
   CPU/Metal operation-level mismatch localization. Use it together with
   `RISC0_RV32IM_METAL_EVAL_CHECK=1` when specifically investigating the unsafe
   full-Metal eval-check path.
+- Use `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` for lower-overhead direct
+  eval-check mismatch localization before falling back to full DualHal runs.
 - Benchmark the default CPU eval-check safety path against full Metal eval-check
   once full Metal is reliable enough to compare. The branch can force full Metal
   eval-check with `RISC0_RV32IM_METAL_EVAL_CHECK=1`.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -302,7 +302,11 @@ Metal-focused validation on the M5 Max:
 - With scoped default no-inline on only generated `eval_check_*.metal` files and
   `RISC0_RV32IM_METAL_EVAL_CHECK=1`, the same filtered `fib prove/poseidon2`
   benchmark completed in 4.89s to 6.16s, about 83.1K to 104.8K rows/sec. This
-  is the best current segment-proving measurement.
+  is the best pre-default-flip segment-proving measurement.
+- After flipping full Metal eval-check on by default, the same filtered
+  benchmark without any rv32im eval-check env flags passed with a 4.73s to 4.84s
+  range, about 105.8K to 108.3K rows/sec. This is the best current default
+  segment-proving measurement.
 - The same `-fno-inline-functions` full-Metal eval-check candidate passed
   `datasheet --max-po2 16 composite`: 658.9ms for 16K rows and 2.04s for 64K
   rows. This improves on the current safety-path baseline of 897.8ms and 4.56s,
@@ -323,9 +327,18 @@ Metal-focused validation on the M5 Max:
   rows, 783.8ms for 64K rows, 1.29s for 128K rows, 2.48s for 256K rows, 4.85s
   for 512K rows, and 9.68s for 1M rows. The 1M-row case reached about 105.7K
   rows/sec.
+- After flipping full Metal eval-check on by default, the same
+  `datasheet --max-po2 20 composite` run passed without any rv32im eval-check
+  env flags and reached 286.9ms for 16K rows, 727.3ms for 64K rows, 1.36s for
+  128K rows, 2.46s for 256K rows, 4.93s for 512K rows, and 9.84s for 1M rows.
+  The 1M-row case reached about 104.1K rows/sec.
 - With the scoped eval-check-only no-inline default, `datasheet --max-po2 18
   succinct` passed: 1.47s for the 64K-row succinct case, about 43.5K rows/sec,
   with about 930MB max RAM and a 217.4KB seal.
+- After flipping full Metal eval-check on by default, the same
+  `datasheet --max-po2 18 succinct` run passed without any rv32im eval-check env
+  flags: 1.49s for the 64K-row succinct case, about 43K rows/sec, with about
+  930MB max RAM and a 217.4KB seal.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
@@ -415,13 +428,13 @@ than at stale C++ header bindings alone.
   - warm `hello-world` proof: present, but too small to distinguish safe
     CPU-eval-check and forced full-Metal eval-check.
   - small Metal-enabled `datasheet execute`, `composite`, `lift`, `join`, and
-    `succinct`: present at `--max-po2 16`; the `-fno-inline-functions`
-    full-Metal candidate also has scoped-default `succinct` coverage at
-    `--max-po2 18` and scoped-default `composite` coverage at `--max-po2 20`.
+    `succinct`: present at `--max-po2 16`; the default full-Metal eval-check
+    path also has `succinct` coverage at `--max-po2 18` and `composite`
+    coverage at `--max-po2 20`.
   - filtered `fib execute`: present.
   - rv32im segment-only benchmark: present through filtered `fib
-    prove/poseidon2`; currently slow because the safety path keeps rv32im
-    eval-check on CPU.
+    prove/poseidon2`; the default full-Metal eval-check path is now the best
+    measured segment-proving configuration on this branch.
   - Keccak-heavy workload: CPU fallback baseline present; Metal Keccak remains
     disabled.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -18,6 +18,16 @@ Use the M3 rv32im segment prover on Apple Silicon with Metal enabled by target
 selection, but keep the current rv32im eval-check safety fallback enabled. Do
 not force full Metal rv32im eval-check for production proofs yet.
 
+The best current experimental full-Metal rv32im candidate is:
+
+`RISC0_RV32IM_METAL_APPEND_FLAGS=-fno-inline-functions
+RISC0_RV32IM_METAL_EVAL_CHECK=1`
+
+On the M5 Max this passes the current serial rv32im suite with eval-check CPU
+verification and is faster than the CPU-eval-check safety fallback on the
+filtered `fib prove/poseidon2` benchmark. The non-serial test harness also
+passes, but this still needs longer stress testing before becoming the default.
+
 For the best local proving throughput, start with `ProverOpts::fast()` or
 `ProverOpts::composite()`. This produces a composite STARK receipt: fastest,
 transparent, no trusted setup, but proof size grows with segment count.
@@ -208,6 +218,13 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`. This strongly implicates
   optimized Metal compilation or optimization-sensitive generated eval-check
   code shape, but it is not a performance fix.
+- `RISC0_RV32IM_METAL_APPEND_FLAGS=-fno-inline-functions` is a narrower and
+  much better mitigation candidate than `-O0`. With full Metal eval-check forced
+  and CPU verification enabled, the focused `sltiu` loop passed 20/20 and the
+  full serial rv32im prove suite passed 46/46. The same filtered suite also
+  passed 46/46 without `--test-threads=1`. This points at inlining pressure in
+  the generated `verifyCircuit` / eval-check path as the most actionable current
+  hypothesis.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
@@ -236,6 +253,10 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_KERNEL_O0=1 RISC0_RV32IM_METAL_EVAL_CHECK=1` completed in
   48.05s, about 10.7K rows/sec. This is slower than the CPU-eval-check safety
   path, so `-O0` should remain diagnostic only.
+- With `RISC0_RV32IM_METAL_APPEND_FLAGS=-fno-inline-functions
+  RISC0_RV32IM_METAL_EVAL_CHECK=1`, the filtered `fib prove/poseidon2`
+  benchmark completed in 15.94s, about 32.1K rows/sec. This is faster than both
+  the CPU-eval-check safety path and the `-O0` diagnostic path.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
@@ -287,6 +308,11 @@ than at stale C++ header bindings alone.
   but it is the best available evidence that optimized Metal compilation is
   mishandling the generated rv32im eval-check shape. Initial measurement shows
   the `-O0` full-Metal path is slower than the CPU-eval-check safety path.
+- Use `RISC0_RV32IM_METAL_APPEND_FLAGS` for targeted compiler-flag experiments.
+  The first strong candidate is `-fno-inline-functions`, which preserves full
+  optimization otherwise and currently outperforms the CPU eval-check fallback.
+  Stress it with parallel tests, longer proof loops, and larger segment
+  benchmarks before promoting it to a default rv32im Metal flag.
 - Investigate a Zirgen/M3 code-shape fix for `eval_check` rather than treating
   Metal bindings alone as the root issue. Promising directions are reducing
   inlining/register pressure in `verifyCircuit`, avoiding the giant

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -11,6 +11,8 @@ Current Apple toolchain used for Metal validation: Xcode 26.5 build `17F42`
 with Metal Toolchain `17F42` installed via `xcodebuild -downloadComponent
 MetalToolchain`; `xcrun --sdk macosx metal -v` reports Apple metal version
 `32023.883`.
+Only `/Applications/Xcode.app` is installed locally, so comparing against an
+older Apple Metal Toolchain requires CI or a second machine.
 
 ## Current Recommendation
 
@@ -447,6 +449,8 @@ than at stale C++ header bindings alone.
 - Compare `.metallib` output and runtime behavior across Apple Metal Toolchain
   versions if possible. A CI Apple Silicon runner passing with a different Xcode
   or Metal Toolchain would be a strong signal that this is toolchain-sensitive.
+  This machine only has Xcode 26.5 build `17F42` installed, so this comparison
+  is not locally actionable without installing another Xcode or using CI.
 - Establish a stable benchmark matrix:
   - warm `hello-world` proof: present, but too small to distinguish safe
     CPU-eval-check and forced full-Metal eval-check.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -248,9 +248,9 @@ Metal-focused validation on the M5 Max:
   scoped `-fno-inline`, the focused `sltiu` eval-check verifier passed and the
   full rv32im prove suite with `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`
   passed 46/46 with one ignored regression test.
-- The narrowed `-fno-inline` default also passed a three-run full-suite stress
-  loop with `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`; each run passed 46/46
-  with the ignored Metal regression test skipped.
+- The narrowed `-fno-inline` default also passed a 10-run full-suite stress loop
+  with `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`; each run passed 46/46 with
+  the ignored Metal regression test skipped.
 - Full Metal eval-check is now the runtime default in this branch. The default
   full rv32im prove suite passed 46/46 with one ignored Metal regression test,
   and a default full-suite run with
@@ -533,10 +533,10 @@ Remaining gaps before marking P0 complete:
 - The mitigation is still a compiler-flag workaround, not a real Zirgen/M3
   code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
   slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
-- The default path has strong local smoke, benchmark, short repeat-loop, and
-  Keccak example coverage, including a 100KB input proof, but not a
-  long-duration stress run or a broad non-example application workload beyond
-  the current datasheet/examples/zkVM tests.
+- The default path has strong local smoke, benchmark, 10-pass verifier-loop, and
+  Keccak example coverage, including a 100KB input proof, but not a broad
+  non-example application workload beyond the current datasheet/examples/zkVM
+  tests.
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -335,6 +335,10 @@ Metal-focused validation on the M5 Max:
     --nocapture` passed a product-style protocol workload: init, five
     pre-freeze ballot submissions, freeze, one post-freeze submission, and
     receipt verification for all seven receipts.
+  - `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14,20 cargo test
+    --manifest-path examples/voting-machine/Cargo.toml --features
+    prove,risc0-zkvm/metal protocol --release -- --nocapture` passed the same
+    protocol workload in 3.28s without the direct CPU verifier.
 - Before flipping the runtime default, the scoped full-Metal path passed five
   consecutive non-serial full-suite verifier runs with
   `RISC0_RV32IM_METAL_EVAL_CHECK=1
@@ -447,9 +451,11 @@ Metal-focused validation on the M5 Max:
   prove suite passed 46/46 with one ignored test in 8.18s. Filtered
   `fib prove/poseidon2` passed in 2.37s to 2.56s, about 200.3K to 215.6K
   rows/sec. `examples/keccak` `hash_long` also passed with
-  `--features prove,risc0-zkvm/metal` in 44.37s. This is faster than the broad
-  default, but it still needs broader workload and cross-machine validation
-  before replacing the safer `eval_check_*.metal` default mitigation.
+  `--features prove,risc0-zkvm/metal` in 44.37s. The voting-machine protocol
+  workload passed with the same exact set and Metal feature in 3.28s. This is
+  faster than the broad default, but it still needs broader workload and
+  cross-machine validation before replacing the safer `eval_check_*.metal`
+  default mitigation.
 - A source-level Metal `__attribute__((noinline))` experiment on
   `computeRow<po2>` compiled and passed the focused default
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -115,17 +115,30 @@ Metal-focused validation on the M5 Max:
 - After installing the Xcode 26.5 Metal Toolchain and forcing the rv32im Metal
   kernels to rebuild, serial rv32im Metal tests are not reliable:
   `cargo test -p risc0-circuit-rv32im --features prove prove::tests --release
-  -- --nocapture --test-threads=1` failed with `Poly check failed` in
-  `prove::tests::addi`, `prove::tests::divu`, and `prove::tests::rem`.
-  Earlier failures also appeared in different tests such as `lh`, `lbu`, and
-  `sub`. Treat rv32im Metal as correctness-suspect on this machine/toolchain.
+  -- --nocapture --test-threads=1` failed with `Poly check failed`. The failing
+  test moves between runs; observed failures include `addi`, `divu`, `rem`,
+  `lh`, `lbu`, `lw`, `or`, and `sub`. Treat rv32im Metal as
+  correctness-suspect on this machine/toolchain.
+- The existing C++ `DualHal` CPU+Metal checker narrows the first divergent
+  rv32im operation to `evalCheck`: with
+  `RISC0_RV32IM_METAL_COMPARE_CPU=1 RISC0_RV32IM_METAL_EVAL_CHECK=1`, a serial
+  suite run failed in `beq` with `DualHal matrix verify mismatch after
+  evalCheck`.
+- Bypassing only the Metal `eval_check_metal_*` kernels restores correctness.
+  The branch now keeps the rest of the Metal HAL active but computes the rv32im
+  validity polynomial on CPU by default:
+  `cargo test -p risc0-circuit-rv32im --features prove prove::tests --release
+  -- --nocapture --test-threads=1` passed 46 tests, and the default parallel
+  run passed 46 tests. Set
+  `RISC0_RV32IM_METAL_EVAL_CHECK=1` to force the full Metal eval-check kernel
+  for diagnosis and benchmarking; the same serial suite failed in that mode
+  with `jalr`, `mulhsu`, and `or` hitting `Poly check failed`.
 - `cargo test -p risc0-zkp --features prove hal::metal --release -- --nocapture`
   passed: 19 tests, including after the Xcode 26.5 Metal Toolchain install.
 - `cargo test -p risc0-circuit-recursion --features prove prove::hal::metal::tests::eval_check --release -- --ignored --nocapture`
   passed: 1 test, including after the Xcode 26.5 Metal Toolchain install.
 - `examples/target/release/hello-world` with `RISC0_PROVER=local` completed a
-  proof in about 0.6s warm and links `Metal.framework` before the full toolchain
-  rebuild. This should be rerun after the rv32im correctness issue is isolated.
+  proof in about 0.9s warm with the default CPU eval-check safety path.
 - Eager `newComputePipelineState` over every function in the rv32im `.metallib`
   can stall badly with this toolchain when it compiles unused kernels such as
   higher-`po2` `eval_check` variants. Lazy pipeline creation avoids that startup
@@ -163,7 +176,16 @@ than at stale C++ header bindings alone.
 
 - Reproduce and isolate the serial rv32im `Poly check failed` failure with the
   Xcode 26.5 Metal Toolchain. This is now a correctness issue, not just a
-  parallel-test flake.
+  parallel-test flake. Current evidence points specifically at the generated
+  `eval_check_metal_*` kernels or the Metal compiler/runtime handling of the
+  generated `EvalCheckReg<po2>` access pattern.
+- Keep the `RISC0_RV32IM_METAL_COMPARE_CPU=1` dual-HAL diagnostic available for
+  CPU/Metal operation-level mismatch localization. Use it together with
+  `RISC0_RV32IM_METAL_EVAL_CHECK=1` when specifically investigating the unsafe
+  full-Metal eval-check path.
+- Benchmark the default CPU eval-check safety path against full Metal eval-check
+  once full Metal is reliable enough to compare. The branch can force full Metal
+  eval-check with `RISC0_RV32IM_METAL_EVAL_CHECK=1`.
 - Add a deterministic Metal rv32im regression command or mark the test harness
   serial if the Metal runtime cannot safely run these tests concurrently.
 - Fix the `risc0-zkvm-methods-cpp-crates` `blst_*` guest link failure so the
@@ -219,7 +241,10 @@ itself dramatically faster without deeper kernel/layout changes.
 - Is the rv32im parallel failure a Metal HAL command-buffer/resource lifetime
   issue, a generated-kernel/toolchain issue, a `gpu_guard` coverage issue, or a
   test harness artifact? The current serial failures make a pure parallelism
-  explanation unlikely.
+  explanation unlikely, and dual-HAL evidence currently points at `evalCheck`.
+- Is the generated `EvalCheckReg<po2>` pointer/array pattern miscompiled by the
+  Xcode 26.5 Metal Toolchain, or is the generated Metal eval-check code relying
+  on undefined behavior that older toolchains happened to tolerate?
 - Which Apple Metal Toolchain versions pass or fail rv32im Metal on Apple
   Silicon, and what does the CI runner use?
 - Which real target workload should represent "best local prover" for M5 Max:

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -245,6 +245,16 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` also passed 46/46. The old CPU
   eval-check fallback remains available with `RISC0_RV32IM_METAL_EVAL_CHECK=0`;
   a focused `sltiu` fallback sanity run passed with that env set.
+- Higher-level zkVM validation also passes with the default full-Metal
+  eval-check path:
+  - `cargo test -p risc0-zkvm --features prove
+    host::server::exec::tests::cpp_test -- --nocapture` passed.
+  - `RISC0_PROVER=local cargo test --manifest-path examples/Cargo.toml -p
+    hello-world --features prove test_hello_world -- --nocapture` passed and
+    produced a local proof for the hello-world multiply example.
+  - `cargo test -p risc0-zkvm --features prove
+    host::server::prove::tests::basic -- --nocapture` passed, producing a
+    succinct receipt for the `DoNothing` multi-test guest.
 - Before flipping the runtime default, the scoped full-Metal path passed five
   consecutive non-serial full-suite verifier runs with
   `RISC0_RV32IM_METAL_EVAL_CHECK=1

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -535,6 +535,59 @@ Remaining gaps before marking P0 complete:
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 
+### Cross-Machine Validation Packet
+
+Run this packet on any other Apple Silicon host or CI runner before treating the
+branch as more than M5 Max/Xcode 26.5 evidence.
+
+Environment capture:
+
+```sh
+git rev-parse --short HEAD
+git branch --show-current
+xcode-select -p
+xcodebuild -version
+xcrun --sdk macosx metal -v
+uname -a
+sysctl -n machdep.cpu.brand_string
+```
+
+Correctness gates:
+
+```sh
+cargo fmt --check
+cargo test -p risc0-circuit-rv32im --features prove prove::tests --release -- --nocapture
+RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
+  cargo test -p risc0-circuit-rv32im --features prove prove::tests --release -- --nocapture
+RISC0_RV32IM_METAL_EVAL_CHECK=1 RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
+  cargo test -p risc0-circuit-rv32im --features prove \
+    prove::tests::metal_eval_check_sltiu_repeated --release -- --ignored --nocapture --test-threads=1
+cargo test -p risc0-zkvm --features prove host::server::prove::tests::basic -- --nocapture
+cargo test -p risc0-zkvm --features prove host::server::prove::tests::keccak::basic -- --nocapture
+cargo test --manifest-path examples/keccak/Cargo.toml --features prove hash_abc -- --nocapture
+```
+
+Benchmark gates:
+
+```sh
+cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2
+cargo run --release -p risc0-zkvm --features prove,metal --example datasheet -- --max-po2 20 composite
+cargo run --release -p risc0-zkvm --features prove,metal --example datasheet -- --max-po2 18 succinct
+RISC0_RV32IM_METAL_EVAL_CHECK=0 \
+  cargo bench -p risc0-zkvm --features prove,metal --bench fib prove/poseidon2
+```
+
+Failure triage:
+
+```sh
+RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1 \
+  RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
+  cargo test -p risc0-circuit-rv32im --features prove prove::tests::sltiu --release -- --nocapture --test-threads=1
+RISC0_RV32IM_METAL_KERNEL_O0=1 \
+  RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 \
+  cargo test -p risc0-circuit-rv32im --features prove prove::tests::sltiu --release -- --nocapture --test-threads=1
+```
+
 ### P1: Optimize Transparent Local Proving
 
 - Treat `ProverOpts::composite()` as the throughput baseline.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -166,6 +166,10 @@ Metal-focused validation on the M5 Max:
   Metal dispatch also did not stabilize non-dual full Metal. The serial suite
   still failed with `Poly check failed` in `bltu`, so this is not just a missing
   post-dispatch readback.
+- Forcing a command-buffer sync after every Metal dispatch also did not
+  stabilize non-dual full Metal. The serial suite still failed with `Poly check
+  failed` in `div`, `divu`, and `lh`, so command-buffer batching is unlikely to
+  be the only root cause.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -304,12 +304,13 @@ Metal-focused validation on the M5 Max:
   host::server::exec::tests::cpp_test -- --nocapture` rebuilt the guest Docker
   artifacts and executed the `blst` guest successfully.
 - The small Metal-enabled release datasheet matrix is now runnable with
-  `--max-po2 16`:
-  - `execute`: 28.8ms for 2.7M instructions.
-  - `composite`: 897.8ms for 16K rows, 4.56s for 64K rows.
-  - `lift`: 731.5ms for 256K recursion rows.
-  - `join`: 923.6ms for 256K recursion rows.
-  - `succinct`: 4.09s for 64K rows.
+  `--max-po2 16`. Refreshed under the current default scoped `-fno-inline`
+  rv32im eval-check path:
+  - `execute`: 29.5ms for 2.7M instructions.
+  - `composite`: 288.4ms for 16K rows, 726.6ms for 64K rows.
+  - `lift`: 728.9ms for 256K recursion rows.
+  - `join`: 920.2ms for 256K recursion rows.
+  - `succinct`: 1.48s for 64K rows.
 - `cargo bench -p risc0-zkvm --features prove,metal --bench fib execute` now
   runs; one filtered run averaged about 73MHz. The full `fib` benchmark suite is
   still not part of the default quick gate because each selected hotbench entry

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -693,7 +693,12 @@ Prompt-to-artifact checklist:
   the per-file flag selection used by the
   `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S` diagnostic, including the case
   where `eval_check_20.metal` must not accidentally match
-  `eval_check_200.metal`.
+  `eval_check_200.metal`. The rv32im build script also rejects empty exact lists
+  and `po2` values outside the generated `12..=23` range so typoed exact-set
+  diagnostics do not silently compile unprotected kernels. This was checked with
+  a valid `13,14,20` `cargo check -p risc0-circuit-rv32im-sys --features prove`,
+  an invalid `200` value that failed with the range error, and an empty value
+  that failed with the non-empty-list error.
 - Metal P0 workflow coverage: present but awaiting fork approval. The workflow
   now triggers for `risc0/build_kernel/**`, runs `risc0-build-kernel` unit tests,
   and can run exact `13,14,20` candidate benchmarks/workloads during manual

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -278,7 +278,8 @@ Metal-focused validation on the M5 Max:
   RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 cargo test -p
   risc0-circuit-rv32im --features prove
   prove::tests::metal_eval_check_sltiu_repeated --release -- --ignored
-  --nocapture --test-threads=1`.
+  --nocapture --test-threads=1`. After narrowing the scoped compiler flag to
+  `-fno-inline`, this ignored regression passed 20 `sltiu` proofs in 14.55s.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -130,16 +130,23 @@ per-`po2` kernels for `data_witgen`, `accum_witgen`, and `eval_check`.
 
 The RISC0 checkout pins Bazel `@zirgen` to
 `df6fb9dda1c20209058d6ee90a8912351b741081`, which is current
-`risc0/zirgen` `main` as of this investigation. So the external Zirgen pin is
-not stale. The recent Zirgen `main` commits checked here are out-of-tree build
-support, V3/PoVW predicate work, and a CUDA `poly_mix` codegen change; they do
-not change the generic Metal `eval_check` template. The checked-in rv32im M3
-`eval_check` implementation is still from the M3 circuit integration lineage,
-though: it entered with `cbcc6f79e` (`Initial commit for rv32im-m3 circuit`, PR
-#3430), was moved into the merged rv32im crates by `ccc793fc9` (PR #3600), and
-has not had a substantive `eval_check` code-shape change since. The generic
-Zirgen Metal `eval_check.tmpl.metal` template dates back to the initial Zirgen
-import and is not the exact code path used by the rv32im M3 C++/Metal HAL.
+`risc0/zirgen` `main` as of 2026-05-16. So the external Zirgen pin is not
+stale: the recently merged Zirgen PR #319 (`ZIR-387: Fix for building circuits
+from out-of-tree`) is exactly this pinned commit. The recent Zirgen `main`
+commits checked here are out-of-tree build support, V3/PoVW predicate work, and
+a CUDA `poly_mix` codegen change; they do not change the generic Metal
+`eval_check` template.
+
+The checked-in rv32im M3 `eval_check` implementation is still from the RISC0 M3
+circuit integration lineage, though: it entered with `cbcc6f79e` (`Initial
+commit for rv32im-m3 circuit`, RISC0 PR #3430), was moved into the merged rv32im
+crates by `ccc793fc9` (RISC0 PR #3600), and has not had a substantive
+`eval_check` code-shape change since. This path is not a direct expansion of
+Zirgen's generic `zirgen/compiler/codegen/gpu/eval_check.tmpl.metal.h`; the
+generic template still uses a `poly_fp` helper, while the rv32im M3 Metal kernel
+wraps checked-in `computeRow<po2>` / `verifyCircuit` code. The generic Zirgen
+Metal `eval_check` template itself dates back to the initial Zirgen import and
+was only wrapped into a static C++ template by Zirgen PR #258.
 
 Historical RISC Zero issue #999 is relevant context: old Metal support was
 deprecated because `eval_check` codegen could exceed Apple temporary-register

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -20,8 +20,12 @@ not force full Metal rv32im eval-check for production proofs yet.
 
 The best current experimental full-Metal rv32im candidate is:
 
-`RISC0_RV32IM_METAL_APPEND_FLAGS=-fno-inline-functions
-RISC0_RV32IM_METAL_EVAL_CHECK=1`
+`RISC0_RV32IM_METAL_EVAL_CHECK=1`
+
+On this branch, generated `eval_check_*.metal` files are compiled with
+`-fno-inline-functions` by default while the other rv32im Metal kernels keep the
+normal optimization pipeline. Set `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1` when
+reproducing the original fully optimized eval-check failure mode.
 
 On the M5 Max this passes the current serial rv32im suite with eval-check CPU
 verification, the non-serial rv32im harness, and small-to-medium composite and
@@ -221,13 +225,18 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`. This strongly implicates
   optimized Metal compilation or optimization-sensitive generated eval-check
   code shape, but it is not a performance fix.
-- `RISC0_RV32IM_METAL_APPEND_FLAGS=-fno-inline-functions` is a narrower and
-  much better mitigation candidate than `-O0`. With full Metal eval-check forced
-  and CPU verification enabled, the focused `sltiu` loop passed 20/20 and the
-  full serial rv32im prove suite passed 46/46. The same filtered suite also
-  passed 46/46 without `--test-threads=1`. This points at inlining pressure in
-  the generated `verifyCircuit` / eval-check path as the most actionable current
-  hypothesis.
+- `-fno-inline-functions` is a narrower and much better mitigation candidate
+  than `-O0`. With full Metal eval-check forced and CPU verification enabled,
+  the focused `sltiu` loop passed 20/20 and the full serial rv32im prove suite
+  passed 46/46 when the flag was appended globally with
+  `RISC0_RV32IM_METAL_APPEND_FLAGS`. The same filtered suite also passed 46/46
+  without `--test-threads=1`. This points at inlining pressure in the generated
+  `verifyCircuit` / eval-check path as the most actionable current hypothesis.
+- The branch now applies `-fno-inline-functions` only to generated
+  `eval_check_*.metal` files by default. With no global append flags, forced
+  Metal eval-check plus CPU verification passed the focused `sltiu` loop 20/20
+  and the full rv32im prove suite 46/46. This preserves the original repro path
+  behind `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
@@ -270,6 +279,10 @@ Metal-focused validation on the M5 Max:
 - The same candidate passed `datasheet --max-po2 18 succinct`: 2.57s for the
   64K-row succinct case, about 24.9K rows/sec, with about 930MB max RAM and a
   217.4KB seal.
+- A larger `datasheet --max-po2 20 composite` run passed with forced full Metal
+  eval-check: 767ms for 16K rows, 2.52s for 64K rows, 4.52s for 128K rows,
+  8.57s for 256K rows, 16.88s for 512K rows, and 37.47s for 1M rows. The 1M-row
+  case reached about 27.3K rows/sec.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
@@ -322,10 +335,10 @@ than at stale C++ header bindings alone.
   mishandling the generated rv32im eval-check shape. Initial measurement shows
   the `-O0` full-Metal path is slower than the CPU-eval-check safety path.
 - Use `RISC0_RV32IM_METAL_APPEND_FLAGS` for targeted compiler-flag experiments.
-  The first strong candidate is `-fno-inline-functions`, which preserves full
-  optimization otherwise and currently outperforms the CPU eval-check fallback.
-  Stress it with parallel tests, longer proof loops, and larger segment
-  benchmarks before promoting it to a default rv32im Metal flag.
+  The first strong candidate, `-fno-inline-functions`, is now applied only to
+  generated `eval_check_*.metal` files by default. Keep stressing this scoped
+  default with longer proof loops and larger real workloads before making full
+  Metal eval-check the runtime default.
 - Investigate a Zirgen/M3 code-shape fix for `eval_check` rather than treating
   Metal bindings alone as the root issue. Promising directions are reducing
   inlining/register pressure in `verifyCircuit`, avoiding the giant
@@ -358,8 +371,8 @@ than at stale C++ header bindings alone.
     CPU-eval-check and forced full-Metal eval-check.
   - small Metal-enabled `datasheet execute`, `composite`, `lift`, `join`, and
     `succinct`: present at `--max-po2 16`; the `-fno-inline-functions`
-    full-Metal candidate also has `composite` and `succinct` coverage at
-    `--max-po2 18`.
+    full-Metal candidate also has `succinct` coverage at `--max-po2 18` and
+    `composite` coverage at `--max-po2 20`.
   - filtered `fib execute`: present.
   - rv32im segment-only benchmark: present through filtered `fib
     prove/poseidon2`; currently slow because the safety path keeps rv32im

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -428,6 +428,14 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14,20` passed that Keccak
   long-input workload. Because verifier overhead dominates these timings, use
   this result for correctness localization, not performance comparison.
+- The same exact `13,14,20` set without the direct CPU verifier is a promising
+  future narrowing candidate, but not the default yet. The full serial rv32im
+  prove suite passed 46/46 with one ignored test in 8.18s. Filtered
+  `fib prove/poseidon2` passed in 2.37s to 2.56s, about 200.3K to 215.6K
+  rows/sec. `examples/keccak` `hash_long` also passed with
+  `--features prove,risc0-zkvm/metal` in 44.37s. This is faster than the broad
+  default, but it still needs broader workload and cross-machine validation
+  before replacing the safer `eval_check_*.metal` default mitigation.
 - A source-level Metal `__attribute__((noinline))` experiment on
   `computeRow<po2>` compiled and passed the focused default
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity
@@ -497,6 +505,10 @@ Metal-focused validation on the M5 Max:
   - `cargo test --manifest-path examples/keccak/Cargo.toml --features prove
     hash_long -- --nocapture` passed the same public example with a 100KB input
     in 72.79s.
+  - `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14,20 cargo test
+    --manifest-path examples/keccak/Cargo.toml --features
+    prove,risc0-zkvm/metal hash_long --release -- --nocapture` passed the same
+    100KB input in 44.37s.
 - The `datasheet composite` harness had a sparse-`po2` bug: it used `.take(...)`
   over a table that intentionally omits too-small powers of two, so `--max-po2
   16` could still run `po2=17` and panic. The harness now filters by the actual
@@ -634,8 +646,9 @@ Prompt-to-artifact checklist:
 - Native and Docker guest C/C++ archiver fix: present. Both native
   `cpp_test`/`--no-run` and Docker `RISC0_USE_DOCKER=1 ... cpp_test` passed.
 - Benchmark matrix: present for default segment proving, CPU eval-check
-  fallback, composite up to 1M rows, succinct at 64K rows, Keccak CPU fallback,
-  and Keccak syscall/assumption proof coverage.
+  fallback, exact `13,14,20` rv32im suite and segment proving, composite up to 1M
+  rows, succinct at 64K rows, Keccak CPU fallback, and Keccak syscall/assumption
+  proof coverage.
 - Product-style workload: present. The voting-machine protocol example passed
   under the default Metal path with eval-check CPU verification enabled.
 - M5 Max and modern Apple toolchain context: present. Validation records Xcode

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -694,6 +694,10 @@ Prompt-to-artifact checklist:
   `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S` diagnostic, including the case
   where `eval_check_20.metal` must not accidentally match
   `eval_check_200.metal`.
+- Metal P0 workflow coverage: present but awaiting fork approval. The workflow
+  now triggers for `risc0/build_kernel/**`, runs `risc0-build-kernel` unit tests,
+  and can run exact `13,14,20` candidate benchmarks/workloads during manual
+  dispatches with `run_benchmarks=true`.
 
 Remaining gaps before marking P0 complete:
 
@@ -726,8 +730,13 @@ themselves run the explicit eval-check CPU-verifier packet below.
 This branch adds `.github/workflows/metal_p0_validation.yml` on the existing
 `apple_m2_pro` runner labels. It has a constrained `pull_request` trigger for
 Metal-relevant paths plus a manual `workflow_dispatch` trigger, runs the focused
-correctness packet and the voting-machine product-style proof workload, and has
-optional longer benchmark gates for manual runs. P0 is still not complete until
+correctness packet, runs `risc0-build-kernel` unit tests for the Metal cache and
+per-file flag-selection helpers, runs the voting-machine product-style proof
+workload, and has optional longer benchmark gates for manual runs. The path
+filter includes `risc0/build_kernel/**` because stale or incorrectly selected
+Metal `.metallib` artifacts can invalidate this investigation. The optional
+manual benchmark packet also includes the exact `13,14,20` candidate segment,
+Keccak long-input, and voting-machine workloads. P0 is still not complete until
 this or an equivalent packet actually passes on another Apple Silicon
 machine/toolchain.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -294,6 +294,10 @@ Metal-focused validation on the M5 Max:
   path it completed one timed iteration in 28.31s, about 18.1K rows/sec. This is
   intentionally recorded as the CPU-eval-check safety-path baseline, not a
   full-Metal result.
+- Re-running the same benchmark after the runtime default flip with
+  `RISC0_RV32IM_METAL_EVAL_CHECK=0` confirmed the old CPU eval-check fallback is
+  still much slower than the default full-Metal path: 30.68s, about 16.7K
+  rows/sec.
 - The same filtered `fib prove/poseidon2` benchmark with
   `RISC0_RV32IM_METAL_KERNEL_O0=1 RISC0_RV32IM_METAL_EVAL_CHECK=1` completed in
   48.05s, about 10.7K rows/sec. This is slower than the CPU-eval-check safety

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -334,6 +334,11 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity
   test, but the single proof took 63.38s. That is not a viable replacement for
   the scoped compiler-flag mitigation.
+- Apple Metal accepts LLVM inline-threshold flags such as
+  `-mllvm -inline-threshold=10`. With the scoped default noinline mitigation
+  disabled, that threshold passed the same focused direct verifier test, but the
+  single proof took 115.90s. That is also not a viable replacement for scoped
+  `-fno-inline`.
 - The same `-fno-inline-functions` full-Metal eval-check candidate passed
   `datasheet --max-po2 16 composite`: 658.9ms for 16K rows and 2.04s for 64K
   rows. This improves on the current safety-path baseline of 897.8ms and 4.56s,

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -123,7 +123,14 @@ Metal-focused validation on the M5 Max:
   rv32im operation to `evalCheck`: with
   `RISC0_RV32IM_METAL_COMPARE_CPU=1 RISC0_RV32IM_METAL_EVAL_CHECK=1`, a serial
   suite run failed in `beq` with `DualHal matrix verify mismatch after
-  evalCheck`.
+  evalCheck`. A later serial run failed in `sltiu` after `evalCheck` at row
+  8288 col 0. Running only `prove::tests::sltiu` can also fail after
+  `evalCheck`, but not every run; one observed loop failed after 19 repeats.
+  Use this as the current compact repro shape:
+  `for i in {1..20}; do RISC0_RV32IM_METAL_COMPARE_CPU=1
+  RISC0_RV32IM_METAL_EVAL_CHECK=1 cargo test -p risc0-circuit-rv32im --features
+  prove prove::tests::sltiu --release -- --nocapture --test-threads=1 || exit
+  $?; done`.
 - Bypassing only the Metal `eval_check_metal_*` kernels restores correctness.
   The branch now keeps the rest of the Metal HAL active but computes the rv32im
   validity polynomial on CPU by default:
@@ -145,6 +152,10 @@ Metal-focused validation on the M5 Max:
   can stall badly with this toolchain when it compiles unused kernels such as
   higher-`po2` `eval_check` variants. Lazy pipeline creation avoids that startup
   problem, but it does not fix the `Poly check failed` correctness failure.
+- Adding missing `device`-qualified compound assignment overloads for Metal
+  `Fp` / `FpExt` was tested as a compiler-sensitivity hypothesis. It rebuilt and
+  initially passed focused `sltiu`, but the 20-run loop still failed after
+  `evalCheck`, so that change was not kept.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -1,0 +1,230 @@
+# Metal Optimization Progress
+
+This document tracks work toward the best local Apple Silicon proving setup.
+The primary target is an untrusted local prover in the normal cryptographic
+sense: the verifier does not trust the prover. When we say "no trusted setup"
+below, we mean staying in the STARK receipt path and not depending on Groth16.
+
+Current checkout: `upstream/main` at `35ed22a1ba1c0025b990befd0c9d7ec4f39f3840`.
+Local machine used for validation: Apple M5 Max.
+Current Apple toolchain used for Metal validation: Xcode 26.5 build `17F42`
+with Metal Toolchain `17F42` installed via `xcodebuild -downloadComponent
+MetalToolchain`; `xcrun --sdk macosx metal -v` reports Apple metal version
+`32023.883`.
+
+## Current Recommendation
+
+Use the M3 rv32im segment prover on Apple Silicon with Metal enabled by target
+selection.
+
+For the best local proving throughput, start with `ProverOpts::fast()` or
+`ProverOpts::composite()`. This produces a composite STARK receipt: fastest,
+transparent, no trusted setup, but proof size grows with segment count.
+
+For the best untrusted constant-size local receipt, use `ProverOpts::succinct()`.
+This keeps the proof in the STARK/recursion path and avoids Groth16 trusted
+setup, but it pays the recursion cost for `lift`, `join`, and `resolve`.
+
+Do not use `ProverOpts::groth16()` for the primary "no trusted setup" goal.
+Groth16 receipts are useful for very small proofs and on-chain verification, but
+they depend on the STARK-to-SNARK trusted setup and are currently documented as
+unsupported on Apple Silicon.
+
+## Prover Selection Path
+
+The public/default local prover path is:
+
+1. `default_prover()` / `get_prover_server(opts)`.
+2. If dev mode is disabled, `get_prover_server` constructs `ProverImpl`.
+3. `ProverImpl::prove_with_ctx` executes the ELF into a `Session`.
+4. `ProverImpl::prove_session` proves each segment with `prove_segment`.
+5. `prove_segment` calls `segment_preflight`, then `prove_preflight`.
+6. `prove_preflight` calls `risc0_circuit_rv32im::prove::segment_prover(po2)`.
+7. On macOS/aarch64, `segment_prover` selects `ProverContext::new_metal(po2)`.
+
+The M3 choice is also baked into execution. `ExecutorImpl::circuit_version()`
+returns `RV32IM_M3_CIRCUIT_VERSION`, and the rv32im circuit defines that version
+as `3`. So the "M3 engine" is not a separate receipt kind; it is the current
+rv32im segment proving circuit used underneath composite/succinct/Groth16.
+
+Receipt kind controls what happens after segment proofs:
+
+- `Composite`: stop after segment receipts and assumption receipts are assembled.
+- `Succinct`: run recursion programs (`lift`, `join`, `resolve`) to compress the
+  composite receipt into a constant-size STARK receipt.
+- `Groth16`: run `identity_p254`, then `risc0_groth16::prove::shrink_wrap`.
+
+## Keccak Path
+
+Keccak is a special accelerator circuit, not ordinary rv32im guest execution.
+Guest code can request Keccak work through the Keccak syscall path. The host then
+builds a `ProveKeccakRequest` and the prover resolves it as an assumption.
+
+The local host path is:
+
+1. `ProverImpl::prove_session` iterates over `session.pending_keccaks`.
+2. Each request calls `prove_keccak`.
+3. `prove_keccak` calls `risc0_circuit_keccak::prove::keccak_prover()`.
+4. The Keccak seal is verified and then lifted with `prove_zkr` into a succinct
+   receipt over an `Unknown` claim.
+5. Keccak receipts are inserted into a union tree and later resolved against the
+   main session receipt.
+
+Current Metal status: Keccak has CUDA and CPU prover branches, but the Metal
+branch is still commented out. On Apple Silicon, Keccak proving falls back to the
+CPU circuit path today. This is a clear gap for workloads that use the Keccak
+precompile heavily.
+
+## Groth16 / Trusted Setup
+
+Groth16 is the final STARK-to-SNARK wrapping stage. It produces the smallest
+receipt and is the usual route for Ethereum-style verification, but it is not a
+transparent proving path.
+
+The project docs describe a trusted setup ceremony for the Groth16 prover and
+verifier. The security model page also notes that the STARK-to-SNARK translator
+uses Groth16 over BN254, so it depends on elliptic curve cryptography and the
+setup ceremony assumptions.
+
+For this optimization track, Groth16 is useful context but not the main target.
+The main target is:
+
+1. Fast local composite STARK proving on M3 + Metal.
+2. Stable local succinct STARK proving on M3 + Metal recursion.
+3. Optional Groth16 only after the transparent/STARK local path is solid.
+
+## Zirgen Role
+
+Zirgen is the circuit DSL/code generator. In the current codebase, it matters for
+Metal because generated circuit kernels include Metal variants for recursion
+work such as `eval_check`, `step_compute_accum`, and `step_verify_accum`.
+
+The practical optimization boundary is:
+
+- RISC Zero decides when a prover uses CPU, CUDA, or Metal.
+- Zirgen decides what generated circuit code exists for those targets.
+- `risc0-build-kernel` compiles Metal source into `.metallib` artifacts.
+
+For M3 rv32im, main already has a hand-integrated Metal HAL and generated
+per-`po2` kernels for `data_witgen`, `accum_witgen`, and `eval_check`.
+
+## Validation Snapshot
+
+Metal-focused validation on the M5 Max:
+
+- After installing the Xcode 26.5 Metal Toolchain and forcing the rv32im Metal
+  kernels to rebuild, serial rv32im Metal tests are not reliable:
+  `cargo test -p risc0-circuit-rv32im --features prove prove::tests --release
+  -- --nocapture --test-threads=1` failed with `Poly check failed` in
+  `prove::tests::addi`, `prove::tests::divu`, and `prove::tests::rem`.
+  Earlier failures also appeared in different tests such as `lh`, `lbu`, and
+  `sub`. Treat rv32im Metal as correctness-suspect on this machine/toolchain.
+- `cargo test -p risc0-zkp --features prove hal::metal --release -- --nocapture`
+  passed: 19 tests, including after the Xcode 26.5 Metal Toolchain install.
+- `cargo test -p risc0-circuit-recursion --features prove prove::hal::metal::tests::eval_check --release -- --ignored --nocapture`
+  passed: 1 test, including after the Xcode 26.5 Metal Toolchain install.
+- `examples/target/release/hello-world` with `RISC0_PROVER=local` completed a
+  proof in about 0.6s warm and links `Metal.framework` before the full toolchain
+  rebuild. This should be rerun after the rv32im correctness issue is isolated.
+- Eager `newComputePipelineState` over every function in the rv32im `.metallib`
+  can stall badly with this toolchain when it compiles unused kernels such as
+  higher-`po2` `eval_check` variants. Lazy pipeline creation avoids that startup
+  problem, but it does not fix the `Poly check failed` correctness failure.
+- Broad zkVM tests and documented `datasheet` / `fib` benchmarks are currently
+  blocked by a guest `risc0-zkvm-methods-cpp-crates` link failure with undefined
+  `blst_*` symbols. This is not a Metal runtime failure, but it blocks the
+  benchmark harness.
+
+## Metal Binding Status
+
+There are two separate Metal binding stacks in the current tree:
+
+- `rv32im-sys` uses C++ through Apple's `metal-cpp` headers. The pinned bundle is
+  `metal-cpp_macOS13.3_iOS16.4.zip`.
+- `risc0-zkp` and `risc0-circuit-recursion` use the Rust `metal` crate from the
+  workspace dependency `metal = "0.29"`.
+
+The Rust `metal` crate is deprecated upstream because it depends on the older
+`objc` ecosystem. That is a real maintenance risk for the Rust ZKP and recursion
+Metal HALs, but it is not the direct rv32im P0 correctness path. The rv32im
+failure reproduces in the C++ Metal-cpp HAL.
+
+Apple's Metal-cpp download page currently publishes `metal-cpp_26.4.zip` as the
+latest observed bundle; a guessed `metal-cpp_26.5.zip` URL did not return a ZIP.
+A trial local bump to `metal-cpp_26.4.zip` was not sufficient to make rv32im
+Metal reliable, and reverting to the older pinned bundle did not restore serial
+rv32im correctness after rebuilding kernels with the Xcode 26.5 Metal Toolchain.
+This points more strongly at generated Metal kernel/compiler/runtime behavior
+than at stale C++ header bindings alone.
+
+## Work Plan
+
+### P0: Make The Current M3 Metal Path Trustworthy
+
+- Reproduce and isolate the serial rv32im `Poly check failed` failure with the
+  Xcode 26.5 Metal Toolchain. This is now a correctness issue, not just a
+  parallel-test flake.
+- Add a deterministic Metal rv32im regression command or mark the test harness
+  serial if the Metal runtime cannot safely run these tests concurrently.
+- Fix the `risc0-zkvm-methods-cpp-crates` `blst_*` guest link failure so the
+  zkVM test and benchmark harness can run.
+- Check whether the pinned Metal-cpp header bundle is stale in a way that
+  affects current Apple Silicon proving. `rv32im-sys` currently downloads
+  `metal-cpp_macOS13.3_iOS16.4.zip`; Apple now publishes newer bundles such as
+  `metal-cpp_26.4.zip`, whose README mentions bugfixing and other improvements.
+  A first trial suggests this is not the root cause. Keep the check open only as
+  a binding-health task, not as the leading correctness hypothesis.
+- Compare `.metallib` output and runtime behavior across Apple Metal Toolchain
+  versions if possible. A CI Apple Silicon runner passing with a different Xcode
+  or Metal Toolchain would be a strong signal that this is toolchain-sensitive.
+- Establish a stable benchmark matrix:
+  - warm `hello-world` proof
+  - rv32im segment-only benchmark
+  - `datasheet execute`, `composite`, `lift`, `join`, `succinct`
+  - Keccak-heavy workload
+
+### P1: Optimize Transparent Local Proving
+
+- Treat `ProverOpts::composite()` as the throughput baseline.
+- Treat `ProverOpts::succinct()` as the constant-size STARK target.
+- Profile M3 Metal segment proving for:
+  - preflight time
+  - GPU kernel time
+  - command buffer and pipeline overhead
+  - memory traffic and shared buffer behavior
+- Profile recursion Metal separately; its witness generation currently still
+  uses CPU witgen in the Metal circuit HAL.
+
+### P2: Fill Metal Coverage Gaps
+
+- Implement or restore Keccak Metal proving.
+- Decide whether recursion CPU witgen is acceptable or should become a Metal
+  target.
+- Plan a Rust Metal HAL binding migration from the deprecated `metal` crate to
+  `objc2-metal`, `objc2-foundation`, or a narrow local ObjC shim. This should be
+  done behind an adapter layer and validated with the existing `risc0-zkp` and
+  recursion Metal tests before touching rv32im.
+- Keep Groth16 out of the primary path unless the product need is on-chain proof
+  size rather than transparent local proving.
+
+### P3: Evaluate Metal 4 Selectively
+
+Metal 4 should be treated as a follow-up optimization, not the first milestone.
+Likely useful areas are command submission, pipeline caching, compilation APIs,
+and argument-table style binding. It is unlikely to make the field arithmetic
+itself dramatically faster without deeper kernel/layout changes.
+
+## Open Questions
+
+- Is the rv32im parallel failure a Metal HAL command-buffer/resource lifetime
+  issue, a generated-kernel/toolchain issue, a `gpu_guard` coverage issue, or a
+  test harness artifact? The current serial failures make a pure parallelism
+  explanation unlikely.
+- Which Apple Metal Toolchain versions pass or fail rv32im Metal on Apple
+  Silicon, and what does the CI runner use?
+- Which real target workload should represent "best local prover" for M5 Max:
+  single segment, multi-segment, Keccak-heavy, or recursion-heavy?
+- Is `Succinct` required for the local workflow, or is `Composite` acceptable as
+  the main artifact when proof size is not the bottleneck?
+- Do we need Apple Silicon Groth16 at all, or is transparent STARK proving the
+  actual target?

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -138,7 +138,9 @@ Metal-focused validation on the M5 Max:
 - `cargo test -p risc0-circuit-recursion --features prove prove::hal::metal::tests::eval_check --release -- --ignored --nocapture`
   passed: 1 test, including after the Xcode 26.5 Metal Toolchain install.
 - `examples/target/release/hello-world` with `RISC0_PROVER=local` completed a
-  proof in about 0.9s warm with the default CPU eval-check safety path.
+  proof in about 0.5s warm with the default CPU eval-check safety path. A
+  forced full-Metal eval-check run of the same binary was also about 0.5s, so
+  this tiny example is not a useful performance discriminator.
 - Eager `newComputePipelineState` over every function in the rv32im `.metallib`
   can stall badly with this toolchain when it compiles unused kernels such as
   higher-`po2` `eval_check` variants. Lazy pipeline creation avoids that startup

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -598,6 +598,11 @@ optional longer benchmark gates for manual runs. P0 is still not complete until
 this or an equivalent packet actually passes on another Apple Silicon
 machine/toolchain.
 
+Draft PR `risc0/risc0#3756` opens this branch against upstream `main` to obtain
+that CI signal. GitHub creates `Metal P0 Validation` runs for the PR, but the
+fork PR currently reports `action_required`, so a maintainer must approve
+Actions before the Apple Silicon runner executes it.
+
 Environment capture:
 
 ```sh

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -590,6 +590,14 @@ Apple Silicon benchmark runner. Those jobs are useful cross-machine signal once
 the branch is pushed as a PR or manually dispatched, but they do not by
 themselves run the explicit eval-check CPU-verifier packet below.
 
+This branch adds `.github/workflows/metal_p0_validation.yml` on the existing
+`apple_m2_pro` runner labels. It has a constrained `pull_request` trigger for
+Metal-relevant paths plus a manual `workflow_dispatch` trigger, runs the focused
+correctness packet and the voting-machine product-style proof workload, and has
+optional longer benchmark gates for manual runs. P0 is still not complete until
+this or an equivalent packet actually passes on another Apple Silicon
+machine/toolchain.
+
 Environment capture:
 
 ```sh

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -148,6 +148,20 @@ wraps checked-in `computeRow<po2>` / `verifyCircuit` code. The generic Zirgen
 Metal `eval_check` template itself dates back to the initial Zirgen import and
 was only wrapped into a static C++ template by Zirgen PR #258.
 
+Source-shape audit: the generated `eval_check_{po2}.metal` files are tiny
+wrappers around `hal/metal/kernels/eval_check_impl.h`, which launches one Metal
+thread per row and calls `computeRow<NUM_ROWS_PO2>`. The heavy code is
+`rv32im/circuit/eval_check.h`: `EvalCheckReg<po2>` defines `Fp data[numRows]`,
+`computeRow` casts row-offset `Fp*` pointers to that huge register type, and
+then `verifyCircuit` expands the checked-in rv32im validity polynomial against
+those pseudo-registers. For `po2=20`, `numRows` is `1 << 22`, so this is an
+optimization-hostile device-memory access shape even though each logical
+register getter returns `data[0]` relative to a row-shifted base. This makes a
+generator/code-shape fix more plausible than a Metal-cpp binding fix: the next
+real fix should reduce the size or inlining pressure of the validity-polynomial
+expansion, not merely move the same giant template call behind a different
+wrapper.
+
 Historical RISC Zero issue #999 is relevant context: old Metal support was
 deprecated because `eval_check` codegen could exceed Apple temporary-register
 limits, and the issue explicitly pointed at needing more structured Zirgen
@@ -657,6 +671,10 @@ Prompt-to-artifact checklist:
 - Zirgen freshness check: present. The local RISC0 pin matches current
   `risc0/zirgen` `main`; recent Zirgen work does not contain a Metal eval-check
   fix for this path.
+- rv32im M3 source-shape audit: present. The current Metal `eval_check` path is a
+  thin generated wrapper around the checked-in `EvalCheckReg<po2>` /
+  `verifyCircuit` template expansion, which is still the leading code-shape risk
+  for the Metal optimizer.
 - Metal binding check: present. Newer Metal-cpp headers did not fix correctness,
   and the deprecated Rust `metal` crate is tracked as a separate maintenance
   risk rather than the rv32im P0 root cause.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -370,6 +370,15 @@ Metal-focused validation on the M5 Max:
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
   fallback baseline and not evidence of Metal Keccak coverage.
+- Higher-level Keccak syscall/assumption proving also passes on the current
+  default M3 + Metal rv32im path, while the Keccak accelerator proof itself
+  still uses the CPU Keccak circuit path:
+  - `cargo test -p risc0-zkvm --features prove
+    host::server::prove::tests::keccak::basic -- --nocapture` passed both
+    built-in `po2=16` and `po2=17` cases, including non-empty assumption
+    receipts and receipt verification.
+  - `cargo test --manifest-path examples/keccak/Cargo.toml --features prove
+    hash_abc -- --nocapture` passed the public tiny-keccak accelerator example.
 - The `datasheet composite` harness had a sparse-`po2` bug: it used `.take(...)`
   over a table that intentionally omits too-small powers of two, so `--max-po2
   16` could still run `po2=17` and panic. The harness now filters by the actual
@@ -465,8 +474,8 @@ than at stale C++ header bindings alone.
   - rv32im segment-only benchmark: present through filtered `fib
     prove/poseidon2`; the default full-Metal eval-check path is now the best
     measured segment-proving configuration on this branch.
-  - Keccak-heavy workload: CPU fallback baseline present; Metal Keccak remains
-    disabled.
+  - Keccak-heavy workload: CPU fallback baseline and higher-level syscall proof
+    coverage present; Metal Keccak remains disabled.
 
 ### P0 Exit Audit
 
@@ -495,8 +504,8 @@ Prompt-to-artifact checklist:
 - Native and Docker guest C/C++ archiver fix: present. Both native
   `cpp_test`/`--no-run` and Docker `RISC0_USE_DOCKER=1 ... cpp_test` passed.
 - Benchmark matrix: present for default segment proving, CPU eval-check
-  fallback, composite up to 1M rows, succinct at 64K rows, and Keccak CPU
-  fallback.
+  fallback, composite up to 1M rows, succinct at 64K rows, Keccak CPU fallback,
+  and Keccak syscall/assumption proof coverage.
 - M5 Max and modern Apple toolchain context: present. Validation records Xcode
   26.5 build `17F42`, Metal `32023.883`, and that no alternate Xcode is locally
   installed.
@@ -515,9 +524,9 @@ Remaining gaps before marking P0 complete:
 - The mitigation is still a compiler-flag workaround, not a real Zirgen/M3
   code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
   slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
-- The default path has strong local smoke, benchmark, and short repeat-loop
-  coverage, but not a long-duration stress run or broad application workload
-  beyond the current datasheet/hello-world/zkVM tests.
+- The default path has strong local smoke, benchmark, short repeat-loop, and
+  Keccak example coverage, but not a long-duration stress run or a broad
+  real-application workload beyond the current datasheet/examples/zkVM tests.
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -240,6 +240,13 @@ Metal-focused validation on the M5 Max:
   behind `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`: a focused inline `sltiu`
   loop passed 25/25, but the inline full rv32im prove suite failed in `sltiu`
   with a direct eval-check verifier mismatch at row 31840 col 0.
+- The branch also has an ignored focused regression test for the scoped
+  eval-check mitigation:
+  `RISC0_RV32IM_METAL_EVAL_CHECK=1
+  RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 cargo test -p
+  risc0-circuit-rv32im --features prove
+  prove::tests::metal_eval_check_sltiu_repeated --release -- --ignored
+  --nocapture --test-threads=1`.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
@@ -363,8 +370,9 @@ than at stale C++ header bindings alone.
 - Benchmark the default CPU eval-check safety path against full Metal eval-check
   once full Metal is reliable enough to compare. The branch can force full Metal
   eval-check with `RISC0_RV32IM_METAL_EVAL_CHECK=1`.
-- Add a deterministic Metal rv32im regression command or mark the test harness
-  serial if the Metal runtime cannot safely run these tests concurrently.
+- Keep the ignored `metal_eval_check_sltiu_repeated` test as the focused
+  regression command for the scoped eval-check mitigation. Broaden it only if a
+  smaller deterministic repro is found for the original inline failure.
 - Keep the `risc0-zkvm-methods-cpp-crates` `blst_*` guest link fix covered in
   both native and Docker guest builds. The current fix sets
   `AR_riscv32im_risc0_zkvm_elf` beside the RISC-V guest compiler.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -178,8 +178,13 @@ Metal-focused validation on the M5 Max:
   RISC0_RV32IM_METAL_EVAL_CHECK=1
   RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` 20-iteration `sltiu` loop passed
   20/20. The current compact current-head repro is the serial full prove suite
-  with the same unsafe inline env; it failed in `xori` with `Metal evalCheck CPU
-  verify mismatch at row 6720 col 0, 1336042307 vs 806756744`.
+  with the same unsafe inline env. After adding `po2` to the mismatch
+  diagnostic, it failed in `rem` with `Metal evalCheck CPU verify mismatch at
+  po2 13 row 24576 col 0, 1808158766 vs 1376630858`.
+  The same unsafe-inline env plus direct CPU verifier did not fail the filtered
+  `fib prove/poseidon2` benchmark probe, which completed in 35.93s at about
+  14.2K rows/sec. That benchmark is therefore not a compact correctness canary
+  for the optimized-inline failure, especially with verifier overhead enabled.
 - Bypassing only the Metal `eval_check_metal_*` kernels restores correctness.
   The branch now keeps the rest of the Metal HAL active but computes the rv32im
   validity polynomial on CPU by default:
@@ -381,6 +386,13 @@ Metal-focused validation on the M5 Max:
 - After narrowing the scoped eval-check flag to `-fno-inline`, the default
   no-env benchmark stayed in the same range: 4.77s to 4.93s, about 103.9K to
   107.4K rows/sec.
+- The unsafe-inline diagnostic path is not a reliable benchmark canary. With
+  `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1
+  RISC0_RV32IM_METAL_EVAL_CHECK=1
+  RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`, filtered `fib prove/poseidon2`
+  completed without a mismatch in 35.93s, about 14.2K rows/sec. The CPU verifier
+  makes this number diagnostic-only, but the pass is still useful evidence that
+  the serial rv32im test suite remains the compact repro for the inline bug.
 - A source-level Metal `__attribute__((noinline))` experiment on
   `computeRow<po2>` compiled and passed the focused default
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity
@@ -571,7 +583,8 @@ Prompt-to-artifact checklist:
   is set.
 - Unsafe original repro path: present. `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`
   removes the scoped noinline mitigation, and current-head inline full-suite
-  testing reproduced a direct eval-check mismatch in `xori` at row 6720 col 0.
+  testing reproduced a direct eval-check mismatch in `eval_check_metal_13`
+  during `rem` at row 24576 col 0.
 - Direct correctness diagnostic: present.
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` compares Metal eval-check output
   against CPU eval-check output from the same inputs.

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -88,10 +88,12 @@ The local host path is:
 5. Keccak receipts are inserted into a union tree and later resolved against the
    main session receipt.
 
-Current Metal status: Keccak has CUDA and CPU prover branches, but the Metal
-branch is still commented out. On Apple Silicon, Keccak proving falls back to the
-CPU circuit path today. This is a clear gap for workloads that use the Keccak
-precompile heavily.
+Current Metal status: Keccak has CUDA and CPU prover branches, but no working
+Metal branch. The selector still has a commented-out Metal arm, but this is not
+just a stale selector gate: `risc0-circuit-keccak` has no `metal` feature or
+Metal HAL module, and `risc0-circuit-keccak-sys` only builds C++ CPU and CUDA
+kernels/FFI. On Apple Silicon, Keccak proving falls back to the CPU circuit path
+today. This is a clear gap for workloads that use the Keccak precompile heavily.
 
 ## Groth16 / Trusted Setup
 
@@ -402,8 +404,9 @@ Metal-focused validation on the M5 Max:
   930MB max RAM and a 217.4KB seal.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
-  Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
-  fallback baseline and not evidence of Metal Keccak coverage.
+  Keccak Metal is still absent in `risc0-circuit-keccak` and
+  `risc0-circuit-keccak-sys`, so this is a CPU fallback baseline and not
+  evidence of Metal Keccak coverage.
 - Higher-level Keccak syscall/assumption proving also passes on the current
   default M3 + Metal rv32im path, while the Keccak accelerator proof itself
   still uses the CPU Keccak circuit path:
@@ -640,7 +643,10 @@ RISC0_RV32IM_METAL_KERNEL_O0=1 \
 
 ### P2: Fill Metal Coverage Gaps
 
-- Implement or restore Keccak Metal proving.
+- Implement Keccak Metal proving. This needs generated Metal kernels and FFI in
+  `risc0-circuit-keccak-sys`, a Rust Metal circuit HAL in
+  `risc0-circuit-keccak`, and a real `metal` feature/selector path; the current
+  commented selector arm is not enough by itself.
 - Decide whether recursion CPU witgen is acceptable or should become a Metal
   target.
 - Plan a Rust Metal HAL binding migration from the deprecated `metal` crate to

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -162,6 +162,10 @@ Metal-focused validation on the M5 Max:
   threadgroup/compiler scheduling pressure. But the non-dual full-Metal serial
   suite still failed with `Poly check failed` in `remu` and `srai`, so the
   one-threadgroup change is not a correctness fix and was not kept.
+- Adding an immediate opt-in CPU readback of the eval-check output after the
+  Metal dispatch also did not stabilize non-dual full Metal. The serial suite
+  still failed with `Poly check failed` in `bltu`, so this is not just a missing
+  post-dispatch readback.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -335,6 +335,10 @@ Metal-focused validation on the M5 Max:
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity
   test, but the single proof took 63.38s. That is not a viable replacement for
   the scoped compiler-flag mitigation.
+- A narrower source-level noinline experiment on only the `verifyCircuit`
+  template also passed the focused direct verifier test with the scoped default
+  noinline mitigation disabled, but the single proof still took 61.00s. That is
+  not a viable replacement either.
 - Apple Metal accepts LLVM inline-threshold flags such as
   `-mllvm -inline-threshold=10`. With the scoped default noinline mitigation
   disabled, that threshold passed the same focused direct verifier test, but the

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -248,6 +248,9 @@ Metal-focused validation on the M5 Max:
   scoped `-fno-inline`, the focused `sltiu` eval-check verifier passed and the
   full rv32im prove suite with `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`
   passed 46/46 with one ignored regression test.
+- The narrowed `-fno-inline` default also passed a three-run full-suite stress
+  loop with `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`; each run passed 46/46
+  with the ignored Metal regression test skipped.
 - Full Metal eval-check is now the runtime default in this branch. The default
   full rv32im prove suite passed 46/46 with one ignored Metal regression test,
   and a default full-suite run with
@@ -512,9 +515,9 @@ Remaining gaps before marking P0 complete:
 - The mitigation is still a compiler-flag workaround, not a real Zirgen/M3
   code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
   slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
-- The default path has strong local smoke and benchmark coverage, but not a
-  long-duration stress run or broad application workload beyond the current
-  datasheet/hello-world/zkVM tests.
+- The default path has strong local smoke, benchmark, and short repeat-loop
+  coverage, but not a long-duration stress run or broad application workload
+  beyond the current datasheet/hello-world/zkVM tests.
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -274,7 +274,10 @@ Metal-focused validation on the M5 Max:
   Setting the target-specific RISC-V archiver fixes the build. Validation:
   `cargo test -p risc0-zkvm --features prove --no-run` now succeeds, and
   `cargo test -p risc0-zkvm --features prove host::server::exec::tests::cpp_test
-  -- --nocapture` passes.
+  -- --nocapture` passes. Docker guest-build validation also passes:
+  `RISC0_USE_DOCKER=1 cargo test -p risc0-zkvm --features prove,docker
+  host::server::exec::tests::cpp_test -- --nocapture` rebuilt the guest Docker
+  artifacts and executed the `blst` guest successfully.
 - The small Metal-enabled release datasheet matrix is now runnable with
   `--max-po2 16`:
   - `execute`: 28.8ms for 2.7M instructions.
@@ -409,7 +412,8 @@ than at stale C++ header bindings alone.
   smaller deterministic repro is found for the original inline failure.
 - Keep the `risc0-zkvm-methods-cpp-crates` `blst_*` guest link fix covered in
   both native and Docker guest builds. The current fix sets
-  `AR_riscv32im_risc0_zkvm_elf` beside the RISC-V guest compiler.
+  `AR_riscv32im_risc0_zkvm_elf` beside the RISC-V guest compiler, and the
+  focused Docker `cpp_test` path now passes.
 - Check whether the pinned Metal-cpp header bundle is stale in a way that
   affects current Apple Silicon proving. `rv32im-sys` currently downloads
   `metal-cpp_macOS13.3_iOS16.4.zip`; Apple now publishes newer bundles such as

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -156,6 +156,12 @@ Metal-focused validation on the M5 Max:
   `Fp` / `FpExt` was tested as a compiler-sensitivity hypothesis. It rebuilt and
   initially passed focused `sltiu`, but the 20-run loop still failed after
   `evalCheck`, so that change was not kept.
+- Forcing `eval_check_metal_*` to dispatch one thread per threadgroup is also
+  only a partial diagnostic. With that local experiment, the 20-run `sltiu`
+  dual-HAL loop and full serial dual-HAL rv32im suite passed, which points at
+  threadgroup/compiler scheduling pressure. But the non-dual full-Metal serial
+  suite still failed with `Poly check failed` in `remu` and `srai`, so the
+  one-threadgroup change is not a correctness fix and was not kept.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -357,6 +357,12 @@ Metal-focused validation on the M5 Max:
   template also passed the focused direct verifier test with the scoped default
   noinline mitigation disabled, but the single proof still took 61.00s. That is
   not a viable replacement either.
+- An even narrower source-level Metal `__attribute__((noinline))` experiment on
+  only `EvalCheckReg<po2>::get()` also passed the focused 20-proof
+  `metal_eval_check_sltiu_repeated` regression with the scoped compiler flag
+  disabled, but it took 83.70s versus 14.55s for the current scoped `-fno-inline`
+  default. That confirms the row-load wrapper is in the sensitive area, but it
+  is still not a viable replacement.
 - Apple Metal accepts LLVM inline-threshold flags such as
   `-mllvm -inline-threshold=10`. With the scoped default noinline mitigation
   disabled, that threshold passed the same focused direct verifier test, but the

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -327,10 +327,18 @@ Metal-focused validation on the M5 Max:
   `eval_check_*.metal`, `data_witgen_*.metal`, and `accum_witgen_*.metal` are
   generated into `OUT_DIR`; without hashing those generated sources, local cache
   reuse could hide a changed generated kernel and weaken Metal validation.
-  After this cache-key fix, the focused rv32im Metal eval-check regression
-  rebuilt through `risc0-build-kernel` and passed in 14.23s. Package-level
+  The Metal cache key also includes the resolved `xcrun` `metal`/`metallib`
+  paths and version banners, so installing or switching Apple Metal Toolchains
+  does not silently reuse a `.metallib` compiled by a different compiler/linker.
+  Cargo rerun signals now also cover `DEVELOPER_DIR`, `SDKROOT`, and the macOS
+  `/var/db/xcode_select_link` symlink when present, so common Xcode switches
+  should rerun the build script before the cache lookup.
+  After these cache-key and rerun-signal fixes, the focused rv32im Metal
+  eval-check regression rebuilt through `risc0-build-kernel` and passed again in
+  14.09s. Package-level
   checks also pass, including the direct
-  `generated_files_are_part_of_kernel_source_hash` regression test:
+  `generated_files_are_part_of_kernel_source_hash` and cache-tag regression
+  tests:
   `cargo test -p risc0-build-kernel` and
   `cargo clippy -p risc0-build-kernel --all-targets -- -D warnings`.
 - The small Metal-enabled release datasheet matrix is now runnable with
@@ -525,7 +533,12 @@ than at stale C++ header bindings alone.
   versions if possible. A CI Apple Silicon runner passing with a different Xcode
   or Metal Toolchain would be a strong signal that this is toolchain-sensitive.
   This machine only has Xcode 26.5 build `17F42` installed, so this comparison
-  is not locally actionable without installing another Xcode or using CI.
+  is not locally actionable without installing another Xcode or using CI. The
+  build cache now keys `.metallib` artifacts by the resolved `metal`/`metallib`
+  tool paths and version banners, so future cross-toolchain runs should rebuild
+  instead of reusing stale local Metal compiler output. The build script also
+  watches common Xcode selection inputs (`DEVELOPER_DIR`, `SDKROOT`, and
+  `/var/db/xcode_select_link` when present).
 - Establish a stable benchmark matrix:
   - warm `hello-world` proof: present, but too small to distinguish safe
     CPU-eval-check and forced full-Metal eval-check.
@@ -582,6 +595,11 @@ Prompt-to-artifact checklist:
 - Metal binding check: present. Newer Metal-cpp headers did not fix correctness,
   and the deprecated Rust `metal` crate is tracked as a separate maintenance
   risk rather than the rv32im P0 root cause.
+- Metal build-cache hygiene: present. Generated Metal sources and Apple Metal
+  compiler/linker identity are included in the persistent `.metallib` cache key,
+  and common Xcode selection inputs are build-script rerun signals. This reduces
+  the chance that local or CI validation accidentally tests stale kernels after
+  source, flag, or toolchain changes.
 
 Remaining gaps before marking P0 complete:
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -145,10 +145,29 @@ Metal-focused validation on the M5 Max:
   can stall badly with this toolchain when it compiles unused kernels such as
   higher-`po2` `eval_check` variants. Lazy pipeline creation avoids that startup
   problem, but it does not fix the `Poly check failed` correctness failure.
-- Broad zkVM tests and documented `datasheet` / `fib` benchmarks are currently
-  blocked by a guest `risc0-zkvm-methods-cpp-crates` link failure with undefined
-  `blst_*` symbols. This is not a Metal runtime failure, but it blocks the
-  benchmark harness.
+- The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
+  the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
+  macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
+  `libblst.a`; the adjacent RISC-V object did contain the missing symbols.
+  Setting the target-specific RISC-V archiver fixes the build. Validation:
+  `cargo test -p risc0-zkvm --features prove --no-run` now succeeds, and
+  `cargo test -p risc0-zkvm --features prove host::server::exec::tests::cpp_test
+  -- --nocapture` passes.
+- The small Metal-enabled release datasheet matrix is now runnable with
+  `--max-po2 16`:
+  - `execute`: 28.8ms for 2.7M instructions.
+  - `composite`: 897.8ms for 16K rows, 4.56s for 64K rows.
+  - `lift`: 731.5ms for 256K recursion rows.
+  - `join`: 923.6ms for 256K recursion rows.
+  - `succinct`: 4.09s for 64K rows.
+- `cargo bench -p risc0-zkvm --features prove,metal --bench fib execute` now
+  runs; one filtered run averaged about 73MHz. The full `fib` benchmark suite is
+  still not part of the default quick gate because each selected hotbench entry
+  runs for roughly 10s plus setup.
+- The `datasheet composite` harness had a sparse-`po2` bug: it used `.take(...)`
+  over a table that intentionally omits too-small powers of two, so `--max-po2
+  16` could still run `po2=17` and panic. The harness now filters by the actual
+  `po2` key.
 
 ## Metal Binding Status
 
@@ -190,8 +209,9 @@ than at stale C++ header bindings alone.
   eval-check with `RISC0_RV32IM_METAL_EVAL_CHECK=1`.
 - Add a deterministic Metal rv32im regression command or mark the test harness
   serial if the Metal runtime cannot safely run these tests concurrently.
-- Fix the `risc0-zkvm-methods-cpp-crates` `blst_*` guest link failure so the
-  zkVM test and benchmark harness can run.
+- Keep the `risc0-zkvm-methods-cpp-crates` `blst_*` guest link fix covered in
+  both native and Docker guest builds. The current fix sets
+  `AR_riscv32im_risc0_zkvm_elf` beside the RISC-V guest compiler.
 - Check whether the pinned Metal-cpp header bundle is stale in a way that
   affects current Apple Silicon proving. `rv32im-sys` currently downloads
   `metal-cpp_macOS13.3_iOS16.4.zip`; Apple now publishes newer bundles such as
@@ -207,9 +227,12 @@ than at stale C++ header bindings alone.
   versions if possible. A CI Apple Silicon runner passing with a different Xcode
   or Metal Toolchain would be a strong signal that this is toolchain-sensitive.
 - Establish a stable benchmark matrix:
-  - warm `hello-world` proof
+  - warm `hello-world` proof: present, but too small to distinguish safe
+    CPU-eval-check and forced full-Metal eval-check.
+  - small Metal-enabled `datasheet execute`, `composite`, `lift`, `join`, and
+    `succinct`: present at `--max-po2 16`.
+  - filtered `fib execute`: present.
   - rv32im segment-only benchmark
-  - `datasheet execute`, `composite`, `lift`, `join`, `succinct`
   - Keccak-heavy workload
 
 ### P1: Optimize Transparent Local Proving

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -28,10 +28,10 @@ normal optimization pipeline. Set `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1` when
 reproducing the original fully optimized eval-check failure mode.
 
 On the M5 Max this passes the current serial rv32im suite with eval-check CPU
-verification, the non-serial rv32im harness, and small-to-medium composite and
-succinct datasheet runs. It is faster than the CPU-eval-check safety fallback on
-the filtered `fib prove/poseidon2` benchmark, but this still needs longer stress
-testing before becoming the default.
+verification, the non-serial rv32im harness, and 1M-row composite plus 64K-row
+succinct datasheet runs. It is much faster than the CPU-eval-check safety
+fallback on the filtered `fib prove/poseidon2` benchmark, but this still needs
+longer stress testing before full Metal eval-check becomes the runtime default.
 
 For the best local proving throughput, start with `ProverOpts::fast()` or
 `ProverOpts::composite()`. This produces a composite STARK receipt: fastest,
@@ -269,6 +269,10 @@ Metal-focused validation on the M5 Max:
   RISC0_RV32IM_METAL_EVAL_CHECK=1`, the filtered `fib prove/poseidon2`
   benchmark completed in 15.94s, about 32.1K rows/sec. This is faster than both
   the CPU-eval-check safety path and the `-O0` diagnostic path.
+- With scoped default no-inline on only generated `eval_check_*.metal` files and
+  `RISC0_RV32IM_METAL_EVAL_CHECK=1`, the same filtered `fib prove/poseidon2`
+  benchmark completed in 4.89s to 6.16s, about 83.1K to 104.8K rows/sec. This
+  is the best current segment-proving measurement.
 - The same `-fno-inline-functions` full-Metal eval-check candidate passed
   `datasheet --max-po2 16 composite`: 658.9ms for 16K rows and 2.04s for 64K
   rows. This improves on the current safety-path baseline of 897.8ms and 4.56s,
@@ -282,7 +286,16 @@ Metal-focused validation on the M5 Max:
 - A larger `datasheet --max-po2 20 composite` run passed with forced full Metal
   eval-check: 767ms for 16K rows, 2.52s for 64K rows, 4.52s for 128K rows,
   8.57s for 256K rows, 16.88s for 512K rows, and 37.47s for 1M rows. The 1M-row
-  case reached about 27.3K rows/sec.
+  case reached about 27.3K rows/sec. This was still using the global append flag
+  and is now a historical lower bound.
+- With the scoped eval-check-only no-inline default, the repeated
+  `datasheet --max-po2 20 composite` run passed and reached 288.7ms for 16K
+  rows, 783.8ms for 64K rows, 1.29s for 128K rows, 2.48s for 256K rows, 4.85s
+  for 512K rows, and 9.68s for 1M rows. The 1M-row case reached about 105.7K
+  rows/sec.
+- With the scoped eval-check-only no-inline default, `datasheet --max-po2 18
+  succinct` passed: 1.47s for the 64K-row succinct case, about 43.5K rows/sec,
+  with about 930MB max RAM and a 217.4KB seal.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
@@ -371,8 +384,8 @@ than at stale C++ header bindings alone.
     CPU-eval-check and forced full-Metal eval-check.
   - small Metal-enabled `datasheet execute`, `composite`, `lift`, `join`, and
     `succinct`: present at `--max-po2 16`; the `-fno-inline-functions`
-    full-Metal candidate also has `succinct` coverage at `--max-po2 18` and
-    `composite` coverage at `--max-po2 20`.
+    full-Metal candidate also has scoped-default `succinct` coverage at
+    `--max-po2 18` and scoped-default `composite` coverage at `--max-po2 20`.
   - filtered `fib execute`: present.
   - rv32im segment-only benchmark: present through filtered `fib
     prove/poseidon2`; currently slow because the safety path keeps rv32im

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -279,6 +279,11 @@ Metal-focused validation on the M5 Max:
   - `cargo test -p risc0-zkvm --features prove
     host::server::prove::tests::bigint_accel -- --nocapture` passed the BigInt
     accelerator proof workload across 15 generated test cases.
+  - `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 cargo test --manifest-path
+    examples/voting-machine/Cargo.toml --features prove protocol --
+    --nocapture` passed a product-style protocol workload: init, five
+    pre-freeze ballot submissions, freeze, one post-freeze submission, and
+    receipt verification for all seven receipts.
 - Before flipping the runtime default, the scoped full-Metal path passed five
   consecutive non-serial full-suite verifier runs with
   `RISC0_RV32IM_METAL_EVAL_CHECK=1
@@ -534,6 +539,8 @@ Prompt-to-artifact checklist:
 - Benchmark matrix: present for default segment proving, CPU eval-check
   fallback, composite up to 1M rows, succinct at 64K rows, Keccak CPU fallback,
   and Keccak syscall/assumption proof coverage.
+- Product-style workload: present. The voting-machine protocol example passed
+  under the default Metal path with eval-check CPU verification enabled.
 - M5 Max and modern Apple toolchain context: present. Validation records Xcode
   26.5 build `17F42`, Metal `32023.883`, and that no alternate Xcode is locally
   installed.
@@ -553,9 +560,10 @@ Remaining gaps before marking P0 complete:
   code-shape fix. Source-level noinline on `computeRow<po2>` was rejected as too
   slow; a better split of `verifyCircuit`/validity-polynomial code is still open.
 - The default path has strong local smoke, benchmark, 10-pass verifier-loop,
-  SHA, continuation, BigInt, and Keccak example coverage, including a 100KB
-  Keccak input proof, but not a broad product-style application workload beyond
-  the current datasheet/examples/zkVM tests.
+  SHA, continuation, BigInt, voting-machine protocol, and Keccak example
+  coverage, including a 100KB Keccak input proof. More external application
+  workloads would still improve confidence, but the earlier absence of any
+  product-style workload is closed locally.
 - Keccak Metal remains disabled. This is outside rv32im eval-check correctness,
   but it is still a major gap for best local proving on Keccak-heavy workloads.
 

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -269,6 +269,28 @@ Metal-focused validation on the M5 Max:
 - The narrowed `-fno-inline` default also passed a 10-run full-suite stress loop
   with `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`; each run passed 46/46 with
   the ignored Metal regression test skipped.
+- The build now has a diagnostic exact-file flag knob:
+  `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13` applies `-fno-inline` only
+  to `eval_check_13.metal` instead of every generated eval-check kernel. With
+  `RISC0_RV32IM_METAL_EVAL_CHECK=1` and
+  `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`, the serial rv32im prove suite
+  passed 46/46 with one ignored regression test under that narrower `po2=13`
+  setting. A larger datasheet composite probe with the same exact `po2=13`
+  setting and CPU verifier enabled failed immediately at 16K rows in
+  `eval_check_metal_14` (`po2 14 row 4864 col 0, 1648141424 vs 659109993`).
+  Re-running the same composite probe with
+  `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14` passed first through
+  `--max-po2 18` and then through `--max-po2 20`, covering 16K, 64K, 128K,
+  256K, 512K, and 1M rows with the direct CPU verifier enabled. This is useful
+  diagnostic evidence, but it is not yet enough to narrow the production
+  default. The exact `13,14` set also passed datasheet `--max-po2 18 succinct`
+  with the direct CPU verifier enabled, producing the 64K-row succinct receipt
+  in 5.54s. The voting-machine protocol example also passed under exact
+  `13,14` with the direct CPU verifier enabled, proving and verifying the full
+  protocol flow in 38.40s. The Keccak long-input example then found another
+  required protected kernel: exact `13,14` failed in `eval_check_metal_20`
+  (`po2 20 row 691936 col 0, 1488903 vs 1888965691`), while exact `13,14,20`
+  passed `hash_long` in 148.27s with the direct CPU verifier enabled.
 - Full Metal eval-check is now the runtime default in this branch. The default
   full rv32im prove suite passed 46/46 with one ignored Metal regression test,
   and a default full-suite run with
@@ -393,6 +415,19 @@ Metal-focused validation on the M5 Max:
   completed without a mismatch in 35.93s, about 14.2K rows/sec. The CPU verifier
   makes this number diagnostic-only, but the pass is still useful evidence that
   the serial rv32im test suite remains the compact repro for the inline bug.
+- Exact-`po2` diagnostics suggest at least `eval_check_13.metal` and
+  `eval_check_14.metal`, and `eval_check_20.metal` need the no-inline mitigation
+  on this M5 Max toolchain. `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13`
+  passed the full serial rv32im prove suite, but failed datasheet composite at
+  16K rows in `eval_check_metal_14`.
+  `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14` then passed datasheet
+  `--max-po2 20 composite` with direct CPU verifier enabled, covering through 1M
+  rows, and datasheet `--max-po2 18 succinct` passed at 64K rows. The same exact
+  set passed the voting-machine protocol proof workload, but failed
+  `examples/keccak` `hash_long` in `eval_check_metal_20`.
+  `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S=13,14,20` passed that Keccak
+  long-input workload. Because verifier overhead dominates these timings, use
+  this result for correctness localization, not performance comparison.
 - A source-level Metal `__attribute__((noinline))` experiment on
   `computeRow<po2>` compiled and passed the focused default
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu` sanity
@@ -515,6 +550,10 @@ than at stale C++ header bindings alone.
   `eval_check_*.metal` files. Full Metal eval-check is now the runtime default
   in this branch. Keep stressing this scoped default with longer proof loops and
   larger real workloads before treating it as upstream-production evidence.
+- Use `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S` to test exact `po2`
+  mitigation sets. `13` is known to cover the current serial rv32im test-suite
+  repro, but that should remain diagnostic until larger `po2` kernels have
+  direct verifier coverage.
 - Investigate a Zirgen/M3 code-shape fix for `eval_check` rather than treating
   Metal bindings alone as the root issue. Promising directions are reducing
   inlining/register pressure in `verifyCircuit`, avoiding the giant

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -15,7 +15,8 @@ MetalToolchain`; `xcrun --sdk macosx metal -v` reports Apple metal version
 ## Current Recommendation
 
 Use the M3 rv32im segment prover on Apple Silicon with Metal enabled by target
-selection.
+selection, but keep the current rv32im eval-check safety fallback enabled. Do
+not force full Metal rv32im eval-check for production proofs yet.
 
 For the best local proving throughput, start with `ProverOpts::fast()` or
 `ProverOpts::composite()`. This produces a composite STARK receipt: fastest,
@@ -201,9 +202,12 @@ Metal-focused validation on the M5 Max:
   (`RISC0_RV32IM_METAL_EVAL_CHECK=1
   RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1 ... prove::tests::sltiu`) passed
   20/20, and the full serial rv32im prove suite passed 46/46 under forced Metal
-  eval-check plus CPU verification. The branch now exposes this as
-  `RISC0_RV32IM_METAL_KERNEL_O0=1` when rebuilding rv32im Metal kernels instead
-  of hardcoding it globally.
+  eval-check plus CPU verification. After wiring this as
+  `RISC0_RV32IM_METAL_KERNEL_O0=1`, the same full serial rv32im suite passed
+  46/46 with `RISC0_RV32IM_METAL_EVAL_CHECK=1` and
+  `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1`. This strongly implicates
+  optimized Metal compilation or optimization-sensitive generated eval-check
+  code shape, but it is not a performance fix.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty
@@ -228,6 +232,10 @@ Metal-focused validation on the M5 Max:
   path it completed one timed iteration in 28.31s, about 18.1K rows/sec. This is
   intentionally recorded as the CPU-eval-check safety-path baseline, not a
   full-Metal result.
+- The same filtered `fib prove/poseidon2` benchmark with
+  `RISC0_RV32IM_METAL_KERNEL_O0=1 RISC0_RV32IM_METAL_EVAL_CHECK=1` completed in
+  48.05s, about 10.7K rows/sec. This is slower than the CPU-eval-check safety
+  path, so `-O0` should remain diagnostic only.
 - `cargo run --release -p risc0-circuit-keccak --features prove --example
   keccak -- --po2 14 --count 1` completed in 1.930s, about 41.975 keccak/sec.
   Keccak Metal is still disabled in `risc0-circuit-keccak`, so this is a CPU
@@ -277,7 +285,8 @@ than at stale C++ header bindings alone.
 - Use `RISC0_RV32IM_METAL_KERNEL_O0=1` as the current strongest compiler/codegen
   diagnostic. It should not become the default without performance measurement,
   but it is the best available evidence that optimized Metal compilation is
-  mishandling the generated rv32im eval-check shape.
+  mishandling the generated rv32im eval-check shape. Initial measurement shows
+  the `-O0` full-Metal path is slower than the CPU-eval-check safety path.
 - Investigate a Zirgen/M3 code-shape fix for `eval_check` rather than treating
   Metal bindings alone as the root issue. Promising directions are reducing
   inlining/register pressure in `verifyCircuit`, avoiding the giant

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -180,9 +180,12 @@ Metal-focused validation on the M5 Max:
   for diagnosis and benchmarking; the same serial suite failed in that mode
   with `jalr`, `mulhsu`, and `or` hitting `Poly check failed`.
 - `cargo test -p risc0-zkp --features prove hal::metal --release -- --nocapture`
-  passed: 19 tests, including after the Xcode 26.5 Metal Toolchain install.
+  passed: 19 tests, including after the Xcode 26.5 Metal Toolchain install and
+  again at the current branch head after narrowing the rv32im eval-check flag to
+  `-fno-inline`.
 - `cargo test -p risc0-circuit-recursion --features prove prove::hal::metal::tests::eval_check --release -- --ignored --nocapture`
-  passed: 1 test, including after the Xcode 26.5 Metal Toolchain install.
+  passed: 1 test, including after the Xcode 26.5 Metal Toolchain install and
+  again at the current branch head.
 - `examples/target/release/hello-world` with `RISC0_PROVER=local` completed a
   proof in about 0.5s warm with the default CPU eval-check safety path. A
   forced full-Metal eval-check run of the same binary was also about 0.5s, so
@@ -521,6 +524,8 @@ Prompt-to-artifact checklist:
 - Direct correctness diagnostic: present.
   `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` compares Metal eval-check output
   against CPU eval-check output from the same inputs.
+- Non-rv32im Metal gates: present. Current-head `risc0-zkp` Metal HAL and
+  recursion Metal eval-check tests pass.
 - Focused regression: present as ignored test
   `prove::tests::metal_eval_check_sltiu_repeated`.
 - Native and Docker guest C/C++ archiver fix: present. Both native

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -25,7 +25,8 @@ The best current experimental full-Metal rv32im candidate is:
 On this branch, generated `eval_check_*.metal` files are compiled with
 `-fno-inline-functions` by default while the other rv32im Metal kernels keep the
 normal optimization pipeline. Set `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1` when
-reproducing the original fully optimized eval-check failure mode.
+comparing against or reproducing the original fully optimized eval-check failure
+mode.
 
 On the M5 Max this passes the current serial rv32im suite with eval-check CPU
 verification, the non-serial rv32im harness, and 1M-row composite plus 64K-row
@@ -236,7 +237,9 @@ Metal-focused validation on the M5 Max:
   `eval_check_*.metal` files by default. With no global append flags, forced
   Metal eval-check plus CPU verification passed the focused `sltiu` loop 20/20
   and the full rv32im prove suite 46/46. This preserves the original repro path
-  behind `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`.
+  behind `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1`: a focused inline `sltiu`
+  loop passed 25/25, but the inline full rv32im prove suite failed in `sltiu`
+  with a direct eval-check verifier mismatch at row 31840 col 0.
 - The guest `risc0-zkvm-methods-cpp-crates` `blst_*` link failure was caused by
   the guest C compiler being set to the RISC-V GCC while `AR` was left unset on
   macOS. The `cc` crate fell back to `/usr/bin/ar`, producing a 96-byte empty

--- a/docs/metal-optimization-progress.md
+++ b/docs/metal-optimization-progress.md
@@ -369,9 +369,10 @@ than at stale C++ header bindings alone.
   the `-O0` full-Metal path is slower than the CPU-eval-check safety path.
 - Use `RISC0_RV32IM_METAL_APPEND_FLAGS` for targeted compiler-flag experiments.
   The first strong candidate, `-fno-inline-functions`, is now applied only to
-  generated `eval_check_*.metal` files by default. Keep stressing this scoped
-  default with longer proof loops and larger real workloads before making full
-  Metal eval-check the runtime default.
+  generated `eval_check_*.metal` files by default, and full Metal eval-check is
+  now the runtime default in this branch. Keep stressing this scoped default
+  with longer proof loops and larger real workloads before treating it as
+  upstream-production evidence.
 - Investigate a Zirgen/M3 code-shape fix for `eval_check` rather than treating
   Metal bindings alone as the root issue. Promising directions are reducing
   inlining/register pressure in `verifyCircuit`, avoiding the giant

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -167,6 +167,10 @@ fn create_dockerfile(manifest_path: &Path, temp_dir: &Path, guest_info: &GuestIn
             "CC_riscv32im_risc0_zkvm_elf",
             "/root/.risc0/cpp/bin/riscv32-unknown-elf-gcc",
         )])
+        .env(&[(
+            "AR_riscv32im_risc0_zkvm_elf",
+            "/root/.risc0/cpp/bin/riscv32-unknown-elf-ar",
+        )])
         .env(&[("CFLAGS_riscv32im_risc0_zkvm_elf", "-march=rv32im -nostdlib")]);
 
     let docker_env = docker_opts.env();

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -420,6 +420,10 @@ pub(crate) fn cargo_command_internal(subcmd: &str, guest_info: &GuestInfo) -> Co
     if !cpp_toolchain_override() {
         if let Some(toolchain_path) = cpp_toolchain() {
             cmd.env("CC", toolchain_path.join("bin/riscv32-unknown-elf-gcc"));
+            cmd.env(
+                "AR_riscv32im_risc0_zkvm_elf",
+                toolchain_path.join("bin/riscv32-unknown-elf-ar"),
+            );
         } else {
             // If you aren't compiling any C/C++ code, it might be just fine to not have a C++
             // toolchain installed, but if you are then your compilation will surely fail. To avoid

--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -350,6 +350,13 @@ impl KernelBuild {
     }
 
     fn compile_metal(&mut self, output: &str) {
+        println!("cargo:rerun-if-env-changed=DEVELOPER_DIR");
+        println!("cargo:rerun-if-env-changed=SDKROOT");
+        let xcode_select_link = Path::new("/var/db/xcode_select_link");
+        if xcode_select_link.exists() {
+            println!("cargo:rerun-if-changed={}", xcode_select_link.display());
+        }
+
         let target = env::var("TARGET").unwrap();
         let sdk_name = if target.ends_with("ios") {
             "iphoneos"
@@ -379,6 +386,7 @@ impl KernelBuild {
         let file_prefix_flags = self.file_prefix_flags.clone();
 
         let mut tags = vec![sdk_name.to_string()];
+        tags.extend(metal_toolchain_cache_tags(sdk_name));
         tags.extend(
             file_prefix_flags
                 .iter()
@@ -525,6 +533,41 @@ impl KernelBuild {
     }
 }
 
+fn metal_toolchain_cache_tags(sdk_name: &str) -> Vec<String> {
+    let commands: &[(&str, &[&str])] = &[
+        ("metal-path", &["--find", "metal"]),
+        ("metallib-path", &["--find", "metallib"]),
+        ("metal-version", &["metal", "-v"]),
+        ("metallib-version", &["metallib", "-v"]),
+    ];
+
+    commands
+        .iter()
+        .map(|(label, args)| {
+            let output = Command::new("xcrun")
+                .arg("--sdk")
+                .arg(sdk_name)
+                .args(*args)
+                .output()
+                .unwrap_or_else(|err| panic!("failed to query {label}: {err}"));
+            format_command_cache_tag(label, &output.status, &output.stdout, &output.stderr)
+        })
+        .collect()
+}
+
+fn format_command_cache_tag(
+    label: &str,
+    status: &std::process::ExitStatus,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> String {
+    format!(
+        "{label}:status={status}:stdout={}:stderr={}",
+        String::from_utf8_lossy(stdout),
+        String::from_utf8_lossy(stderr)
+    )
+}
+
 fn risc0_cache() -> PathBuf {
     directories::ProjectDirs::from("com.risczero", "RISC Zero", "risc0")
         .unwrap()
@@ -587,6 +630,19 @@ mod tests {
         fs::write(&generated, "kernel void after() {}\n").unwrap();
         let mut after = Hasher::new();
         build.add_kernel_source_files_to_hash(&mut after);
+        let after = after.finalize();
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn cache_tags_are_part_of_hash() {
+        let mut before = Hasher::new();
+        before.add_flag("metal-version:old");
+        let before = before.finalize();
+
+        let mut after = Hasher::new();
+        after.add_flag("metal-version:new");
         let after = after.finalize();
 
         assert_ne!(before, after);

--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -63,6 +63,7 @@ pub enum KernelType {
 pub struct KernelBuild {
     kernel_type: KernelType,
     flags: Vec<String>,
+    file_prefix_flags: Vec<(String, String)>,
     files: Vec<PathBuf>,
     generated_files: Vec<PathBuf>,
     inc_dirs: Vec<PathBuf>,
@@ -75,6 +76,7 @@ impl KernelBuild {
         Self {
             kernel_type,
             flags: Vec::new(),
+            file_prefix_flags: Vec::new(),
             files: Vec::new(),
             generated_files: Vec::new(),
             inc_dirs: Vec::new(),
@@ -92,6 +94,13 @@ impl KernelBuild {
     /// Add an arbitrary flag to the invocation of the compiler
     pub fn flag(&mut self, flag: &str) -> &mut KernelBuild {
         self.flags.push(flag.to_string());
+        self
+    }
+
+    /// Add an arbitrary flag to files whose file name starts with `prefix`.
+    pub fn flag_file_prefix(&mut self, prefix: &str, flag: &str) -> &mut KernelBuild {
+        self.file_prefix_flags
+            .push((prefix.to_string(), flag.to_string()));
         self
     }
 
@@ -367,6 +376,14 @@ impl KernelBuild {
             "-Wno-unused-variable".to_string(),
         ];
         flags.extend(self.flags.clone());
+        let file_prefix_flags = self.file_prefix_flags.clone();
+
+        let mut tags = vec![sdk_name.to_string()];
+        tags.extend(
+            file_prefix_flags
+                .iter()
+                .map(|(prefix, flag)| format!("file-prefix-flag:{prefix}:{flag}")),
+        );
 
         self.cached_compile(
             output,
@@ -374,7 +391,7 @@ impl KernelBuild {
             &deps,
             METAL_INCS,
             &flags,
-            &[sdk_name.to_string()],
+            &tags,
             |out_dir, out_path, sys_inc_dir, flags| {
                 let files: Vec<_> = files.iter().map(|x| x.as_path()).collect();
 
@@ -391,6 +408,13 @@ impl KernelBuild {
 
                         for flag in flags {
                             cmd.arg(flag);
+                        }
+                        if let Some(file_name) = src.file_name().and_then(|name| name.to_str()) {
+                            for (prefix, flag) in &file_prefix_flags {
+                                if file_name.starts_with(prefix) {
+                                    cmd.arg(flag);
+                                }
+                            }
                         }
 
                         cmd.arg("-o").arg(&air_path);

--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -433,15 +433,12 @@ impl KernelBuild {
                             cmd.arg(flag);
                         }
                         if let Some(file_name) = src.file_name().and_then(|name| name.to_str()) {
-                            for (prefix, flag) in &file_prefix_flags {
-                                if file_name.starts_with(prefix) {
-                                    cmd.arg(flag);
-                                }
-                            }
-                            for (flag_file_name, flag) in &file_name_flags {
-                                if file_name == flag_file_name {
-                                    cmd.arg(flag);
-                                }
+                            for flag in metal_file_specific_flags(
+                                file_name,
+                                &file_prefix_flags,
+                                &file_name_flags,
+                            ) {
+                                cmd.arg(flag);
                             }
                         }
 
@@ -575,6 +572,20 @@ fn metal_toolchain_cache_tags(sdk_name: &str) -> Vec<String> {
         .collect()
 }
 
+fn metal_file_specific_flags<'a>(
+    file_name: &str,
+    file_prefix_flags: &'a [(String, String)],
+    file_name_flags: &'a [(String, String)],
+) -> Vec<&'a str> {
+    file_prefix_flags
+        .iter()
+        .filter_map(|(prefix, flag)| file_name.starts_with(prefix).then_some(flag.as_str()))
+        .chain(file_name_flags.iter().filter_map(|(flag_file_name, flag)| {
+            (file_name == flag_file_name).then_some(flag.as_str())
+        }))
+        .collect()
+}
+
 fn format_command_cache_tag(
     label: &str,
     status: &std::process::ExitStatus,
@@ -666,5 +677,34 @@ mod tests {
         let after = after.finalize();
 
         assert_ne!(before, after);
+    }
+
+    #[test]
+    fn metal_file_specific_flags_match_prefixes_and_exact_names() {
+        let prefix_flags = vec![
+            ("eval_check_".to_string(), "-fno-inline".to_string()),
+            ("data_witgen_".to_string(), "-fdata".to_string()),
+        ];
+        let file_name_flags = vec![
+            ("eval_check_20.metal".to_string(), "-fpo2-20".to_string()),
+            ("eval_check_2.metal".to_string(), "-fpo2-2".to_string()),
+        ];
+
+        assert_eq!(
+            metal_file_specific_flags("eval_check_20.metal", &prefix_flags, &file_name_flags),
+            vec!["-fno-inline", "-fpo2-20"]
+        );
+        assert_eq!(
+            metal_file_specific_flags("eval_check_200.metal", &prefix_flags, &file_name_flags),
+            vec!["-fno-inline"]
+        );
+        assert_eq!(
+            metal_file_specific_flags("data_witgen_20.metal", &prefix_flags, &file_name_flags),
+            vec!["-fdata"]
+        );
+        assert!(
+            metal_file_specific_flags("accum_witgen_20.metal", &prefix_flags, &file_name_flags)
+                .is_empty()
+        );
     }
 }

--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -490,9 +490,7 @@ impl KernelBuild {
         for tag in tags {
             hasher.add_flag(tag);
         }
-        for src in self.files.iter() {
-            hasher.add_file(src);
-        }
+        self.add_kernel_source_files_to_hash(&mut hasher);
         for (name, contents) in assets {
             let path = sys_inc_dir.join(name);
             if let Some(parent) = path.parent() {
@@ -515,6 +513,15 @@ impl KernelBuild {
         fs::copy(cache_path, &out_path).unwrap();
 
         println!("cargo:{}={}", output, out_path.display());
+    }
+
+    fn add_kernel_source_files_to_hash(&self, hasher: &mut Hasher) {
+        for src in self.files.iter() {
+            hasher.add_file(src);
+        }
+        for src in self.generated_files.iter() {
+            hasher.add_file(src);
+        }
     }
 }
 
@@ -558,4 +565,30 @@ fn rerun_if_changed<P: AsRef<Path>>(path: P) {
     );
 
     println!("cargo:rerun-if-changed={}", path.as_ref().display());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_files_are_part_of_kernel_source_hash() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let generated = temp_dir.path().join("generated.metal");
+
+        fs::write(&generated, "kernel void before() {}\n").unwrap();
+        let mut build = KernelBuild::new(KernelType::Metal, temp_dir.path().join("manifest"));
+        build.generated_file(&generated);
+
+        let mut before = Hasher::new();
+        build.add_kernel_source_files_to_hash(&mut before);
+        let before = before.finalize();
+
+        fs::write(&generated, "kernel void after() {}\n").unwrap();
+        let mut after = Hasher::new();
+        build.add_kernel_source_files_to_hash(&mut after);
+        let after = after.finalize();
+
+        assert_ne!(before, after);
+    }
 }

--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -362,7 +362,11 @@ impl KernelBuild {
             .collect();
         deps.extend(self.deps.clone());
 
-        let flags = ["-std=metal3.0", "-Wno-unused-variable"];
+        let mut flags = vec![
+            "-std=metal3.0".to_string(),
+            "-Wno-unused-variable".to_string(),
+        ];
+        flags.extend(self.flags.clone());
 
         self.cached_compile(
             output,
@@ -421,13 +425,13 @@ impl KernelBuild {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn cached_compile<F: Fn(&Path, &Path, &Path, &[&str])>(
+    fn cached_compile<F: Fn(&Path, &Path, &Path, &[String])>(
         &self,
         output: &str,
         extension: &str,
         deps: &[PathBuf],
         assets: &[(&str, &str)],
-        flags: &[&str],
+        flags: &[String],
         tags: &[String],
         inner: F,
     ) {

--- a/risc0/build_kernel/src/lib.rs
+++ b/risc0/build_kernel/src/lib.rs
@@ -64,6 +64,7 @@ pub struct KernelBuild {
     kernel_type: KernelType,
     flags: Vec<String>,
     file_prefix_flags: Vec<(String, String)>,
+    file_name_flags: Vec<(String, String)>,
     files: Vec<PathBuf>,
     generated_files: Vec<PathBuf>,
     inc_dirs: Vec<PathBuf>,
@@ -77,6 +78,7 @@ impl KernelBuild {
             kernel_type,
             flags: Vec::new(),
             file_prefix_flags: Vec::new(),
+            file_name_flags: Vec::new(),
             files: Vec::new(),
             generated_files: Vec::new(),
             inc_dirs: Vec::new(),
@@ -101,6 +103,13 @@ impl KernelBuild {
     pub fn flag_file_prefix(&mut self, prefix: &str, flag: &str) -> &mut KernelBuild {
         self.file_prefix_flags
             .push((prefix.to_string(), flag.to_string()));
+        self
+    }
+
+    /// Add an arbitrary flag to files whose file name exactly matches `file_name`.
+    pub fn flag_file_name(&mut self, file_name: &str, flag: &str) -> &mut KernelBuild {
+        self.file_name_flags
+            .push((file_name.to_string(), flag.to_string()));
         self
     }
 
@@ -384,6 +393,7 @@ impl KernelBuild {
         ];
         flags.extend(self.flags.clone());
         let file_prefix_flags = self.file_prefix_flags.clone();
+        let file_name_flags = self.file_name_flags.clone();
 
         let mut tags = vec![sdk_name.to_string()];
         tags.extend(metal_toolchain_cache_tags(sdk_name));
@@ -391,6 +401,11 @@ impl KernelBuild {
             file_prefix_flags
                 .iter()
                 .map(|(prefix, flag)| format!("file-prefix-flag:{prefix}:{flag}")),
+        );
+        tags.extend(
+            file_name_flags
+                .iter()
+                .map(|(file_name, flag)| format!("file-name-flag:{file_name}:{flag}")),
         );
 
         self.cached_compile(
@@ -420,6 +435,11 @@ impl KernelBuild {
                         if let Some(file_name) = src.file_name().and_then(|name| name.to_str()) {
                             for (prefix, flag) in &file_prefix_flags {
                                 if file_name.starts_with(prefix) {
+                                    cmd.arg(flag);
+                                }
+                            }
+                            for (flag_file_name, flag) in &file_name_flags {
+                                if file_name == flag_file_name {
                                     cmd.arg(flag);
                                 }
                             }

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -71,6 +71,7 @@ fn compile_provers() {
     rerun_if_env_changed("RISC0_RV32IM_METAL_COMPARE_CPU");
     rerun_if_env_changed("RISC0_RV32IM_METAL_APPEND_FLAGS");
     rerun_if_env_changed("RISC0_RV32IM_METAL_INLINE_EVAL_CHECK");
+    rerun_if_env_changed("RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S");
     rerun_if_env_changed("RISC0_RV32IM_METAL_KERNEL_O0");
     rerun_if_env_changed("SCCACHE_RECACHE");
 
@@ -150,7 +151,13 @@ fn compile_provers() {
             metal_build.flag("-O0");
         }
         if env::var_os("RISC0_RV32IM_METAL_INLINE_EVAL_CHECK").is_none() {
-            metal_build.flag_file_prefix("eval_check_", "-fno-inline");
+            if let Ok(po2s) = env::var("RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S") {
+                for po2 in parse_po2_list(&po2s) {
+                    metal_build.flag_file_name(&format!("eval_check_{po2}.metal"), "-fno-inline");
+                }
+            } else {
+                metal_build.flag_file_prefix("eval_check_", "-fno-inline");
+            }
         }
         if let Ok(flags) = env::var("RISC0_RV32IM_METAL_APPEND_FLAGS") {
             for flag in flags.split_whitespace() {
@@ -484,6 +491,17 @@ fn rerun_if_env_changed(var_name: &str) {
 
 fn glob_paths(pattern: &str) -> Vec<PathBuf> {
     glob::glob(pattern).unwrap().map(|x| x.unwrap()).collect()
+}
+
+fn parse_po2_list(value: &str) -> Vec<usize> {
+    value
+        .split([',', ' '])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.parse::<usize>()
+                .unwrap_or_else(|err| panic!("invalid po2 '{part}': {err}"))
+        })
+        .collect()
 }
 
 const METAL_SDK_URL: &str =

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -150,7 +150,7 @@ fn compile_provers() {
             metal_build.flag("-O0");
         }
         if env::var_os("RISC0_RV32IM_METAL_INLINE_EVAL_CHECK").is_none() {
-            metal_build.flag_file_prefix("eval_check_", "-fno-inline-functions");
+            metal_build.flag_file_prefix("eval_check_", "-fno-inline");
         }
         if let Ok(flags) = env::var("RISC0_RV32IM_METAL_APPEND_FLAGS") {
             for flag in flags.split_whitespace() {

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -20,9 +20,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use quote::{format_ident, quote};
-use xshell::{cmd, Shell};
+use xshell::{Shell, cmd};
 
 use risc0_build_kernel::{KernelBuild, KernelType};
 
@@ -69,6 +69,7 @@ fn compile_provers() {
     rerun_if_env_changed("NVCC_APPEND_FLAGS");
     rerun_if_env_changed("NVCC_PREPEND_FLAGS");
     rerun_if_env_changed("RISC0_RV32IM_METAL_COMPARE_CPU");
+    rerun_if_env_changed("RISC0_RV32IM_METAL_KERNEL_O0");
     rerun_if_env_changed("SCCACHE_RECACHE");
 
     let platform = if is_cuda() {
@@ -138,11 +139,15 @@ fn compile_provers() {
             make_po2s(spec, &out_dir, &mut generated_files);
         }
 
-        KernelBuild::new(KernelType::Metal, "kernel_build.manifest")
+        let mut metal_build = KernelBuild::new(KernelType::Metal, "kernel_build.manifest");
+        metal_build
             .include("cxx")
             .files(glob_paths("cxx/hal/metal/kernels/*.metal"))
-            .generated_files(generated_files)
-            .compile("metal_kernel");
+            .generated_files(generated_files);
+        if env::var_os("RISC0_RV32IM_METAL_KERNEL_O0").is_some() {
+            metal_build.flag("-O0");
+        }
+        metal_build.compile("metal_kernel");
 
         add_metal_kernel_include(
             &mut build,

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -494,14 +494,25 @@ fn glob_paths(pattern: &str) -> Vec<PathBuf> {
 }
 
 fn parse_po2_list(value: &str) -> Vec<usize> {
-    value
+    let po2s: Vec<_> = value
         .split([',', ' '])
         .filter(|part| !part.is_empty())
         .map(|part| {
-            part.parse::<usize>()
-                .unwrap_or_else(|err| panic!("invalid po2 '{part}': {err}"))
+            let po2 = part
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("invalid po2 '{part}': {err}"));
+            assert!(
+                (MIN_PO2..=MAX_PO2).contains(&po2),
+                "po2 '{po2}' is outside the generated rv32im range {MIN_PO2}..={MAX_PO2}"
+            );
+            po2
         })
-        .collect()
+        .collect();
+    assert!(
+        !po2s.is_empty(),
+        "RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S must contain at least one po2"
+    );
+    po2s
 }
 
 const METAL_SDK_URL: &str =

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -20,9 +20,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use quote::{format_ident, quote};
-use xshell::{Shell, cmd};
+use xshell::{cmd, Shell};
 
 use risc0_build_kernel::{KernelBuild, KernelType};
 
@@ -68,6 +68,7 @@ fn compile_provers() {
 
     rerun_if_env_changed("NVCC_APPEND_FLAGS");
     rerun_if_env_changed("NVCC_PREPEND_FLAGS");
+    rerun_if_env_changed("RISC0_RV32IM_METAL_COMPARE_CPU");
     rerun_if_env_changed("SCCACHE_RECACHE");
 
     let platform = if is_cuda() {
@@ -101,6 +102,7 @@ fn compile_provers() {
         .include(env::var("DEP_RISC0_SYS_CXX_ROOT").unwrap())
         .files(glob_paths("cxx/core/*.cpp"))
         .files(glob_paths("cxx/hal/cpu/*.cpp"))
+        .files(glob_paths("cxx/hal/dual/*.cpp"))
         .files(glob_paths("cxx/prove/*.cpp"))
         .files(glob_paths("cxx/rv32im/*.cpp"))
         .files(glob_paths("cxx/rv32im/emu/*.cpp"))

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -70,6 +70,7 @@ fn compile_provers() {
     rerun_if_env_changed("NVCC_PREPEND_FLAGS");
     rerun_if_env_changed("RISC0_RV32IM_METAL_COMPARE_CPU");
     rerun_if_env_changed("RISC0_RV32IM_METAL_APPEND_FLAGS");
+    rerun_if_env_changed("RISC0_RV32IM_METAL_INLINE_EVAL_CHECK");
     rerun_if_env_changed("RISC0_RV32IM_METAL_KERNEL_O0");
     rerun_if_env_changed("SCCACHE_RECACHE");
 
@@ -147,6 +148,9 @@ fn compile_provers() {
             .generated_files(generated_files);
         if env::var_os("RISC0_RV32IM_METAL_KERNEL_O0").is_some() {
             metal_build.flag("-O0");
+        }
+        if env::var_os("RISC0_RV32IM_METAL_INLINE_EVAL_CHECK").is_none() {
+            metal_build.flag_file_prefix("eval_check_", "-fno-inline-functions");
         }
         if let Ok(flags) = env::var("RISC0_RV32IM_METAL_APPEND_FLAGS") {
             for flag in flags.split_whitespace() {

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -69,6 +69,7 @@ fn compile_provers() {
     rerun_if_env_changed("NVCC_APPEND_FLAGS");
     rerun_if_env_changed("NVCC_PREPEND_FLAGS");
     rerun_if_env_changed("RISC0_RV32IM_METAL_COMPARE_CPU");
+    rerun_if_env_changed("RISC0_RV32IM_METAL_APPEND_FLAGS");
     rerun_if_env_changed("RISC0_RV32IM_METAL_KERNEL_O0");
     rerun_if_env_changed("SCCACHE_RECACHE");
 
@@ -146,6 +147,11 @@ fn compile_provers() {
             .generated_files(generated_files);
         if env::var_os("RISC0_RV32IM_METAL_KERNEL_O0").is_some() {
             metal_build.flag("-O0");
+        }
+        if let Ok(flags) = env::var("RISC0_RV32IM_METAL_APPEND_FLAGS") {
+            for flag in flags.split_whitespace() {
+                metal_build.flag(flag);
+            }
         }
         metal_build.compile("metal_kernel");
 

--- a/risc0/circuit/rv32im-sys/cxx/hal/dual/hal.cpp
+++ b/risc0/circuit/rv32im-sys/cxx/hal/dual/hal.cpp
@@ -76,30 +76,33 @@ class DualHal : public IHal {
     return out;
   }
 
-  void verify(IBufferPtr buf) {
+  void verify(const char* label, IBufferPtr buf) {
     uint8_t* aPin = reinterpret_cast<uint8_t*>(a->pin(getA(buf), 0, buf->size(), true));
     uint8_t* bPin = reinterpret_cast<uint8_t*>(b->pin(getB(buf), 0, buf->size(), true));
     for (size_t i = 0; i < buf->size(); i++) {
       if (aPin[i] != bPin[i]) {
         LOG(0,
-            "DualHal buffer verify mismatch at byte " << i << ", " << aPin[i] << " vs " << bPin[i]);
+            "DualHal buffer verify mismatch after " << label << " at byte " << i << ", "
+                                                     << aPin[i] << " vs " << bPin[i]);
         throw std::runtime_error("DualHal mismatch");
       }
     }
     a->unpin(getA(buf), aPin, 0, buf->size(), false);
     b->unpin(getB(buf), bPin, 0, buf->size(), false);
   }
-  template <typename T> void verify(HalArray<T> buf) {
+  template <typename T> void verify(const char* label, HalArray<T> buf) {
     PinnedArrayRO<T> aBuf(a, getA(buf));
     PinnedArrayRO<T> bBuf(b, getB(buf));
     for (size_t i = 0; i < buf.size(); i++) {
       if (aBuf[i] != bBuf[i]) {
-        LOG(0, "DualHal array verify mismatch at " << i << ", " << aBuf[i] << " vs " << bBuf[i]);
+        LOG(0,
+            "DualHal array verify mismatch after " << label << " at " << i << ", " << aBuf[i]
+                                                   << " vs " << bBuf[i]);
         throw std::runtime_error("DualHal mismatch");
       }
     }
   }
-  template <typename T> void verify(HalMatrix<T> buf) {
+  template <typename T> void verify(const char* label, HalMatrix<T> buf) {
     PinnedMatrixRO<T> aBuf(a, getA(buf));
     PinnedMatrixRO<T> bBuf(b, getB(buf));
     for (size_t i = 0; i < buf.size(); i++) {
@@ -107,8 +110,9 @@ class DualHal : public IHal {
       size_t col = i / buf.rows();
       if (aBuf[i] != bBuf[i]) {
         LOG(0,
-            "DualHal matrix verify mismatch at row " << row << "col " << col << ", " << aBuf[i]
-                                                     << " vs " << bBuf[i]);
+            "DualHal matrix verify mismatch after " << label << " at row " << row << " col "
+                                                    << col << ", " << aBuf[i] << " vs "
+                                                    << bBuf[i]);
         throw std::runtime_error("DualHal mismatch");
       }
     }
@@ -125,25 +129,25 @@ public:
   copy(IBufferPtr dst, size_t dstOffset, IBufferPtr src, size_t srcOffset, size_t count) override {
     a->copy(getA(dst), dstOffset, getA(src), srcOffset, count);
     b->copy(getB(dst), dstOffset, getB(src), srcOffset, count);
-    verify(dst);
+    verify("copy", dst);
   }
 
   void zero(IBufferPtr buf, size_t offset, size_t size) override {
     a->zero(getA(buf), offset, size);
     b->zero(getB(buf), offset, size);
-    verify(buf);
+    verify("zero", buf);
   }
 
   void hashRows(HalArray<Digest> out, HalMatrix<Fp> in) override {
     a->hashRows(getA(out), getA(in));
     b->hashRows(getB(out), getB(in));
-    verify(out);
+    verify("hashRows", out);
   }
 
   void hashFold(HalArray<Digest> out, HalArray<Digest> in) override {
     a->hashFold(getA(out), getA(in));
     b->hashFold(getB(out), getB(in));
-    verify(out);
+    verify("hashFold", out);
   }
 
   void query(HalArray<Fp> out,
@@ -153,31 +157,31 @@ public:
              size_t idx) override {
     a->query(getA(out), getA(data), getA(tree), topSize, idx);
     b->query(getB(out), getB(data), getB(tree), topSize, idx);
-    verify(out);
+    verify("query", out);
   }
 
   void batchBitReverse(HalMatrix<Fp> io) override {
     a->batchBitReverse(getA(io));
     b->batchBitReverse(getB(io));
-    verify(io);
+    verify("batchBitReverse", io);
   }
 
   void batchExpandAndEvaluate(HalMatrix<Fp> out, HalMatrix<Fp> in) override {
     a->batchExpandAndEvaluate(getA(out), getA(in));
     b->batchExpandAndEvaluate(getB(out), getB(in));
-    verify(out);
+    verify("batchExpandAndEvaluate", out);
   }
 
   void batchInterpolate(HalMatrix<Fp> io) override {
     a->batchInterpolate(getA(io));
     b->batchInterpolate(getB(io));
-    verify(io);
+    verify("batchInterpolate", io);
   }
 
   void batchShift(HalMatrix<Fp> io) override {
     a->batchShift(getA(io));
     b->batchShift(getB(io));
-    verify(io);
+    verify("batchShift", io);
   }
 
   void batchPolyEval(HalArray<FpExt> out,
@@ -186,7 +190,7 @@ public:
                      HalArray<FpExt> xs) override {
     a->batchPolyEval(getA(out), getA(coeffs), getA(cols), getA(xs));
     b->batchPolyEval(getB(out), getB(coeffs), getB(cols), getB(xs));
-    verify(out);
+    verify("batchPolyEval", out);
   }
 
   void combosMix(HalMatrix<FpExt> combos,
@@ -196,7 +200,7 @@ public:
                  FpExt mix) override {
     a->combosMix(getA(combos), getA(coeffs), getA(whichCombo), cur, mix);
     b->combosMix(getB(combos), getB(coeffs), getB(whichCombo), cur, mix);
-    verify(combos);
+    verify("combosMix", combos);
   }
 
   void combosPrep(HalMatrix<FpExt> combos,
@@ -205,25 +209,25 @@ public:
                   FpExt mix) override {
     a->combosPrep(getA(combos), getA(eval), getA(info), mix);
     b->combosPrep(getB(combos), getB(eval), getB(info), mix);
-    verify(combos);
+    verify("combosPrep", combos);
   }
 
   void combosDivide(HalMatrix<FpExt> combos, HalArray<DivideInfo> info) override {
     a->combosDivide(getA(combos), getA(info));
     b->combosDivide(getB(combos), getB(info));
-    verify(combos);
+    verify("combosDivide", combos);
   }
 
   void combosFinalize(HalMatrix<Fp> out, HalMatrix<FpExt> combos) override {
     a->combosFinalize(getA(out), getA(combos));
     b->combosFinalize(getB(out), getB(combos));
-    verify(out);
+    verify("combosFinalize", out);
   }
 
   void friFold(HalMatrix<Fp> out, HalMatrix<Fp> in, FpExt mix) override {
     a->friFold(getA(out), getA(in), mix);
     b->friFold(getB(out), getB(in), mix);
-    verify(out);
+    verify("friFold", out);
   }
 
   void computeDataWitness(HalMatrix<Fp> data,
@@ -233,9 +237,9 @@ public:
                           HalArray<uint32_t> tables) override {
     a->computeDataWitness(getA(data), getA(globals), getA(rows), getA(aux), getA(tables));
     b->computeDataWitness(getB(data), getB(globals), getB(rows), getB(aux), getB(tables));
-    verify(data);
-    verify(globals);
-    verify(tables);
+    verify("computeDataWitness/data", data);
+    verify("computeDataWitness/globals", globals);
+    verify("computeDataWitness/tables", tables);
   }
 
   void computeAccumWitness(HalMatrix<Fp> accum,
@@ -244,7 +248,7 @@ public:
                            HalArray<FpExt> accMix) override {
     a->computeAccumWitness(getA(accum), getA(data), getA(globals), getA(accMix));
     b->computeAccumWitness(getB(accum), getB(data), getB(globals), getB(accMix));
-    verify(accum);
+    verify("computeAccumWitness", accum);
   }
 
   void evalCheck(HalMatrix<Fp> check,
@@ -255,7 +259,7 @@ public:
                  FpExt ecMix) override {
     a->evalCheck(getA(check), getA(data), getA(accum), getA(globals), getA(accMix), ecMix);
     b->evalCheck(getB(check), getB(data), getB(accum), getB(globals), getB(accMix), ecMix);
-    verify(check);
+    verify("evalCheck", check);
   }
 
   void sync() override {

--- a/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
+++ b/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <map>
+#include <sstream>
 
 #define NS_PRIVATE_IMPLEMENTATION
 #define MTL_PRIVATE_IMPLEMENTATION
@@ -523,11 +524,11 @@ public:
         if (cpuCheck[i] != pCheck[i]) {
           size_t row = i % check.rows();
           size_t col = i / check.rows();
-          LOG(0,
-              "Metal evalCheck CPU verify mismatch at po2 "
-                  << po2 << " row " << row << " col " << col << ", " << cpuCheck[i] << " vs "
-                  << pCheck[i]);
-          throw std::runtime_error("Metal evalCheck CPU verify mismatch");
+          std::ostringstream msg;
+          msg << "Metal evalCheck CPU verify mismatch at po2 " << po2 << " row " << row << " col "
+              << col << ", " << cpuCheck[i] << " vs " << pCheck[i];
+          LOG(0, msg.str());
+          throw std::runtime_error(msg.str());
         }
       }
     }

--- a/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
+++ b/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
@@ -502,6 +502,34 @@ public:
     setFpExtArg(encoder, 5, ecMix);
     setFpArg(encoder, 6, ROU_FWD[po2 + 2]);
     dispatchEasy(encoder, check.rows(), groupSize);
+
+    const char* verifyEvalCheck = std::getenv("RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU");
+    if (verifyEvalCheck && verifyEvalCheck[0] != '\0' && verifyEvalCheck[0] != '0') {
+      PinnedMatrixRO<Fp> pCheck(shared_from_this(), check);
+      PinnedMatrixRO<Fp> pData(shared_from_this(), data);
+      PinnedMatrixRO<Fp> pAccum(shared_from_this(), accum);
+      PinnedArrayRO<Fp> pGlobals(shared_from_this(), globals);
+      PinnedArrayRO<FpExt> pAccMix(shared_from_this(), accMix);
+
+      std::vector<Fp> cpuCheck(check.size());
+      evalCheckCpu(cpuCheck.data(),
+                   pData.data(),
+                   pAccum.data(),
+                   pGlobals.data(),
+                   pAccMix.data(),
+                   ecMix,
+                   check.rows());
+      for (size_t i = 0; i < cpuCheck.size(); i++) {
+        if (cpuCheck[i] != pCheck[i]) {
+          size_t row = i % check.rows();
+          size_t col = i / check.rows();
+          LOG(0,
+              "Metal evalCheck CPU verify mismatch at row "
+                  << row << " col " << col << ", " << cpuCheck[i] << " vs " << pCheck[i]);
+          throw std::runtime_error("Metal evalCheck CPU verify mismatch");
+        }
+      }
+    }
   }
 
   void sync() override {

--- a/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
+++ b/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
@@ -473,7 +473,7 @@ public:
     }
     const char* metalEvalCheck = std::getenv("RISC0_RV32IM_METAL_EVAL_CHECK");
     bool useMetalEvalCheck =
-        metalEvalCheck && metalEvalCheck[0] != '\0' && metalEvalCheck[0] != '0';
+        !metalEvalCheck || (metalEvalCheck[0] != '\0' && metalEvalCheck[0] != '0');
     if (!useMetalEvalCheck) {
       PinnedMatrixWO<Fp> pCheck(shared_from_this(), check);
       PinnedMatrixRO<Fp> pData(shared_from_this(), data);

--- a/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
+++ b/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
@@ -16,6 +16,7 @@
 #include "hal/hal.h"
 #include "hal/po2s.h"
 
+#include <cstdlib>
 #include <iostream>
 #include <map>
 
@@ -35,6 +36,18 @@
 using namespace risc0;
 
 class MetalHal;
+
+namespace risc0 {
+
+void evalCheckCpu(Fp* check,
+                  const Fp* data,
+                  const Fp* accum,
+                  const Fp* globals,
+                  const FpExt* accMix,
+                  FpExt ecMix,
+                  size_t numRows);
+
+} // namespace risc0
 
 class MetalBuffer : public IBuffer {
   friend class MetalHal;
@@ -67,7 +80,7 @@ size_t getPo2(size_t in) {
 
 class MetalHal : public IHal {
 public:
-  MetalHal() : device(nullptr) {
+  MetalHal() : autoreleasePool(NS::AutoreleasePool::alloc()->init()), device(nullptr) {
     // Get all metal devices and pick the first
     NS::Array* all = MTLCopyAllDevices();
     if (all->count() == 0) {
@@ -91,7 +104,7 @@ public:
                                      metal_kernel_len,
                                      dispatch_get_main_queue(),
                                      DISPATCH_DATA_DESTRUCTOR_DEFAULT);
-    MTL::Library* library = device->newLibrary(data, &error);
+    library = device->newLibrary(data, &error);
     dispatch_release(data);
 
     if (!library) {
@@ -99,28 +112,13 @@ public:
       throw std::runtime_error("Unable to load library");
     }
 
-    std::mutex m;
     auto allNames = library->functionNames();
-    parallel_map(allNames->count(), [this, &allNames, &library, &m](size_t i) {
+    for (size_t i = 0; i < allNames->count(); i++) {
       NS::String* name = allNames->object<NS::String>(i);
       std::string cppName = name->utf8String();
-      MTL::Function* func = library->newFunction(name);
-      NS::Error* error;
-      MTL::ComputePipelineState* pls = device->newComputePipelineState(func, &error);
-      func->release();
-      if (!pls) {
-        LOG(0,
-            "Unable to load kernel `" << cppName
-                                      << "`: " << error->localizedDescription()->utf8String());
-        throw std::runtime_error("Unable to load kernel");
-      }
-
-      m.lock();
-      kernels[cppName] = pls;
-      m.unlock();
-    });
-
-    library->release();
+      name->retain();
+      functionNames[cppName] = name;
+    }
 
     // Prepare some constants
     roundConstants = copyData(risc0::p2impl::ROUND_CONSTANTS, sizeof(Fp) * 696);
@@ -145,11 +143,20 @@ public:
     for (auto& [_, value] : kernels) {
       value->release();
     }
+    for (auto& [_, value] : functionNames) {
+      value->release();
+    }
+    if (library) {
+      library->release();
+    }
     if (commandQueue) {
       commandQueue->release();
     }
     if (device) {
       device->release();
+    }
+    if (autoreleasePool) {
+      autoreleasePool->release();
     }
   }
 
@@ -464,6 +471,25 @@ public:
     if (check.rows() != accum.rows() || accum.rows() != data.rows()) {
       throw std::runtime_error("Mismatched sizes in evalCheck");
     }
+    const char* metalEvalCheck = std::getenv("RISC0_RV32IM_METAL_EVAL_CHECK");
+    bool useMetalEvalCheck =
+        metalEvalCheck && metalEvalCheck[0] != '\0' && metalEvalCheck[0] != '0';
+    if (!useMetalEvalCheck) {
+      PinnedMatrixWO<Fp> pCheck(shared_from_this(), check);
+      PinnedMatrixRO<Fp> pData(shared_from_this(), data);
+      PinnedMatrixRO<Fp> pAccum(shared_from_this(), accum);
+      PinnedArrayRO<Fp> pGlobals(shared_from_this(), globals);
+      PinnedArrayRO<FpExt> pAccMix(shared_from_this(), accMix);
+      evalCheckCpu(
+          pCheck.data(),
+          pData.data(),
+          pAccum.data(),
+          pGlobals.data(),
+          pAccMix.data(),
+          ecMix,
+          check.rows());
+      return;
+    }
     // -2 to undo to expansion factor
     size_t po2 = getPo2(check.rows()) - 2;
     size_t groupSize;
@@ -498,9 +524,12 @@ public:
   }
 
 private:
+  NS::AutoreleasePool* autoreleasePool = nullptr;
   MTL::Device* device = nullptr;
   MTL::CommandQueue* commandQueue = nullptr;
   MTL::CommandBuffer* commandBuffer = nullptr;
+  MTL::Library* library = nullptr;
+  std::map<std::string, NS::String*> functionNames;
   std::map<std::string, MTL::ComputePipelineState*> kernels;
   IBufferPtr roundConstants;
   IBufferPtr mIntDiag;
@@ -556,8 +585,25 @@ private:
   MTL::ComputeCommandEncoder* getEncoder(const std::string& name, size_t& groupSize) {
     auto it = kernels.find(name);
     if (it == kernels.end()) {
-      LOG(0, "Invalid kernel name in call to `" << name);
-      throw std::runtime_error("Invalid kernel name");
+      auto funcName = functionNames.find(name);
+      if (funcName == functionNames.end()) {
+        LOG(0, "Invalid kernel name in call to `" << name);
+        throw std::runtime_error("Invalid kernel name");
+      }
+
+      LOG(1, "Loading metal kernel `" << name << "`");
+      MTL::Function* func = library->newFunction(funcName->second);
+      NS::Error* error = nullptr;
+      MTL::ComputePipelineState* pls = device->newComputePipelineState(func, &error);
+      func->release();
+      if (!pls) {
+        LOG(0,
+            "Unable to load kernel `" << name << "`: "
+                                      << error->localizedDescription()->utf8String());
+        throw std::runtime_error("Unable to load kernel");
+      }
+
+      it = kernels.emplace(name, pls).first;
     }
     groupSize = it->second->maxTotalThreadsPerThreadgroup();
     prepBuffer();

--- a/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
+++ b/risc0/circuit/rv32im-sys/cxx/hal/metal/hal.cpp
@@ -524,8 +524,9 @@ public:
           size_t row = i % check.rows();
           size_t col = i / check.rows();
           LOG(0,
-              "Metal evalCheck CPU verify mismatch at row "
-                  << row << " col " << col << ", " << cpuCheck[i] << " vs " << pCheck[i]);
+              "Metal evalCheck CPU verify mismatch at po2 "
+                  << po2 << " row " << row << " col " << col << ", " << cpuCheck[i] << " vs "
+                  << pCheck[i]);
           throw std::runtime_error("Metal evalCheck CPU verify mismatch");
         }
       }

--- a/risc0/circuit/rv32im-sys/cxx/rv32im/ffi.cpp
+++ b/risc0/circuit/rv32im-sys/cxx/rv32im/ffi.cpp
@@ -15,11 +15,13 @@
 
 #include "rv32im/ffi.h"
 
+#include "hal/dual/dual.h"
 #include "hal/hal.h"
 #include "prove/rv32im.h"
 #include "vendor/nvtx3/nvtx3.hpp"
 #include "verify/rv32im.h"
 
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <exception>
@@ -277,6 +279,10 @@ ProverContext* risc0_circuit_rv32im_prover_new_cpu(size_t po2) {
 ProverContext* risc0_circuit_rv32im_prover_new_gpu(size_t po2) {
   return tryRet([&] {
     IHalPtr hal = getGpuHal();
+    const char* compareCpu = std::getenv("RISC0_RV32IM_METAL_COMPARE_CPU");
+    if (compareCpu && compareCpu[0] != '\0' && compareCpu[0] != '0') {
+      hal = getDualHal(getCpuHal(), hal);
+    }
     return new ProverContext(hal, po2);
   });
 }

--- a/risc0/circuit/rv32im/src/prove.rs
+++ b/risc0/circuit/rv32im/src/prove.rs
@@ -287,4 +287,29 @@ mod tests {
     test_case!(sw);
     test_case!(xor);
     test_case!(xori);
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn require_enabled_env(name: &str) {
+        let enabled = std::env::var(name)
+            .map(|value| !value.is_empty() && value != "0")
+            .unwrap_or(false);
+        assert!(
+            enabled,
+            "{name}=1 must be set by the test command; this test intentionally \
+             avoids mutating process-global environment"
+        );
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test_log::test]
+    #[ignore = "requires Metal eval-check env vars; see metal-optimization-progress.md"]
+    #[gpu_guard::gpu_guard]
+    fn metal_eval_check_sltiu_repeated() {
+        require_enabled_env("RISC0_RV32IM_METAL_EVAL_CHECK");
+        require_enabled_env("RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU");
+
+        for _ in 0..20 {
+            run_test("sltiu", DEFAULT_PO2);
+        }
+    }
 }

--- a/risc0/zkvm/examples/datasheet.rs
+++ b/risc0/zkvm/examples/datasheet.rs
@@ -95,6 +95,10 @@ impl Po2Table {
     fn iter(&self) -> impl Iterator<Item = (u32, u32)> {
         self.0.iter().map(|(k, v)| (*k, *v))
     }
+
+    fn iter_up_to(&self, max_po2: usize) -> impl Iterator<Item = (u32, u32)> {
+        self.iter().filter(move |(po2, _)| *po2 <= max_po2 as u32)
+    }
 }
 
 /// Pre-compiled program that simply loops `count: u32` times (read from stdin).
@@ -280,11 +284,7 @@ impl Datasheet {
         let opts = ProverOpts::all_po2s().with_hashfn(hashfn.to_string());
         let prover = get_prover_server(&opts).unwrap();
 
-        for (po2, iterations) in self
-            .po2_table
-            .iter()
-            .take(args.max_po2 - MIN_CYCLES_PO2 + 1)
-        {
+        for (po2, iterations) in self.po2_table.iter_up_to(args.max_po2) {
             let expected = 1 << po2;
             println!("rv32im/{hashfn}: {expected}");
 


### PR DESCRIPTION
## Summary

This is a draft validation branch for the Apple Silicon Metal P0 investigation. It keeps the M3 rv32im Metal path enabled locally while applying a scoped Metal compiler mitigation to generated `eval_check_*.metal` kernels, adds diagnostics for the unsafe optimized path, and records validation/gaps in `docs/metal-optimization-progress.md`.

Key points:
- rv32im Metal eval-check is enabled by default on this branch.
- Generated `eval_check_*.metal` files are compiled with scoped `-fno-inline` unless `RISC0_RV32IM_METAL_INLINE_EVAL_CHECK=1` is set.
- `RISC0_RV32IM_METAL_VERIFY_EVAL_CHECK_CPU=1` compares Metal eval-check output against CPU output for focused correctness checks.
- `RISC0_RV32IM_METAL_NOINLINE_EVAL_CHECK_PO2S` can test exact protected `po2` sets; local evidence currently points at `13,14,20` as a promising but not-yet-default narrowing candidate.
- Keccak Metal remains unimplemented; Apple Silicon Keccak proofs still use the CPU Keccak circuit path.
- Adds `.github/workflows/metal_p0_validation.yml` to get explicit Apple Silicon CI signal on the existing `apple_m2_pro` runner labels, including `risc0-build-kernel` unit coverage and manual exact `13,14,20` candidate gates.

## Local validation on M5 Max

Local machine: Apple M5 Max, Xcode 26.5 build `17F42`, Apple metal `32023.883`.

Representative passes recorded in the progress doc include:
- rv32im prove suite with direct eval-check CPU verification.
- 10-pass rv32im verifier stress loop.
- focused ignored `metal_eval_check_sltiu_repeated` regression.
- `fib prove/poseidon2` segment benchmark: default Metal eval-check around 104K-108K rows/sec versus CPU eval-check fallback around 16K-18K rows/sec.
- exact `13,14,20` diagnostic set: full serial rv32im suite passed 46/46 with one ignored test, `fib prove/poseidon2` passed around 200K-216K rows/sec, and `examples/keccak hash_long` passed with `prove,risc0-zkvm/metal` in 44.37s; voting-machine protocol passed with the same exact set in 3.28s.
- datasheet composite up to 1M rows and succinct at 64K rows.
- zkVM basic, SHA, continuation, BigInt, Keccak syscall/example workloads.
- voting-machine product-style protocol workload under eval-check CPU verification.

## Current code-shape hypothesis

The local RISC0 checkout pins `@zirgen` to current `risc0/zirgen` main, so this does not look like a stale Zirgen pin. The rv32im M3 Metal `eval_check` path is a thin generated per-`po2` wrapper around checked-in `EvalCheckReg<po2>` / `verifyCircuit` code. For large `po2` values this expands a huge validity-polynomial template over row-shifted pseudo-registers, which remains the leading Metal optimizer pressure point. The current mitigation is therefore intentionally compiler-scoped while we look for a real Zirgen/M3 code-shape fix.

## CI status

The draft PR creates the `Metal P0 Validation` workflow run, but because this is a fork PR GitHub currently marks the Actions runs as `action_required`. A maintainer needs to approve running Actions before the Apple Silicon runner executes the cross-machine validation packet.

## Still draft / not production-ready

This should not be treated as final upstream-ready proof yet. The current mitigation is still a compiler-flag workaround, not a real Zirgen/M3 code-shape fix. The main missing confidence item is cross-machine/cross-toolchain Apple Silicon validation. The new Metal P0 workflow is intended to gather that signal.