### PR TITLE
docs: add GITHUB_TOKEN requirement for rzup install

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ To install `rzup` run the following command and follow the instructions:
 curl -L https://risczero.com/install | bash
 ```
 
+> **Note:** If you encounter rate limiting errors during installation, you may need to set a GitHub personal access token. Create one at [GitHub Settings > Tokens](https://github.com/settings/tokens) and export it:
+> ```bash
+> export GITHUB_TOKEN=your_token_here
+> ```
+
 Next we can install the RISC Zero toolchain by running `rzup install`:
 
 ```bash


### PR DESCRIPTION
## Description
Adds documentation about the GITHUB_TOKEN requirement during `rzup install` to help users who encounter rate limiting errors.

## Fixes
Closes #3728

## Changes
- Added a note in the Getting Started section explaining how to set up a GitHub personal access token
- Placed the note between the rzup installation and the `rzup install` command for maximum visibility

## Testing
- Reviewed the formatting in the GitHub markdown preview
- Verified the link to GitHub token settings works
- Confirmed the placement makes sense in the install flow