### PR TITLE
Return serde error for partial-word input

### DIFF
--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use alloc::{string::String, vec};
+use core::mem::size_of_val;
 
 use bytemuck::Pod;
 use risc0_zkvm_platform::WORD_SIZE;
@@ -74,6 +75,10 @@ impl WordRead for &[u32] {
 /// possible, such as if `slice` is not the serialized form of an object of type
 /// `T`.
 pub fn from_slice<T: DeserializeOwned, P: Pod>(slice: &[P]) -> Result<T> {
+    if size_of_val(slice) % WORD_SIZE != 0 {
+        return Err(Error::DeserializeUnexpectedEnd);
+    }
+
     match bytemuck::try_cast_slice(slice) {
         Ok(slice) => {
             let mut deserializer = Deserializer::new(slice);
@@ -590,5 +595,19 @@ mod tests {
             second: "abc".into(),
         };
         assert_eq!(expected, from_slice(&words).unwrap());
+    }
+
+    #[test]
+    fn partial_word_byte_slice_returns_error() {
+        assert_eq!(
+            Err(Error::DeserializeUnexpectedEnd),
+            from_slice::<u32, u8>(&[0, 1, 2]),
+        );
+    }
+
+    #[test]
+    fn unaligned_complete_byte_slice_deserializes() {
+        let bytes = [0xff, 1, 0, 0, 0];
+        assert_eq!(1u32, from_slice::<u32, u8>(&bytes[1..]).unwrap());
     }
 }


### PR DESCRIPTION
Motivation

`risc0_zkvm::serde::from_slice<T, P>` returns `Result<T>`, but partial-word byte input could panic while handling the bytemuck cast path instead of returning a deserialization error.

Semantic change

This patch rejects inputs whose total byte length is not a multiple of `WORD_SIZE` before attempting the cast to `[u32]`.

That preserves the existing unaligned-but-complete copy path, while making incomplete byte input return `Error::DeserializeUnexpectedEnd` instead of panicking.

Preserved behavior

Complete but unaligned byte slices still deserialize through the existing copy path.

Testing

I added two focused serde tests in `risc0/zkvm/src/serde/deserializer.rs`:
- `partial_word_byte_slice_returns_error`
- `unaligned_complete_byte_slice_deserializes`

Local verification on this Windows host used a focused smoke crate against the patched local `risc0-zkvm` checkout. That smoke test passed for both behaviors with a locally configured `CXX` override.
