### PR TITLE
docs: mention build-essential for rzup build

### DIFF
--- a/rzup/README.md
+++ b/rzup/README.md
@@ -123,6 +123,10 @@ the default version.
 
 The resulting version of the component will contain the commit hash.
 
+Building the Rust toolchain also requires native build dependencies such as `cmake`,
+`ninja`, and a C/C++ toolchain. On Debian/Ubuntu systems, install packages such as
+`build-essential`, `cmake`, and `ninja-build` first.
+
 ## Components
 
 rzup manages the following components:

--- a/rzup/src/cli/commands.rs
+++ b/rzup/src/cli/commands.rs
@@ -286,7 +286,11 @@ pub const BUILD_HELP: &str = "Discussion:
     Builds and installs the given component.
 
     Grabs the source code from GitHub, compiles it, installs it, and makes it
-    the default version. The resulting component version contains the commit hash.";
+    the default version. The resulting component version contains the commit hash.
+
+    Building the Rust toolchain also requires native build dependencies such as
+    cmake, ninja, and a C/C++ toolchain. On Debian/Ubuntu systems, install
+    packages such as build-essential, cmake, and ninja-build first.";
 
 #[derive(Parser)]
 #[command(group(

--- a/website/api/zkvm/install.md
+++ b/website/api/zkvm/install.md
@@ -31,7 +31,7 @@ For users who prefer manual installation or those who use systems such as x86-64
 
 - Clone the repository with `git clone https://github.com/risc0/risc0.git`.
 - In the root of the repository, install `rzup` with `cargo install --path rzup`.
-- Build and install the rust toolchain with `rzup build rust`. This command may require utilities such as `cmake` and the `ninja` build system to be installed.
+- Build and install the rust toolchain with `rzup build rust`. This command may require native build tooling such as `cmake`, the `ninja` build system, and a C/C++ toolchain. On Debian/Ubuntu systems, install packages such as `build-essential`, `cmake`, and `ninja-build` first.
 - Build and install the `cargo-risczero` by first checking out the branch `release-*` where `*` is `[major release number].[minor release number]` of your desired zkVM version. For example, if you would like to install version 1.1.0, run `git checkout origin/release-1.1` and run `cargo install --path risc0/cargo-risczero`.
 
 For x86-64 linux and arm64 macOS, install the C++ toolchains by running:


### PR DESCRIPTION
This documents an existing manual-build prerequisite for `rzup build rust`.

Failure mechanism:
The manual installation docs currently mention `cmake` and `ninja`, but they do not mention that a native C/C++ toolchain is also required. On Debian/Ubuntu systems, missing `build-essential` can leave users with an opaque `cmake` build failure during `rzup build rust`.

Evidence:
- issue #3708 reports the missing `build-essential` dependency in the manual installation flow
- `risc0/cargo-risczero/docker/Dockerfile.release` already installs `build-essential`

Semantic change:
- update the manual installation docs to mention the native build-tool requirement explicitly
- add the same prerequisite hint to `rzup build` help text and the `rzup` README so the CLI and docs stay aligned

Files changed:
- website/api/zkvm/install.md
- rzup/src/cli/commands.rs
- rzup/README.md

Testing:
- `cargo fmt --all --check`
- `cargo test -p rzup` still fails on Windows because of pre-existing Unix-only code paths in `rzup`, unrelated to this doc/help-text change