### PR TITLE
fix: replace deprecated Command::cargo_bin with assert_cmd::cargo::cargo_bin

### DIFF
--- a/risc0/r0vm/tests/dev_mode.rs
+++ b/risc0/r0vm/tests/dev_mode.rs
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin;
 use assert_fs::{TempDir, fixture::PathChild};
 use risc0_zkvm::{Receipt, serde::to_vec};
 use risc0_zkvm_methods::{MULTI_TEST_PATH, multi_test::MultiTestSpec};
@@ -23,7 +24,7 @@ fn run_dev_mode() -> Receipt {
     let receipt_file = temp.child("receipt.dat");
     let input = to_vec(&MultiTestSpec::DoNothing).unwrap();
 
-    let mut cmd = Command::cargo_bin("r0vm").unwrap();
+    let mut cmd = Command::new(cargo_bin("r0vm"));
     cmd.arg("--elf")
         .env("RISC0_DEV_MODE", "1")
         .arg(MULTI_TEST_PATH)

--- a/risc0/r0vm/tests/standard_lib.rs
+++ b/risc0/r0vm/tests/standard_lib.rs
@@ -16,6 +16,7 @@
 use std::path::Path;
 
 use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin;
 use assert_fs::{TempDir, fixture::PathChild};
 use risc0_zkvm::Receipt;
 use risc0_zkvm_methods::STANDARD_LIB_ID;
@@ -38,7 +39,7 @@ fn stdio_outputs_in_receipt() {
     let temp = TempDir::new().unwrap();
     let receipt_file = temp.child("receipt.dat");
 
-    let mut cmd = Command::cargo_bin("r0vm").unwrap();
+    let mut cmd = Command::new(cargo_bin("r0vm"));
 
     cmd.arg("--elf")
         .arg(risc0_zkvm_methods::STANDARD_LIB_PATH)


### PR DESCRIPTION
Fixes #3612

## Changes
- `risc0/r0vm/tests/standard_lib.rs`: replaced deprecated `Command::cargo_bin("r0vm")` with `Command::new(cargo_bin("r0vm"))`
- `risc0/r0vm/tests/dev_mode.rs`: same fix applied

## Notes
Used `assert_cmd::cargo::cargo_bin` function over the macro form — consistent 
with existing usage in `default_prover.rs` which already had the correct pattern.
`dev_mode.rs` and `standard_lib.rs` were the only two remaining files using the 
deprecated method.