### PR TITLE
docs: add rzup auth hint to onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Next we can install the RISC Zero toolchain by running `rzup install`:
 rzup install
 ```
 
+If this step fails while querying GitHub releases with a `401` or `Bad credentials` error, set a `GITHUB_TOKEN` environment variable or sign in with the GitHub CLI so `rzup` can reuse `~/.config/gh/hosts.yml`.
+
 You can verify the installation was successful by running:
 
 ```bash

--- a/risc0/cargo-risczero/README.md
+++ b/risc0/cargo-risczero/README.md
@@ -15,6 +15,8 @@ curl -L https://risczero.com/install | bash
 rzup install
 ```
 
+If `rzup install` fails while querying GitHub releases with a `401` or `Bad credentials` error, set a `GITHUB_TOKEN` environment variable or sign in with the GitHub CLI so `rzup` can reuse `~/.config/gh/hosts.yml`.
+
 To install from local source, use:
 
 ```bash

--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -20,6 +20,7 @@ The RISC Zero zkVM requires [Rust]. If you don't already have Rust and [rustup] 
    ```
 
 Running `rzup` will install the latest released version of the RISC Zero toolchain.
+If the GitHub releases request returns `401` or `Bad credentials`, set a `GITHUB_TOKEN` environment variable or sign in with the GitHub CLI so `rzup` can reuse `~/.config/gh/hosts.yml`.
 
 For a specific version, use `rzup install cargo-risczero <version>`, where the `<version>` is a released SemVer version (e.g `1.1.1`). See [releases].
 

--- a/website/api/zkvm/quickstart.md
+++ b/website/api/zkvm/quickstart.md
@@ -30,6 +30,8 @@ Run `rzup` to install the RISC Zero toolchain and `cargo-risczero`.
 rzup install
 ```
 
+If `rzup install` fails while querying GitHub releases with a `401` or `Bad credentials` error, set a `GITHUB_TOKEN` environment variable or sign in with the GitHub CLI so `rzup` can reuse `~/.config/gh/hosts.yml`.
+
 ## 2. Create a New Project
 
 The `cargo-risczero` tool takes `--guest-name` parameter, a [guest] program that


### PR DESCRIPTION
This adds an onboarding hint for a common `rzup install` failure mode.

Failure mechanism:
New users are told to run `rzup install`, but the onboarding docs do not mention that `rzup` may query GitHub releases and can fail with `401` / `Bad credentials`.

Code and existing docs evidence:
- `rzup/src/env.rs` loads GitHub auth from `GITHUB_TOKEN`, then falls back to `~/.config/gh/hosts.yml`
- `rzup/src/cli/commands.rs` and `rzup/README.md` already describe that auth behavior

Semantic change:
- add a short remediation note at the main onboarding entry points that tell users to run `rzup install`
- point users to either set `GITHUB_TOKEN` or sign in with the GitHub CLI so `rzup` can reuse `~/.config/gh/hosts.yml`

Files changed:
- README.md
- website/api/zkvm/quickstart.md
- website/api/zkvm/install.md
- risc0/cargo-risczero/README.md

Testing:
- inspected the focused docs diff for scope and wording only
- did not run a docs build