### PR TITLE
perf(cuda): enable po2=22 proving on RTX4090 GPUs (+40% throughput)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ compile_commands.json
 .vercel
 node_modules
 *.code-workspace
+logs/

--- a/risc0/circuit/keccak/Cargo.toml
+++ b/risc0/circuit/keccak/Cargo.toml
@@ -63,3 +63,5 @@ prove = [
   "std",
 ]
 std = ["risc0-zkp/std", "risc0-binfmt/std"]
+
+low_vram = []

--- a/risc0/circuit/keccak/src/prove/hal/cpu.rs
+++ b/risc0/circuit/keccak/src/prove/hal/cpu.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::rc::Rc;
-
 use anyhow::Result;
 use rayon::{iter::IntoParallelIterator, prelude::*};
 use risc0_circuit_keccak_sys::{
@@ -31,6 +29,7 @@ use risc0_zkp::{
     },
     INV_RATE,
 };
+use std::rc::Rc;
 
 use crate::{
     prove::{KeccakProver, KeccakProverImpl, GLOBAL_MIX, GLOBAL_OUT},
@@ -206,11 +205,26 @@ impl CircuitHal<CpuHal<CircuitField>> for CpuCircuitHal {
             }
         });
     }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        _check: &CpuBuffer<Val>,
+        _groups: &[&CpuBuffer<Val>],
+        _globals: &[&CpuBuffer<Val>],
+        _poly_mix: ExtVal,
+        _po2: usize,
+        _steps: usize,
+        _codeword_id: usize,
+    ) {
+        panic!("eval_check_interleave is not supported for CpuCircuitHal");
+    }
 }
 
 #[allow(dead_code)]
 pub fn keccak_prover() -> Result<Box<dyn KeccakProver>> {
     let hash_suite = Poseidon2HashSuite::new_suite();
+
     let hal = Rc::new(CpuHal::new(hash_suite));
     let circuit_hal = Rc::new(CpuCircuitHal);
     Ok(Box::new(KeccakProverImpl { hal, circuit_hal }))

--- a/risc0/circuit/keccak/src/prove/hal/cuda.rs
+++ b/risc0/circuit/keccak/src/prove/hal/cuda.rs
@@ -219,6 +219,20 @@ impl<CH: CudaHash> CircuitHal<CudaHal<CH>> for CudaCircuitHal<CH> {
         })
         .unwrap();
     }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        _check: &CudaBuffer<BabyBearElem>,
+        _groups: &[&CudaBuffer<BabyBearElem>],
+        _globals: &[&CudaBuffer<BabyBearElem>],
+        _poly_mix: BabyBearExtElem,
+        _po2: usize,
+        _steps: usize,
+        _codeword_id: usize,
+    ) {
+        panic!("eval_check_interleave is not supported for CudaCircuitHal");
+    }
 }
 
 pub type CudaCircuitHalPoseidon2 = CudaCircuitHal<CudaHashPoseidon2>;

--- a/risc0/circuit/recursion-sys/kernels/cuda/sppark.cu
+++ b/risc0/circuit/recursion-sys/kernels/cuda/sppark.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ff/baby_bear.hpp"
+#include <ff/baby_bear.hpp>
 #include "polynomial/prefix_op.cuh"
 #include "util/gpu_t.cuh"
 

--- a/risc0/circuit/recursion/Cargo.toml
+++ b/risc0/circuit/recursion/Cargo.toml
@@ -78,3 +78,5 @@ prove = [
 ]
 std = ["risc0-zkp/std"]
 test = []
+low_vram = []
+pinned_witgen = []

--- a/risc0/circuit/recursion/src/prove/hal/cpu.rs
+++ b/risc0/circuit/recursion/src/prove/hal/cpu.rs
@@ -160,6 +160,20 @@ impl CircuitHal<CpuHal> for CpuCircuitHal {
     ) {
         unimplemented!()
     }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        _check: &CpuBuffer<BabyBearElem>,
+        _groups: &[&CpuBuffer<BabyBearElem>],
+        _globals: &[&CpuBuffer<BabyBearElem>],
+        _poly_mix: BabyBearExtElem,
+        _po2: usize,
+        _steps: usize,
+        _codeword_id: usize,
+    ) {
+        panic!("eval_check_interleave is not supported for CpuCircuitHal");
+    }
 }
 
 #[allow(dead_code)]

--- a/risc0/circuit/recursion/src/prove/hal/cuda.rs
+++ b/risc0/circuit/recursion/src/prove/hal/cuda.rs
@@ -49,6 +49,7 @@ type CudaCircuitHalPoseidon2 = CudaCircuitHal<CudaHashPoseidon2>;
 type CudaCircuitHalPoseidon254 = CudaCircuitHal<CudaHashPoseidon254>;
 
 struct CudaCircuitHal<CH: CudaHash> {
+    // _hal: Rc<CudaHal<CH>>,
     _hal: Rc<CudaHal<CH>>, // retain a reference to ensure the context remains valid
 }
 
@@ -181,6 +182,20 @@ impl<CH: CudaHash> CircuitHal<CudaHal<CH>> for CudaCircuitHal<CH> {
         steps: usize,
     ) {
         unimplemented!()
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        _check: &CudaBuffer<BabyBearElem>,
+        _groups: &[&CudaBuffer<BabyBearElem>],
+        _globals: &[&CudaBuffer<BabyBearElem>],
+        _poly_mix: BabyBearExtElem,
+        _po2: usize,
+        _steps: usize,
+        _codeword_id: usize,
+    ) {
+        panic!("eval_check_interleave is not supported for CudaCircuitHal");
     }
 }
 

--- a/risc0/circuit/recursion/src/prove/hal/metal.rs
+++ b/risc0/circuit/recursion/src/prove/hal/metal.rs
@@ -39,12 +39,12 @@ use crate::{
 
 #[derive(Debug)]
 pub struct MetalCircuitHal<MH: MetalHash> {
-    hal: Rc<MetalHal<MH>>,
+    hal: Arc<MetalHal<MH>>,
     kernels: HashMap<String, ComputePipelineDescriptor>,
 }
 
 impl<MH: MetalHash> MetalCircuitHal<MH> {
-    pub fn new(hal: Rc<MetalHal<MH>>) -> Self {
+    pub fn new(hal: Arc<MetalHal<MH>>) -> Self {
         let library = hal.device.new_library_with_data(METAL_LIB).unwrap();
         let mut kernels = HashMap::new();
         for name in KERNEL_NAMES {
@@ -154,11 +154,25 @@ impl<MH: MetalHash> CircuitHal<MetalHal<MH>> for MetalCircuitHal<MH> {
         self.hal
             .dispatch_by_name("eltwise_zeroize_fp", &[io.as_arg()], io.size() as u64);
     }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        _check: &MetalBuffer<BabyBearElem>,
+        _groups: &[&MetalBuffer<BabyBearElem>],
+        _globals: &[&MetalBuffer<BabyBearElem>],
+        _poly_mix: BabyBearExtElem,
+        _po2: usize,
+        _steps: usize,
+        _codeword_id: usize,
+    ) {
+        panic!("eval_check_interleave is not supported for MetalCircuitHal");
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
+use std::rc::Rc;
 
     use risc0_core::field::baby_bear::BabyBear;
     use risc0_zkp::{

--- a/risc0/circuit/recursion/src/prove/mod.rs
+++ b/risc0/circuit/recursion/src/prove/mod.rs
@@ -48,6 +48,11 @@ use crate::{
 };
 
 pub use self::program::Program;
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "cuda", feature = "pinned_witgen"))] {
+        use risc0_zkp::hal::{release_buffer};
+    }
+}
 
 // TODO: Automatically generate this constant from the circuit somehow without
 // messing up bootstrap dependencies.
@@ -167,12 +172,23 @@ where
 
         let preflight = self.preflight(&program, input)?;
 
-        let witgen = WitnessGenerator::new(
-            self.hal.as_ref(),
-            self.circuit_hal.as_ref(),
-            &program,
-            &preflight,
-        )?;
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "cuda", feature = "pinned_witgen"))] {
+                let mut witgen = WitnessGenerator::new(
+                    self.hal.as_ref(),
+                    self.circuit_hal.as_ref(),
+                    &program,
+                    &preflight,
+                )?;
+            } else {
+                let witgen = WitnessGenerator::new(
+                    self.hal.as_ref(),
+                    self.circuit_hal.as_ref(),
+                    &program,
+                    &preflight,
+                )?;
+            }
+        }
 
         let global = &witgen.global;
 
@@ -214,7 +230,12 @@ where
                     std::array::from_fn(|_| prover.iop().random_elem());
 
                 let mix = witgen.accum(&self.hal, self.circuit_hal.as_ref(), &mix)?;
-
+                cfg_if::cfg_if! {
+                    if #[cfg(all(feature = "cuda", feature = "pinned_witgen"))] {
+                        release_buffer("recursion_witgen_data", self.hal.as_ref(), &mut witgen.data);
+                        release_buffer("recursion_witgen_ctrl", self.hal.as_ref(), &mut witgen.ctrl);
+                    }
+                }
                 prover.commit_group(REGISTER_GROUP_ACCUM, &witgen.accum);
 
                 mix

--- a/risc0/circuit/recursion/src/prove/program.rs
+++ b/risc0/circuit/recursion/src/prove/program.rs
@@ -95,7 +95,10 @@ impl Program {
         let coeffs = hal.copy_from_elem("coeffs", &code);
         // Do interpolate & shift
         hal.batch_interpolate_ntt(&coeffs, self.code_size);
-        hal.zk_shift(&coeffs, self.code_size);
+        let beta = BabyBearElem::from(3u32);
+        let factor = 1;
+        hal.zk_shift(&coeffs, self.code_size, beta, factor);
+
         // Make the poly-group & extract the root
         let code_group = PolyGroup::new(hal, coeffs, self.code_size, cycles, "code");
         let root = *code_group.merkle.root();

--- a/risc0/circuit/rv32im-sys/Cargo.toml
+++ b/risc0/circuit/rv32im-sys/Cargo.toml
@@ -24,3 +24,5 @@ risc0-build-kernel = { workspace = true }
 default = []
 cuda = ["dep:cust", "dep:sppark", "risc0-sys/cuda"]
 metal = []
+low_vram = ["risc0-sys/low_vram"]
+pinned_witgen = []

--- a/risc0/circuit/rv32im-sys/build.rs
+++ b/risc0/circuit/rv32im-sys/build.rs
@@ -82,7 +82,32 @@ fn build_cuda_kernels() {
     if env::var_os("NVCC_PREPEND_FLAGS").is_none() && env::var_os("NVCC_APPEND_FLAGS").is_none() {
         build.flag("-arch=native");
     }
-    build.files(glob_paths("kernels/cuda/*.cu")).compile(output);
+
+    if env::var("CARGO_FEATURE_PINNED_WITGEN").is_ok() {
+        println!("cargo:warning=Building with pinned_witgen feature.");
+        build.define("PINNED_WITGEN", None);
+    }
+
+    let cu_files: Vec<PathBuf> = if env::var("CARGO_FEATURE_LOW_VRAM").is_ok() {
+        println!("cargo:warning=Building with low_vram feature.");
+        build.define("LOW_VRAM", None);
+        // Include all .cu files except *_opt.cu files
+        glob_paths("kernels/cuda/*.cu")
+            .into_iter()
+            .filter(|path| !path.to_string_lossy().contains("_opt.cu"))
+            .collect()
+    } else {
+        // Exclude *_opt.cu/*low_mem_*.cu files when feature is not enabled
+        glob_paths("kernels/cuda/*.cu")
+            .into_iter()
+            .filter(|path| {
+                !(path.to_string_lossy().contains("_opt.cu")
+                    || path.to_string_lossy().contains("_lowmem_"))
+            })
+            .collect()
+    };
+
+    build.files(cu_files).compile(output);
 }
 
 fn rerun_if_changed<P: AsRef<Path>>(path: P) {

--- a/risc0/circuit/rv32im-sys/kernels/cuda/eval_check.cuh
+++ b/risc0/circuit/rv32im-sys/kernels/cuda/eval_check.cuh
@@ -298,7 +298,12 @@ extern __device__ FpExt poly_fp(uint32_t idx,
                                 const Fp* mix,
                                 const Fp* accum);
 
+#ifdef LOW_VRAM
+extern __constant__ size_t INV_RATE;
+#else
 constexpr size_t INV_RATE = 4;
+#endif
+
 constexpr size_t kNumPolyMixPows = 458;
 extern __constant__ FpExt poly_mix[kNumPolyMixPows];
 

--- a/risc0/circuit/rv32im-sys/kernels/cuda/ffi.cu
+++ b/risc0/circuit/rv32im-sys/kernels/cuda/ffi.cu
@@ -55,6 +55,76 @@ struct DeviceExecContext {
   LookupTables* tables;
 };
 
+#ifdef PINNED_WITGEN
+PreflightTrace gd_preflight;
+
+struct HostExecContext {
+  DeviceExecContext* ctx;
+//   PreflightTrace d_preflight;
+  LookupTables d_tables;
+
+  HostExecContext(ExecBuffers* buffers, PreflightTrace* preflight, size_t cycles) {
+    CUDA_OK(cudaMallocManaged(&ctx, sizeof(DeviceExecContext)));
+
+    CUDA_OK(cudaMalloc(&ctx->data, sizeof(Buffer)));
+    CUDA_OK(cudaMemcpy(ctx->data, &buffers->data, sizeof(Buffer), cudaMemcpyHostToDevice));
+
+    CUDA_OK(cudaMalloc(&ctx->global, sizeof(Buffer)));
+    CUDA_OK(cudaMemcpy(ctx->global, &buffers->global, sizeof(Buffer), cudaMemcpyHostToDevice));
+
+    size_t cycles_mem_size = cycles * sizeof(PreflightCycle);
+    CUDA_OK(cudaMalloc(&gd_preflight.cycles, cycles_mem_size));
+
+    CUDA_OK(cudaMemcpy(gd_preflight.cycles,
+                       preflight->cycles,
+                       cycles_mem_size,
+                       cudaMemcpyHostToDevice));
+
+    CUDA_OK(cudaMalloc(&gd_preflight.txns, preflight->txnsLen * sizeof(MemoryTransaction)));
+    CUDA_OK(cudaMemcpy(gd_preflight.txns,
+                       preflight->txns,
+                       preflight->txnsLen * sizeof(MemoryTransaction),
+                       cudaMemcpyHostToDevice));
+
+    CUDA_OK(cudaMalloc(&gd_preflight.bigintBytes, preflight->bigintBytesLen));
+    CUDA_OK(cudaMemcpy(gd_preflight.bigintBytes,
+                       preflight->bigintBytes,
+                       preflight->bigintBytesLen,
+                       cudaMemcpyHostToDevice));
+
+    gd_preflight.txnsLen = preflight->txnsLen;
+    gd_preflight.bigintBytesLen = preflight->bigintBytesLen;
+    gd_preflight.tableSplitCycle = preflight->tableSplitCycle;
+
+    CUDA_OK(cudaMalloc(&ctx->preflight, sizeof(PreflightTrace)));
+    CUDA_OK(
+        cudaMemcpy(ctx->preflight, &gd_preflight, sizeof(PreflightTrace), cudaMemcpyHostToDevice));
+
+    CUDA_OK(cudaMalloc(&d_tables.tableU8, (1 << 8) * sizeof(uint32_t)));
+    CUDA_OK(cudaMemset(d_tables.tableU8, 0, (1 << 8) * sizeof(uint32_t)));
+
+    CUDA_OK(cudaMalloc(&d_tables.tableU16, (1 << 16) * sizeof(uint32_t)));
+    CUDA_OK(cudaMemset(d_tables.tableU16, 0, (1 << 16) * sizeof(uint32_t)));
+
+    CUDA_OK(cudaMalloc(&ctx->tables, sizeof(LookupTables)));
+    CUDA_OK(cudaMemcpy(ctx->tables, &d_tables, sizeof(LookupTables), cudaMemcpyHostToDevice));
+  }
+
+  ~HostExecContext() {
+    cudaFree(d_tables.tableU16);
+    cudaFree(d_tables.tableU8);
+    cudaFree(ctx->tables);
+    cudaFree(gd_preflight.bigintBytes);
+    // cudaFree(d_preflight.txns);
+    // cudaFree(d_preflight.cycles);
+    cudaFree(ctx->preflight);
+    cudaFree(ctx->global);
+    cudaFree(ctx->data);
+    cudaFree(ctx);
+  }
+};
+#else
+
 struct HostExecContext {
   DeviceExecContext* ctx;
   PreflightTrace d_preflight;
@@ -119,6 +189,8 @@ struct HostExecContext {
   }
 };
 
+#endif
+
 struct AccumBuffers {
   Buffer data;
   Buffer accum;
@@ -135,6 +207,75 @@ struct DeviceAccumContext {
   LookupTables* tables;
 };
 
+
+#ifdef PINNED_WITGEN
+
+struct HostAccumContext {
+    DeviceAccumContext* ctx;
+  //   PreflightTrace d_preflight;
+    LookupTables d_tables;
+
+    HostAccumContext(AccumBuffers* buffers, PreflightTrace* preflight, size_t cycles) {
+      CUDA_OK(cudaMallocManaged(&ctx, sizeof(DeviceAccumContext)));
+
+      CUDA_OK(cudaMalloc(&ctx->data, sizeof(Buffer)));
+      CUDA_OK(cudaMemcpy(ctx->data, &buffers->data, sizeof(Buffer), cudaMemcpyHostToDevice));
+
+      CUDA_OK(cudaMalloc(&ctx->accum, sizeof(Buffer)));
+      CUDA_OK(cudaMemcpy(ctx->accum, &buffers->accum, sizeof(Buffer), cudaMemcpyHostToDevice));
+
+      CUDA_OK(cudaMalloc(&ctx->global, sizeof(Buffer)));
+      CUDA_OK(cudaMemcpy(ctx->global, &buffers->global, sizeof(Buffer), cudaMemcpyHostToDevice));
+
+      CUDA_OK(cudaMalloc(&ctx->mix, sizeof(Buffer)));
+      CUDA_OK(cudaMemcpy(ctx->mix, &buffers->mix, sizeof(Buffer), cudaMemcpyHostToDevice));
+
+    //   size_t cycles_mem_size = cycles * sizeof(PreflightCycle);
+      // CUDA_OK(cudaMalloc(&d_preflight.cycles, cycles_mem_size));
+      // CUDA_OK(cudaMemcpy(d_preflight.cycles,
+      //                    preflight->cycles,
+      //                    cycles_mem_size,
+      //                    cudaMemcpyHostToDevice));
+
+      // CUDA_OK(cudaMalloc(&d_preflight.txns, preflight->txnsLen * sizeof(MemoryTransaction)));
+      // CUDA_OK(cudaMemcpy(d_preflight.txns,
+      //                    preflight->txns,
+      //                    preflight->txnsLen * sizeof(MemoryTransaction),
+      //                    cudaMemcpyHostToDevice));
+
+      // d_preflight.txnsLen = preflight->txnsLen;
+      // d_preflight.tableSplitCycle = preflight->tableSplitCycle;
+
+      CUDA_OK(cudaMalloc(&ctx->preflight, sizeof(PreflightTrace)));
+      CUDA_OK(
+          cudaMemcpy(ctx->preflight, &gd_preflight, sizeof(PreflightTrace), cudaMemcpyHostToDevice));
+
+      CUDA_OK(cudaMalloc(&d_tables.tableU8, (1 << 8) * sizeof(uint32_t)));
+      CUDA_OK(cudaMemset(d_tables.tableU8, 0, (1 << 8) * sizeof(uint32_t)));
+
+      CUDA_OK(cudaMalloc(&d_tables.tableU16, (1 << 16) * sizeof(uint32_t)));
+      CUDA_OK(cudaMemset(d_tables.tableU16, 0, (1 << 16) * sizeof(uint32_t)));
+
+      CUDA_OK(cudaMalloc(&ctx->tables, sizeof(LookupTables)));
+      CUDA_OK(cudaMemcpy(ctx->tables, &d_tables, sizeof(LookupTables), cudaMemcpyHostToDevice));
+    }
+
+    ~HostAccumContext() {
+      cudaFree(d_tables.tableU16);
+      cudaFree(d_tables.tableU8);
+      cudaFree(ctx->tables);
+      cudaFree(gd_preflight.txns);
+      cudaFree(gd_preflight.cycles);
+      cudaFree(ctx->preflight);
+      cudaFree(ctx->mix);
+      cudaFree(ctx->global);
+      cudaFree(ctx->accum);
+      cudaFree(ctx->data);
+      cudaFree(ctx);
+    }
+  };
+
+#else
 struct HostAccumContext {
   DeviceAccumContext* ctx;
   PreflightTrace d_preflight;
@@ -198,6 +339,8 @@ struct HostAccumContext {
     cudaFree(ctx);
   }
 };
+
+#endif
 
 __device__ ::cuda::std::array<uint32_t, 2>
 divide_rv32im(uint32_t numer, uint32_t denom, uint32_t signType) {
@@ -428,6 +571,30 @@ extern "C" {
 
 using namespace risc0::circuit::rv32im_v2::cuda;
 
+__global__ void rv32im_witgen_scatter(Fp* into,
+    PreflightCycle* cycles,
+    const uint32_t count) {
+
+    #define CYCLE_COL         (0)
+    #define NEXT_PC_LOW       (14)
+    #define NEXT_PC_HIGH      (15)
+    #define NEXT_STATE        (16)
+    #define NEXT_MACHINE_MODE (17)
+
+    uint32_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid < count) {
+        uint32_t pc    = cycles[gid].pc;
+        uint32_t state = cycles[gid].state;
+        uint32_t mode  = cycles[gid].machineMode;
+
+        into[count*CYCLE_COL + gid]         = Fp(gid);
+        into[count*NEXT_PC_LOW + gid]       = Fp(pc & 0xffff);
+        into[count*NEXT_PC_HIGH + gid]      = Fp(pc >> 16);
+        into[count*NEXT_STATE + gid]        = Fp(state);
+        into[count*NEXT_MACHINE_MODE + gid] = Fp(mode);
+    }
+}
+
 const char* risc0_circuit_rv32im_cuda_witgen(uint32_t mode,
                                              ExecBuffers* buffers,
                                              PreflightTrace* preflight,
@@ -436,6 +603,14 @@ const char* risc0_circuit_rv32im_cuda_witgen(uint32_t mode,
     HostExecContext ctx(buffers, preflight, lastCycle);
     CudaStream stream;
     size_t split = preflight->tableSplitCycle;
+
+    launchKernel(rv32im_witgen_scatter, buffers->data.rows, 0,
+#ifdef PINNED_WITGEN
+        buffers->data.buf, gd_preflight.cycles, buffers->data.rows);
+#else
+        buffers->data.buf, ctx.d_preflight.cycles, buffers->data.rows);
+#endif
+    CUDA_OK(cudaStreamSynchronize(stream));
 
     switch (mode) {
     case kStepModeParallel: {

--- a/risc0/circuit/rv32im-sys/kernels/cuda/ffi_supra.cu
+++ b/risc0/circuit/rv32im-sys/kernels/cuda/ffi_supra.cu
@@ -22,27 +22,58 @@
 namespace risc0::circuit::rv32im_v2::cuda {
 
 __constant__ FpExt poly_mix[kNumPolyMixPows];
+#ifdef LOW_VRAM
+__constant__ size_t INV_RATE;
+#endif
+
+#ifdef LOW_VRAM
+__launch_bounds__(32, 4) __global__ void eval_check_interleave(Fp* check,
+    const Fp* ctrl,
+    const Fp* data,
+    const Fp* accum,
+    const Fp* mix,
+    const Fp* out,
+    const Fp rou,
+    uint32_t po2,
+    uint32_t domain,
+    uint32_t codeword_id) {
+
+    uint32_t cycle = blockDim.x * blockIdx.x + threadIdx.x;
+    if (cycle < domain) {
+
+        FpExt tot = poly_fp(cycle, domain, ctrl, out, data, mix, accum);
+
+        Fp x = pow(rou, 4*cycle + codeword_id);
+        Fp y = pow(Fp(3) * x, 1 << po2);
+        FpExt ret = tot * inv(y - Fp(1));
+        check[domain * 0  + 4*cycle + codeword_id] = ret[0];
+        check[domain * 4  + 4*cycle + codeword_id] = ret[1];
+        check[domain * 8  + 4*cycle + codeword_id] = ret[2];
+        check[domain * 12 + 4*cycle + codeword_id] = ret[3];
+    }
+}
+#endif
 
 __global__ void eval_check(Fp* check,
-                           const Fp* ctrl,
-                           const Fp* data,
-                           const Fp* accum,
-                           const Fp* mix,
-                           const Fp* out,
-                           const Fp rou,
-                           uint32_t po2,
-                           uint32_t domain) {
-  uint32_t cycle = blockDim.x * blockIdx.x + threadIdx.x;
-  if (cycle < domain) {
-    FpExt tot = poly_fp(cycle, domain, ctrl, out, data, mix, accum);
-    Fp x = pow(rou, cycle);
-    Fp y = pow(Fp(3) * x, 1 << po2);
-    FpExt ret = tot * inv(y - Fp(1));
-    check[domain * 0 + cycle] = ret[0];
-    check[domain * 1 + cycle] = ret[1];
-    check[domain * 2 + cycle] = ret[2];
-    check[domain * 3 + cycle] = ret[3];
-  }
+    const Fp* ctrl,
+    const Fp* data,
+    const Fp* accum,
+    const Fp* mix,
+    const Fp* out,
+    const Fp rou,
+    uint32_t po2,
+    uint32_t domain) {
+    uint32_t cycle = blockDim.x * blockIdx.x + threadIdx.x;
+    if (cycle < domain) {
+        FpExt tot = poly_fp(cycle, domain, ctrl, out, data, mix, accum);
+        Fp x = pow(rou, cycle);
+        Fp y = pow(Fp(3) * x, 1 << po2);
+        FpExt ret = tot * inv(y - Fp(1));
+        check[domain * 0 + cycle] = ret[0];
+        check[domain * 1 + cycle] = ret[1];
+        check[domain * 2 + cycle] = ret[2];
+        check[domain * 3 + cycle] = ret[3];
+    }
 }
 
 } // namespace risc0::circuit::rv32im_v2::cuda
@@ -51,31 +82,106 @@ using namespace risc0::circuit::rv32im_v2::cuda;
 
 extern "C" {
 
+
+#ifdef LOW_VRAM
 const char* risc0_circuit_rv32im_cuda_eval_check(Fp* check,
-                                                 const Fp* ctrl,
-                                                 const Fp* data,
-                                                 const Fp* accum,
-                                                 const Fp* mix,
-                                                 const Fp* out,
-                                                 const Fp& rou,
-                                                 uint32_t po2,
-                                                 uint32_t domain,
-                                                 const FpExt* poly_mix_pows) {
-  try {
+    const Fp* ctrl,
+    const Fp* data,
+    const Fp* accum,
+    const Fp* mix,
+    const Fp* out,
+    const Fp& rou,
+    uint32_t po2,
+    uint32_t domain,
+    const FpExt* poly_mix_pows) {
+try {
     CUDA_OK(cudaDeviceSynchronize());
 
     CudaStream stream;
     auto cfg = getSimpleConfig(domain);
+    const size_t inv_rate = 4;
     cudaMemcpyToSymbol(poly_mix, poly_mix_pows, sizeof(poly_mix));
+    cudaMemcpyToSymbol(INV_RATE, &inv_rate, sizeof(size_t));
+
+    cfg.block.x >>= 3;
+    cfg.grid.x  <<= 3;
+
     eval_check<<<cfg.grid, cfg.block, 0, stream>>>(
-        check, ctrl, data, accum, mix, out, rou, po2, domain);
+    check, ctrl, data, accum, mix, out, rou, po2, domain);
+
     CUDA_OK(cudaStreamSynchronize(stream));
-  } catch (const std::exception& err) {
-    return strdup(err.what());
-  } catch (...) {
-    return strdup("Generic exception");
-  }
-  return nullptr;
+} catch (const std::exception& err) {
+return strdup(err.what());
+} catch (...) {
+return strdup("Generic exception");
 }
+return nullptr;
+}
+
+const char* risc0_circuit_rv32im_cuda_eval_check_interleave(Fp* check,
+    const Fp* ctrl,
+    const Fp* data,
+    const Fp* accum,
+    const Fp* mix,
+    const Fp* out,
+    const Fp& rou,
+    uint32_t po2,
+    const FpExt* poly_mix_pows,
+    uint32_t codeword_id) {
+try {
+    CUDA_OK(cudaDeviceSynchronize());
+
+    CudaStream stream;
+    uint32_t domain = 1<<po2;
+
+    const size_t inv_rate = 1;
+    cudaMemcpyToSymbol(poly_mix, poly_mix_pows, sizeof(poly_mix));
+    cudaMemcpyToSymbol(INV_RATE, &inv_rate, sizeof(size_t));
+    CUDA_OK(cudaStreamSynchronize(stream));
+
+    uint32_t block = 32;
+    uint32_t grid  = (domain + block-1) / block;
+
+    eval_check_interleave<<<grid, block, 0, stream>>>(
+    check, ctrl, data, accum, mix, out, rou, po2, domain, codeword_id);
+
+    CUDA_OK(cudaStreamSynchronize(stream));
+
+} catch (const std::exception& err) {
+return strdup(err.what());
+} catch (...) {
+return strdup("Generic exception");
+}
+return nullptr;
+}
+
+#else
+const char* risc0_circuit_rv32im_cuda_eval_check(Fp* check,
+    const Fp* ctrl,
+    const Fp* data,
+    const Fp* accum,
+    const Fp* mix,
+    const Fp* out,
+    const Fp& rou,
+    uint32_t po2,
+    uint32_t domain,
+    const FpExt* poly_mix_pows) {
+try {
+CUDA_OK(cudaDeviceSynchronize());
+
+CudaStream stream;
+auto cfg = getSimpleConfig(domain);
+cudaMemcpyToSymbol(poly_mix, poly_mix_pows, sizeof(poly_mix));
+eval_check<<<cfg.grid, cfg.block, 0, stream>>>(
+check, ctrl, data, accum, mix, out, rou, po2, domain);
+CUDA_OK(cudaStreamSynchronize(stream));
+} catch (const std::exception& err) {
+return strdup(err.what());
+} catch (...) {
+return strdup("Generic exception");
+}
+return nullptr;
+}
+#endif
 
 } // extern "C"

--- a/risc0/circuit/rv32im-sys/src/lib.rs
+++ b/risc0/circuit/rv32im-sys/src/lib.rs
@@ -130,4 +130,19 @@ extern "C" {
         domain: u32,
         poly_mix_pows: *const u32,
     ) -> *const std::os::raw::c_char;
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    pub fn risc0_circuit_rv32im_cuda_eval_check_interleave(
+        check: DevicePointer<u8>,
+        ctrl: DevicePointer<u8>,
+        data: DevicePointer<u8>,
+        accum: DevicePointer<u8>,
+        mix: DevicePointer<u8>,
+        out: DevicePointer<u8>,
+        rou: *const BabyBearElem,
+        po2: u32,
+        poly_mix_pows: *const u32,
+        codeword_id: u32,
+    ) -> *const std::os::raw::c_char;
+
 }

--- a/risc0/circuit/rv32im/Cargo.toml
+++ b/risc0/circuit/rv32im/Cargo.toml
@@ -69,6 +69,8 @@ cuda = [
 ]
 default = []
 # entropy_finder = []
+low_vram = ["risc0-circuit-rv32im-sys/low_vram"]
+pinned_witgen = ["risc0-circuit-rv32im-sys/pinned_witgen"]
 execute = [
   "anyhow/backtrace",
   "dep:byteorder",

--- a/risc0/circuit/rv32im/src/prove/hal/cpu.rs
+++ b/risc0/circuit/rv32im/src/prove/hal/cpu.rs
@@ -216,12 +216,27 @@ impl CircuitHal<CpuHal> for CpuCircuitHal {
     ) {
         unimplemented!()
     }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        _check: &CpuBuffer<Val>,
+        _groups: &[&CpuBuffer<Val>],
+        _globals: &[&CpuBuffer<Val>],
+        _poly_mix: ExtVal,
+        _po2: usize,
+        _steps: usize,
+        _codeword_id: usize,
+    ) {
+        panic!("eval_check_interleave is not supported for CpuCircuitHal");
+    }
 }
 
 #[allow(dead_code)]
 pub fn segment_prover() -> Result<Box<dyn SegmentProver>> {
     let hal_factory = || {
         let suite = Poseidon2HashSuite::new_suite();
+        // (Rc::new(CpuHal::new(suite)), Rc::new(CpuCircuitHal))
         (Rc::new(CpuHal::new(suite)), Rc::new(CpuCircuitHal))
     };
     Ok(Box::new(SegmentProverImpl::new(hal_factory)))

--- a/risc0/circuit/rv32im/src/prove/hal/cuda.rs
+++ b/risc0/circuit/rv32im/src/prove/hal/cuda.rs
@@ -34,6 +34,9 @@ use risc0_zkp::{
     INV_RATE,
 };
 
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+use risc0_circuit_rv32im_sys::risc0_circuit_rv32im_cuda_eval_check_interleave;
+
 use crate::{
     prove::{SegmentProver, GLOBAL_MIX, GLOBAL_OUT},
     zirgen::{
@@ -48,6 +51,7 @@ use super::{
 };
 
 pub struct CudaCircuitHal<CH: CudaHash> {
+    // _hal: Rc<CudaHal<CH>>, // retain a reference to ensure the context remains valid
     _hal: Rc<CudaHal<CH>>, // retain a reference to ensure the context remains valid
 }
 
@@ -96,9 +100,10 @@ impl<CH: CudaHash> CircuitWitnessGenerator<CudaHal<CH>> for CudaCircuitHal<CH> {
             bigint_bytes_len: preflight.bigint_bytes.len() as u32,
             table_split_cycle: preflight.table_split_cycle,
         };
-        ffi_wrap(|| unsafe {
+        let __r = ffi_wrap(|| unsafe {
             risc0_circuit_rv32im_cuda_witgen(mode as u32, &buffers, &preflight, cycles as u32)
-        })
+        });
+        __r
     }
 }
 
@@ -222,6 +227,66 @@ impl<CH: CudaHash> CircuitHal<CudaHal<CH>> for CudaCircuitHal<CH> {
                 po2 as u32,
                 domain as u32,
                 poly_mix_pows.as_ptr(),
+            )
+        })
+        .unwrap();
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        check: &CudaBuffer<Val>,
+        groups: &[&CudaBuffer<Val>],
+        globals: &[&CudaBuffer<Val>],
+        poly_mix: ExtVal,
+        po2: usize,
+        steps: usize,
+        codeword_id: usize,
+    ) {
+        scope!("eval_check_interleave");
+
+        let accum = groups[REGISTER_GROUP_ACCUM];
+        let ctrl = groups[REGISTER_GROUP_CODE];
+        let data = groups[REGISTER_GROUP_DATA];
+        let mix = globals[GLOBAL_MIX];
+        let out = globals[GLOBAL_OUT];
+        tracing::debug!(
+            "check: {}, ctrl: {}, data: {}, accum: {}, mix: {} out: {}",
+            check.size(),
+            ctrl.size(),
+            data.size(),
+            accum.size(),
+            mix.size(),
+            out.size()
+        );
+        tracing::debug!(
+            "total: {}",
+            (check.size() + ctrl.size() + data.size() + accum.size() + mix.size() + out.size()) * 4
+        );
+
+        const EXP_PO2: usize = log2_ceil(INV_RATE);
+        let domain = steps * INV_RATE;
+        let rou = Val::ROU_FWD[po2 + EXP_PO2];
+
+        tracing::debug!("steps: {steps}, domain: {domain}, po2: {po2}, rou: {rou:?}");
+        let poly_mix_pows = map_pow(poly_mix, POLY_MIX_POWERS);
+        let poly_mix_pows: &[u32; ExtVal::EXT_SIZE * NUM_POLY_MIX_POWERS] =
+            ExtVal::as_u32_slice(poly_mix_pows.as_slice())
+                .try_into()
+                .unwrap();
+
+        ffi_wrap(|| unsafe {
+            risc0_circuit_rv32im_cuda_eval_check_interleave(
+                check.as_device_ptr(),
+                ctrl.as_device_ptr(),
+                data.as_device_ptr(),
+                accum.as_device_ptr(),
+                mix.as_device_ptr(),
+                out.as_device_ptr(),
+                &rou as *const Val,
+                po2 as u32,
+                poly_mix_pows.as_ptr(),
+                codeword_id as u32,
             )
         })
         .unwrap();

--- a/risc0/circuit/rv32im/src/prove/hal/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/hal/mod.rs
@@ -26,6 +26,8 @@ use risc0_zkp::{
     hal::{Buffer, CircuitHal, Hal},
     prove::Prover,
 };
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+use risc0_zkp::{core::digest::Digest, LARGE_SEGMENT_PO2};
 
 use super::{
     witgen::{preflight::PreflightTrace, PreflightResults, WitnessGenerator},
@@ -43,6 +45,19 @@ use crate::{
     },
     RV32IM_SEAL_VERSION,
 };
+
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+use anyhow::anyhow;
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+use std::sync::Once;
+
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+        use risc0_zkp::hal::cuda::init_pinned_arena;
+        use risc0_zkp::hal::{release_buffer};
+        use std::mem;
+    }
+}
 
 pub(crate) struct MetaBuffer<H: Hal> {
     pub buf: H::Buffer<H::Elem>,
@@ -104,6 +119,7 @@ pub(crate) struct SegmentProverImpl<H, C, F>
 where
     H: Hal<Field = CircuitField, Elem = Val, ExtElem = ExtVal>,
     C: CircuitHal<H> + CircuitWitnessGenerator<H>,
+    // F: Fn() -> (Rc<H>, Rc<C>),
     F: Fn() -> (Rc<H>, Rc<C>),
 {
     hal_factory: F,
@@ -113,6 +129,7 @@ impl<H, C, F> SegmentProverImpl<H, C, F>
 where
     H: Hal<Field = CircuitField, Elem = Val, ExtElem = ExtVal>,
     C: CircuitHal<H> + CircuitWitnessGenerator<H>,
+    // F: Fn() -> (Rc<H>, Rc<C>),
     F: Fn() -> (Rc<H>, Rc<C>),
 {
     pub fn new(hal_factory: F) -> Self {
@@ -120,10 +137,120 @@ where
     }
 }
 
+#[allow(dead_code)]
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+fn release_digest_buf<H>(
+    name: &'static str,
+    _hal: &H,
+    buf: &mut H::Buffer<Digest>,
+    newbuf: &H::Buffer<Digest>,
+) where
+    H: Hal<Field = CircuitField, Elem = Val, ExtElem = ExtVal>,
+    H::Buffer<Digest>: Clone,
+{
+    tracing::debug!("Release {}", name);
+
+    let _dropped = mem::replace(buf, newbuf.clone());
+    drop(_dropped);
+}
+
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+fn copy_merkle2host<H>(
+    _hal: &H,
+    nodes: &H::Buffer<Digest>,
+    name: &'static str,
+) -> Result<H::Buffer<Digest>>
+where
+    H: Hal<Field = CircuitField, Elem = Val, ExtElem = ExtVal> + 'static,
+{
+    use risc0_zkp::hal::cuda::{BufferImpl, TrackedLockedBuffer};
+    let nodes_size = nodes.size();
+    let nodes_size_bytes = nodes_size * std::mem::size_of::<Digest>();
+
+    let host_buf = TrackedLockedBuffer::new(name, nodes_size_bytes)
+        .map_err(|e| anyhow!("Failed to allocate from pinned arena: {}", e))?;
+    let host_ptr = host_buf.as_raw_ptr();
+
+    unsafe {
+        let host_digests = std::slice::from_raw_parts(host_ptr as *const Digest, nodes_size);
+
+        if nodes.get_at(1) == host_digests[1] {
+            let host_buffer_impl =
+                BufferImpl::from_tracked_locked_buffer(name, host_buf, nodes_size);
+            let host_buffer: H::Buffer<Digest> = std::ptr::read(
+                &host_buffer_impl as *const BufferImpl<Digest> as *const H::Buffer<Digest>,
+            );
+
+            std::mem::forget(host_buffer_impl); // Prevent double-drop
+            return Ok(host_buffer);
+        }
+    }
+
+    unsafe {
+        extern "C" {
+            fn cudaStreamCreate(stream: *mut *mut std::ffi::c_void) -> i32;
+            fn cudaMemcpyAsync(
+                dst: *mut std::ffi::c_void,
+                src: *const std::ffi::c_void,
+                count: usize,
+                kind: u32,
+                stream: *mut std::ffi::c_void,
+            ) -> i32;
+            fn cudaStreamSynchronize(stream: *mut std::ffi::c_void) -> i32;
+            fn cudaStreamDestroy(stream: *mut std::ffi::c_void) -> i32;
+        }
+
+        // Create CUDA stream for async operations
+        let mut stream_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+        let stream_result = cudaStreamCreate(&mut stream_ptr);
+        if stream_result != 0 {
+            return Err(anyhow!(
+                "cudaStreamCreate failed: error code {}",
+                stream_result
+            ));
+        }
+
+        let buffer_impl: &BufferImpl<Digest> = std::mem::transmute(nodes);
+        let device_ptr = buffer_impl.as_device_ptr();
+
+        let result = cudaMemcpyAsync(
+            host_ptr as *mut std::ffi::c_void,
+            device_ptr.as_raw() as *const std::ffi::c_void,
+            nodes_size_bytes,
+            2, // cudaMemcpyDeviceToHost
+            stream_ptr,
+        );
+
+        if result != 0 {
+            let _ = cudaStreamDestroy(stream_ptr);
+            return Err(anyhow!("cudaMemcpyAsync failed: error code {}", result));
+        }
+
+        let sync_result = cudaStreamSynchronize(stream_ptr);
+        if sync_result != 0 {
+            let _ = cudaStreamDestroy(stream_ptr);
+            return Err(anyhow!(
+                "cudaStreamSynchronize failed: error code {}",
+                sync_result
+            ));
+        }
+
+        let host_buffer_impl = BufferImpl::from_tracked_locked_buffer(name, host_buf, nodes_size);
+        let host_buffer: H::Buffer<Digest> = std::ptr::read(
+            &host_buffer_impl as *const BufferImpl<Digest> as *const H::Buffer<Digest>,
+        );
+
+        std::mem::forget(host_buffer_impl); // Prevent double-drop
+        Ok(host_buffer)
+    }
+}
+
 impl<H, C, F> SegmentProver for SegmentProverImpl<H, C, F>
 where
-    H: Hal<Field = CircuitField, Elem = Val, ExtElem = ExtVal>,
+    // H: Hal<Field = CircuitField, Elem = Val, ExtElem = ExtVal>,
+    H: Hal<Field = CircuitField, Elem = Val, ExtElem = ExtVal> + 'static,
     C: CircuitHal<H> + CircuitWitnessGenerator<H> + CircuitAccumulator<H>,
+    // F: Fn() -> (Rc<H>, Rc<C>),
     F: Fn() -> (Rc<H>, Rc<C>),
 {
     fn preflight(&self, segment: &Segment) -> Result<PreflightResults> {
@@ -158,12 +285,31 @@ where
         let (hal, circuit_hal) = (self.hal_factory)();
 
         let po2 = preflight_results.po2();
-        let witgen =
-            WitnessGenerator::new(hal.as_ref(), circuit_hal.as_ref(), preflight_results, mode)?;
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                let mut witgen =
+                    WitnessGenerator::new(hal.as_ref(), circuit_hal.as_ref(), preflight_results, mode)?;
+            } else {
+                let witgen =
+                    WitnessGenerator::new(hal.as_ref(), circuit_hal.as_ref(), preflight_results, mode)?;
+            }
+        }
 
         let code = &witgen.code.buf;
         let data = &witgen.data.buf;
         let global = &witgen.global.buf;
+
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                static INIT_ARENA: Once = Once::new();
+                INIT_ARENA.call_once(|| {
+                    if let Err(e) = init_pinned_arena(Some(1)) {
+                        tracing::error!("Failed to initialize pinned memory arena: {}", e);
+                        tracing::warn!("Falling back to slow per-allocation cudaMallocHost");
+                    }
+                });
+            }
+        }
 
         Ok(scope!("prove_inner", {
             tracing::debug!("prove_inner");
@@ -207,12 +353,28 @@ where
                 prover.set_po2(po2 as usize);
 
                 prover.commit_group(REGISTER_GROUP_CODE, code);
+
+                cfg_if::cfg_if! {
+                    if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                        if po2 >= LARGE_SEGMENT_PO2 as u32 {
+                            let code_g = prover.groups[REGISTER_GROUP_CODE].as_mut().unwrap();
+                            let code_h = copy_merkle2host(hal.as_ref(), &code_g.merkle.nodes, "code.merkle.nodes")?;
+                            release_digest_buf("code merkle tree", hal.as_ref(), &mut code_g.merkle.nodes, &code_h);
+                        }
+                    }
+                }
+
                 prover.commit_group(REGISTER_GROUP_DATA, data);
 
                 // Make the mixing values
                 let mix: [Val; REGCOUNT_MIX] = std::array::from_fn(|_| prover.iop().random_elem());
 
                 let mix = witgen.accum(hal.as_ref(), circuit_hal.as_ref(), &mix)?;
+                cfg_if::cfg_if! {
+                    if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                        release_buffer("witgen.data.buf", hal.as_ref(), &mut witgen.data.buf);
+                    }
+                }
 
                 prover.commit_group(REGISTER_GROUP_ACCUM, &witgen.accum.buf);
 

--- a/risc0/circuit/rv32im/src/prove/witgen/mod.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/mod.rs
@@ -15,12 +15,14 @@
 pub(crate) mod bigint;
 pub(crate) mod byte_poly;
 pub(crate) mod paged_map;
+pub(crate) mod pinned_vec;
 pub(crate) mod poseidon2;
 pub(crate) mod preflight;
 pub(crate) mod sha2;
 #[cfg(test)]
 mod tests;
 
+use rayon::prelude::*;
 use std::iter::zip;
 
 use anyhow::{Context, Result};
@@ -64,7 +66,7 @@ impl PreflightResults {
     pub fn new(segment: &Segment, rand_z: ExtVal) -> Result<Self> {
         scope!("preflight_result_new");
 
-        let trace = segment.preflight(rand_z)?;
+        let mut trace = segment.preflight(rand_z)?;
 
         tracing::trace!("{segment:#?}");
         tracing::trace!("{trace:#?}");
@@ -75,6 +77,23 @@ impl PreflightResults {
 
         let global = build_global_vec(segment, &trace);
         let injector = build_injector(&trace, cycles);
+
+        let mut bigint_items: Vec<(usize, BigIntState)> = trace
+            .backs
+            .par_iter()
+            .enumerate()
+            .filter_map(|(row, back)| {
+                if let Back::BigInt(state) = back {
+                    Some((row, state.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Sort by row to maintain original order
+        bigint_items.sort_by_key(|(row, _)| *row);
+        trace.bigint_items = bigint_items;
 
         Ok(Self {
             global,
@@ -188,15 +207,14 @@ where
         let mut injector = Injector::new(self.cycles);
         let mut bigint_accum = BigIntAccum::new(last_mix);
 
-        for (row, back) in self.trace.backs.iter().enumerate() {
-            if let Back::BigInt(state) = back {
-                bigint_accum.step(state)?;
-                for (col, value) in zip(BigIntAccumState::offsets(), bigint_accum.state.as_array())
-                {
-                    injector.set(row, col, value);
-                }
-                injector.push();
+        let bigint_items = &self.trace.bigint_items;
+
+        for (row, state) in bigint_items {
+            bigint_accum.step(&state)?;
+            for (col, value) in zip(BigIntAccumState::offsets(), bigint_accum.state.as_array()) {
+                injector.set(*row, col, value);
             }
+            injector.push();
         }
 
         hal.scatter(
@@ -230,13 +248,9 @@ fn build_injector(trace: &PreflightTrace, cycles: usize) -> Injector {
     let mut injector = Injector::new(cycles);
     for (row, back) in trace.backs.iter().enumerate() {
         let cycle = &trace.cycles[row];
-        // tracing::trace!(
-        //     "[{row}] pc: {:#010x}, state: {:?}",
-        //     cycle.pc,
-        //     crate::execute::CycleState::from_u32(cycle.state).unwrap()
-        // );
-        match back {
-            Back::None => {}
+
+        let need_push = match back {
+            Back::None => false,
             Back::Ecall(s0, s1, s2) => {
                 const ECALL_S0: usize = LAYOUT_TOP.inst_result.arm8.s0._super.offset;
                 const ECALL_S1: usize = LAYOUT_TOP.inst_result.arm8.s1._super.offset;
@@ -244,11 +258,13 @@ fn build_injector(trace: &PreflightTrace, cycles: usize) -> Injector {
                 injector.set(row, ECALL_S0, *s0);
                 injector.set(row, ECALL_S1, *s1);
                 injector.set(row, ECALL_S2, *s2);
+                true
             }
             Back::Poseidon2(p2_state) => {
                 for (col, value) in zip(Poseidon2State::offsets(), p2_state.as_array()) {
                     injector.set(row, col, value);
                 }
+                true
             }
             Back::Sha2(sha2_state) => {
                 for (col, value) in zip(Sha2State::fp_offsets(), sha2_state.fp_array()) {
@@ -257,14 +273,25 @@ fn build_injector(trace: &PreflightTrace, cycles: usize) -> Injector {
                 for (col, value) in zip(Sha2State::u32_offsets(), sha2_state.u32_array()) {
                     injector.set_u32_bits(row, col, value);
                 }
+                true
             }
             Back::BigInt(state) => {
                 for (col, value) in zip(BigIntState::offsets(), state.as_array()) {
                     injector.set(row, col, value);
                 }
+                true
             }
+        };
+
+        // Skip set_cycle for Back::None rows only under cuda+pinned_witgen:
+        // there the per-row work avoided is a real perf win. For other
+        // backends (notably the cpu C++ witgen via ffi.cpp), skipping leaves
+        // injector.index unpushed for that row; stepExec then reads garbage
+        // offsets out of injector.offsets / values and MutableBufObj::load
+        // segfaults. Keep the v3.0.4 unconditional call there.
+        if need_push || !cfg!(all(feature = "pinned_witgen", feature = "cuda")) {
+            injector.set_cycle(row, cycle);
         }
-        injector.set_cycle(row, cycle);
     }
     injector
 }

--- a/risc0/circuit/rv32im/src/prove/witgen/pinned_vec.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/pinned_vec.rs
@@ -1,0 +1,346 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `PinnedVec<T>`: a `Vec`-like container backed by CUDA pinned (page-locked)
+//! host memory via `cudaMallocHost`/`cudaFreeHost`.
+//!
+//! Used by `PreflightTrace` for the three large H2D buffers (`cycles`, `txns`,
+//! `bigint_bytes`). Putting the source memory in pinned arena lets
+//! `cudaMemcpy` skip the driver's pageable→pinned bounce buffer and DMA at
+//! full PCIe gen4 bandwidth (~22 GB/s instead of ~6 GB/s).
+//!
+//! When the `cuda` feature is disabled (CPU build), `PinnedVec<T>` falls back
+//! to wrapping a plain `Vec<T>` so all callers compile unchanged.
+//!
+//! API surface is the minimum needed by `preflight.rs`: `with_capacity`,
+//! `push`, `extend_from_slice` (T: Copy), `truncate`, `len`/`is_empty`, plus
+//! `Deref<Target=[T]>` / `DerefMut<Target=[T]>` so indexing, `iter()`,
+//! `iter_mut()`, `last()`, etc. just work via the standard slice methods.
+
+#[cfg(all(feature = "cuda", feature = "pinned_witgen"))]
+mod imp {
+    use std::fmt;
+    use std::ops::{Deref, DerefMut};
+    use std::ptr::NonNull;
+
+    extern "C" {
+        fn cudaMallocHost(ptr: *mut *mut std::ffi::c_void, size: usize) -> i32;
+        fn cudaFreeHost(ptr: *mut std::ffi::c_void) -> i32;
+    }
+
+    // Global reuse pool: PinnedVec drops return their buffer here instead
+    // of calling cudaFreeHost. Subsequent with_capacity() calls scan this
+    // pool for a big-enough buffer first. Persistent for process lifetime.
+    struct PoolEntry {
+        ptr: *mut u8,
+        cap_bytes: usize,
+    }
+    unsafe impl Send for PoolEntry {}
+
+    static PINNED_POOL: std::sync::Mutex<Vec<PoolEntry>> = std::sync::Mutex::new(Vec::new());
+
+    fn pool_take(bytes_needed: usize) -> Option<PoolEntry> {
+        let mut pool = PINNED_POOL.lock().unwrap();
+        // Find the smallest buffer that fits — minimizes wasted capacity.
+        let mut best: Option<usize> = None;
+        for (i, e) in pool.iter().enumerate() {
+            if e.cap_bytes >= bytes_needed {
+                if best
+                    .map(|b| pool[b].cap_bytes > e.cap_bytes)
+                    .unwrap_or(true)
+                {
+                    best = Some(i);
+                }
+            }
+        }
+        best.map(|i| pool.swap_remove(i))
+    }
+
+    fn pool_return(entry: PoolEntry) {
+        PINNED_POOL.lock().unwrap().push(entry);
+    }
+
+    pub struct PinnedVec<T> {
+        ptr: NonNull<T>,
+        len: usize,
+        cap: usize,
+    }
+
+    // Pinned host memory is plain bytes; sharing across threads is no different
+    // from sharing a Vec across threads (still subject to T's own Send/Sync).
+    unsafe impl<T: Send> Send for PinnedVec<T> {}
+    unsafe impl<T: Sync> Sync for PinnedVec<T> {}
+
+    impl<T> PinnedVec<T> {
+        pub fn new() -> Self {
+            Self {
+                ptr: NonNull::dangling(),
+                len: 0,
+                cap: 0,
+            }
+        }
+
+        pub fn with_capacity(cap: usize) -> Self {
+            if cap == 0 {
+                return Self::new();
+            }
+            let bytes = cap
+                .checked_mul(std::mem::size_of::<T>())
+                .expect("PinnedVec capacity overflow");
+            // Try to satisfy from the global pool first: pick the smallest
+            // pooled buffer that's big enough. If none fits, fall back to
+            // cudaMallocHost.
+            if let Some(entry) = pool_take(bytes) {
+                let pooled_cap = entry.cap_bytes / std::mem::size_of::<T>();
+                return Self {
+                    ptr: unsafe { NonNull::new_unchecked(entry.ptr as *mut T) },
+                    len: 0,
+                    cap: pooled_cap,
+                };
+            }
+            let mut v = Self::new();
+            unsafe { v.alloc_to(cap) };
+            v
+        }
+
+        #[inline]
+        pub fn len(&self) -> usize {
+            self.len
+        }
+
+        #[inline]
+        #[allow(dead_code)]
+        pub fn push(&mut self, value: T) {
+            if self.len == self.cap {
+                let new_cap = if self.cap == 0 { 64 } else { self.cap * 2 };
+                unsafe { self.grow_to(new_cap) };
+            }
+            unsafe {
+                self.ptr.as_ptr().add(self.len).write(value);
+            }
+            self.len += 1;
+        }
+
+        pub fn extend_from_slice(&mut self, src: &[T])
+        where
+            T: Copy,
+        {
+            let need = self.len + src.len();
+            if need > self.cap {
+                let mut new_cap = if self.cap == 0 { 64 } else { self.cap };
+                while new_cap < need {
+                    new_cap *= 2;
+                }
+                unsafe { self.grow_to(new_cap) };
+            }
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    src.as_ptr(),
+                    self.ptr.as_ptr().add(self.len),
+                    src.len(),
+                );
+            }
+            self.len += src.len();
+        }
+
+        pub fn truncate(&mut self, new_len: usize) {
+            if new_len >= self.len {
+                return;
+            }
+            let drop_count = self.len - new_len;
+            unsafe {
+                let drop_start = self.ptr.as_ptr().add(new_len);
+                std::ptr::drop_in_place(std::slice::from_raw_parts_mut(drop_start, drop_count));
+            }
+            self.len = new_len;
+        }
+
+        // Allocate a fresh pinned buffer of `new_cap` slots; assumes cap == 0.
+        unsafe fn alloc_to(&mut self, new_cap: usize) {
+            debug_assert_eq!(self.cap, 0);
+            let bytes = new_cap
+                .checked_mul(std::mem::size_of::<T>())
+                .expect("PinnedVec capacity overflow");
+            let mut new_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+            let res = cudaMallocHost(&mut new_ptr, bytes);
+            if res != 0 {
+                panic!("cudaMallocHost({} bytes) failed: code {}", bytes, res);
+            }
+            self.ptr = NonNull::new_unchecked(new_ptr as *mut T);
+            self.cap = new_cap;
+        }
+
+        // Grow capacity to `new_cap`; allocates a new buffer, copies existing
+        // initialized prefix, frees the old one.
+        unsafe fn grow_to(&mut self, new_cap: usize) {
+            debug_assert!(new_cap >= self.len);
+            let bytes = new_cap
+                .checked_mul(std::mem::size_of::<T>())
+                .expect("PinnedVec capacity overflow");
+            let mut new_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+            let res = cudaMallocHost(&mut new_ptr, bytes);
+            if res != 0 {
+                panic!("cudaMallocHost({} bytes) failed: code {}", bytes, res);
+            }
+            let new_ptr = new_ptr as *mut T;
+            if self.len > 0 {
+                std::ptr::copy_nonoverlapping(self.ptr.as_ptr(), new_ptr, self.len);
+            }
+            if self.cap > 0 {
+                cudaFreeHost(self.ptr.as_ptr() as *mut std::ffi::c_void);
+            }
+            self.ptr = NonNull::new_unchecked(new_ptr);
+            self.cap = new_cap;
+        }
+    }
+
+    impl<T> Drop for PinnedVec<T> {
+        fn drop(&mut self) {
+            // Drop initialized elements; T may have non-trivial destructors.
+            self.truncate(0);
+            if self.cap > 0 {
+                // Return the underlying pinned buffer to the global pool
+                // instead of cudaFreeHost, so next allocation can reuse.
+                let cap_bytes = self.cap * std::mem::size_of::<T>();
+                pool_return(PoolEntry {
+                    ptr: self.ptr.as_ptr() as *mut u8,
+                    cap_bytes,
+                });
+                self.cap = 0;
+            }
+        }
+    }
+
+    impl<T> Default for PinnedVec<T> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<T> Deref for PinnedVec<T> {
+        type Target = [T];
+        fn deref(&self) -> &[T] {
+            if self.len == 0 {
+                &[]
+            } else {
+                unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+            }
+        }
+    }
+
+    impl<T> DerefMut for PinnedVec<T> {
+        fn deref_mut(&mut self) -> &mut [T] {
+            if self.len == 0 {
+                &mut []
+            } else {
+                unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+            }
+        }
+    }
+
+    impl<T: Clone> Clone for PinnedVec<T> {
+        fn clone(&self) -> Self {
+            let mut new = Self::with_capacity(self.len);
+            for item in self.iter() {
+                new.push(item.clone());
+            }
+            new
+        }
+    }
+
+    impl<T: fmt::Debug> fmt::Debug for PinnedVec<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.deref().fmt(f)
+        }
+    }
+}
+
+#[cfg(not(all(feature = "cuda", feature = "pinned_witgen")))]
+mod imp {
+    use std::fmt;
+    use std::ops::{Deref, DerefMut};
+
+    /// Fallback for non-CUDA builds: just wraps a plain `Vec<T>`.
+    /// Same API as the pinned variant so callers compile unchanged.
+    pub struct PinnedVec<T> {
+        inner: Vec<T>,
+    }
+
+    impl<T> Default for PinnedVec<T> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<T: Clone> Clone for PinnedVec<T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+
+    impl<T> PinnedVec<T> {
+        pub fn new() -> Self {
+            Self { inner: Vec::new() }
+        }
+
+        pub fn with_capacity(cap: usize) -> Self {
+            Self {
+                inner: Vec::with_capacity(cap),
+            }
+        }
+
+        #[inline]
+        pub fn len(&self) -> usize {
+            self.inner.len()
+        }
+
+        pub fn push(&mut self, value: T) {
+            self.inner.push(value)
+        }
+
+        pub fn extend_from_slice(&mut self, src: &[T])
+        where
+            T: Copy,
+        {
+            self.inner.extend_from_slice(src)
+        }
+
+        pub fn truncate(&mut self, new_len: usize) {
+            self.inner.truncate(new_len)
+        }
+    }
+
+    impl<T> Deref for PinnedVec<T> {
+        type Target = [T];
+        fn deref(&self) -> &[T] {
+            &self.inner
+        }
+    }
+
+    impl<T> DerefMut for PinnedVec<T> {
+        fn deref_mut(&mut self) -> &mut [T] {
+            &mut self.inner
+        }
+    }
+
+    impl<T: fmt::Debug> fmt::Debug for PinnedVec<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.inner.fmt(f)
+        }
+    }
+}
+
+pub use imp::PinnedVec;

--- a/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
+++ b/risc0/circuit/rv32im/src/prove/witgen/preflight.rs
@@ -55,18 +55,21 @@ pub(crate) enum Back {
     BigInt(BigIntState),
 }
 
+use super::pinned_vec::PinnedVec;
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PreflightTrace {
     #[debug("{}", cycles.len())]
-    pub cycles: Vec<RawPreflightCycle>,
+    pub cycles: PinnedVec<RawPreflightCycle>,
     #[debug("{}", txns.len())]
-    pub txns: Vec<RawMemoryTransaction>,
+    pub txns: PinnedVec<RawMemoryTransaction>,
     #[debug("{}", bigint_bytes.len())]
-    pub bigint_bytes: Vec<u8>,
+    pub bigint_bytes: PinnedVec<u8>,
     #[debug("{}", backs.len())]
     pub backs: Vec<Back>,
     pub table_split_cycle: u32,
     pub rand_z: ExtVal,
+    pub bigint_items: Vec<(usize, BigIntState)>,
 }
 
 pub(crate) struct Preflight<'a> {
@@ -124,7 +127,12 @@ impl<'a> Preflight<'a> {
         }
         Self {
             trace: PreflightTrace {
-                cycles: Vec::with_capacity(total_cycles),
+                cycles: PinnedVec::with_capacity(total_cycles),
+                // txns: observed ~4 txns per cycle on rv32im at po2=22.
+                // Pre-allocating avoids ~log2(N) cudaMallocHost calls during grow.
+                txns: PinnedVec::with_capacity(total_cycles * 4),
+                // bigint_bytes: usually 0 (no bigint), small starting cap.
+                bigint_bytes: PinnedVec::with_capacity(1024),
                 backs: Vec::with_capacity(total_cycles),
                 rand_z,
                 ..Default::default()

--- a/risc0/sys/Cargo.toml
+++ b/risc0/sys/Cargo.toml
@@ -21,3 +21,4 @@ sppark = { workspace = true, optional = true }
 default = []
 cuda = ["dep:blst", "dep:cust", "dep:sppark"]
 metal = []
+low_vram = []

--- a/risc0/sys/build.rs
+++ b/risc0/sys/build.rs
@@ -42,16 +42,41 @@ fn main() {
 }
 
 fn build_cuda_kernels(cxx_root: &Path) {
-    KernelBuild::new(KernelType::Cuda)
-        .files([
-            "kernels/zkp/cuda/combos.cu",
-            "kernels/zkp/cuda/eltwise.cu",
-            "kernels/zkp/cuda/ffi.cu",
-            "kernels/zkp/cuda/kernels.cu",
-            "kernels/zkp/cuda/sha.cu",
-            "kernels/zkp/cuda/supra/api.cu",
-            "kernels/zkp/cuda/supra/ntt.cu",
-        ])
+    // KernelBuild::new(KernelType::Cuda)
+    //     .files([
+    //         "kernels/zkp/cuda/combos.cu",
+    //         "kernels/zkp/cuda/eltwise.cu",
+    //         "kernels/zkp/cuda/ffi.cu",
+    //         "kernels/zkp/cuda/kernels.cu",
+    //         "kernels/zkp/cuda/sha.cu",
+    //         "kernels/zkp/cuda/supra/api.cu",
+    //         "kernels/zkp/cuda/supra/ntt.cu",
+    //     ])
+    //     .deps(["kernels/zkp/cuda", "kernels/zkp/cuda/supra"])
+    //     .flag("-DFEATURE_BABY_BEAR")
+    //     .include(cxx_root)
+    //     .include(env::var("DEP_BLST_C_SRC").unwrap())
+    //     .include(env::var("DEP_SPPARK_ROOT").unwrap())
+    //     .compile("risc0_zkp_cuda");
+
+    let mut builder = KernelBuild::new(KernelType::Cuda);
+
+    let files = vec![
+        "kernels/zkp/cuda/combos.cu",
+        "kernels/zkp/cuda/eltwise.cu",
+        "kernels/zkp/cuda/ffi.cu",
+        "kernels/zkp/cuda/kernels.cu",
+        "kernels/zkp/cuda/sha.cu",
+        "kernels/zkp/cuda/supra/api.cu",
+        "kernels/zkp/cuda/supra/ntt.cu",
+    ];
+
+    if env::var("CARGO_FEATURE_LOW_VRAM").is_ok() {
+        builder.flag("-DLOW_VRAM");
+    }
+
+    builder
+        .files(files)
         .deps(["kernels/zkp/cuda", "kernels/zkp/cuda/supra"])
         .flag("-DFEATURE_BABY_BEAR")
         .include(cxx_root)

--- a/risc0/sys/kernels/zkp/cuda/ffi.cu
+++ b/risc0/sys/kernels/zkp/cuda/ffi.cu
@@ -87,22 +87,207 @@ const char* risc0_zkp_cuda_mix_poly_coeffs(FpExt* out,
 }
 
 const char* risc0_zkp_cuda_batch_bit_reverse(Fp* io, const uint32_t nBits, const uint32_t count) {
-  return launchKernel(batch_bit_reverse, count, 0, io, nBits, count);
+try {
+    CudaStream stream;
+    #ifdef LOW_VRAM
+    CUDA_OK(cudaStreamSynchronize(stream));
+    #endif
+
+    int device;
+    CUDA_OK(cudaGetDevice(&device));
+    int maxThreads;
+    CUDA_OK(cudaDeviceGetAttribute(&maxThreads, cudaDevAttrMaxThreadsPerBlock, device));
+
+    uint32_t rowSize = 1 << nBits;
+    uint32_t numRows = count / rowSize;
+
+    int blockSize = maxThreads;
+    int blocksPerRow = (rowSize + blockSize - 1) / blockSize;
+
+    dim3 gridDim(blocksPerRow, numRows);
+    dim3 blockDim(blockSize);
+
+    cudaLaunchConfig_t config;
+    config.attrs = nullptr;
+    config.numAttrs = 0;
+    config.gridDim = gridDim;
+    config.blockDim = blockDim;
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+
+    CUDA_OK(cudaLaunchKernelEx(&config, batch_bit_reverse, io, nBits, count));
+    CUDA_OK(cudaStreamSynchronize(stream));
+  } catch (const std::exception& err) {
+    return strdup(err.what());
+  } catch (...) {
+    return strdup("Generic exception");
+  }
+  return nullptr;
 }
 
-const char* risc0_zkp_cuda_batch_evaluate_any(FpExt* out,
-                                              const Fp* coeffs,
-                                              const uint32_t* which,
-                                              const FpExt* xs,
-                                              uint32_t shared_size,
-                                              const uint32_t count,
-                                              const uint32_t deg) {
-  return launchKernel(batch_evaluate_any, count, shared_size, out, coeffs, which, xs, deg);
+const char* risc0_zkp_cuda_batch_evaluate_any(FpExt* d_out,
+    FpExt* d_chunk_out,
+    const Fp* coeffs,
+    const uint32_t* which,
+    const FpExt* xs,
+    const uint32_t eval_n,
+    const uint32_t deg,
+    const uint32_t chunk_n) {
+
+    try {
+        CudaStream stream;
+        #ifdef LOW_VRAM
+        CUDA_OK(cudaStreamSynchronize(stream));
+        #endif
+        int device;
+        CUDA_OK(cudaGetDevice(&device));
+        int maxThreads;
+        CUDA_OK(cudaDeviceGetAttribute(&maxThreads, cudaDevAttrMaxThreadsPerBlock, device));
+        int block = maxThreads / 4; // 256 threads for better occupancy
+        // Use the shared_size passed from Rust, or calculate if needed
+        int ssize = block * 4 * sizeof(uint32_t); // Shared memory for FpExt (4 Fp elements)
+        int grid  = eval_n * chunk_n; // grid = eval_n * chunk_n blocks
+
+        // Launch batch_evaluate_any kernel to compute chunk results
+        cudaLaunchConfig_t config;
+        config.attrs            = nullptr;
+        config.numAttrs         = 0;
+        config.gridDim          = grid;
+        config.blockDim         = block;
+        config.dynamicSmemBytes = ssize;
+        config.stream           = stream;
+
+        CUDA_OK(cudaLaunchKernelEx(&config, batch_evaluate_any, d_chunk_out, coeffs, which, xs, deg, eval_n, chunk_n));
+
+        // Launch merge kernel to combine chunk results
+
+        // int merge_block = 256;
+        // int merge_grid = (eval_n + merge_block - 1) / merge_block;
+        block = 256;
+        grid  = (eval_n + block - 1) / block;
+
+        // cudaLaunchConfig_t merge_config;
+        config.attrs            = nullptr;
+        config.numAttrs         = 0;
+        config.gridDim          = grid;
+        config.blockDim         = block;
+        config.dynamicSmemBytes = 0;
+        config.stream           = stream;
+
+        uint32_t csize = deg / chunk_n;
+        CUDA_OK(cudaLaunchKernelEx(&config, batch_evaluate_any_merge, d_out, d_chunk_out, xs, eval_n, chunk_n, csize));
+
+        CUDA_OK(cudaStreamSynchronize(stream));
+    } catch (const std::exception& err) {
+        return strdup(err.what());
+    } catch (...) {
+        return strdup("Generic exception");
+    }
+    return nullptr;
+}
+
+__constant__ Fp x_pows[50*5];
+const char* risc0_zkp_cuda_batch_evaluate_same_x(Fp* out_host,
+                                                 const Fp* coeffs,
+                                                 const uint32_t* which,
+                                                 const Fp* xs_h,
+                                                 uint32_t chunk_n,
+                                                 const uint32_t poly_n,
+                                                 const uint32_t deg,
+                                                 const uint32_t x_n) {
+  try {
+
+    size_t out_size = poly_n * chunk_n * sizeof(Fp) * x_n;
+    Fp* out_dev = nullptr;
+    CUDA_OK(cudaMalloc(&out_dev, out_size));
+
+    CudaStream stream;
+    CUDA_OK(cudaStreamSynchronize(stream));
+    int device;
+    CUDA_OK(cudaGetDevice(&device));
+    int maxThreads;
+    CUDA_OK(cudaDeviceGetAttribute(&maxThreads, cudaDevAttrMaxThreadsPerBlock, device));
+    int block = maxThreads / 4;// / 4; // 256 threads
+    int ssize = block * 4;
+    int grid  = poly_n * chunk_n;      // poly_n * 4 blocks
+
+    static Fp powxs_h[50*5];
+    for (uint32_t i=0; i<x_n; i++) {
+        Fp x = xs_h[i];
+        powxs_h[i*5] = x;
+        powxs_h[i*5 + 1] = x*x;     // x^2
+        powxs_h[i*5 + 2] = powxs_h[i*5 + 1]*x; // x^3
+        powxs_h[i*5 + 3] = powxs_h[i*5 + 2]*x; // x^4
+        powxs_h[i*5 + 4] = pow(x, block*4);      // x^(block*4)
+    }
+    cudaMemcpyToSymbol(x_pows, &powxs_h, sizeof(powxs_h));
+    CUDA_OK(cudaStreamSynchronize(stream));
+
+    cudaLaunchConfig_t config;
+    config.attrs = nullptr;
+    config.numAttrs = 0;
+    config.gridDim = grid;
+    config.blockDim = block;
+    config.dynamicSmemBytes = ssize;
+    config.stream = stream;
+
+    // Launch kernel with device memory
+    CUDA_OK(cudaLaunchKernelEx(&config, batch_evaluate_same_x, out_dev, coeffs, which, deg, poly_n, x_n, chunk_n));
+    // CUDA_OK(cudaStreamSynchronize(stream));
+
+    // Copy results from device to host
+    CUDA_OK(cudaMemcpy(out_host, out_dev, out_size, cudaMemcpyDeviceToHost));
+
+    // Free device memory
+    CUDA_OK(cudaFree(out_dev));
+    CUDA_OK(cudaStreamSynchronize(stream));
+  } catch (const std::exception& err) {
+    return strdup(err.what());
+  } catch (...) {
+    return strdup("Generic exception");
+  }
+  return nullptr;
 }
 
 const char* risc0_zkp_cuda_gather_sample(
     Fp* dst, const Fp* src, const uint32_t idx, const uint32_t size, const uint32_t stride) {
   return launchKernel(gather_sample, size, 0, dst, src, idx, size, stride);
+}
+
+const char* risc0_zkp_cuda_gather_samples_batch(Fp* dst,
+                                                const Fp* src,
+                                                const uint32_t* idxs,
+                                                const uint32_t n_idxs,
+                                                const uint32_t col_size,
+                                                const uint32_t stride) {
+  try {
+    CudaStream stream;
+    int device;
+    CUDA_OK(cudaGetDevice(&device));
+    int maxThreads;
+    CUDA_OK(cudaDeviceGetAttribute(&maxThreads, cudaDevAttrMaxThreadsPerBlock, device));
+
+    // 1D block over col_size, 2D grid (col_blocks, n_idxs).
+    int block = maxThreads / 4; // 256 typical
+    int col_blocks = (col_size + block - 1) / block;
+    dim3 grid(col_blocks, n_idxs);
+
+    cudaLaunchConfig_t config;
+    config.attrs = nullptr;
+    config.numAttrs = 0;
+    config.gridDim = grid;
+    config.blockDim = dim3(block);
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+    CUDA_OK(cudaLaunchKernelEx(&config, gather_samples_batch,
+                               dst, src, idxs, n_idxs, col_size, stride));
+    CUDA_OK(cudaStreamSynchronize(stream));
+  } catch (const std::exception& err) {
+    return strdup(err.what());
+  } catch (...) {
+    return strdup("Generic exception");
+  }
+  return nullptr;
 }
 
 const char* risc0_zkp_cuda_scatter(Fp* into,
@@ -111,6 +296,13 @@ const char* risc0_zkp_cuda_scatter(Fp* into,
                                    const Fp* values,
                                    const uint32_t count) {
   return launchKernel(scatter, count, 0, into, index, offsets, values, count);
+}
+
+const char* risc0_zkp_cuda_gather_digests_batch(uint32_t* dst,
+                                                const uint32_t* src,
+                                                const uint32_t* idxs,
+                                                const uint32_t n) {
+  return launchKernel(gather_digests_batch, n, 0, dst, src, idxs, n);
 }
 
 const char*
@@ -134,8 +326,12 @@ const char* risc0_zkp_cuda_combos_prepare(FpExt* combos,
 
   try {
     CudaStream stream;
+    #ifdef LOW_VRAM
+    CUDA_OK(cudaStreamSynchronize(stream));
+    #endif
     combos_prepare<<<1, 1, 0, stream>>>(
         combos, coeffU, regsCount, regSizes, regComboIds, cycles, mix, checkSize, comboCount);
+    CUDA_OK(cudaStreamSynchronize(stream));
   } catch (const std::exception& err) {
     return strdup(err.what());
   }

--- a/risc0/sys/kernels/zkp/cuda/kernels.cu
+++ b/risc0/sys/kernels/zkp/cuda/kernels.cu
@@ -27,48 +27,188 @@ __device__ inline constexpr size_t log2Ceil(size_t in) {
 }
 
 __global__ void batch_bit_reverse(Fp* io, const uint32_t nBits, const uint32_t count) {
-  uint totIdx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (totIdx < count) {
     uint32_t rowSize = 1 << nBits;
-    uint32_t idx = totIdx & (rowSize - 1);
-    uint32_t s = totIdx >> nBits;
-    uint32_t ridx = __brev(idx) >> (32 - nBits);
-    if (idx < ridx) {
-      size_t idx1 = s * rowSize + idx;
-      size_t idx2 = s * rowSize + ridx;
-      Fp tmp = io[idx1];
-      io[idx1] = io[idx2];
-      io[idx2] = tmp;
+    uint32_t rowIdx = blockIdx.y;
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    uint32_t numRows = count / rowSize;
+
+    if (rowIdx < numRows && idx < rowSize) {
+        uint32_t ridx = __brev(idx) >> (32 - nBits);
+
+        if (idx < ridx) {
+            size_t baseIdx = rowIdx * rowSize;
+            size_t idx1 = baseIdx + idx;
+            size_t idx2 = baseIdx + ridx;
+
+            Fp tmp = io[idx1];
+            io[idx1] = io[idx2];
+            io[idx2] = tmp;
+        }
     }
-  }
 }
 
 __global__ void batch_evaluate_any(
-    FpExt* out, const Fp* coeffs, const uint32_t* which, const FpExt* xs, const uint32_t deg) {
-  const Fp* cur_poly = coeffs + which[blockIdx.x] * deg;
-  FpExt x = xs[blockIdx.x];
-  FpExt stepx = pow(x, blockDim.x);
-  FpExt powx = pow(x, threadIdx.x);
-  FpExt tot;
-  for (size_t i = threadIdx.x; i < deg; i += blockDim.x) {
-    tot += powx * cur_poly[i];
-    powx *= stepx;
-  }
-  extern __shared__ uint32_t totsBuf[];
-  FpExt* tots = reinterpret_cast<FpExt*>(totsBuf);
-  tots[threadIdx.x] = tot;
-  __syncthreads();
-  unsigned cur = blockDim.x;
-  while (cur) {
-    cur /= 2;
-    if (threadIdx.x < cur) {
-      tots[threadIdx.x] = FpExt(tots[threadIdx.x]) + FpExt(tots[threadIdx.x + cur]);
+    FpExt* out, const Fp* coeffs, const uint32_t* which, const FpExt* xs, const uint32_t deg,
+    const uint32_t eval_n, const uint32_t chunk_n) {
+
+    uint32_t x_idx = blockIdx.x % eval_n;
+    uint32_t chunk = blockIdx.x / eval_n;
+    uint32_t poly = which[x_idx];
+
+    const Fp* coeff = coeffs + poly * deg;
+    FpExt x = xs[x_idx];
+
+    size_t cidx = chunk * (deg / chunk_n) + threadIdx.x*4;
+    FpExt stepx = pow(x, blockDim.x*4);
+    FpExt powx  = pow(x, cidx);
+
+    FpExt tot, tot1, tot2, tot3;
+    // FpExt x2 = x * x;
+    // FpExt x3 = x2 * x;
+
+    #pragma unroll 1
+    for (size_t i = threadIdx.x; i < deg/(4*chunk_n); i += blockDim.x) {
+        // size_t idx = base_idx + i * 4;
+
+        uint4 vec = *reinterpret_cast<const uint4*>(&coeff[cidx]);
+        Fp c0 = Fp::fromRaw(vec.x);
+        Fp c1 = Fp::fromRaw(vec.y);
+        Fp c2 = Fp::fromRaw(vec.z);
+        Fp c3 = Fp::fromRaw(vec.w);
+
+        tot  += powx * c0;
+        tot1 += powx * c1;// * x;
+        tot2 += powx * c2;// * x2;
+        tot3 += powx * c3;// * x3;
+
+        powx *= stepx;
+        cidx += blockDim.x*4;
     }
+    tot += x*(tot1 + (x*(tot2 + (tot3*x))));
+
+    extern __shared__ uint32_t totsBuf[];
+    FpExt* tots = reinterpret_cast<FpExt*>(totsBuf);
+    tots[threadIdx.x] = tot;
     __syncthreads();
-  }
-  if (threadIdx.x == 0) {
-    out[blockIdx.x] = tots[0];
-  }
+
+    unsigned cur = blockDim.x;
+    while (cur) {
+        cur /= 2;
+        if (threadIdx.x < cur) {
+            tots[threadIdx.x] = tots[threadIdx.x] + tots[threadIdx.x + cur];
+        }
+        __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+        out[blockIdx.x] = tots[0];
+    }
+}
+
+// Merge chunk results for batch_evaluate_any
+__global__ void batch_evaluate_any_merge(
+    FpExt* out, const FpExt* chunk_out, const FpExt* xs,
+    const uint32_t eval_n, const uint32_t chunk_n, const uint32_t csize) {
+
+    uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= eval_n) return;
+
+    FpExt x = xs[i];
+    // FpExt xp = pow(x, csize);
+
+    FpExt y = chunk_out[i];
+    // FpExt xpow = FpExt(1);
+    for (uint32_t c = 1; c < chunk_n; c++) {
+        // xpow = xpow * xp;
+        y += chunk_out[i + eval_n * c];
+        // y = y + (chunk_out[i + eval_n * c] * xpow);
+    }
+    out[i] = y;
+}
+
+extern __constant__ Fp x_pows[50*5];
+// out_dev, coeffs, which, x_pows, deg, poly_n, 1, chunk_n
+__global__ void batch_evaluate_same_x(
+    Fp* out, const Fp* coeffs, const uint32_t* which, const uint32_t deg,
+    const uint32_t poly_n, const uint32_t x_n, const uint32_t chunk_n) {
+
+    int poly  = blockIdx.x % poly_n;
+    int chunk = blockIdx.x / poly_n;
+    const Fp* coeff = coeffs + poly * deg;
+
+    Fp sum[25], powx[25];
+    #pragma unroll
+    for (uint32_t xid=0; xid<x_n; xid++) {
+        sum[xid] = Fp(0);
+        powx[xid] = pow(x_pows[xid*5 + 3], threadIdx.x);
+    }
+
+    size_t cidx = (chunk * (deg / chunk_n)) + (threadIdx.x*4);
+
+    #pragma unroll 1
+    for (uint32_t j=0, i = threadIdx.x; i < deg/(4*chunk_n); i += blockDim.x, j++) {
+
+        uint4 vec = *reinterpret_cast<const uint4*>(&coeff[cidx]);
+        Fp c0 = Fp::fromRaw(vec.x);
+        Fp c1 = Fp::fromRaw(vec.y);
+        Fp c2 = Fp::fromRaw(vec.z);
+        Fp c3 = Fp::fromRaw(vec.w);
+
+        #pragma unroll
+        for (uint32_t xid=0; xid<x_n; xid++) {
+            //         0  1    2    3    4
+            // x_pows, x, x^2, x^3, x^4, x^(block*4)
+            // sum[xid] += powx[xid] * c0;
+            // sum[xid] += powx[xid] * c1 * x_pows[xid*5];     // x
+            // sum[xid] += powx[xid] * c2 * x_pows[xid*5 + 1]; // x^2
+            // sum[xid] += powx[xid] * c3 * x_pows[xid*5 + 2]; // x^3
+
+            Fp tmp = c0 + (c1*x_pows[xid*5])     +
+                          (c2*x_pows[xid*5 + 1]) +
+                          (c3*x_pows[xid*5 + 2]);
+            sum[xid] += powx[xid] * tmp;
+
+            powx[xid] *= x_pows[xid*5 + 4];
+        }
+
+        cidx += blockDim.x*4;
+    }
+
+    const unsigned int laneId = threadIdx.x % 32;// warpSize;
+    const unsigned int warpId = threadIdx.x / 32; //warpSize;
+
+    #pragma unroll
+    for (uint32_t xid=0; xid<x_n; xid++) {
+        Fp tot = sum[xid];
+
+        for (int offset = 16; offset > 0; offset /= 2) { // 4
+            uint32_t other_val = __shfl_down_sync(0xffffffff, tot.asRaw(), offset);
+            tot = tot + Fp::fromRaw(other_val);
+        }
+
+        extern __shared__ uint32_t totsBuf[];
+        Fp* tots = reinterpret_cast<Fp*>(totsBuf);
+        if (laneId == 0) {
+            tots[warpId] = tot;
+        }
+        __syncthreads();
+
+        unsigned cur = (blockDim.x + 32 - 1) / 32; // 8
+        while (cur) {
+            cur /= 2;
+            if (threadIdx.x < cur) {
+                tots[threadIdx.x] = tots[threadIdx.x] + tots[threadIdx.x + cur];
+            }
+            __syncthreads();
+        }
+
+        if (threadIdx.x == 0) {
+            out[blockIdx.x + xid*gridDim.x] = tots[0];
+        }
+    }
+
+    // out[blockIdx.x] = tot;
 }
 
 __global__ void fri_fold(Fp* out, const Fp* in, const FpExt* mix, const uint32_t count) {
@@ -97,6 +237,38 @@ __global__ void gather_sample(
   uint gid = blockIdx.x * blockDim.x + threadIdx.x;
   if (gid < size) {
     dst[gid] = src[gid * stride + idx];
+  }
+}
+
+// One launch handles n_idxs row pickups. blockIdx.y indexes into idxs[].
+__global__ void gather_samples_batch(Fp* dst,
+                                     const Fp* src,
+                                     const uint32_t* idxs,
+                                     const uint32_t n_idxs,
+                                     const uint32_t col_size,
+                                     const uint32_t stride) {
+  uint gid = blockIdx.x * blockDim.x + threadIdx.x; // 0..col_size
+  uint k = blockIdx.y;                              // 0..n_idxs
+  if (gid < col_size && k < n_idxs) {
+    uint32_t idx = idxs[k];
+    dst[k * col_size + gid] = src[gid * stride + idx];
+  }
+}
+
+// Gather n digests (8 × u32 each) from src[idxs[k]] into dst[k]. One thread per digest.
+// Used to batch the per-idx merkle-path get_at into one kernel + one D2H instead of
+// ~50 × depth tiny cudaMemcpy calls.
+__global__ void gather_digests_batch(uint32_t* dst,
+                                     const uint32_t* src,
+                                     const uint32_t* idxs,
+                                     const uint32_t n) {
+  uint k = blockIdx.x * blockDim.x + threadIdx.x;
+  if (k < n) {
+    uint32_t idx = idxs[k];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+      dst[k * 8 + i] = src[idx * 8 + i];
+    }
   }
 }
 

--- a/risc0/sys/kernels/zkp/cuda/kernels.h
+++ b/risc0/sys/kernels/zkp/cuda/kernels.h
@@ -54,10 +54,35 @@ __global__ void mix_poly_coeffs(FpExt* out,
 __global__ void batch_bit_reverse(Fp* io, const uint32_t nBits, const uint32_t count);
 
 __global__ void batch_evaluate_any(
-    FpExt* out, const Fp* coeffs, const uint32_t* which, const FpExt* xs, const uint32_t deg);
+    FpExt* out, const Fp* coeffs, const uint32_t* which, const FpExt* xs, const uint32_t deg,
+    const uint32_t eval_count, const uint32_t chunk_num);
+
+__global__ void batch_evaluate_any_merge(
+        FpExt* out, const FpExt* chunk_out, const FpExt* xs,
+        const uint32_t eval_count, const uint32_t chunk_num, const uint32_t chunk_size);
+
+__global__ void batch_evaluate_same_x(
+    Fp* out, const Fp* coeffs, const uint32_t* which, const uint32_t deg, const uint32_t poly_n, const uint32_t x_n, const uint32_t chunk_n);
 
 __global__ void gather_sample(
     Fp* dst, const Fp* src, const uint32_t idx, const uint32_t size, const uint32_t stride);
+
+// Batched variant: gather n_idxs samples from `src` (col-major matrix) in one
+// kernel launch. dst layout: [n_idxs][col_size] row-major. Used by FRI query
+// phase where N>=50 distinct row indices are sampled from the same source.
+__global__ void gather_samples_batch(Fp* dst,
+                                     const Fp* src,
+                                     const uint32_t* idxs,
+                                     const uint32_t n_idxs,
+                                     const uint32_t col_size,
+                                     const uint32_t stride);
+
+// Batch-gather n digests from src[idxs[k]] into dst[k]. Each digest = 8×u32.
+// Replaces ~50×depth tiny per-element cudaMemcpy in merkle path collection.
+__global__ void gather_digests_batch(uint32_t* dst,
+                                     const uint32_t* src,
+                                     const uint32_t* idxs,
+                                     const uint32_t n);
 
 __global__ void scatter(Fp* into,
                         const uint32_t* index,

--- a/risc0/sys/kernels/zkp/cuda/supra/api.cu
+++ b/risc0/sys/kernels/zkp/cuda/supra/api.cu
@@ -55,6 +55,31 @@ sppark_poseidon2_rows(poseidon_out_t* d_out, const fr_t* d_in, uint32_t count, u
   return RustError{cudaSuccess};
 }
 
+#ifdef LOW_VRAM
+extern "C" RustError::by_value
+sppark_poseidon2_rows_interleave(poseidon_out_t* d_out, const fr_t* d_in, uint32_t count, uint32_t col_size, uint32_t codeword_id) {
+  const gpu_t& gpu = select_gpu();
+
+  size_t block_size = count < 256 ? count : 256;
+  size_t num_blocks = (count + block_size - 1) / block_size;
+
+  try {
+    CUDA_OK(cudaDeviceSynchronize());
+
+    _poseidon2_rows_interleave<<<num_blocks, block_size, 0, gpu>>>(d_out, d_in, count, col_size, codeword_id);
+
+    CUDA_OK(cudaGetLastError());
+
+    gpu.sync();
+  } catch (const cuda_error& e) {
+    gpu.sync();
+    return RustError{e.code(), e.what()};
+  }
+
+  return RustError{cudaSuccess};
+}
+#endif // LOW_VRAM
+
 static void compute_grid_block_size(size_t total_count, size_t& block_size, size_t& num_blocks) {
   size_t min_block_size = 4 * WARP_SZ;
 

--- a/risc0/sys/kernels/zkp/cuda/supra/ntt.cu
+++ b/risc0/sys/kernels/zkp/cuda/supra/ntt.cu
@@ -1,5 +1,10 @@
-#include "ff/baby_bear.hpp"
-#include "ntt/ntt.cuh"
+#include <ff/baby_bear.hpp>
+
+#include <ntt/ntt.cuh>  // For NTT::Base, NTT::LDE_expand, NTT::Base_dev_ptr (upstream sppark)
+
+// Include ntt_kernels.cu before ntt_lde.cuh to ensure template definitions are visible
+#include "ntt_kernels.cu"
+#include "ntt_lde.cuh"  // For NTTLDE::LDE_powers (local implementation)
 
 extern "C" RustError::by_value sppark_init() {
   uint32_t lg_domain_size = 1;
@@ -125,19 +130,98 @@ sppark_batch_iNTT(fr_t* d_inout, uint32_t lg_domain_size, uint32_t poly_count) {
 }
 
 extern "C" RustError::by_value
-sppark_batch_zk_shift(fr_t* d_inout, uint32_t lg_domain_size, uint32_t poly_count) {
+sppark_batch_zk_shift(fr_t* d_inout, uint32_t lg_domain_size, uint32_t poly_count, uint32_t beta_u32, uint32_t factor) {
   if (lg_domain_size == 0)
     return RustError{cudaSuccess};
 
-  uint32_t domain_size = 1U << lg_domain_size;
+  uint32_t batch_size = 4;
+  uint32_t batch_num = poly_count / batch_size;
+  uint32_t tail = poly_count % batch_size;
 
+  uint32_t domain_size = 1U << lg_domain_size;
+  fr_t beta = fr_t(beta_u32);
+  const gpu_t& gpu = select_gpu();
+
+  try {
+    CUDA_OK(cudaDeviceSynchronize());
+
+    for (size_t c = 0; c < batch_num; c++) {
+        uint32_t fac = factor;
+      NTTLDE::LDE_shift(gpu, &d_inout[domain_size * c * batch_size], lg_domain_size, beta, fac, batch_size);
+    }
+    if (tail>0) {
+        uint32_t fac = factor;
+      NTTLDE::LDE_shift(gpu, &d_inout[domain_size * batch_num * batch_size], lg_domain_size, beta, fac, tail);
+    }
+
+    gpu.sync();
+  } catch (const cuda_error& e) {
+    gpu.sync();
+    return RustError{e.code(), e.what()};
+  } catch (...) {
+    return RustError(cudaErrorUnknown, "Generic exception");
+  }
+
+  return RustError{cudaSuccess};
+}
+
+extern "C" RustError::by_value
+sppark_batch_zk_shift_outplace(fr_t* d_in, fr_t* d_out, uint32_t lg_domain_size,
+                               uint32_t poly_count, uint32_t beta_u32, uint32_t factor) {
+  if (lg_domain_size == 0)
+    return RustError{cudaSuccess};
+
+  uint32_t batch_size = 4;
+  uint32_t batch_num = poly_count / batch_size;
+  uint32_t tail = poly_count % batch_size;
+
+  uint32_t domain_size = 1U << lg_domain_size;
+  fr_t beta = fr_t(beta_u32);
+
+  uint32_t base_idx;
+  const gpu_t& gpu = select_gpu();
+
+  try {
+    CUDA_OK(cudaDeviceSynchronize());
+
+    for (size_t c = 0; c < batch_num; c++) {
+      uint32_t fac = factor;
+      base_idx = domain_size * c * batch_size;
+      NTTLDE::LDE_shift_outplace(gpu, &d_in[base_idx], &d_out[base_idx], lg_domain_size, beta, fac, batch_size);
+    }
+
+    if (tail>0) {
+      uint32_t fac = factor;
+      base_idx = domain_size * batch_num * batch_size;
+      NTTLDE::LDE_shift_outplace(gpu, &d_in[base_idx], &d_out[base_idx], lg_domain_size, beta, fac, tail);
+    }
+
+    gpu.sync();
+  } catch (const cuda_error& e) {
+    gpu.sync();
+    return RustError{e.code(), e.what()};
+  } catch (...) {
+    return RustError(cudaErrorUnknown, "Generic exception");
+  }
+
+  return RustError{cudaSuccess};
+}
+
+extern "C" RustError::by_value
+sppark_batch_coeffs_bitrev(fr_t* d_inout, uint32_t lg_domain_size, uint32_t poly_count) {
+  if (lg_domain_size == 0)
+    return RustError{cudaSuccess};
+
+  uint32_t base_idx;
+  uint32_t domain_size = 1U << lg_domain_size;
   const gpu_t& gpu = select_gpu();
 
   try {
     CUDA_OK(cudaDeviceSynchronize());
 
     for (size_t c = 0; c < poly_count; c++) {
-      NTT::LDE_powers(gpu, &d_inout[c * domain_size], lg_domain_size);
+      base_idx = domain_size * c;
+      NTTLDE::LDE_coeffs_bitrev(gpu, &d_inout[base_idx], lg_domain_size);
     }
 
     gpu.sync();

--- a/risc0/sys/kernels/zkp/cuda/supra/ntt_kernels.cu
+++ b/risc0/sys/kernels/zkp/cuda/supra/ntt_kernels.cu
@@ -1,0 +1,159 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __NTT_KERNELS_CU__
+#define __NTT_KERNELS_CU__
+
+#if defined(__NVCC__)
+# include <cooperative_groups.h>
+#elif defined(__HIPCC__)
+# include <hip/hip_cooperative_groups.h>
+#endif
+
+#include <ntt/parameters.cuh>
+
+__device__
+fr_t get_intermed_root(index_t pow, const fr_t (*roots)[WINDOW_SIZE])
+{
+    unsigned int off = 0;
+
+    fr_t t, root;
+
+    if (sizeof(fr_t) <= 8) {
+        root = fr_t::one();
+        bool root_set = false;
+
+        #pragma unroll
+        for (unsigned int pow_win, i = 0; i < WINDOW_NUM; i++) {
+            if (!root_set && (pow_win = pow % WINDOW_SIZE)) {
+                root = roots[i][pow_win];
+                root_set = true;
+            }
+            if (!root_set) {
+                pow >>= LG_WINDOW_SIZE;
+                off++;
+            }
+        }
+    } else {
+        if ((pow % WINDOW_SIZE) == 0) {
+            pow >>= LG_WINDOW_SIZE;
+            off++;
+        }
+        root = roots[off][pow % WINDOW_SIZE];
+    }
+
+    #pragma unroll 1
+    while (pow >>= LG_WINDOW_SIZE)
+        root *= (t = roots[++off][pow % WINDOW_SIZE]);
+
+    return root;
+}
+
+template<class fr_t>
+__launch_bounds__(1024) __global__
+void LDE_distribute_pows(fr_t* d_inout, uint32_t lg_domain_size,
+                           uint32_t lg_blowup, bool bitrev,
+                           const fr_t (*gen_powers)[WINDOW_SIZE])
+{
+#if 0
+    assert(blockDim.x * gridDim.x == blockDim.x * (size_t)gridDim.x);
+#endif
+    size_t domain_size = (size_t)1 << lg_domain_size;
+    index_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+
+    #pragma unroll 1
+    for (; idx < domain_size; idx += blockDim.x * gridDim.x) {
+        fr_t r = d_inout[idx];
+
+        index_t pow = bitrev ? bit_rev(idx, lg_domain_size) : idx;
+        pow <<= lg_blowup;
+        r *= get_intermed_root(pow, gen_powers);
+
+        d_inout[idx] = r;
+    }
+}
+
+template<class fr_t>
+__global__ //__launch_bounds__(1024)
+void LDE_distribute_shift(fr_t* d_inout, uint32_t lg_domain_size,
+                           uint32_t factor, bool bitrev,
+                           const fr_t (*gen_powers)[WINDOW_SIZE], const uint32_t poly_count)
+{
+#if 0
+    assert(blockDim.x * gridDim.x == blockDim.x * (size_t)gridDim.x);
+#endif
+    size_t domain_size = (size_t)1 << lg_domain_size;
+    index_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+
+    #pragma unroll 1
+    for (; idx < domain_size; idx += blockDim.x * gridDim.x) {
+        index_t pow = bitrev ? bit_rev(idx, lg_domain_size) : idx;
+        pow *= factor;
+        fr_t p = get_intermed_root(pow, gen_powers);
+
+        #pragma unroll
+        for (uint32_t j=0; j<poly_count; j++) {
+            fr_t r = d_inout[idx + j*domain_size];
+            r *= p;
+            d_inout[idx + j*domain_size] = r;
+        }
+    }
+}
+
+template<class fr_t>
+__global__ //__launch_bounds__(1024)
+void LDE_distribute_shift_outplace(fr_t* d_in, fr_t* d_out, uint32_t lg_domain_size,
+                           uint32_t factor, bool bitrev,
+                           const fr_t (*gen_powers)[WINDOW_SIZE], const uint32_t poly_count)
+{
+#if 0
+    assert(blockDim.x * gridDim.x == blockDim.x * (size_t)gridDim.x);
+#endif
+    size_t domain_size = (size_t)1 << lg_domain_size;
+    // index_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+
+    index_t idx = (threadIdx.x + blockDim.x * blockIdx.x) << 2;
+
+    #pragma unroll 1
+    for (; idx < domain_size; idx += blockDim.x * 4 * gridDim.x) {
+        index_t pow0 = bitrev ? bit_rev(idx+0, lg_domain_size) : idx+0;
+        index_t pow1 = bitrev ? bit_rev(idx+1, lg_domain_size) : idx+1;
+        index_t pow2 = bitrev ? bit_rev(idx+2, lg_domain_size) : idx+2;
+        index_t pow3 = bitrev ? bit_rev(idx+3, lg_domain_size) : idx+3;
+        pow0 *= factor;
+        pow1 *= factor;
+        pow2 *= factor;
+        pow3 *= factor;
+
+        // fr_t p = get_intermediate_root(pow, gen_powers);
+        fr_t p0 = get_intermed_root(pow0, gen_powers);
+        fr_t p1 = get_intermed_root(pow1, gen_powers);
+        fr_t p2 = get_intermed_root(pow2, gen_powers);
+        fr_t p3 = get_intermed_root(pow3, gen_powers);
+
+        #pragma unroll
+        for (uint32_t j=0; j<poly_count; j++) {
+
+            uint4 vec = *reinterpret_cast<const uint4*>(&d_in[idx + j*domain_size]);
+            fr_t c0 = fr_t(vec.x);
+            fr_t c1 = fr_t(vec.y);
+            fr_t c2 = fr_t(vec.z);
+            fr_t c3 = fr_t(vec.w);
+            c0 *= p0;
+            c1 *= p1;
+            c2 *= p2;
+            c3 *= p3;
+            vec.x = *c0;
+            vec.y = *c1;
+            vec.z = *c2;
+            vec.w = *c3;
+            *reinterpret_cast<uint4*>(&d_out[idx + j*domain_size]) = vec;
+        }
+
+
+    }
+}
+
+#endif // __NTT_KERNELS_CU__
+

--- a/risc0/sys/kernels/zkp/cuda/supra/ntt_lde.cuh
+++ b/risc0/sys/kernels/zkp/cuda/supra/ntt_lde.cuh
@@ -1,0 +1,245 @@
+// Copyright Supranational LLC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __SPPARK_NTT_LDE_CUH__
+#define __SPPARK_NTT_LDE_CUH__
+
+#include <ntt/parameters.cuh>
+// Ensure ntt_kernels.cu is included - undefine guard if already defined to force inclusion
+#ifdef __NTT_KERNELS_CU__
+#undef __NTT_KERNELS_CU__
+#undef __NTT_KERNELS_CU__  // Also undefine the closing endif marker if needed
+#endif
+#include "ntt_kernels.cu"
+#include <cuda_runtime.h>
+#include <util/gpu_t.cuh>
+#include <util/exception.cuh>
+#include <util/rusterror.h>
+
+// This matches the original NTT::LDE_powers implementation exactly
+class NTTLDE {
+private:
+    static void LDE_powers(fr_t* inout, bool innt, bool bitrev,
+                           uint32_t lg_dsz, uint32_t lg_blowup,
+                           stream_t& stream)
+    {
+        size_t domain_size = (size_t)1 << lg_dsz;
+        const uint32_t warpSize = gpu_props(stream).warpSize;
+        const auto gen_powers = get_partial_group_gen_powers(innt, stream, group_gen);
+
+        if (domain_size < warpSize)
+            LDE_distribute_pows<<<1, domain_size, 0, stream>>>
+                (inout, lg_dsz, lg_blowup, bitrev, gen_powers);
+        else if (lg_dsz < 32)
+            LDE_distribute_pows<<<domain_size / warpSize, warpSize, 0, stream>>>
+                (inout, lg_dsz, lg_blowup, bitrev, gen_powers);
+        else
+            LDE_distribute_pows<<<stream.sm_count(), 1024, 0, stream>>>
+                (inout, lg_dsz, lg_blowup, bitrev, gen_powers);
+
+        CUDA_OK(cudaGetLastError());
+    }
+
+    static void LDE_shift(fr_t* inout, bool innt, bool bitrev,
+                           uint32_t lg_dsz, uint32_t factor,
+                           stream_t& stream, fr_t beta, uint32_t poly_count)
+    {
+        size_t domain_size = (size_t)1 << lg_dsz;
+        const uint32_t warpSize = gpu_props(stream).warpSize;
+        const auto gen_powers = get_partial_group_gen_powers(innt, stream, beta);
+
+        if (domain_size < warpSize)
+            LDE_distribute_shift<<<1, domain_size, 0, stream>>>
+                (inout, lg_dsz, factor, bitrev, gen_powers, poly_count);
+        else if (lg_dsz < 32) {
+            int block = 256;
+            int grid  = domain_size / block;
+            LDE_distribute_shift<<<grid, block, 0, stream>>>
+                (inout, lg_dsz, factor, bitrev, gen_powers, poly_count);
+        }
+        else
+            LDE_distribute_shift<<<stream.sm_count(), 1024, 0, stream>>>
+                (inout, lg_dsz, factor, bitrev, gen_powers, poly_count);
+
+        CUDA_OK(cudaGetLastError());
+    }
+
+    static void LDE_shift_outplace(fr_t* d_in, fr_t* d_out, bool innt, bool bitrev,
+                           uint32_t lg_dsz, uint32_t factor,
+                           stream_t& stream, fr_t beta, uint32_t poly_count)
+    {
+        size_t domain_size = (size_t)1 << lg_dsz;
+        const uint32_t warpSize = gpu_props(stream).warpSize;
+        const auto gen_powers = get_partial_group_gen_powers(innt, stream, beta);
+
+        if (domain_size < warpSize)
+            LDE_distribute_shift_outplace<<<1, domain_size, 0, stream>>>
+                (d_in, d_out, lg_dsz, factor, bitrev, gen_powers, poly_count);
+        else if (lg_dsz < 32) {
+            int block = 256;
+            int grid  = domain_size / (block*4);
+            LDE_distribute_shift_outplace<<<grid, block, 0, stream>>>
+                (d_in, d_out, lg_dsz, factor, bitrev, gen_powers, poly_count);
+        }
+        else
+            LDE_distribute_shift_outplace<<<stream.sm_count(), 1024, 0, stream>>>
+                (d_in, d_out, lg_dsz, factor, bitrev, gen_powers, poly_count);
+
+        CUDA_OK(cudaGetLastError());
+    }
+
+    static auto get_partial_group_gen_powers(bool innt, stream_t& stream, fr_t beta) -> fr_t (*)[WINDOW_SIZE]
+    {
+        static fr_t (*partial_group_gen_powers)[WINDOW_SIZE] = nullptr;
+        static fr_t* partial_twiddles_base = nullptr;  // Store base pointer for deallocation
+        static fr_t beta_prv(0);
+
+        if (beta_prv != beta) {
+            // Free old memory if it exists
+            if (partial_twiddles_base != nullptr) {
+                CUDA_OK(cudaFree(partial_twiddles_base));
+                partial_twiddles_base = nullptr;
+                partial_group_gen_powers = nullptr;
+            }
+
+            const size_t partial_sz = WINDOW_NUM * WINDOW_SIZE;
+            partial_twiddles_base = reinterpret_cast<fr_t*>(stream.Dmalloc(2 * partial_sz * sizeof(fr_t)));
+            partial_group_gen_powers = reinterpret_cast<decltype(partial_group_gen_powers)>(&partial_twiddles_base[WINDOW_NUM]);
+
+            // Generate partial_group_gen_powers using group_gen (which is 3 for Baby Bear, or group_gen_inverse if innt)
+            // const fr_t gen = innt ? group_gen_inverse : group_gen; // commented by He
+            generate_partial_twiddles<<<WINDOW_SIZE/32, 32, 0, stream>>>
+                (partial_group_gen_powers, beta);
+            CUDA_OK(cudaGetLastError());
+            CUDA_OK(cudaStreamSynchronize(stream));
+
+            beta_prv = beta;
+        }
+
+        return partial_group_gen_powers;
+    }
+
+    static void bit_rev(fr_t* d_out, const fr_t* d_inp,
+        uint32_t lg_domain_size, stream_t& stream)
+{
+assert(lg_domain_size <= MAX_LG_DOMAIN_SIZE);
+
+size_t domain_size = (size_t)1 << lg_domain_size;
+// aim to read 4 cache lines of consecutive data per read
+const uint32_t Z_COUNT = 256 / sizeof(fr_t);
+// const uint32_t Z_COUNT = 256 / sizeof(fr_t);
+const uint32_t warpSize = gpu_props(stream).warpSize;
+const uint32_t bsize = Z_COUNT>warpSize ? Z_COUNT : warpSize;
+#ifdef __HIPCC__
+const uint32_t lg_switch = 17;
+#else
+const uint32_t lg_switch = 32;
+#endif
+
+if (domain_size <= 1024)
+bit_rev_permutation<<<1, domain_size, 0, stream>>>
+               (d_out, d_inp, lg_domain_size);
+else if (domain_size < bsize * Z_COUNT)
+bit_rev_permutation<<<domain_size / bsize, bsize, 0, stream>>>
+               (d_out, d_inp, lg_domain_size);
+else if (Z_COUNT > warpSize || lg_domain_size <= lg_switch)
+bit_rev_permutation_z<Z_COUNT><<<domain_size / Z_COUNT / bsize, bsize,
+                             bsize * Z_COUNT * sizeof(fr_t),
+                             stream>>>
+                 (d_out, d_inp, lg_domain_size);
+else
+// Those GPUs that can reserve 96KB of shared memory can
+// schedule 2 blocks to each SM...
+bit_rev_permutation_z<Z_COUNT><<<stream.sm_count()*2, 192,
+                             192 * Z_COUNT * sizeof(fr_t),
+                             stream>>>
+                 (d_out, d_inp, lg_domain_size);
+
+CUDA_OK(cudaGetLastError());
+}
+
+public:
+    static void LDE_powers(stream_t& stream, fr_t* d_inout, uint32_t lg_domain_size)
+    {
+        LDE_powers(d_inout, false, true, lg_domain_size, 0, stream);
+    }
+
+    // Overload to accept gpu_t (which can be implicitly converted to stream_t&)
+    static void LDE_powers(const gpu_t& gpu, fr_t* d_inout, uint32_t lg_domain_size)
+    {
+        stream_t& stream = const_cast<gpu_t&>(gpu);
+        LDE_powers(stream, d_inout, lg_domain_size);
+    }
+
+    static void LDE_shift(stream_t& stream, fr_t* d_inout, uint32_t lg_domain_size, fr_t beta, uint32_t factor, uint32_t poly_count)
+    {
+        bool bitrev = true;
+        bool prvrev = factor & 0x100;
+        bool postrev = factor & 0x80;
+
+        factor &= ~0x80;
+        factor &= ~0x100;
+        uint32_t size = 1<<lg_domain_size;
+
+        if (prvrev) {
+            for (uint32_t i=0; i<poly_count; i++)
+                bit_rev(&d_inout[i*size], &d_inout[i*size], lg_domain_size, stream);
+        }
+        LDE_shift(d_inout, false, bitrev, lg_domain_size, factor, stream, beta, poly_count);
+        if (postrev) {
+            for (uint32_t i=0; i<poly_count; i++)
+                bit_rev(&d_inout[i*size], &d_inout[i*size], lg_domain_size, stream);
+        }
+    }
+
+    static void LDE_shift_outplace(stream_t& stream, fr_t* d_in, fr_t* d_out, uint32_t lg_domain_size, fr_t beta, uint32_t factor, uint32_t poly_count)
+    {
+        bool bitrev = true;
+        bool prvrev = factor & 0x100;
+        bool postrev = factor & 0x80;
+
+        factor &= ~0x80;
+        factor &= ~0x100;
+        uint32_t size = 1<<lg_domain_size;
+
+        if (prvrev) {
+            for (uint32_t i=0; i<poly_count; i++)
+                bit_rev(&d_in[i*size], &d_in[i*size], lg_domain_size, stream);
+        }
+        LDE_shift_outplace(d_in, d_out, false, bitrev, lg_domain_size, factor, stream, beta, poly_count);
+        if (postrev) {
+            for (uint32_t i=0; i<poly_count; i++)
+                bit_rev(&d_in[i*size], &d_in[i*size], lg_domain_size, stream);
+        }
+    }
+
+    static void LDE_coeffs_bitrev(stream_t& stream, fr_t* d_inout, uint32_t lg_domain_size)
+    {
+        bit_rev(&d_inout[0], &d_inout[0], lg_domain_size, stream);
+    }
+
+    // Overload to accept gpu_t (which can be implicitly converted to stream_t&)
+    static void LDE_shift(const gpu_t& gpu, fr_t* d_inout, uint32_t lg_domain_size, fr_t beta, uint32_t factor, uint32_t poly_count)
+    {
+        stream_t& stream = const_cast<gpu_t&>(gpu);
+        LDE_shift(stream, d_inout, lg_domain_size, beta, factor, poly_count);
+    }
+
+    // Overload to accept gpu_t (which can be implicitly converted to stream_t&)
+    static void LDE_shift_outplace(const gpu_t& gpu, fr_t* d_in, fr_t* d_out, uint32_t lg_domain_size, fr_t beta, uint32_t factor, uint32_t poly_count)
+    {
+        stream_t& stream = const_cast<gpu_t&>(gpu);
+        LDE_shift_outplace(stream, d_in, d_out, lg_domain_size, beta, factor, poly_count);
+    }
+
+    static void LDE_coeffs_bitrev(const gpu_t& gpu, fr_t* d_inout, uint32_t lg_domain_size)
+    {
+        stream_t& stream = const_cast<gpu_t&>(gpu);
+        LDE_coeffs_bitrev(stream, d_inout, lg_domain_size);
+    }
+
+};
+
+#endif // __SPPARK_NTT_LDE_CUH__
+

--- a/risc0/sys/kernels/zkp/cuda/supra/poseidon2.cuh
+++ b/risc0/sys/kernels/zkp/cuda/supra/poseidon2.cuh
@@ -161,3 +161,55 @@ __launch_bounds__(256, 4) __global__
 
   out[gid] = tmp;
 }
+
+#ifdef LOW_VRAM
+
+__launch_bounds__(256, 4) __global__
+    void _poseidon2_rows_interleave(poseidon_out_t* out, const fr_t* matrix, uint32_t dim_x, uint32_t dim_y, uint32_t codeword_id) {
+  // Shared memory buffer for thread block results
+  __shared__ poseidon_out_t s_results[256];
+
+  uint32_t gid = blockDim.x * blockIdx.x + threadIdx.x;
+  uint32_t tid = threadIdx.x;
+  bool valid = (gid < dim_x);
+
+  //          24
+  fr_t cells[CELLS] = {0};
+
+  if (valid) {
+    matrix += gid;
+    uint32_t i = 0;
+
+    do {
+#pragma unroll //                16
+      for (uint32_t j = 0; j < CELLS_RATE; j++, i++)
+        cells[j] = i < dim_y ? matrix[i * dim_x] : fr_t{0};
+
+      poseidon2::poseidon2_mix(cells);
+    } while (i < dim_y);
+
+    // Store result directly in shared memory (avoiding temporary variable)
+#pragma unroll
+    for (uint32_t i = 0; i < CELLS_OUT; i++) {
+      s_results[tid].data[i] = cells[i];
+    }
+  }
+
+  __syncthreads();
+
+  // Write to global memory using vectorized access (uint4 = 16 bytes)
+  // poseidon_out_t is 32 bytes (8 * 4 bytes), aligned to 16 bytes
+  // Use uint4 to reduce memory transactions from 8 to 2
+  if (valid) {
+    uint32_t out_idx = 4 * gid + codeword_id;
+    // Cast shared memory result to uint4 for vectorized write
+    const uint4* s_data = reinterpret_cast<const uint4*>(&s_results[tid]);
+    uint4* g_data = reinterpret_cast<uint4*>(&out[out_idx]);
+
+    // Write first 16 bytes (4 fr_t elements) as a single vectorized transaction
+    g_data[0] = s_data[0];
+    // Write second 16 bytes (4 fr_t elements) as a single vectorized transaction
+    g_data[1] = s_data[1];
+  }
+}
+#endif // LOW_VRAM

--- a/risc0/sys/src/cuda.rs
+++ b/risc0/sys/src/cuda.rs
@@ -43,6 +43,23 @@ extern "C" {
         d_inout: DevicePointer<u8>,
         lg_domain_size: u32,
         poly_count: u32,
+        beta: u32,
+        factor: u32,
+    ) -> sppark::Error;
+
+    pub fn sppark_batch_zk_shift_outplace(
+        d_in: DevicePointer<u8>,
+        d_out: DevicePointer<u8>,
+        lg_domain_size: u32,
+        poly_count: u32,
+        beta: u32,
+        factor: u32,
+    ) -> sppark::Error;
+
+    pub fn sppark_batch_coeffs_bitrev(
+        d_inout: DevicePointer<u8>,
+        lg_domain_size: u32,
+        poly_count: u32,
     ) -> sppark::Error;
 
     pub fn sppark_poseidon2_fold(
@@ -56,6 +73,15 @@ extern "C" {
         d_in: DevicePointer<u8>,
         count: u32,
         col_size: u32,
+    ) -> sppark::Error;
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    pub fn sppark_poseidon2_rows_interleave(
+        d_out: DevicePointer<u8>,
+        d_in: DevicePointer<u8>,
+        count: u32,
+        col_size: u32,
+        codeword_id: u32,
     ) -> sppark::Error;
 
     pub fn sppark_poseidon254_fold(

--- a/risc0/zkp/Cargo.toml
+++ b/risc0/zkp/Cargo.toml
@@ -72,3 +72,5 @@ prove = [
 ]
 std = ["anyhow/std"]
 unstable = []
+
+low_vram = []

--- a/risc0/zkp/src/hal/cpu.rs
+++ b/risc0/zkp/src/hal/cpu.rs
@@ -349,6 +349,17 @@ impl<F: Field> Hal for CpuHal<F> {
             });
     }
 
+    fn batch_evaluate_ntt(&self, io: &Self::Buffer<Self::Elem>, count: usize) {
+        use crate::core::ntt::evaluate_ntt;
+        let row_size = io.size() / count;
+        assert_eq!(row_size * count, io.size());
+        io.as_slice_mut()
+            .par_chunks_exact_mut(row_size)
+            .for_each(|row| {
+                evaluate_ntt::<Self::Elem, Self::Elem>(row, 0);
+            });
+    }
+
     fn batch_bit_reverse(&self, io: &Self::Buffer<Self::Elem>, count: usize) {
         let row_size = io.size() / count;
         assert_eq!(row_size * count, io.size());
@@ -392,7 +403,44 @@ impl<F: Field> Hal for CpuHal<F> {
             });
     }
 
-    fn zk_shift(&self, io: &Self::Buffer<Self::Elem>, poly_count: usize) {
+    fn batch_evaluate_same_x(
+        &self,
+        coeffs: &Self::Buffer<Self::Elem>,
+        poly_count: usize,
+        which: &Self::Buffer<u32>,
+        x: Vec<Self::Elem>,
+    ) -> Vec<Self::Elem> {
+        let po2 = log2_ceil(coeffs.size() / poly_count);
+        assert_eq!(poly_count * (1 << po2), coeffs.size());
+        let eval_count = which.size();
+        let coeffs = &*coeffs.as_slice();
+        let which = which.as_slice();
+        let mut result = vec![Self::Elem::ZERO; eval_count];
+        let x_val = x.first().copied().unwrap_or(Self::Elem::ZERO);
+        (&which[..], &mut result[..])
+            .into_par_iter()
+            .for_each(|(id, out)| {
+                let mut tot = Self::Elem::ZERO;
+                let mut cur = x_val;
+                let id = *id as usize;
+                let count = 1 << po2;
+                let local = &coeffs[count * id..count * id + count];
+                for coeff in local {
+                    tot += cur * *coeff;
+                    cur *= x_val;
+                }
+                *out = tot;
+            });
+        result
+    }
+
+    fn zk_shift(
+        &self,
+        io: &Self::Buffer<Self::Elem>,
+        poly_count: usize,
+        _beta: Self::Elem,
+        _factor: u32,
+    ) {
         let bits = log2_ceil(io.size() / poly_count);
         let count = io.size();
         assert_eq!(io.size(), poly_count * (1 << bits));
@@ -405,6 +453,20 @@ impl<F: Field> Hal for CpuHal<F> {
                 let pow3 = Self::Elem::from_u64(3).pow(rev as usize);
                 *io *= pow3;
             });
+    }
+
+    fn zk_shift_outplace(
+        &self,
+        _d_in: &Self::Buffer<Self::Elem>,
+        _d_out: &Self::Buffer<Self::Elem>,
+        _poly_count: usize,
+        _beta: Self::Elem,
+        _factor: u32,
+    ) {
+    }
+
+    fn batch_coeffs_bitrev(&self, _d_inout: &Self::Buffer<Self::Elem>, _poly_count: usize) {
+        panic!("batch_coeffs_bitrev is not implemented for CPU backend");
     }
 
     fn mix_poly_coeffs(
@@ -515,6 +577,24 @@ impl<F: Field> Hal for CpuHal<F> {
             });
     }
 
+    fn copy_digest2elem(
+        &self,
+        _output: &Self::Buffer<Self::Elem>,
+        _input: &Self::Buffer<Digest>,
+        _offset_bytes: usize,
+    ) {
+        panic!("copy_digest2elem is only supported for CUDA HAL");
+    }
+
+    fn elem2dig_buffer_transmute(
+        &self,
+        _buffer: &Self::Buffer<Self::Elem>,
+        _offset_bytes: usize,
+        _count: usize,
+    ) -> Self::Buffer<Digest> {
+        panic!("elem2dig_buffer_transmute is only supported for CUDA HAL");
+    }
+
     fn eltwise_zeroize_elem(&self, elems: &Self::Buffer<Self::Elem>) {
         elems.as_slice_mut().par_iter_mut().for_each(|elem| {
             *elem = elem.valid_or_zero();
@@ -564,6 +644,16 @@ impl<F: Field> Hal for CpuHal<F> {
                 (0..col_size).map(|i| matrix[i * row_size + idx]).collect();
             *output = *hashfn.hash_elem_slice(column.as_slice());
         });
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        _output: &Self::Buffer<Digest>,
+        _matrix: &Self::Buffer<Self::Elem>,
+        _codeword_id: u32,
+    ) {
+        panic!("hash_rows_interleave is not supported for CpuHal");
     }
 
     fn hash_fold(&self, io: &Self::Buffer<Digest>, input_size: usize, output_size: usize) {

--- a/risc0/zkp/src/hal/cuda.rs
+++ b/risc0/zkp/src/hal/cuda.rs
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cell::RefCell, fmt::Debug, marker::PhantomData, rc::Rc, sync::OnceLock};
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    marker::PhantomData,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        OnceLock,
+    },
+};
 
 use anyhow::{bail, Context as _, Result};
 use cust::{
@@ -49,6 +58,195 @@ pub fn singleton() -> &'static ReentrantMutex<()> {
     ONCE.get_or_init(|| ReentrantMutex::new(()))
 }
 
+pub struct PinnedArena {
+    pub(crate) base_ptr: *mut u8,
+    pub(crate) total_size: usize,
+    current_offset: AtomicUsize,
+    // Fixed 1GB region reserved for code.merkle.nodes
+    code_merkle_nodes_ptr: *mut u8,
+    code_merkle_nodes_size: usize,
+}
+
+unsafe impl Send for PinnedArena {}
+unsafe impl Sync for PinnedArena {}
+
+impl PinnedArena {
+    unsafe fn new(size_bytes: usize) -> Result<Self> {
+        extern "C" {
+            fn cudaMallocHost(ptr: *mut *mut std::ffi::c_void, size: usize) -> i32;
+        }
+
+        let mut ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+        let result = cudaMallocHost(&mut ptr, size_bytes);
+        if result != 0 {
+            panic!(
+                "FATAL: Failed to allocate {:.2} GB pinned memory arena: CUDA error code {}. Cannot continue execution.",
+                size_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+                result
+            );
+        }
+
+        // Reserve 1GB at the beginning for code.merkle.nodes
+        const CODE_MERKLE_NODES_SIZE: usize = 1024 * 1024 * 1024; // 1GB
+        let code_merkle_nodes_ptr = ptr as *mut u8;
+        let reserved_offset = CODE_MERKLE_NODES_SIZE;
+
+        // Ensure we have enough space for the reserved region
+        if size_bytes < reserved_offset {
+            bail!("Pinned arena size ({:.2} GB) is too small. Need at least 1GB for code.merkle.nodes reservation.",
+                  size_bytes as f64 / (1024.0 * 1024.0 * 1024.0));
+        }
+
+        tracing::info!(
+            "Pinned memory arena initialized: {:.2} GB at {:p} (1GB reserved for code.merkle.nodes)",
+            size_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+            ptr
+        );
+
+        Ok(Self {
+            base_ptr: ptr as *mut u8,
+            total_size: size_bytes,
+            current_offset: AtomicUsize::new(reserved_offset), // Start after reserved region
+            code_merkle_nodes_ptr,
+            code_merkle_nodes_size: CODE_MERKLE_NODES_SIZE,
+        })
+    }
+
+    /// This method is thread-safe. Multiple threads can call `alloc` concurrently
+    /// without memory corruption. However, when the arena wraps around, previous
+    /// allocations may be overwritten, so callers must ensure their buffers are
+    /// no longer in use before wrap-around occurs.
+    fn alloc(&self, size: usize) -> Option<*mut u8> {
+        // Align to 256 bytes for optimal PCIe transfer performance
+        let aligned_size = (size + 255) & !255;
+
+        // Use a compare-and-swap loop to handle wrap-around atomically
+        loop {
+            let current = self.current_offset.load(Ordering::SeqCst);
+            let new_offset = current + aligned_size;
+
+            if new_offset > self.total_size {
+                // Arena is full, try to wrap around atomically
+                // Wrap around to after the reserved region (code.merkle.nodes)
+                let wrap_around_offset = self.code_merkle_nodes_size;
+                match self.current_offset.compare_exchange(
+                    current,
+                    wrap_around_offset + aligned_size,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => {
+                        // This thread won the race to wrap around
+                        tracing::warn!(
+                            "Pinned arena full ({}%), wrapping around. Previous allocations may be overwritten.",
+                            (current * 100) / self.total_size
+                        );
+                        // Return pointer after reserved region
+                        return unsafe { Some(self.base_ptr.add(wrap_around_offset)) };
+                    }
+                    Err(_) => {
+                        // Another thread already wrapped around, retry with new offset
+                        continue;
+                    }
+                }
+            } else {
+                // Try to atomically update the offset
+                match self.current_offset.compare_exchange(
+                    current,
+                    new_offset,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => {
+                        // Successfully allocated at offset 'current'
+                        return unsafe { Some(self.base_ptr.add(current)) };
+                    }
+                    Err(_) => {
+                        // Another thread modified current_offset, retry
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get the fixed memory address for code.merkle.nodes
+    /// This always returns the same 1GB region reserved at arena initialization.
+    fn alloc_fixed_for_code_merkle_nodes(&self, size: usize) -> Option<*mut u8> {
+        if size > self.code_merkle_nodes_size {
+            tracing::warn!(
+                "Requested size {} bytes exceeds reserved 1GB for code.merkle.nodes",
+                size
+            );
+            return None;
+        }
+        Some(self.code_merkle_nodes_ptr)
+    }
+
+    /// Get current usage statistics
+    fn usage(&self) -> (usize, usize, f64) {
+        let used = self.current_offset.load(Ordering::SeqCst);
+        let percent = (used as f64 / self.total_size as f64) * 100.0;
+        (used, self.total_size, percent)
+    }
+}
+
+impl Drop for PinnedArena {
+    fn drop(&mut self) {
+        unsafe {
+            extern "C" {
+                fn cudaFreeHost(ptr: *mut std::ffi::c_void) -> i32;
+            }
+            let result = cudaFreeHost(self.base_ptr as *mut std::ffi::c_void);
+            if result != 0 {
+                tracing::error!("Failed to free pinned arena: CUDA error code {}", result);
+            } else {
+                tracing::info!("Pinned memory arena freed");
+            }
+        }
+    }
+}
+
+// Global pinned memory arena singleton
+static PINNED_ARENA: OnceLock<PinnedArena> = OnceLock::new();
+
+/// Get or initialize the global pinned memory arena.
+pub fn pinned_arena() -> &'static PinnedArena {
+    PINNED_ARENA
+        .get()
+        .expect("Pinned arena not initialized! Call init_pinned_arena() first.")
+}
+
+pub fn init_pinned_arena(size_gb: Option<usize>) -> Result<()> {
+    let size_gb = size_gb.unwrap_or_else(|| {
+        std::env::var("PINNED_ARENA_SIZE_GB")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10) // Default: 10GB
+    });
+
+    let size_bytes = size_gb * 1024 * 1024 * 1024;
+
+    tracing::info!(
+        "Initializing pinned memory arena: {} GB (this may take 2-3 seconds)...",
+        size_gb
+    );
+    let t_start = std::time::Instant::now();
+
+    let arena = unsafe { PinnedArena::new(size_bytes)? };
+
+    PINNED_ARENA
+        .set(arena)
+        .map_err(|_| anyhow::anyhow!("Pinned arena already initialized"))?;
+
+    tracing::info!(
+        "Pinned arena ready in {:.2}s - subsequent allocations will be <1μs!",
+        t_start.elapsed().as_secs_f64()
+    );
+
+    Ok(())
+}
+
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct DeviceElem(pub BabyBearElem);
@@ -70,6 +268,15 @@ pub trait CudaHash {
 
     /// Run the hash_rows function
     fn hash_rows(&self, output: &BufferImpl<Digest>, matrix: &BufferImpl<BabyBearElem>);
+
+    /// Run the hash_rows_interleave function
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        output: &BufferImpl<Digest>,
+        matrix: &BufferImpl<BabyBearElem>,
+        codeword_id: u32,
+    );
 
     /// Return the HashSuite
     fn get_hash_suite(&self) -> &HashSuite<BabyBear>;
@@ -126,6 +333,16 @@ impl CudaHash for CudaHashSha256 {
         .unwrap();
     }
 
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        _output: &BufferImpl<Digest>,
+        _matrix: &BufferImpl<BabyBearElem>,
+        _codeword_id: u32,
+    ) {
+        panic!("hash_rows_interleave is not supported for CudaHashSha256");
+    }
+
     fn get_hash_suite(&self) -> &HashSuite<BabyBear> {
         &self.suite
     }
@@ -164,6 +381,31 @@ impl CudaHash for CudaHashPoseidon2 {
                 matrix.as_device_ptr(),
                 row_size.try_into().unwrap(),
                 col_size.try_into().unwrap(),
+            )
+        };
+        if err.code != 0 {
+            panic!("Failure during hash_rows: {err}");
+        }
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        output: &BufferImpl<Digest>,
+        matrix: &BufferImpl<BabyBearElem>,
+        codeword_id: u32,
+    ) {
+        let row_size = output.size() / 4;
+        let col_size = matrix.size() / row_size;
+        assert_eq!(matrix.size(), col_size * row_size);
+
+        let err = unsafe {
+            sppark_poseidon2_rows_interleave(
+                output.as_device_ptr(),
+                matrix.as_device_ptr(),
+                row_size.try_into().unwrap(),
+                col_size.try_into().unwrap(),
+                codeword_id,
             )
         };
         if err.code != 0 {
@@ -216,6 +458,16 @@ impl CudaHash for CudaHashPoseidon254 {
         }
     }
 
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        _output: &BufferImpl<Digest>,
+        _matrix: &BufferImpl<BabyBearElem>,
+        _codeword_id: u32,
+    ) {
+        panic!("hash_rows_interleave is not supported for CudaHashPoseidon254");
+    }
+
     fn get_hash_suite(&self) -> &HashSuite<BabyBear> {
         &self.suite
     }
@@ -232,9 +484,22 @@ pub type CudaHalSha256 = CudaHal<CudaHashSha256>;
 pub type CudaHalPoseidon2 = CudaHal<CudaHashPoseidon2>;
 pub type CudaHalPoseidon254 = CudaHal<CudaHashPoseidon254>;
 
+enum BufferStorage {
+    Device(DeviceBuffer<u8>),
+    Host(TrackedLockedBuffer),
+}
+
 struct RawBuffer {
     name: &'static str,
-    buf: DeviceBuffer<u8>,
+    storage: BufferStorage,
+}
+
+/// A wrapper for page-locked (pinned) host memory allocated via `cudaMallocHost`.
+/// The memory is uninitialized and suitable for asynchronous device-to-host transfers.
+pub struct TrackedLockedBuffer {
+    name: &'static str,
+    ptr: *mut u8,
+    size: usize,
 }
 
 impl RawBuffer {
@@ -244,18 +509,153 @@ impl RawBuffer {
         let buf = unsafe { DeviceBuffer::uninitialized(size) }
             .context(format!("allocation failed on {name}: {size} bytes"))
             .unwrap();
-        Self { name, buf }
+        Self {
+            name,
+            storage: BufferStorage::Device(buf),
+        }
+    }
+
+    pub fn from_tracked_locked_buffer(name: &'static str, host_buf: TrackedLockedBuffer) -> Self {
+        Self {
+            name,
+            storage: BufferStorage::Host(host_buf),
+        }
     }
 
     pub fn set_u32(&mut self, value: u32) {
-        self.buf.set_32(value).unwrap();
+        match &mut self.storage {
+            BufferStorage::Device(buf) => {
+                buf.set_32(value).unwrap();
+            }
+            BufferStorage::Host(_) => {
+                panic!("set_u32 not supported for host storage");
+            }
+        }
+    }
+
+    pub fn as_device_ptr(&self) -> DevicePointer<u8> {
+        match &self.storage {
+            BufferStorage::Device(buf) => buf.as_device_ptr(),
+            BufferStorage::Host(_) => {
+                panic!("as_device_ptr() not supported for host storage");
+            }
+        }
+    }
+
+    pub fn as_host_ptr(&self) -> Option<*mut u8> {
+        match &self.storage {
+            BufferStorage::Device(_) => None,
+            BufferStorage::Host(host_buf) => Some(host_buf.as_raw_ptr()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match &self.storage {
+            BufferStorage::Device(buf) => buf.len(),
+            BufferStorage::Host(host_buf) => host_buf.len(),
+        }
+    }
+
+    pub fn as_host_vec(&mut self) -> Result<Vec<u8>> {
+        match &mut self.storage {
+            BufferStorage::Device(buf) => buf.as_host_vec().map_err(|e| anyhow::anyhow!("{}", e)),
+            BufferStorage::Host(host_buf) => {
+                // For host storage, directly read from pinned memory
+                let size = host_buf.len();
+                let ptr = host_buf.as_raw_ptr();
+                let slice = unsafe { std::slice::from_raw_parts(ptr, size) };
+                Ok(slice.to_vec())
+            }
+        }
+    }
+
+    pub fn copy_from(&mut self, src: &[u8]) -> Result<()> {
+        match &mut self.storage {
+            BufferStorage::Device(buf) => buf.copy_from(src).map_err(|e| anyhow::anyhow!("{}", e)),
+            BufferStorage::Host(_) => {
+                bail!("copy_from() not supported for host storage");
+            }
+        }
     }
 }
 
 impl Drop for RawBuffer {
     fn drop(&mut self) {
-        tracing::trace!("free: {} bytes, {}", self.buf.len(), self.name);
-        tracker().lock().unwrap().free(self.buf.len());
+        let size = self.len();
+        tracing::trace!("free: {} bytes, {}", size, self.name);
+        tracker().lock().unwrap().free(size);
+        // TrackedLockedBuffer will handle its own cleanup
+    }
+}
+
+impl TrackedLockedBuffer {
+    pub fn new(name: &'static str, size: usize) -> Result<Self> {
+        tracing::trace!("alloc_locked_host_from_arena: {size} bytes, {name}");
+        tracker().lock().unwrap().alloc(size);
+
+        // Allocate from global pinned arena (fast: <1μs instead of 90-130ms!)
+        let arena = pinned_arena();
+
+        // Use fixed 1GB region for code.merkle.nodes
+        let ptr = if name == "code.merkle.nodes" {
+            arena.alloc_fixed_for_code_merkle_nodes(size).ok_or_else(|| {
+                anyhow::anyhow!("Failed to allocate fixed memory for code.merkle.nodes: requested {} bytes exceeds 1GB limit", size)
+            })?
+        } else {
+            arena.alloc(size).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Pinned arena exhausted! Requested {} bytes, arena usage: {:.1}%",
+                    size,
+                    arena.usage().2
+                )
+            })?
+        };
+
+        if name == "code.merkle.nodes" {
+            tracing::trace!(
+                "Allocated {} bytes from fixed code.merkle.nodes region at offset {} (always same address)",
+                size,
+                (ptr as usize) - (arena.base_ptr as usize)
+            );
+        } else {
+            tracing::trace!(
+                "Allocated {} bytes from arena at offset {} ({:.1}% used)",
+                size,
+                (ptr as usize) - (arena.base_ptr as usize),
+                arena.usage().2
+            );
+        }
+
+        // Memory is uninitialized - perfect for async memcpy from device
+        Ok(Self { name, ptr, size })
+    }
+
+    pub fn as_raw_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Get the size in bytes
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+}
+
+impl Drop for TrackedLockedBuffer {
+    fn drop(&mut self) {
+        tracing::trace!(
+            "release_locked_host_to_arena: {} bytes, {}",
+            self.size,
+            self.name
+        );
+
+        // Memory belongs to the global arena, no need to call cudaFreeHost.
+        // The arena will reuse this memory when it wraps around.
+        // Just update the tracker for accounting purposes.
+        tracker().lock().unwrap().free(self.size);
     }
 }
 
@@ -297,7 +697,7 @@ impl<T> BufferImpl<T> {
         assert!(bytes_len > 0);
         let mut buffer = RawBuffer::new(name, bytes_len);
         let bytes = unchecked_cast(slice);
-        buffer.buf.copy_from(bytes).unwrap();
+        buffer.copy_from(bytes).unwrap();
 
         BufferImpl {
             buffer: Rc::new(RefCell::new(buffer)),
@@ -307,14 +707,28 @@ impl<T> BufferImpl<T> {
         }
     }
 
+    pub fn from_tracked_locked_buffer(
+        name: &'static str,
+        host_buf: TrackedLockedBuffer,
+        size: usize,
+    ) -> Self {
+        let buffer = RawBuffer::from_tracked_locked_buffer(name, host_buf);
+        BufferImpl {
+            buffer: Rc::new(RefCell::new(buffer)),
+            size,
+            offset: 0,
+            marker: PhantomData,
+        }
+    }
+
     pub fn as_device_ptr(&self) -> DevicePointer<u8> {
-        let ptr = self.buffer.borrow_mut().buf.as_device_ptr();
+        let ptr = self.buffer.borrow().as_device_ptr();
         let offset = self.offset * std::mem::size_of::<T>();
         unsafe { ptr.offset(offset.try_into().unwrap()) }
     }
 
     pub fn as_device_ptr_with_offset(&self, offset: usize) -> DevicePointer<u8> {
-        let ptr = self.buffer.borrow_mut().buf.as_device_ptr();
+        let ptr = self.buffer.borrow().as_device_ptr();
         let offset = (self.offset + offset) * std::mem::size_of::<T>();
         unsafe { ptr.offset(offset.try_into().unwrap()) }
     }
@@ -341,9 +755,27 @@ impl<T: Clone> Buffer<T> for BufferImpl<T> {
 
     fn get_at(&self, idx: usize) -> T {
         let item_size = std::mem::size_of::<T>();
+
+        // Check if this is host storage (in a separate scope to release borrow)
+        let is_host_storage = {
+            let buf = self.buffer.borrow();
+            buf.as_host_ptr().is_some()
+        };
+
+        if is_host_storage {
+            // Host storage: directly read from host memory
+            let buf = self.buffer.borrow();
+            if let Some(host_ptr) = buf.as_host_ptr() {
+                let offset = (self.offset + idx) * item_size;
+                let ptr = unsafe { host_ptr.add(offset) as *const T };
+                return unsafe { ptr.read() };
+            }
+        }
+
+        // Device storage: use existing logic
         let buf = self.buffer.borrow_mut();
         let offset = (self.offset + idx) * item_size;
-        let ptr = unsafe { buf.buf.as_device_ptr().offset(offset as isize) };
+        let ptr = unsafe { buf.as_device_ptr().offset(offset as isize) };
         let device_slice = unsafe { DeviceSlice::from_raw_parts(ptr, item_size) };
         let host_buf = device_slice.as_host_vec().unwrap();
         let slice: &[T] = unchecked_cast(&host_buf);
@@ -353,10 +785,30 @@ impl<T: Clone> Buffer<T> for BufferImpl<T> {
     fn view<F: FnOnce(&[T])>(&self, f: F) {
         scope!("view");
         let item_size = std::mem::size_of::<T>();
+
+        // Check if this is host storage (in a separate scope to release borrow)
+        let is_host_storage = {
+            let buf = self.buffer.borrow();
+            buf.as_host_ptr().is_some()
+        };
+
+        if is_host_storage {
+            // Host storage: directly read from host memory
+            let buf = self.buffer.borrow();
+            if let Some(host_ptr) = buf.as_host_ptr() {
+                let offset = self.offset * item_size;
+                let ptr = unsafe { host_ptr.add(offset) as *const T };
+                let slice = unsafe { std::slice::from_raw_parts(ptr, self.size) };
+                f(slice);
+                return;
+            }
+        }
+
+        // Device storage: use existing logic
         let buf = self.buffer.borrow_mut();
         let offset = self.offset * item_size;
         let len = self.size * item_size;
-        let ptr = unsafe { buf.buf.as_device_ptr().offset(offset as isize) };
+        let ptr = unsafe { buf.as_device_ptr().offset(offset as isize) };
         let device_slice = unsafe { DeviceSlice::from_raw_parts(ptr, len) };
         let host_buf = device_slice.as_host_vec().unwrap();
         let slice = unchecked_cast(&host_buf);
@@ -365,16 +817,56 @@ impl<T: Clone> Buffer<T> for BufferImpl<T> {
 
     fn view_mut<F: FnOnce(&mut [T])>(&self, f: F) {
         scope!("view_mut");
-        let mut buf = self.buffer.borrow_mut();
-        let mut host_buf = buf.buf.as_host_vec().unwrap();
-        let slice = unchecked_cast_mut(&mut host_buf);
-        f(&mut slice[self.offset..]);
-        buf.buf.copy_from(&host_buf).unwrap();
+        let item_size = std::mem::size_of::<T>();
+
+        // Check if this is host storage (in a separate scope to release borrow)
+        let is_host_storage = {
+            let buf = self.buffer.borrow();
+            buf.as_host_ptr().is_some()
+        };
+
+        if is_host_storage {
+            // Host storage: directly write to host memory
+            let buf = self.buffer.borrow();
+            if let Some(host_ptr) = buf.as_host_ptr() {
+                let offset = self.offset * item_size;
+                let ptr = unsafe { host_ptr.add(offset) as *mut T };
+                let slice = unsafe { std::slice::from_raw_parts_mut(ptr, self.size) };
+                f(slice);
+                // No need to copy back for host storage
+            }
+        } else {
+            // Device storage: use existing logic
+            let mut buf = self.buffer.borrow_mut();
+            let mut host_buf = buf.as_host_vec().unwrap();
+            let slice = unchecked_cast_mut(&mut host_buf);
+            f(&mut slice[self.offset..]);
+            buf.copy_from(&host_buf).unwrap();
+        }
     }
 
     fn to_vec(&self) -> Vec<T> {
-        let buf = self.buffer.borrow_mut();
-        let host_buf = buf.buf.as_host_vec().unwrap();
+        // Check if this is host storage (in a separate scope to release borrow)
+        let is_host_storage = {
+            let buf = self.buffer.borrow();
+            buf.as_host_ptr().is_some()
+        };
+
+        if is_host_storage {
+            // Host storage: directly read from host memory
+            let buf = self.buffer.borrow();
+            if let Some(host_ptr) = buf.as_host_ptr() {
+                let item_size = std::mem::size_of::<T>();
+                let offset = self.offset * item_size;
+                let ptr = unsafe { host_ptr.add(offset) as *const T };
+                let slice = unsafe { std::slice::from_raw_parts(ptr, self.size) };
+                return slice.to_vec();
+            }
+        }
+
+        // Device storage: use existing logic
+        let mut buf = self.buffer.borrow_mut();
+        let host_buf = buf.as_host_vec().unwrap();
         let slice = unchecked_cast(&host_buf);
         slice.to_vec()
     }
@@ -418,6 +910,14 @@ impl<CH: CudaHash + ?Sized> CudaHal<CH> {
         };
         hal.hash = Some(hash);
         hal
+    }
+
+    pub fn alloc_locked_host_buffer(
+        &self,
+        name: &'static str,
+        size: usize,
+    ) -> Result<TrackedLockedBuffer> {
+        TrackedLockedBuffer::new(name, size)
     }
 
     fn poly_divide(
@@ -591,6 +1091,30 @@ impl<CH: CudaHash + ?Sized> Hal for CudaHal<CH> {
         }
     }
 
+    fn batch_evaluate_ntt(&self, io: &Self::Buffer<Self::Elem>, count: usize) {
+        let pcount = if count >= (1 << 15) {
+            count - (1 << 15)
+        } else {
+            count
+        };
+        let row_size = io.size() / pcount;
+        assert_eq!(row_size * pcount, io.size());
+        let n_bits = log2_ceil(row_size);
+        assert_eq!(row_size, 1 << n_bits);
+        assert!(n_bits < Self::Elem::MAX_ROU_PO2);
+
+        let err = unsafe {
+            sppark_batch_NTT(
+                io.as_device_ptr(),
+                n_bits.try_into().unwrap(),
+                count.try_into().unwrap(),
+            )
+        };
+        if err.code != 0 {
+            panic!("Failure during batch_interpolate_ntt: {err}");
+        }
+    }
+
     fn batch_bit_reverse(&self, io: &Self::Buffer<Self::Elem>, count: usize) {
         let row_size = io.size() / count;
         assert_eq!(row_size * count, io.size());
@@ -615,48 +1139,133 @@ impl<CH: CudaHash + ?Sized> Hal for CudaHal<CH> {
     fn batch_evaluate_any(
         &self,
         coeffs: &Self::Buffer<Self::Elem>,
-        poly_count: usize,
+        poly_n: usize,
         which: &Self::Buffer<u32>,
         xs: &Self::Buffer<Self::ExtElem>,
         out: &Self::Buffer<Self::ExtElem>,
     ) {
-        let po2 = log2_ceil(coeffs.size() / poly_count);
-        let count = 1 << po2;
-        assert_eq!(poly_count * count, coeffs.size());
-        let eval_count = which.size();
-        assert_eq!(xs.size(), eval_count);
-        assert_eq!(out.size(), eval_count);
+        let po2 = log2_ceil(coeffs.size() / poly_n);
+        let deg = 1 << po2;
+        assert_eq!(poly_n * deg, coeffs.size());
 
-        let threads_per_block = self.max_threads / 4;
-        const BYTES_PER_WORD: u32 = 4;
-        const WORDS_PER_FPEXT: u32 = 4;
-        let shared_size = threads_per_block * BYTES_PER_WORD * WORDS_PER_FPEXT;
-        let kernel_count = out.size() * threads_per_block as usize;
+        let eval_n = which.size();
+        assert_eq!(xs.size(), eval_n);
+        assert_eq!(out.size(), eval_n);
+
+        // Determine chunk_n based on poly_n (similar to batch_evaluate_same_x_bk)
+        let chunk_n: usize = if poly_n > 100 { 8 } else { 32 };
+
+        // Allocate temporary device buffer for chunk results
+        let chunk_out = self.alloc_extelem("chunk_out", eval_n * chunk_n);
 
         extern "C" {
             fn risc0_zkp_cuda_batch_evaluate_any(
                 output: DevicePointer<u8>,
+                chunk_output: DevicePointer<u8>,
                 coeffs: DevicePointer<u8>,
                 which: DevicePointer<u8>,
                 xs: DevicePointer<u8>,
-                shared_size: u32,
-                kernel_count: u32,
-                count: u32,
+                eval_n: u32,
+                deg: u32,
+                chunk_n: u32,
             ) -> *const std::os::raw::c_char;
         }
 
         ffi_wrap(|| unsafe {
             risc0_zkp_cuda_batch_evaluate_any(
                 out.as_device_ptr(),
+                chunk_out.as_device_ptr(),
                 coeffs.as_device_ptr(),
                 which.as_device_ptr(),
                 xs.as_device_ptr(),
-                shared_size,
-                kernel_count as u32,
-                count as u32,
+                eval_n as u32,
+                deg as u32,
+                chunk_n as u32,
             )
         })
         .unwrap();
+
+        // chunk_out will be automatically freed when it goes out of scope
+    }
+
+    fn batch_evaluate_same_x(
+        &self,
+        coeffs: &Self::Buffer<Self::Elem>,
+        poly_n: usize,
+        which: &Self::Buffer<u32>,
+        xs: Vec<Self::Elem>,
+    ) -> Vec<Self::Elem> {
+        let po2 = log2_ceil(coeffs.size() / poly_n);
+        let deg = 1 << po2;
+        let x_n = xs.len();
+
+        assert_eq!(poly_n, which.size());
+        assert_eq!(poly_n * deg, coeffs.size());
+
+        let chunk_n: usize = if poly_n > 100 { 4 } else { 32 };
+
+        extern "C" {
+            fn risc0_zkp_cuda_batch_evaluate_same_x(
+                output: *mut u8,
+                coeffs: DevicePointer<u8>,
+                which: DevicePointer<u8>,
+                xs: *const u8,
+                chunk_n: u32,
+                poly_n: u32,
+                deg: u32,
+                x_n: u32,
+            ) -> *const std::os::raw::c_char;
+        }
+
+        // The underlying CUDA kernel hardcodes Fp sum[25] / powx[25] for
+        // register-pressure reasons; loop in chunks of X_BATCH internally so
+        // callers can pass an arbitrary number of x's.
+        const X_BATCH: usize = 25;
+        let mut ys = Vec::with_capacity(poly_n * x_n);
+
+        for xs_chunk in xs.chunks(X_BATCH) {
+            let chunk_x_n = xs_chunk.len();
+            let mut out_host = vec![Self::Elem::ZERO; poly_n * chunk_n * chunk_x_n];
+
+            ffi_wrap(|| unsafe {
+                risc0_zkp_cuda_batch_evaluate_same_x(
+                    out_host.as_mut_ptr() as *mut u8,
+                    coeffs.as_device_ptr(),
+                    which.as_device_ptr(),
+                    xs_chunk.as_ptr() as *const u8,
+                    chunk_n as u32,
+                    poly_n as u32,
+                    deg as u32,
+                    chunk_x_n as u32,
+                )
+            })
+            .unwrap();
+
+            // Compute per-x chunk-folding powers
+            let mut xpows = Vec::with_capacity(chunk_n * chunk_x_n);
+            for x in xs_chunk.iter().take(chunk_x_n) {
+                let xp = x.pow(deg / chunk_n);
+                let mut xpow = Self::Elem::ONE;
+                for _ in 0..chunk_n {
+                    xpows.push(xpow);
+                    xpow *= xp;
+                }
+            }
+
+            // Fold chunk outputs into final ys[xid][poly] entries
+            for xid in 0..chunk_x_n {
+                for i in 0..poly_n {
+                    let c0id = i + xid * poly_n * chunk_n;
+                    let mut y = out_host[c0id];
+                    for c in 1..chunk_n {
+                        y += out_host[c0id + poly_n * c] * xpows[c + chunk_n * xid];
+                    }
+                    ys.push(y);
+                }
+            }
+        }
+
+        ys
     }
 
     fn gather_sample(
@@ -689,11 +1298,101 @@ impl<CH: CudaHash + ?Sized> Hal for CudaHal<CH> {
         .unwrap();
     }
 
+    fn gather_samples_batch(
+        &self,
+        dst: &Self::Buffer<Self::Elem>,
+        src: &Self::Buffer<Self::Elem>,
+        idxs: &[u32],
+        col_size: usize,
+        stride: usize,
+    ) {
+        // Upload idxs to a GPU buffer, then launch one batched kernel.
+        let idxs_buf = self.copy_from_u32("gather_idxs", idxs);
+
+        extern "C" {
+            fn risc0_zkp_cuda_gather_samples_batch(
+                dst: DevicePointer<u8>,
+                src: DevicePointer<u8>,
+                idxs: DevicePointer<u8>,
+                n_idxs: u32,
+                col_size: u32,
+                stride: u32,
+            ) -> *const std::os::raw::c_char;
+        }
+
+        ffi_wrap(|| unsafe {
+            risc0_zkp_cuda_gather_samples_batch(
+                dst.as_device_ptr(),
+                src.as_device_ptr(),
+                idxs_buf.as_device_ptr(),
+                idxs.len() as u32,
+                col_size as u32,
+                stride as u32,
+            )
+        })
+        .unwrap();
+    }
+
+    fn gather_digests_batch(&self, nodes: &Self::Buffer<Digest>, indices: &[u32]) -> Vec<Digest> {
+        let n = indices.len();
+        if n == 0 {
+            return Vec::new();
+        }
+
+        // host pinned (e.g. rv32im code group merkle.nodes after copy_merkle2host):
+        // walk the host slice directly, no kernel + no D2H.
+        let is_host = nodes.buffer.borrow().as_host_ptr().is_some();
+        if is_host {
+            let buf = nodes.buffer.borrow();
+            let host_ptr = buf.as_host_ptr().unwrap();
+            let base = nodes.offset;
+            let mut out = Vec::with_capacity(n);
+            for &i in indices {
+                let p = unsafe { (host_ptr as *const Digest).add(base + i as usize) };
+                out.push(unsafe { p.read() });
+            }
+            return out;
+        }
+
+        // device storage: gather kernel + single D2H of n digests.
+        let dst: BufferImpl<Digest> = BufferImpl::new("gather_digests_dst", n);
+        let idxs_buf = self.copy_from_u32("gather_digests_idxs", indices);
+
+        extern "C" {
+            fn risc0_zkp_cuda_gather_digests_batch(
+                dst: DevicePointer<u8>,
+                src: DevicePointer<u8>,
+                idxs: DevicePointer<u8>,
+                n: u32,
+            ) -> *const std::os::raw::c_char;
+        }
+
+        ffi_wrap(|| unsafe {
+            risc0_zkp_cuda_gather_digests_batch(
+                dst.as_device_ptr(),
+                nodes.as_device_ptr(),
+                idxs_buf.as_device_ptr(),
+                n as u32,
+            )
+        })
+        .unwrap();
+
+        let mut out = Vec::with_capacity(n);
+        dst.view(|view| out.extend_from_slice(view));
+        out
+    }
+
     fn has_unified_memory(&self) -> bool {
         false
     }
 
-    fn zk_shift(&self, io: &Self::Buffer<Self::Elem>, poly_count: usize) {
+    fn zk_shift(
+        &self,
+        io: &Self::Buffer<Self::Elem>,
+        poly_count: usize,
+        beta: Self::Elem,
+        factor: u32,
+    ) {
         let bits = log2_ceil(io.size() / poly_count);
         assert_eq!(io.size(), poly_count * (1 << bits));
 
@@ -702,10 +1401,54 @@ impl<CH: CudaHash + ?Sized> Hal for CudaHal<CH> {
                 io.as_device_ptr(),
                 bits.try_into().unwrap(),
                 poly_count.try_into().unwrap(),
+                beta.as_u32_montgomery(),
+                factor,
             )
         };
         if err.code != 0 {
             panic!("Failure during zk_shift: {err}");
+        }
+    }
+
+    fn zk_shift_outplace(
+        &self,
+        d_in: &Self::Buffer<Self::Elem>,
+        d_out: &Self::Buffer<Self::Elem>,
+        poly_count: usize,
+        beta: Self::Elem,
+        factor: u32,
+    ) {
+        let bits = log2_ceil(d_in.size() / poly_count);
+        assert_eq!(d_in.size(), poly_count * (1 << bits));
+
+        let err = unsafe {
+            sppark_batch_zk_shift_outplace(
+                d_in.as_device_ptr(),
+                d_out.as_device_ptr(),
+                bits.try_into().unwrap(),
+                poly_count.try_into().unwrap(),
+                beta.as_u32_montgomery(),
+                factor,
+            )
+        };
+        if err.code != 0 {
+            panic!("Failure during zk_shift_outplace: {err}");
+        }
+    }
+
+    fn batch_coeffs_bitrev(&self, d_inout: &Self::Buffer<Self::Elem>, poly_count: usize) {
+        let bits = log2_ceil(d_inout.size() / poly_count);
+        assert_eq!(d_inout.size(), poly_count * (1 << bits));
+
+        let err = unsafe {
+            sppark_batch_coeffs_bitrev(
+                d_inout.as_device_ptr(),
+                bits.try_into().unwrap(),
+                poly_count.try_into().unwrap(),
+            )
+        };
+        if err.code != 0 {
+            panic!("Failure during sppark_batch_coeffs_bitrev: {err}");
         }
     }
 
@@ -832,6 +1575,67 @@ impl<CH: CudaHash + ?Sized> Hal for CudaHal<CH> {
             )
         })
         .unwrap();
+    }
+
+    fn copy_digest2elem(
+        &self,
+        output: &Self::Buffer<Self::Elem>,
+        input: &Self::Buffer<Digest>,
+        offset_bytes: usize,
+    ) {
+        use std::mem::size_of;
+
+        unsafe {
+            extern "C" {
+                fn cudaMemcpy(
+                    dst: *mut std::ffi::c_void,
+                    src: *const std::ffi::c_void,
+                    count: usize,
+                    kind: u32,
+                ) -> i32;
+            }
+
+            // Calculate input size in bytes
+            let input_size_bytes = input.size() * size_of::<Digest>();
+
+            // Get device pointers
+            let src_ptr = input.as_device_ptr();
+            let output_base_ptr = output.as_device_ptr();
+            let dst_ptr = output_base_ptr.offset(offset_bytes as isize);
+
+            // Perform device-to-device copy (kind = 1 for cudaMemcpyDeviceToDevice)
+            let result = cudaMemcpy(
+                dst_ptr.as_raw() as *mut std::ffi::c_void,
+                src_ptr.as_raw() as *const std::ffi::c_void,
+                input_size_bytes,
+                1, // cudaMemcpyDeviceToDevice
+            );
+
+            if result != 0 {
+                panic!("cudaMemcpy failed: error code {}", result);
+            }
+        }
+    }
+
+    fn elem2dig_buffer_transmute(
+        &self,
+        buffer: &Self::Buffer<Self::Elem>,
+        offset_bytes: usize,
+        count: usize,
+    ) -> Self::Buffer<Digest> {
+        use std::mem::size_of;
+
+        // SAFETY: BufferImpl<Digest> and Self::Buffer<Digest> resolve to the
+        // same concrete type when monomorphized on the CUDA backend; the
+        // transmute is a no-op cast through the trait's associated type.
+        #[allow(clippy::useless_transmute)]
+        let buffer_as_digest: BufferImpl<Digest> =
+            unsafe { std::mem::transmute(buffer.clone()) };
+        let digest_elem_offset = offset_bytes / size_of::<Digest>();
+
+        let nodes_slice = buffer_as_digest.slice(digest_elem_offset, count);
+        #[allow(clippy::useless_transmute)]
+        unsafe { std::mem::transmute(nodes_slice) }
     }
 
     fn eltwise_zeroize_elem(&self, elems: &Self::Buffer<Self::Elem>) {
@@ -969,6 +1773,19 @@ impl<CH: CudaHash + ?Sized> Hal for CudaHal<CH> {
 
     fn hash_rows(&self, output: &Self::Buffer<Digest>, matrix: &Self::Buffer<Self::Elem>) {
         self.hash.as_ref().unwrap().hash_rows(output, matrix);
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        output: &Self::Buffer<Digest>,
+        matrix: &Self::Buffer<Self::Elem>,
+        codeword_id: u32,
+    ) {
+        self.hash
+            .as_ref()
+            .unwrap()
+            .hash_rows_interleave(output, matrix, codeword_id);
     }
 
     fn get_hash_suite(&self) -> &HashSuite<Self::Field> {

--- a/risc0/zkp/src/hal/dual.rs
+++ b/risc0/zkp/src/hal/dual.rs
@@ -235,10 +235,49 @@ where
         out.assert_eq();
     }
 
-    fn zk_shift(&self, io: &Self::Buffer<Self::Elem>, count: usize) {
-        self.lhs.zk_shift(&io.lhs, count);
-        self.rhs.zk_shift(&io.rhs, count);
+    fn batch_evaluate_ntt(&self, io: &Self::Buffer<Self::Elem>, count: usize) {
+        self.lhs.batch_evaluate_ntt(&io.lhs, count);
+        self.rhs.batch_evaluate_ntt(&io.rhs, count);
         io.assert_eq();
+    }
+
+    fn batch_evaluate_same_x(
+        &self,
+        coeffs: &Self::Buffer<Self::Elem>,
+        poly_count: usize,
+        which: &Self::Buffer<u32>,
+        x: Vec<Self::Elem>,
+    ) -> Vec<Self::Elem> {
+        let lhs_result =
+            self.lhs
+                .batch_evaluate_same_x(&coeffs.lhs, poly_count, &which.lhs, x.clone());
+        let rhs_result = self
+            .rhs
+            .batch_evaluate_same_x(&coeffs.rhs, poly_count, &which.rhs, x);
+        assert_eq!(lhs_result, rhs_result);
+        lhs_result
+    }
+
+    fn zk_shift(&self, io: &Self::Buffer<Self::Elem>, count: usize, beta: Self::Elem, factor: u32) {
+        self.lhs.zk_shift(&io.lhs, count, beta, factor);
+        self.rhs.zk_shift(&io.rhs, count, beta, factor);
+        io.assert_eq();
+    }
+
+    fn zk_shift_outplace(
+        &self,
+        _d_in: &Self::Buffer<Self::Elem>,
+        _d_out: &Self::Buffer<Self::Elem>,
+        _poly_count: usize,
+        _beta: Self::Elem,
+        _factor: u32,
+    ) {
+    }
+
+    fn batch_coeffs_bitrev(&self, d_inout: &Self::Buffer<Self::Elem>, poly_count: usize) {
+        self.lhs.batch_coeffs_bitrev(&d_inout.lhs, poly_count);
+        self.rhs.batch_coeffs_bitrev(&d_inout.rhs, poly_count);
+        d_inout.assert_eq();
     }
 
     fn mix_poly_coeffs(
@@ -305,6 +344,24 @@ where
         output.assert_eq();
     }
 
+    fn copy_digest2elem(
+        &self,
+        _output: &Self::Buffer<Self::Elem>,
+        _input: &Self::Buffer<Digest>,
+        _offset_bytes: usize,
+    ) {
+        panic!("copy_digest2elem is only supported for CUDA HAL");
+    }
+
+    fn elem2dig_buffer_transmute(
+        &self,
+        _buffer: &Self::Buffer<Self::Elem>,
+        _offset_bytes: usize,
+        _count: usize,
+    ) -> Self::Buffer<Digest> {
+        panic!("elem2dig_buffer_transmute is only supported for CUDA HAL");
+    }
+
     fn eltwise_zeroize_elem(&self, elems: &Self::Buffer<Self::Elem>) {
         self.lhs.eltwise_zeroize_elem(&elems.lhs);
         self.rhs.eltwise_zeroize_elem(&elems.rhs);
@@ -326,6 +383,16 @@ where
         self.lhs.hash_rows(&output.lhs, &matrix.lhs);
         self.rhs.hash_rows(&output.rhs, &matrix.rhs);
         output.assert_eq();
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        _output: &Self::Buffer<Digest>,
+        _matrix: &Self::Buffer<Self::Elem>,
+        _codeword_id: u32,
+    ) {
+        panic!("hash_rows_interleave is not supported for DualHal");
     }
 
     fn hash_fold(&self, io: &Self::Buffer<Digest>, input_size: usize, output_size: usize) {
@@ -496,5 +563,19 @@ where
         _steps: usize,
     ) {
         todo!()
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        _check: &<DualHal<F, LH, RH> as Hal>::Buffer<F::Elem>,
+        _groups: &[&<DualHal<F, LH, RH> as Hal>::Buffer<F::Elem>],
+        _globals: &[&<DualHal<F, LH, RH> as Hal>::Buffer<F::Elem>],
+        _poly_mix: <DualHal<F, LH, RH> as Hal>::ExtElem,
+        _po2: usize,
+        _steps: usize,
+        _codeword_id: usize,
+    ) {
+        panic!("eval_check_interleave is not supported for DualCircuitHal");
     }
 }

--- a/risc0/zkp/src/hal/metal.rs
+++ b/risc0/zkp/src/hal/metal.rs
@@ -746,7 +746,13 @@ impl<MH: MetalHash> Hal for MetalHal<MH> {
         self.hash.as_ref().unwrap().hash_rows(self, output, matrix);
     }
 
-    fn zk_shift(&self, io: &Self::Buffer<Self::Elem>, poly_count: usize) {
+    fn zk_shift(
+        &self,
+        io: &Self::Buffer<Self::Elem>,
+        poly_count: usize,
+        _beta: Self::Elem,
+        _factor: u32,
+    ) {
         let bits = log2_ceil(io.size() / poly_count);
         let count = io.size();
         assert_eq!(io.size(), poly_count * (1 << bits));

--- a/risc0/zkp/src/hal/mod.rs
+++ b/risc0/zkp/src/hal/mod.rs
@@ -52,6 +52,19 @@ pub trait Buffer<T>: Clone {
     fn to_vec(&self) -> Vec<T>;
 }
 
+/// Pre-NTT bit-reverse flag for the `factor` argument of
+/// [`Hal::zk_shift_outplace`]. Set when the input coefficients are in
+/// NTT-friendly (bit-reversed) layout and must be unscrambled to natural
+/// order before the coset shift. Honored only by the CUDA HAL (sppark
+/// `LDE_shift_outplace`); other HALs panic or no-op on `zk_shift_outplace`.
+pub const ZK_SHIFT_PRE_BITREV: u32 = 0x100;
+
+/// Post-NTT bit-reverse flag for the `factor` argument of
+/// [`Hal::zk_shift_outplace`]. Set when the input is in natural order;
+/// the result is left in bit-reversed order after the shift. See
+/// [`ZK_SHIFT_PRE_BITREV`] for backend caveats.
+pub const ZK_SHIFT_POST_BITREV: u32 = 0x80;
+
 pub trait Hal {
     type Field: Field<Elem = Self::Elem, ExtElem = Self::ExtElem>;
     type Elem: Elem + RootsOfUnity;
@@ -108,9 +121,11 @@ pub trait Hal {
     );
 
     fn batch_interpolate_ntt(&self, io: &Self::Buffer<Self::Elem>, count: usize);
-
     fn batch_bit_reverse(&self, io: &Self::Buffer<Self::Elem>, count: usize);
 
+    fn batch_evaluate_ntt(&self, _io: &Self::Buffer<Self::Elem>, _count: usize) {
+        unimplemented!("batch_evaluate_ntt not implemented for this HAL");
+    }
     fn batch_evaluate_any(
         &self,
         coeffs: &Self::Buffer<Self::Elem>,
@@ -120,7 +135,31 @@ pub trait Hal {
         out: &Self::Buffer<Self::ExtElem>,
     );
 
-    fn zk_shift(&self, io: &Self::Buffer<Self::Elem>, count: usize);
+    fn batch_evaluate_same_x(
+        &self,
+        _coeffs: &Self::Buffer<Self::Elem>,
+        _poly_count: usize,
+        _which: &Self::Buffer<u32>,
+        _x: Vec<Self::Elem>,
+    ) -> Vec<Self::Elem> {
+        unimplemented!("batch_evaluate_same_x not implemented for this HAL");
+    }
+
+    fn zk_shift(&self, io: &Self::Buffer<Self::Elem>, count: usize, beta: Self::Elem, factor: u32);
+    fn zk_shift_outplace(
+        &self,
+        _d_in: &Self::Buffer<Self::Elem>,
+        _d_out: &Self::Buffer<Self::Elem>,
+        _poly_count: usize,
+        _beta: Self::Elem,
+        _factor: u32,
+    ) {
+        unimplemented!("zk_shift_outplace not implemented for this HAL");
+    }
+
+    fn batch_coeffs_bitrev(&self, _d_inout: &Self::Buffer<Self::Elem>, _poly_count: usize) {
+        unimplemented!("batch_coeffs_bitrev not implemented for this HAL");
+    }
 
     #[allow(clippy::too_many_arguments)]
     fn mix_poly_coeffs(
@@ -153,6 +192,28 @@ pub trait Hal {
         input: &Self::Buffer<Self::Elem>,
     );
 
+    /// Copy Digest buffer to Elem buffer at specified byte offset.
+    /// This is a device-to-device copy for CUDA HAL, panics for other HALs.
+    fn copy_digest2elem(
+        &self,
+        _output: &Self::Buffer<Self::Elem>,
+        _input: &Self::Buffer<Digest>,
+        _offset_bytes: usize,
+    ) {
+        unimplemented!("copy_digest2elem not implemented for this HAL");
+    }
+
+    /// Reinterpret a Buffer<Elem> as Buffer<Digest> at specified byte offset.
+    /// This is only supported for CUDA HAL, panics for other HALs.
+    fn elem2dig_buffer_transmute(
+        &self,
+        _buffer: &Self::Buffer<Self::Elem>,
+        _offset_bytes: usize,
+        _count: usize,
+    ) -> Self::Buffer<Digest> {
+        unimplemented!("elem2dig_buffer_transmute not implemented for this HAL");
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn eltwise_copy_elem_slice(
         &self,
@@ -177,6 +238,14 @@ pub trait Hal {
 
     fn hash_rows(&self, output: &Self::Buffer<Digest>, matrix: &Self::Buffer<Self::Elem>);
 
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn hash_rows_interleave(
+        &self,
+        output: &Self::Buffer<Digest>,
+        matrix: &Self::Buffer<Self::Elem>,
+        codeword_id: u32,
+    );
+
     fn hash_fold(&self, io: &Self::Buffer<Digest>, input_size: usize, output_size: usize);
 
     fn gather_sample(
@@ -187,6 +256,36 @@ pub trait Hal {
         size: usize,
         stride: usize,
     );
+
+    /// Batched variant of `gather_sample`: gather `idxs.len()` samples
+    /// from `src` in a single kernel launch. `dst` must hold
+    /// `idxs.len() * col_size` elements; result layout is
+    /// `[k][col]` row-major (sample k starts at offset `k * col_size`).
+    /// Used by FRI query phase to avoid one launch per query index.
+    ///
+    /// Default impl loops `gather_sample` so non-CUDA backends compile
+    /// unchanged. CUDA overrides for a real kernel launch.
+    fn gather_samples_batch(
+        &self,
+        dst: &Self::Buffer<Self::Elem>,
+        src: &Self::Buffer<Self::Elem>,
+        idxs: &[u32],
+        col_size: usize,
+        stride: usize,
+    ) {
+        // Generic fallback: per-index single gather + slice into dst.
+        for (k, &idx) in idxs.iter().enumerate() {
+            let slot = dst.slice(k * col_size, col_size);
+            self.gather_sample(&slot, src, idx as usize, col_size, stride);
+        }
+    }
+
+    /// Batched merkle-path Digest fetch: gather `indices.len()` digests from
+    /// `nodes` in one shot. Replaces ~50×depth tiny per-element cudaMemcpy
+    /// in `prove_with_idxs` idx2nodes loop. CUDA backend overrides.
+    fn gather_digests_batch(&self, nodes: &Self::Buffer<Digest>, indices: &[u32]) -> Vec<Digest> {
+        indices.iter().map(|&i| nodes.get_at(i as usize)).collect()
+    }
 
     fn scatter(
         &self,
@@ -287,6 +386,19 @@ pub trait CircuitHal<H: Hal> {
         po2: usize,
         steps: usize,
     );
+
+    /// Compute check polynomial with interleaved evaluation.
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check_interleave(
+        &self,
+        check: &H::Buffer<H::Elem>,
+        groups: &[&H::Buffer<H::Elem>],
+        globals: &[&H::Buffer<H::Elem>],
+        poly_mix: H::ExtElem,
+        po2: usize,
+        steps: usize,
+        codeword_id: usize,
+    );
 }
 
 pub fn tracker() -> &'static Mutex<MemoryTracker> {
@@ -314,6 +426,28 @@ impl MemoryTracker {
     pub fn free(&mut self, size: usize) {
         self.total -= size as isize;
     }
+}
+
+pub fn release_buffer<H>(name: &'static str, hal: &H, buf: &mut H::Buffer<H::Elem>)
+where
+    H: Hal,
+{
+    tracing::debug!("Release {}", name);
+
+    let placeholder = hal.alloc_elem("placeholder", 1024);
+    let _dropped = std::mem::replace(buf, placeholder);
+    drop(_dropped);
+}
+
+pub fn release_buffer_ext<H>(name: &'static str, hal: &H, buf: &mut H::Buffer<H::ExtElem>)
+where
+    H: Hal,
+{
+    tracing::debug!("Release {}", name);
+
+    let placeholder = hal.alloc_extelem("placeholder", 1024);
+    let _dropped = std::mem::replace(buf, placeholder);
+    drop(_dropped);
 }
 
 #[cfg(test)]
@@ -607,10 +741,12 @@ mod testutil {
         let hal_cpu = CpuHal::new(hal_gpu.get_hash_suite().clone());
         let hal = DualHal::new(Rc::new(hal_cpu), Rc::new(hal_gpu));
         let counts = [(1000, (1 << 8)), (900, (1 << 12))];
+        let beta = H::Elem::from_u64(3);
+        let factor = 1;
         for (poly_count, steps) in counts {
             let count = poly_count * steps;
             let io = generate_elem(&hal, &mut rng, count);
-            hal.zk_shift(&io, poly_count);
+            hal.zk_shift(&io, poly_count, beta, factor);
         }
     }
 }

--- a/risc0/zkp/src/lib.rs
+++ b/risc0/zkp/src/lib.rs
@@ -45,6 +45,15 @@ pub const MIN_PO2: usize = core::log2_ceil(1 + ZK_CYCLES);
 /// Inverse of Reed-Solomon Expansion Rate
 pub const INV_RATE: usize = 4;
 
+/// Minimum segment po2 considered "large".
+///
+/// At po2 >= LARGE_SEGMENT_PO2 the LDE codeword domain (INV_RATE * 2^po2
+/// base elements) plus auxiliary buffers no longer fits comfortably in a
+/// 24 GB GPU, so the prover dispatches memory-efficient code paths
+/// (codeword coset split, early buffer release, host-pinned Merkle
+/// nodes). At po2 < LARGE_SEGMENT_PO2 the standard v3.0.4 path is used.
+pub const LARGE_SEGMENT_PO2: usize = 22;
+
 const FRI_FOLD_PO2: usize = 4;
 
 /// FRI folding factor is 2 ^ FRI_FOLD_PO2

--- a/risc0/zkp/src/prove/fri.rs
+++ b/risc0/zkp/src/prove/fri.rs
@@ -18,16 +18,25 @@ use risc0_core::{field::ExtElem, scope};
 use tracing::debug;
 
 use crate::{
-    core::log2_ceil,
+    core::{digest::Digest, log2_ceil},
     hal::{Buffer, Hal},
     prove::{merkle::MerkleTreeProver, write_iop::WriteIOP},
     FRI_FOLD, FRI_MIN_DEGREE, INV_RATE, QUERIES,
 };
 
+#[cfg(not(all(feature = "low_vram", feature = "cuda")))]
 struct ProveRoundInfo<H: Hal> {
     domain: usize,
     coeffs: H::Buffer<H::Elem>,
     merkle: MerkleTreeProver<H>,
+}
+
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+struct ProveRoundInfo<H: Hal> {
+    domain: usize,
+    coeffs: H::Buffer<H::Elem>,
+    merkle: MerkleTreeProver<H>,
+    evaluated: Option<H::Buffer<H::Elem>>,
 }
 
 impl<H: Hal> ProveRoundInfo<H> {
@@ -66,20 +75,90 @@ impl<H: Hal> ProveRoundInfo<H> {
         let out_coeffs = hal.alloc_elem("out_coeffs", size / FRI_FOLD * ext_size);
         // Compute the folded polynomial
         hal.fri_fold(&out_coeffs, coeffs, &fold_mix);
-        ProveRoundInfo {
+
+        #[cfg(all(feature = "low_vram", feature = "cuda"))]
+        return Self {
+            domain,
+            coeffs: out_coeffs,
+            merkle,
+            evaluated: Some(evaluated),
+        };
+
+        #[cfg(not(all(feature = "low_vram", feature = "cuda")))]
+        Self {
             domain,
             coeffs: out_coeffs,
             merkle,
         }
     }
 
+    #[cfg(not(all(feature = "low_vram", feature = "cuda")))]
     pub fn prove_query(&mut self, hal: &H, iop: &mut WriteIOP<H::Field>, pos: &mut usize) {
         // Compute which group we are in
         let group = *pos % (self.domain / FRI_FOLD);
         // Generate the proof
         self.merkle.prove(hal, iop, group);
+
         // Update pos
         *pos = group;
+    }
+
+    /// Batched variant of `prove_query`: takes all `groups` in one shot,
+    /// returns (samples, merkle_paths) per group. Caller writes IOP in
+    /// pos-major order to preserve verifier byte stream.
+    /// Only the `low_vram` Some(evals) path is implemented (matches
+    /// what `prove_query` actually exercises in this build).
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    pub fn prove_queries_batch(
+        &self,
+        hal: &H,
+        groups: &[usize],
+    ) -> (Vec<Vec<H::Elem>>, Vec<Vec<Digest>>) {
+        let n = groups.len();
+        let col_size = self.merkle.params.col_size;
+        let row_size = self.merkle.params.row_size;
+        let top_size = self.merkle.params.top_size;
+
+        // 1. Batched gather of samples (replaces n×gather_sample launches).
+        let evals = self
+            .evaluated
+            .as_ref()
+            .expect("low_vram ProveRoundInfo always has evaluated=Some");
+        let groups_u32: Vec<u32> = groups.iter().map(|&g| g as u32).collect();
+        let batch = hal.alloc_elem("fri_round_samples_batch", n * col_size);
+        hal.gather_samples_batch(&batch, evals, &groups_u32, col_size, row_size);
+        let mut samples: Vec<Vec<H::Elem>> = Vec::with_capacity(n);
+        batch.view(|view| {
+            for k in 0..n {
+                samples.push(view[k * col_size..(k + 1) * col_size].to_vec());
+            }
+        });
+
+        // 2. Batched gather of merkle-path digests across all groups
+        //    (replaces n×depth single-element get_at cudaMemcpy).
+        let mut all_indices: Vec<u32> = Vec::new();
+        let mut counts: Vec<usize> = Vec::with_capacity(n);
+        for &group in groups {
+            let mut count = 0;
+            let mut current_idx = group + row_size;
+            while current_idx >= 2 * top_size {
+                let low_bit = current_idx % 2;
+                current_idx /= 2;
+                let other_idx = 2 * current_idx + (1 - low_bit);
+                all_indices.push(other_idx as u32);
+                count += 1;
+            }
+            counts.push(count);
+        }
+        let all_digests = hal.gather_digests_batch(&self.merkle.nodes, &all_indices);
+        let mut paths: Vec<Vec<Digest>> = Vec::with_capacity(n);
+        let mut offset = 0;
+        for count in counts {
+            paths.push(all_digests[offset..offset + count].to_vec());
+            offset += count;
+        }
+
+        (samples, paths)
     }
 }
 
@@ -89,7 +168,7 @@ pub fn fri_prove<H: Hal, F>(
     coeffs: &H::Buffer<H::Elem>,
     inner: F,
 ) where
-    F: Fn(&mut WriteIOP<H::Field>, usize),
+    F: Fn(&mut WriteIOP<H::Field>, Vec<usize>) -> Vec<(Vec<Vec<H::Elem>>, Vec<Vec<Digest>>)>,
 {
     scope!("fri_prove");
     let ext_size = H::ExtElem::EXT_SIZE;
@@ -112,15 +191,67 @@ pub fn fri_prove<H: Hal, F>(
         iop.commit(&digest);
     });
     // Do queries
-    debug!("Doing Queries");
-    for _ in 0..QUERIES {
-        // Get a 'random' index.
-        let mut pos = iop.random_bits(log2_ceil(orig_domain)) as usize;
-        // Do the 'inner' proof for this index
-        inner(iop, pos);
-        // Write the per-round proofs
-        for round in rounds.iter_mut() {
-            round.prove_query(hal, iop, &mut pos);
+    debug!("Doing Queries: {}, rounds: {}", QUERIES, rounds.len());
+    #[allow(unused_mut)]
+    let mut positions: Vec<usize> = (0..QUERIES)
+        .map(|_| iop.random_bits(log2_ceil(orig_domain)) as usize)
+        .collect();
+
+    let querys = inner(iop, positions.clone());
+
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+            // Batched per-round prove: avoid n×rounds of single-idx kernel
+            // launches + per-element get_at. Then write IOP in pos-major
+            // order so the verifier byte stream matches the original.
+            let n = positions.len();
+            let n_rounds = rounds.len();
+
+            // 1. Replicate prove_query's `*pos = group` chain offline so we
+            //    know each round's group indices before launching anything.
+            let mut round_groups: Vec<Vec<usize>> = Vec::with_capacity(n_rounds);
+            {
+                let mut cur = positions.clone();
+                for round in rounds.iter() {
+                    let mut g = Vec::with_capacity(n);
+                    for pi in 0..n {
+                        cur[pi] = cur[pi] % (round.domain / FRI_FOLD);
+                        g.push(cur[pi]);
+                    }
+                    round_groups.push(g);
+                }
+            }
+
+            // 2. Per-round one batched prove for all positions.
+            let mut round_outputs: Vec<(Vec<Vec<H::Elem>>, Vec<Vec<Digest>>)>
+                = Vec::with_capacity(n_rounds);
+            for ri in 0..n_rounds {
+                round_outputs.push(rounds[ri].prove_queries_batch(hal, &round_groups[ri]));
+            }
+
+            // 3. Write IOP pos-major (same byte order as the original loop).
+            for pi in 0..n {
+                for query in querys.iter() {
+                    iop.write_field_elem_slice::<H::Elem>(query.0[pi].as_slice());
+                    iop.write_pod_slice(&query.1[pi]);
+                }
+                for ri in 0..n_rounds {
+                    let (samples, paths) = &round_outputs[ri];
+                    iop.write_field_elem_slice::<H::Elem>(&samples[pi]);
+                    iop.write_pod_slice(&paths[pi]);
+                }
+            }
+        } else {
+            for (pid, pos) in positions.iter_mut().enumerate() {
+                for query in querys.iter() {
+                    iop.write_field_elem_slice::<H::Elem>(query.0[pid].as_slice());
+                    iop.write_pod_slice(&query.1[pid]);
+                }
+                // Write the per-round proofs
+                for round in rounds.iter_mut() {
+                    round.prove_query(hal, iop, pos);
+                }
+            }
         }
     }
 }

--- a/risc0/zkp/src/prove/merkle.rs
+++ b/risc0/zkp/src/prove/merkle.rs
@@ -14,6 +14,8 @@
 
 use alloc::vec::Vec;
 
+#[allow(unused_imports)]
+use risc0_core::field::Elem;
 use risc0_core::scope;
 
 use crate::{
@@ -24,18 +26,19 @@ use crate::{
 };
 
 pub struct MerkleTreeProver<H: Hal> {
-    params: MerkleTreeParams,
+    pub params: MerkleTreeParams,
 
     // The retained matrix of values
+    #[cfg(not(all(feature = "low_vram", feature = "cuda")))]
     matrix: H::Buffer<H::Elem>,
 
     // A heap style array where node N has children 2*N and 2*N+1.  The size of
     // this buffer is (1 << (layers + 1)) and begins at offset 1 (zero is unused
     // to make indexing nicer).
-    nodes: H::Buffer<Digest>,
+    pub nodes: H::Buffer<Digest>,
 
     // The root value
-    root: Digest,
+    pub root: Digest,
 }
 
 impl<H: Hal> MerkleTreeProver<H> {
@@ -72,11 +75,12 @@ impl<H: Hal> MerkleTreeProver<H> {
             }
         });
         let root = nodes.get_at(1);
-        MerkleTreeProver {
+        Self {
             params,
-            matrix: matrix.clone(),
             nodes,
             root,
+            #[cfg(not(all(feature = "low_vram", feature = "cuda")))]
+            matrix: matrix.clone(),
         }
     }
 
@@ -105,6 +109,118 @@ impl<H: Hal> MerkleTreeProver<H> {
     /// It is presumed the verifier is given the index of the row from other
     /// parts of the protocol, and verification will of course fail if the
     /// wrong row is specified.
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    #[allow(unused_variables)]
+    pub fn prove_with_idxs(
+        &self,
+        hal: &H,
+        iop: &mut WriteIOP<H::Field>,
+        idxs: Vec<usize>,
+        coeffs: &H::Buffer<H::Elem>,
+        rou: H::Elem,
+        evals: Option<H::Buffer<H::Elem>>,
+        codewords: [Option<H::Buffer<H::Elem>>; 4],
+    ) -> (Vec<Vec<H::Elem>>, Vec<Vec<Digest>>) {
+        let mut idx2evals = Vec::with_capacity(idxs.len());
+
+        if let Some(evals) = evals {
+            for idx in idxs.iter() {
+                assert!(*idx < self.params.row_size);
+            }
+            if hal.has_unified_memory() {
+                evals.view(|view| {
+                    for idx in idxs.iter() {
+                        let mut out = Vec::with_capacity(self.params.col_size);
+                        for i in 0..self.params.col_size {
+                            out.push(view[*idx + i * self.params.row_size]);
+                        }
+                        idx2evals.push(out);
+                    }
+                });
+            } else {
+                let col_size = self.params.col_size;
+                let n = idxs.len();
+                let batch = hal.alloc_elem("samples_batch", n * col_size);
+                let idxs_u32: Vec<u32> = idxs.iter().map(|&i| i as u32).collect();
+                hal.gather_samples_batch(&batch, &evals, &idxs_u32, col_size, self.params.row_size);
+                batch.view(|view| {
+                    for k in 0..n {
+                        let chunk = &view[k * col_size..(k + 1) * col_size];
+                        idx2evals.push(chunk.to_vec());
+                    }
+                });
+            }
+        } else if let [Some(c0), Some(c1), Some(c2), Some(c3)] = &codewords {
+            let codes: [&H::Buffer<H::Elem>; 4] = [c0, c1, c2, c3];
+            for idx in idxs.iter() {
+                let code = codes[idx % 4];
+
+                let mut out = Vec::with_capacity(self.params.col_size);
+                if hal.has_unified_memory() {
+                    code.view(|view| {
+                        for i in 0..self.params.col_size {
+                            out.push(view[*idx / 4 + i * self.params.row_size / 4]);
+                        }
+                    });
+                } else {
+                    let sample = hal.alloc_elem("sample", self.params.col_size);
+                    hal.gather_sample(
+                        &sample,
+                        &code,
+                        *idx / 4,
+                        self.params.col_size,
+                        self.params.row_size / 4,
+                    );
+                    sample.view(|view| {
+                        out.extend_from_slice(view);
+                    });
+                }
+                idx2evals.push(out);
+            }
+        } else {
+            let xs: Vec<_> = idxs.iter().map(|idx| rou.pow(*idx)).collect();
+            let seq: Vec<u32> = (0..self.params.col_size).map(|i| i as u32).collect();
+            let ps = hal.copy_from_u32("which", seq.as_slice());
+
+            let out = hal.batch_evaluate_same_x(&coeffs, self.params.col_size, &ps, xs);
+
+            // Split out into chunks of col_size and push to idx2evals
+            for chunk in out.chunks(self.params.col_size) {
+                idx2evals.push(chunk.to_vec());
+            }
+        }
+
+        // iop.write_field_elem_slice::<H::Elem>(out.as_slice());
+
+        // Batch the merkle-path Digest fetch: collect all (idx, level) node
+        // indices into one Vec, then call gather_digests_batch to do one D2H
+        // (or one host walk if nodes is host-pinned, e.g. rv32im code group).
+        let mut all_indices: Vec<u32> = Vec::new();
+        let mut counts: Vec<usize> = Vec::with_capacity(idxs.len());
+        for idx in idxs.iter() {
+            let mut count = 0;
+            let mut current_idx = *idx + self.params.row_size;
+            while current_idx >= 2 * self.params.top_size {
+                let low_bit = current_idx % 2;
+                current_idx /= 2;
+                let other_idx = 2 * current_idx + (1 - low_bit);
+                all_indices.push(other_idx as u32);
+                count += 1;
+            }
+            counts.push(count);
+        }
+        let all_digests = hal.gather_digests_batch(&self.nodes, &all_indices);
+        let mut idx2nodes = Vec::with_capacity(idxs.len());
+        let mut offset = 0;
+        for count in counts {
+            idx2nodes.push(all_digests[offset..offset + count].to_vec());
+            offset += count;
+        }
+
+        (idx2evals, idx2nodes)
+    }
+
+    #[cfg(not(all(feature = "low_vram", feature = "cuda")))]
     pub fn prove(&self, hal: &H, iop: &mut WriteIOP<H::Field>, idx: usize) -> Vec<H::Elem> {
         assert!(idx < self.params.row_size);
         let mut out = Vec::with_capacity(self.params.col_size);
@@ -128,6 +244,7 @@ impl<H: Hal> MerkleTreeProver<H> {
             });
         }
         iop.write_field_elem_slice::<H::Elem>(out.as_slice());
+
         let mut idx = idx + self.params.row_size;
         while idx >= 2 * self.params.top_size {
             let low_bit = idx % 2;
@@ -138,9 +255,64 @@ impl<H: Hal> MerkleTreeProver<H> {
         }
         out
     }
+
+    #[cfg(not(all(feature = "low_vram", feature = "cuda")))]
+    pub fn prove_with_idxs(
+        &self,
+        hal: &H,
+        _iop: &mut WriteIOP<H::Field>,
+        idxs: Vec<usize>,
+    ) -> (Vec<Vec<H::Elem>>, Vec<Vec<Digest>>) {
+        let mut idx2evals = Vec::with_capacity(idxs.len());
+
+        for idx in idxs.iter() {
+            assert!(*idx < self.params.row_size);
+            let mut out = Vec::with_capacity(self.params.col_size);
+
+            if hal.has_unified_memory() {
+                self.matrix.view(|view| {
+                    for i in 0..self.params.col_size {
+                        out.push(view[*idx + i * self.params.row_size]);
+                    }
+                });
+            } else {
+                let sample = hal.alloc_elem("sample", self.params.col_size);
+                hal.gather_sample(
+                    &sample,
+                    &self.matrix,
+                    *idx,
+                    self.params.col_size,
+                    self.params.row_size,
+                );
+                sample.view(|view| {
+                    out.extend_from_slice(view);
+                });
+            }
+            idx2evals.push(out);
+        }
+        // Per-element merkle path Digest fetch (matches v3.0.4 semantics:
+        // one cudaMemcpy D2H per merkle-path element via get_at). The
+        // batched gather_digests_batch is reserved for low_vram.
+        let mut idx2nodes = Vec::with_capacity(idxs.len());
+        for idx in idxs.iter() {
+            let mut nodes_for_idx = Vec::new();
+            let mut current_idx = *idx + self.params.row_size;
+            while current_idx >= 2 * self.params.top_size {
+                let low_bit = current_idx % 2;
+                current_idx /= 2;
+                let other_idx = 2 * current_idx + (1 - low_bit);
+                let other = self.nodes.get_at(other_idx);
+                nodes_for_idx.push(other);
+            }
+            idx2nodes.push(nodes_for_idx);
+        }
+
+        (idx2evals, idx2nodes)
+    }
 }
 
 #[cfg(test)]
+#[cfg(not(all(feature = "low_vram", feature = "cuda")))]
 mod tests {
     use rand::Rng;
     use risc0_core::field::{

--- a/risc0/zkp/src/prove/poly_group.rs
+++ b/risc0/zkp/src/prove/poly_group.rs
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+use risc0_core::field::RootsOfUnity;
 use risc0_core::scope_with;
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+use std::mem::size_of;
 
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+use crate::{core::digest::Digest, merkle::MerkleTreeParams, LARGE_SEGMENT_PO2};
 use crate::{
     core::log2_ceil,
     hal::{Buffer, Hal},
@@ -52,6 +58,171 @@ use crate::{
 /// which means that the normal NTT evaluation domain does not reveal anything
 /// about the original datapoints (i.e. is zero knowledge) so long as there is
 /// sufficient randomized padding.
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+pub struct PolyGroup<H: Hal> {
+    pub coeffs: H::Buffer<H::Elem>,
+    pub count: usize,
+    pub merkle: MerkleTreeProver<H>,
+    pub evaluated: Option<H::Buffer<H::Elem>>,
+    pub codewords: [Option<H::Buffer<H::Elem>>; 4],
+}
+
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+impl<H: Hal> PolyGroup<H> {
+    fn proc_codeword(
+        hal: &H,
+        coeffs: &H::Buffer<H::Elem>,
+        codeword: &mut H::Buffer<H::Elem>,
+        count: usize,
+        beta: H::Elem,
+        nodes_slice: &H::Buffer<Digest>,
+        codeword_id: u32,
+    ) {
+        if codeword_id == 0 {
+            hal.eltwise_copy_elem(&codeword, &coeffs);
+        } else {
+            hal.zk_shift_outplace(coeffs, codeword, count, beta, codeword_id);
+        }
+
+        hal.batch_evaluate_ntt(codeword, count);
+        hal.hash_rows_interleave(nodes_slice, codeword, codeword_id);
+    }
+
+    pub fn from_codeword_interleave(
+        hal: &H,
+        coeffs: H::Buffer<H::Elem>,
+        count: usize,
+        size: usize,
+        name: &'static str,
+    ) -> Self {
+        scope_with!("poly_group({})", name);
+        assert_eq!(coeffs.size(), count * size);
+
+        let domain = size * INV_RATE;
+        let po2 = log2_ceil(size);
+
+        let nodes = hal.alloc_digest("nodes", domain * 2);
+        let mut codeword = hal.alloc_elem("codeword", count * size); // size = |H|, H is trace domoain
+        let mut codeword2 = hal.alloc_elem("codeword2", count * size);
+
+        let beta = <H::Elem as RootsOfUnity>::ROU_FWD[po2 + 2];
+        let nodes_slice = nodes.slice(domain, domain);
+        Self::proc_codeword(hal, &coeffs, &mut codeword, count, beta, &nodes_slice, 0);
+        Self::proc_codeword(hal, &coeffs, &mut codeword, count, beta, &nodes_slice, 1);
+        Self::proc_codeword(hal, &coeffs, &mut codeword2, count, beta, &nodes_slice, 2);
+        Self::proc_codeword(hal, &coeffs, &mut codeword, count, beta, &nodes_slice, 3);
+
+        let params = MerkleTreeParams::new(domain, count, QUERIES);
+        for i in (0..params.layers).rev() {
+            let layer_size = 1 << i;
+            hal.hash_fold(&nodes, layer_size * 2, layer_size);
+        }
+        let root = nodes.get_at(1);
+
+        let merkle = MerkleTreeProver {
+            params,
+            nodes,
+            root,
+        };
+        PolyGroup {
+            coeffs,
+            count,
+            evaluated: None,
+            merkle,
+            codewords: [None, None, Some(codeword2), Some(codeword)],
+        }
+    }
+
+    pub fn from_codeword_check(
+        hal: &H,
+        coeffs: H::Buffer<H::Elem>,
+        count: usize,
+        size: usize,
+        name: &'static str,
+    ) -> Self {
+        scope_with!("from_codeword_check({})", name);
+        assert_eq!(coeffs.size(), count * size);
+        assert_eq!(count, 16);
+
+        let domain = size * INV_RATE;
+        let leafs = hal.alloc_digest("leafs", domain);
+        let eval = hal.alloc_elem("evaluated", count * domain);
+
+        hal.batch_expand_into_evaluate_ntt(&eval, &coeffs, count, log2_ceil(INV_RATE));
+        hal.batch_bit_reverse(&coeffs, count);
+
+        hal.hash_rows(&leafs, &eval);
+        let offset = domain * size_of::<Digest>();
+        hal.copy_digest2elem(&eval, &leafs, offset);
+
+        let nodes = hal.elem2dig_buffer_transmute(&eval, 0, domain * 2);
+        let params = MerkleTreeParams::new(domain, count, QUERIES);
+
+        for i in (0..params.layers).rev() {
+            let layer_size = 1 << i;
+            hal.hash_fold(&nodes, layer_size * 2, layer_size);
+        }
+        let root = nodes.get_at(1);
+
+        let merkle = MerkleTreeProver {
+            params,
+            nodes,
+            root,
+        };
+        PolyGroup {
+            coeffs,
+            count,
+            evaluated: None,
+            merkle,
+            codewords: [None, None, None, None],
+        }
+    }
+
+    pub fn from_codeword(
+        hal: &H,
+        coeffs: H::Buffer<H::Elem>,
+        count: usize,
+        size: usize,
+        name: &'static str,
+    ) -> Self {
+        scope_with!("poly_group({})", name);
+        assert_eq!(coeffs.size(), count * size);
+        let domain = size * INV_RATE;
+
+        let eval = hal.alloc_elem("evaluated", count * domain);
+        hal.batch_expand_into_evaluate_ntt(&eval, &coeffs, count, log2_ceil(INV_RATE));
+        hal.batch_bit_reverse(&coeffs, count);
+
+        let merkle = MerkleTreeProver::new(hal, &eval, domain, count, QUERIES);
+        PolyGroup {
+            coeffs,
+            count,
+            evaluated: Some(eval),
+            merkle,
+            codewords: [None, None, None, None],
+        }
+    }
+
+    pub fn new(
+        hal: &H,
+        coeffs: H::Buffer<H::Elem>,
+        count: usize,
+        size: usize,
+        name: &'static str,
+    ) -> Self {
+        let po2 = log2_ceil(size);
+        // H::CHECK_SIZE = INV_RATE * EXT_SIZE = 4 * 4 = 16, the check polynomial group's column count.
+        if po2 >= LARGE_SEGMENT_PO2 && count == H::CHECK_SIZE {
+            Self::from_codeword_check(hal, coeffs, count, size, name)
+        } else if po2 >= LARGE_SEGMENT_PO2 && count > 1 {
+            Self::from_codeword_interleave(hal, coeffs, count, size, name)
+        } else {
+            Self::from_codeword(hal, coeffs, count, size, name)
+        }
+    }
+}
+
+#[cfg(not(all(feature = "low_vram", feature = "cuda")))]
 pub struct PolyGroup<H: Hal> {
     pub coeffs: H::Buffer<H::Elem>,
     pub count: usize,
@@ -59,6 +230,7 @@ pub struct PolyGroup<H: Hal> {
     pub merkle: MerkleTreeProver<H>,
 }
 
+#[cfg(not(all(feature = "low_vram", feature = "cuda")))]
 impl<H: Hal> PolyGroup<H> {
     pub fn new(
         hal: &H,
@@ -70,14 +242,16 @@ impl<H: Hal> PolyGroup<H> {
         scope_with!("poly_group({})", name);
         assert_eq!(coeffs.size(), count * size);
         let domain = size * INV_RATE;
-        let evaluated = hal.alloc_elem("evaluated", count * domain);
-        hal.batch_expand_into_evaluate_ntt(&evaluated, &coeffs, count, log2_ceil(INV_RATE));
+
+        let eval = hal.alloc_elem("evaluated", count * domain);
+        hal.batch_expand_into_evaluate_ntt(&eval, &coeffs, count, log2_ceil(INV_RATE));
         hal.batch_bit_reverse(&coeffs, count);
-        let merkle = MerkleTreeProver::new(hal, &evaluated, domain, count, QUERIES);
+
+        let merkle = MerkleTreeProver::new(hal, &eval, domain, count, QUERIES);
         PolyGroup {
             coeffs,
             count,
-            evaluated,
+            evaluated: eval,
             merkle,
         }
     }

--- a/risc0/zkp/src/prove/prover.rs
+++ b/risc0/zkp/src/prove/prover.rs
@@ -17,25 +17,78 @@ use risc0_core::{
     scope, scope_with,
 };
 
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
 use crate::{
-    core::poly::poly_interpolate,
+    adapter::{REGISTER_GROUP_ACCUM, REGISTER_GROUP_CODE, REGISTER_GROUP_DATA},
+    hal::{release_buffer, release_buffer_ext, ZK_SHIFT_POST_BITREV, ZK_SHIFT_PRE_BITREV},
+    LARGE_SEGMENT_PO2,
+};
+use crate::{
+    core::{digest::Digest, poly::poly_interpolate},
     hal::{Buffer, CircuitHal, Hal},
     prove::{fri::fri_prove, poly_group::PolyGroup, write_iop::WriteIOP},
     taps::TapSet,
     INV_RATE,
 };
 
+/// Tag value used to detect that the active circuit is rv32im (and not
+/// recursion/keccak). It mirrors `risc0_circuit_rv32im::zirgen::REGCOUNT_ACCUM`
+/// (set by `define_tap_buffer!{accum, 103, 0}` in
+/// `risc0/circuit/rv32im/src/zirgen/defs.rs.inc`). `risc0-zkp` cannot import
+/// that constant directly because `risc0-circuit-rv32im` depends on
+/// `risc0-zkp` — taking the reverse path would form a circular dep. Only used
+/// under `low_vram + cuda` to release rv32im's accum evaluated buffer at
+/// po2 > 21, where memory pressure is real; recursion/keccak's accum groups
+/// have different sizes and don't need the release.
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+const RV32IM_ACCUM_REGCOUNT: usize = 103;
+
 /// Object to generate a zero-knowledge proof of the execution of some circuit.
 pub struct Prover<'a, H: Hal> {
     hal: &'a H,
     taps: &'a TapSet<'a>,
     iop: WriteIOP<H::Field>,
-    groups: Vec<Option<PolyGroup<H>>>,
+    pub groups: Vec<Option<PolyGroup<H>>>,
     cycles: usize,
     po2: usize,
 }
 
-fn make_coeffs<H: Hal>(hal: &H, witness: &H::Buffer<H::Elem>, count: usize) -> H::Buffer<H::Elem> {
+#[cfg(all(feature = "low_vram", feature = "cuda"))]
+fn make_coeffs<H: Hal>(
+    hal: &H,
+    witness: &H::Buffer<H::Elem>,
+    count: usize,
+    grp_id: usize,
+) -> H::Buffer<H::Elem> {
+    scope!("make_coeffs");
+
+    let coeffs = if grp_id != REGISTER_GROUP_ACCUM {
+        let coeffs = hal.alloc_elem("coeffs", witness.size());
+        hal.eltwise_copy_elem(&coeffs, witness);
+        coeffs
+    } else {
+        witness.clone()
+    };
+
+    // Do interpolate
+    hal.batch_interpolate_ntt(&coeffs, count);
+    // Convert f(x) -> f(3x), which effective multiplies coefficients c_i by 3^i.
+    #[cfg(not(feature = "circuit_debug"))]
+    {
+        let beta = Elem::from_u64(3);
+        hal.zk_shift(&coeffs, count, beta, 1);
+    }
+
+    coeffs
+}
+
+#[cfg(not(all(feature = "low_vram", feature = "cuda")))]
+fn make_coeffs<H: Hal>(
+    hal: &H,
+    witness: &H::Buffer<H::Elem>,
+    count: usize,
+    _grp_id: usize,
+) -> H::Buffer<H::Elem> {
     scope!("make_coeffs");
     let coeffs = hal.alloc_elem("coeffs", witness.size());
     hal.eltwise_copy_elem(&coeffs, witness);
@@ -43,11 +96,258 @@ fn make_coeffs<H: Hal>(hal: &H, witness: &H::Buffer<H::Elem>, count: usize) -> H
     hal.batch_interpolate_ntt(&coeffs, count);
     // Convert f(x) -> f(3x), which effective multiplies coefficients c_i by 3^i.
     #[cfg(not(feature = "circuit_debug"))]
-    hal.zk_shift(&coeffs, count);
+    {
+        let beta = Elem::from_u64(3);
+        hal.zk_shift(&coeffs, count, beta, 1);
+    }
+
     coeffs
 }
 
 impl<'a, H: Hal> Prover<'a, H> {
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn eval_check<C>(
+        &mut self,
+        check_poly: &H::Buffer<H::Elem>,
+        globals: &[&H::Buffer<H::Elem>],
+        poly_mix: H::ExtElem,
+        circuit_hal: &C,
+    ) -> Result<&str, &str>
+    where
+        C: CircuitHal<H>,
+    {
+        let data_id = REGISTER_GROUP_DATA;
+        let accum_id = REGISTER_GROUP_ACCUM;
+        let code_id = REGISTER_GROUP_CODE;
+
+        // Collect evaluated buffers into owned vector first, then create references
+        if self.groups[accum_id].as_ref().unwrap().evaluated.is_some()
+            || self.po2 < LARGE_SEGMENT_PO2
+        {
+            let buffers: Vec<_> = self
+                .groups
+                .iter()
+                .map(|pg| pg.as_ref().unwrap().evaluated.as_ref().unwrap().clone())
+                .collect();
+            let groups: Vec<&_> = buffers.iter().collect();
+
+            circuit_hal.eval_check(
+                check_poly,
+                groups.as_slice(),
+                globals,
+                poly_mix,
+                self.po2,
+                self.cycles,
+            );
+
+            {
+                let pg = self.groups[accum_id].as_mut().unwrap();
+                if pg.count == RV32IM_ACCUM_REGCOUNT && self.po2 >= LARGE_SEGMENT_PO2 {
+                    release_buffer(
+                        "accum poly evalueated",
+                        self.hal,
+                        &mut pg.evaluated.as_mut().unwrap(),
+                    );
+                }
+            }
+        } else {
+            {
+                let dgp = &self.groups[data_id].as_ref().unwrap();
+                let agp = &self.groups[accum_id].as_ref().unwrap();
+                let cgp = &self.groups[code_id].as_ref().unwrap();
+                let dcode2 = dgp.codewords[2].as_ref().unwrap();
+                let acode2 = agp.codewords[2].as_ref().unwrap();
+
+                let groups: Vec<&_> = vec![acode2, cgp.evaluated.as_ref().unwrap(), dcode2];
+
+                circuit_hal.eval_check_interleave(
+                    check_poly,
+                    groups.as_slice(),
+                    globals,
+                    poly_mix,
+                    self.po2,
+                    self.cycles,
+                    2,
+                );
+            }
+            {
+                let pg = self.groups[REGISTER_GROUP_ACCUM].as_mut().unwrap();
+                release_buffer(
+                    "accum codeword 2",
+                    self.hal,
+                    &mut pg.codewords[2].as_mut().unwrap(),
+                );
+                pg.codewords[2] = None;
+            }
+
+            {
+                let dgp = &self.groups[data_id].as_ref().unwrap();
+                let agp = &self.groups[accum_id].as_ref().unwrap();
+                let cgp = &self.groups[code_id].as_ref().unwrap();
+                let dcode3 = dgp.codewords[3].as_ref().unwrap();
+                let acode3 = agp.codewords[3].as_ref().unwrap();
+
+                let groups: Vec<&_> = vec![acode3, cgp.evaluated.as_ref().unwrap(), dcode3];
+
+                circuit_hal.eval_check_interleave(
+                    check_poly,
+                    groups.as_slice(),
+                    globals,
+                    poly_mix,
+                    self.po2,
+                    self.cycles,
+                    3,
+                );
+            }
+
+            {
+                let dgp = self.groups[data_id].as_mut().unwrap();
+                let dcode0 = self.hal.alloc_elem("dcodeword0", dgp.count * self.cycles);
+                dgp.codewords[0] = Some(dcode0);
+            }
+            {
+                let dgp = &self.groups[data_id].as_ref().unwrap();
+                let agp = &self.groups[accum_id].as_ref().unwrap();
+                let cgp = &self.groups[code_id].as_ref().unwrap();
+                let dcode0 = dgp.codewords[0].as_ref().unwrap();
+                let acode0 = agp.codewords[3].as_ref().unwrap();
+
+                self.hal.eltwise_copy_elem(&dcode0, &dgp.coeffs);
+                self.hal.batch_evaluate_ntt(&dcode0, dgp.count);
+                self.hal.eltwise_copy_elem(acode0, &agp.coeffs);
+                self.hal.batch_evaluate_ntt(acode0, agp.count);
+
+                let groups: Vec<&_> = vec![acode0, cgp.evaluated.as_ref().unwrap(), &dcode0];
+                circuit_hal.eval_check_interleave(
+                    check_poly,
+                    groups.as_slice(),
+                    globals,
+                    poly_mix,
+                    self.po2,
+                    self.cycles,
+                    0,
+                );
+            }
+
+            {
+                let pg = self.groups[data_id].as_mut().unwrap();
+                pg.codewords[1] = pg.codewords[3].clone();
+                pg.codewords[3] = None;
+            }
+            {
+                let beta = H::Elem::ROU_FWD[self.po2 + 2];
+                let dgp = &self.groups[data_id].as_ref().unwrap();
+                let agp = &self.groups[accum_id].as_ref().unwrap();
+                let cgp = &self.groups[code_id].as_ref().unwrap();
+                let dcode1 = dgp.codewords[1].as_ref().unwrap();
+                let acode1 = agp.codewords[3].as_ref().unwrap();
+
+                self.hal.zk_shift_outplace(
+                    &dgp.coeffs,
+                    dcode1,
+                    dgp.count,
+                    beta,
+                    1 | ZK_SHIFT_POST_BITREV,
+                ); // codeword_id=1, post-NTT bit-reverse
+                self.hal.batch_evaluate_ntt(&dcode1, dgp.count);
+                self.hal.zk_shift_outplace(
+                    &agp.coeffs,
+                    acode1,
+                    agp.count,
+                    beta,
+                    1 | ZK_SHIFT_POST_BITREV,
+                ); // codeword_id=1, post-NTT bit-reverse
+                self.hal.batch_evaluate_ntt(&acode1, agp.count);
+
+                let groups: Vec<&_> = vec![acode1, cgp.evaluated.as_ref().unwrap(), &dcode1];
+                circuit_hal.eval_check_interleave(
+                    check_poly,
+                    groups.as_slice(),
+                    globals,
+                    poly_mix,
+                    self.po2,
+                    self.cycles,
+                    1,
+                );
+            }
+        }
+
+        {
+            let pg = self.groups[accum_id].as_mut().unwrap();
+            if pg.codewords[2].is_some() {
+                release_buffer(
+                    "accum codeword 2",
+                    self.hal,
+                    &mut pg.codewords[2].as_mut().unwrap(),
+                )
+            };
+            if pg.codewords[3].is_some() {
+                release_buffer(
+                    "accum codeword 3",
+                    self.hal,
+                    &mut pg.codewords[3].as_mut().unwrap(),
+                )
+            };
+        }
+
+        Ok("Eval Check.")
+    }
+
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn prove_group_with_idxs(
+        hal: &'a H,
+        pg: &PolyGroup<H>,
+        iop: &mut WriteIOP<H::Field>,
+        idxs: Vec<usize>,
+        rou: H::Elem,
+    ) -> (Vec<Vec<H::Elem>>, Vec<Vec<Digest>>) {
+        pg.merkle.prove_with_idxs(
+            hal,
+            iop,
+            idxs,
+            &pg.coeffs,
+            rou,
+            pg.evaluated.clone(),
+            pg.codewords.clone(),
+        )
+    }
+
+    #[cfg(not(all(feature = "low_vram", feature = "cuda")))]
+    fn prove_group_with_idxs(
+        hal: &'a H,
+        pg: &PolyGroup<H>,
+        iop: &mut WriteIOP<H::Field>,
+        idxs: Vec<usize>,
+        _rou: H::Elem,
+    ) -> (Vec<Vec<H::Elem>>, Vec<Vec<Digest>>) {
+        pg.merkle.prove_with_idxs(hal, iop, idxs)
+    }
+
+    #[allow(dead_code)]
+    #[cfg(all(feature = "low_vram", feature = "cuda"))]
+    fn fri_prepare(&mut self, _check: &mut PolyGroup<H>) {
+        let beta = H::Elem::ROU_FWD[self.po2 + 2];
+
+        {
+            let pg = self.groups[REGISTER_GROUP_DATA].as_mut().unwrap();
+            if self.po2 >= LARGE_SEGMENT_PO2 && pg.codewords[0].is_some() {
+                let codeword3 = pg.coeffs.clone();
+
+                self.hal.zk_shift_outplace(
+                    &pg.coeffs,
+                    &codeword3,
+                    pg.count,
+                    beta,
+                    3 | ZK_SHIFT_PRE_BITREV,
+                ); // codeword_id=3, pre-NTT bit-reverse
+                self.hal.batch_evaluate_ntt(&codeword3, pg.count);
+                pg.codewords[3] = Some(codeword3);
+            } else {
+                release_buffer("data coeffs", self.hal, &mut pg.coeffs);
+            }
+        }
+    }
+
     /// Creates a new prover.
     pub fn new(hal: &'a H, taps: &'a TapSet) -> Self {
         Self {
@@ -89,7 +389,7 @@ impl<'a, H: Hal> Prover<'a, H> {
             self.taps.group_name(tap_group_index)
         );
 
-        let coeffs = make_coeffs(self.hal, witness, group_size);
+        let coeffs = make_coeffs(self.hal, witness, group_size, tap_group_index);
         let group_ref = self.groups[tap_group_index].insert(PolyGroup::new(
             self.hal,
             coeffs,
@@ -126,19 +426,25 @@ impl<'a, H: Hal> Prover<'a, H> {
         // DEEP-ALI paper for details on the construction of the check_poly.
         let check_poly = self.hal.alloc_elem("check_poly", ext_size * domain);
 
-        let groups: Vec<&_> = self
-            .groups
-            .iter()
-            .map(|pg| &pg.as_ref().unwrap().evaluated)
-            .collect();
-        circuit_hal.eval_check(
-            &check_poly,
-            groups.as_slice(),
-            globals,
-            poly_mix,
-            self.po2,
-            self.cycles,
-        );
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                let _ = self.eval_check(&check_poly, globals, poly_mix, circuit_hal);
+            } else {
+                let groups: Vec<&_> = self
+                    .groups
+                    .iter()
+                    .map(|pg| &pg.as_ref().unwrap().evaluated)
+                    .collect();
+                circuit_hal.eval_check(
+                    &check_poly,
+                    groups.as_slice(),
+                    globals,
+                    poly_mix,
+                    self.po2,
+                    self.cycles,
+                );
+            }
+        }
 
         #[cfg(feature = "circuit_debug")]
         let mut bad_z = None;
@@ -175,7 +481,14 @@ impl<'a, H: Hal> Prover<'a, H> {
         // invRate*size to 16 polys of size, without actually doing anything.
 
         // Make the PolyGroup + add it to the IOP;
-        let check_group = PolyGroup::new(self.hal, check_poly, H::CHECK_SIZE, self.cycles, "check");
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                let mut check_group = PolyGroup::new(self.hal, check_poly, H::CHECK_SIZE, self.cycles, "check");
+            } else {
+                let check_group = PolyGroup::new(self.hal, check_poly, H::CHECK_SIZE, self.cycles, "check");
+            }
+        }
+
         check_group.merkle.commit(&mut self.iop);
         tracing::debug!("checkGroup: {}", check_group.merkle.root());
 
@@ -275,11 +588,22 @@ impl<'a, H: Hal> Prover<'a, H> {
         // Do the coefficient mixing
         // Begin by making a zeroed output buffer
         let combo_count = self.taps.combos_size();
-        let combos = scope!(
-            "alloc(combos)",
-            self.hal
-                .alloc_extelem_zeroed("combos", self.cycles * (combo_count + 1))
-        );
+
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                let mut combos = scope!(
+                    "alloc(combos)",
+                    self.hal
+                        .alloc_extelem_zeroed("combos", self.cycles * (combo_count + 1))
+                );
+            } else {
+                let combos = scope!(
+                    "alloc(combos)",
+                    self.hal
+                        .alloc_extelem_zeroed("combos", self.cycles * (combo_count + 1))
+                );
+            }
+        }
 
         scope!("mix_poly_coeffs", {
             let mut cur_mix = H::ExtElem::ONE;
@@ -363,6 +687,12 @@ impl<'a, H: Hal> Prover<'a, H> {
             final_poly_coeffs
         });
 
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                release_buffer_ext("combos", self.hal, &mut combos);
+            }
+        }
+
         // Finally do the FRI protocol to prove the degree of the polynomial
         scope!(
             "bit_rev",
@@ -370,12 +700,33 @@ impl<'a, H: Hal> Prover<'a, H> {
         );
         tracing::debug!("FRI-proof, size = {}", final_poly_coeffs.size() / ext_size);
 
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "low_vram", feature = "cuda"))] {
+                self.fri_prepare(&mut check_group);
+            }
+        }
+
+        let rou = H::Elem::ROU_FWD[self.po2 + 2];
         fri_prove(self.hal, &mut self.iop, &final_poly_coeffs, |iop, idx| {
+            let mut querys = Vec::new();
             for pg in self.groups.iter() {
                 let pg = pg.as_ref().unwrap();
-                pg.merkle.prove(self.hal, iop, idx);
+                querys.push(Self::prove_group_with_idxs(
+                    self.hal,
+                    pg,
+                    iop,
+                    idx.clone(),
+                    rou,
+                ));
             }
-            check_group.merkle.prove(self.hal, iop, idx);
+            querys.push(Self::prove_group_with_idxs(
+                self.hal,
+                &check_group,
+                iop,
+                idx.clone(),
+                rou,
+            ));
+            querys
         });
 
         let proven_soundness_error =

--- a/risc0/zkvm/Cargo.toml
+++ b/risc0/zkvm/Cargo.toml
@@ -160,7 +160,7 @@ cuda = [
   "risc0-groth16/cuda",
   "risc0-zkp/cuda",
 ]
-default = ["client", "bonsai"]
+default = ["client", "bonsai", "low_vram", "pinned_witgen"]
 r0vm-ver-compat = []
 disable-dev-mode = []
 # This flag uses the docker environment to build test guests such as multi-test
@@ -219,3 +219,14 @@ std = [
 ]
 unstable = ["risc0-zkvm-platform/unstable"]
 witgen_debug = ["risc0-circuit-rv32im/witgen_debug"]
+
+low_vram = [
+    "risc0-zkp/low_vram",
+    "risc0-circuit-keccak/low_vram",
+    "risc0-circuit-recursion/low_vram",
+    "risc0-circuit-rv32im/low_vram",
+]
+pinned_witgen = [
+    "risc0-circuit-rv32im/pinned_witgen",
+    "risc0-circuit-recursion/pinned_witgen",
+]

--- a/risc0/zkvm/benches/fib.rs
+++ b/risc0/zkvm/benches/fib.rs
@@ -14,7 +14,8 @@
 
 use hotbench::{benchmark_group, benchmark_main, BenchGroup};
 use risc0_zkvm::{
-    get_prover_server, ExecutorEnv, ExecutorImpl, ProverOpts, VerifierContext, RECURSION_PO2,
+    get_prover_server, ExecutorEnv, ExecutorImpl, ProverOpts, ReceiptKind, VerifierContext,
+    RECURSION_PO2,
 };
 use risc0_zkvm_methods::FIB_ELF;
 
@@ -170,6 +171,51 @@ fn total_succinct(group: &mut BenchGroup) {
     });
 }
 
+/// Parameterized Succinct end-to-end bench.
+///
+/// Reads two env vars at run time, defaulting to (n=12_000_000, po2=22):
+///   FIB_N    — value of `n` passed to the fib guest (fib(n) iterations)
+///   FIB_PO2  — segment_limit_po2 controlling how cycles are sharded
+///
+/// Always uses ReceiptKind::Succinct. Used as the canonical perf bench for
+/// the low_vram + pinned_witgen feature combination on RTX 4090.
+///
+/// Example:
+///   FIB_N=12000000 FIB_PO2=22 cargo bench -F cuda --features low_vram,pinned_witgen --bench fib -- fib_succinct
+fn fib_succinct(group: &mut BenchGroup) {
+    let n: u32 = std::env::var("FIB_N")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(12_000_000);
+    let po2: u32 = std::env::var("FIB_PO2")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(22);
+
+    let label = format!("fib_succinct/n={n}/po2={po2}");
+    group.bench(label, |b| {
+        let env = ExecutorEnv::builder()
+            .write_slice(&[n])
+            .segment_limit_po2(po2)
+            .build()
+            .unwrap();
+        let mut exec = ExecutorImpl::from_elf(env, FIB_ELF).unwrap();
+        let session = exec.run().unwrap();
+
+        let opts = ProverOpts::default().with_receipt_kind(ReceiptKind::Succinct);
+        let prover = get_prover_server(&opts).unwrap();
+        let ctx = VerifierContext::default();
+
+        b.iter(
+            session.total_cycles as usize,
+            || {},
+            |()| {
+                let _receipt = prover.prove_session(&ctx, &session).unwrap().receipt;
+            },
+        );
+    });
+}
+
 benchmark_group!(
     fib,
     warmup,
@@ -178,6 +224,7 @@ benchmark_group!(
     lift,
     join,
     total_composite,
-    total_succinct
+    total_succinct,
+    fib_succinct,
 );
 benchmark_main!(fib);


### PR DESCRIPTION
Adds two opt-in Cargo features that together unlock po2=22 segment proving on 24 GB consumer GPUs and improve fib_succinct throughput by ~40% on RTX 4090.

Features
--------
  low_vram      Reduces per-segment GPU memory footprint:
                  - early release / reuse of codeword GPU memory at
                    po2 >= LARGE_SEGMENT_PO2 (= 22)
                  - early release / reuse of rv32im data/accum codeword buffers
                  - host-pinned 1 GB arena for code Merkle Tree Node
  pinned_witgen cudaMallocHost-backed PinnedVec for witgen H2D buffers
                (cycles, txns, bigint_bytes); host->device DMA at full
                PCIe gen4 bandwidth instead of via the driver's
                pageable bounce buffer.

Both features are cuda-gated via `cfg(all(low_vram, cuda))` / `cfg(all(pinned_witgen, cuda))` and default-on in `risc0-zkvm` default features. The cuda code path matches v3.0.4 when the features are not active.

Performance
-----------
  RTX 4090, fib 12M cycles:
    v3.0.4 prebuilt baseline (po2=21):                724.7 KHz
    this PR --features cuda+low_vram+pinned_witgen
       po2=22:                                       ~1015  KHz
    throughput improvement vs v3.0.4 baseline:        +40.0%

Backend support
---------------
  cuda + low_vram + pinned_witgen     primary perf path
  cuda only                            compiles + runs; identical
                                       to v3.0.4 behavior
  cpu                                  compiles + runs
                                       (build_injector gated to v3.0.4
                                       behavior outside low_vram+cuda)
  metal                                compiles via default
                                       unimplemented!() trait impls for
                                       six new HAL methods; panics if
                                       called, but the metal prove path
                                       does not call them under
                                       po2 < LARGE_SEGMENT_PO2

Reproduce
---------
  cargo bench -F cuda --bench fib --no-run
  FIB_N=12000000 FIB_PO2=22 \
    target/release/deps/fib-<hash> --bench fib_succinct