### PR TITLE
Reject reserved JALR func3 encodings

### DIFF
--- a/risc0/circuit/rv32im/src/execute/rv32im.rs
+++ b/risc0/circuit/rv32im/src/execute/rv32im.rs
@@ -285,7 +285,7 @@ impl Emulator {
             // J-format jal
             (0b1101111, _, _) => self.step_compute(ctx, InsnKind::Jal, decoded),
             // I-format jalr
-            (0b1100111, _, _) => self.step_compute(ctx, InsnKind::JalR, decoded),
+            (0b1100111, 0b000, _) => self.step_compute(ctx, InsnKind::JalR, decoded),
             // System instruction
             (0b1110011, 0b000, 0b0011000) => self.step_system(ctx, InsnKind::Mret, decoded),
             (0b1110011, 0b000, 0b0000000) => self.step_system(ctx, InsnKind::Eany, decoded),

--- a/risc0/circuit/rv32im/src/execute/tests.rs
+++ b/risc0/circuit/rv32im/src/execute/tests.rs
@@ -13,7 +13,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use risc0_binfmt::MemoryImage;
+use risc0_binfmt::{MemoryImage, Program};
 use risc0_zkp::core::digest::Digest;
 use test_log::test;
 
@@ -49,6 +49,33 @@ fn basic() {
     assert_eq!(segment.terminate_state, Some(TerminateState::default()));
     assert!(segment.read_record.is_empty());
     assert!(segment.write_record.is_empty());
+}
+
+#[test]
+fn reserved_jalr_func3_is_illegal() {
+    const RESERVED_JALR_FUNC3: u32 = 0x0002_90e7;
+
+    let entry = crate::execute::USER_START_ADDR.waddr() + 1;
+    let mut image = MemoryImage::default();
+    image.set_word(entry, RESERVED_JALR_FUNC3).unwrap();
+    let program = Program::new_from_entry_and_image(entry.baddr().0, image);
+    let image = MemoryImage::new_kernel(program);
+
+    let error = testutil::execute(
+        image,
+        ExecutionLimit::default()
+            .with_segment_po2(testutil::MIN_CYCLES_PO2)
+            .with_max_insn_rows(100),
+        testutil::NullSyscall,
+        None,
+    )
+    .map(|_| ())
+    .unwrap_err();
+
+    assert!(
+        error.to_string().contains("IllegalInstruction(0x000290e7"),
+        "unexpected error: {error:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #3767.

The fast RV32IM executor currently accepts all opcode `0b1100111` instructions as `JALR`, regardless of `func3`. Only `func3 = 0` is a valid JALR encoding, and the proof-side preflight decoder already enforces that.

This tightens the fast executor decode arm so reserved JALR-family encodings with nonzero `func3` follow the illegal-instruction path instead of executing as JALR.

Adds a regression test for `0x000290e7`, which has opcode `0b1100111` and `func3 = 1`.

Verification:
- `cargo test -p risc0-circuit-rv32im --features execute reserved_jalr_func3_is_illegal -- --nocapture`
- `cargo test -p risc0-circuit-rv32im --features execute --lib execute::tests`