### PR TITLE
fix(cargo-risczero): forward guest feature flags

### DIFF
--- a/risc0/build/src/config.rs
+++ b/risc0/build/src/config.rs
@@ -92,12 +92,19 @@ impl DockerOptions {
 ///     .build()
 ///     .unwrap();
 /// ```
-#[derive(Default, Clone, Debug, Builder)]
+#[derive(Clone, Debug, Builder)]
 #[builder(default)]
 #[non_exhaustive]
 pub struct GuestOptions {
     /// Features for cargo to build the guest with.
     pub features: Vec<String>,
+
+    /// Whether to build the guest with all features enabled.
+    pub all_features: bool,
+
+    /// Whether to build the guest with default features enabled.
+    #[builder(default = "true")]
+    pub default_features: bool,
 
     /// Use a docker environment for building.
     #[builder(setter(strip_option))]
@@ -106,6 +113,18 @@ pub struct GuestOptions {
     /// Override the default kernel ELF to be used for execution.
     #[builder(setter(strip_option))]
     pub kernel: Option<Vec<u8>>,
+}
+
+impl Default for GuestOptions {
+    fn default() -> Self {
+        Self {
+            features: Vec::new(),
+            all_features: false,
+            default_features: true,
+            use_docker: None,
+            kernel: None,
+        }
+    }
 }
 
 impl GuestOptions {

--- a/risc0/build/src/docker.rs
+++ b/risc0/build/src/docker.rs
@@ -21,8 +21,8 @@ use docker_generate::DockerFile;
 use tempfile::tempdir;
 
 use crate::{
-    GuestOptions, RISC0_TARGET_TRIPLE, config::GuestInfo, encode_rust_flags, get_env_var,
-    get_package,
+    GuestOptions, RISC0_TARGET_TRIPLE, cargo_feature_args, config::GuestInfo, encode_rust_flags,
+    get_env_var, get_package,
 };
 
 const DOCKER_IGNORE: &str = r#"
@@ -123,26 +123,33 @@ fn create_dockerfile(manifest_path: &Path, temp_dir: &Path, guest_info: &GuestIn
     let rustflags_env = &[("CARGO_ENCODED_RUSTFLAGS", encoded_rust_flags.as_str())];
 
     let common_args = vec![
-        "--locked",
-        "--target",
-        RISC0_TARGET_TRIPLE,
-        "--manifest-path",
-        "$CARGO_MANIFEST_PATH",
+        "--locked".to_string(),
+        "--target".to_string(),
+        RISC0_TARGET_TRIPLE.to_string(),
+        "--manifest-path".to_string(),
+        "$CARGO_MANIFEST_PATH".to_string(),
     ];
 
-    let mut build_args = common_args.clone();
-    let features_str = guest_info.options.features.join(",");
-    if !guest_info.options.features.is_empty() {
-        build_args.push("--features");
-        build_args.push(&features_str);
-    }
+    let build_args = [common_args.clone(), cargo_feature_args(&guest_info.options)].concat();
 
-    let fetch_cmd = [&["cargo", "+risc0", "fetch"], common_args.as_slice()]
-        .concat()
-        .join(" ");
+    let fetch_cmd = [
+        vec![
+            "cargo".to_string(),
+            "+risc0".to_string(),
+            "fetch".to_string(),
+        ],
+        common_args,
+    ]
+    .concat()
+    .join(" ");
     let build_cmd = [
-        &["cargo", "+risc0", "build", "--release"],
-        build_args.as_slice(),
+        vec![
+            "cargo".to_string(),
+            "+risc0".to_string(),
+            "build".to_string(),
+            "--release".to_string(),
+        ],
+        build_args,
     ]
     .concat()
     .join(" ");

--- a/risc0/build/src/lib.rs
+++ b/risc0/build/src/lib.rs
@@ -446,6 +446,26 @@ pub(crate) fn cargo_command_internal(subcmd: &str, guest_info: &GuestInfo) -> Co
     cmd
 }
 
+pub(crate) fn cargo_feature_args(options: &GuestOptions) -> Vec<String> {
+    let mut args = Vec::new();
+
+    if options.all_features {
+        args.push("--all-features".to_string());
+    }
+
+    if !options.default_features {
+        args.push("--no-default-features".to_string());
+    }
+
+    let features_str = options.features.join(",");
+    if !features_str.is_empty() {
+        args.push("--features".to_string());
+        args.push(features_str);
+    }
+
+    args
+}
+
 fn get_rust_toolchain_version() -> semver::Version {
     let rzup = rzup::Rzup::new().unwrap();
     let Some((version, _)) = rzup
@@ -628,11 +648,7 @@ fn build_guest_package(pkg: &Package, target_dir: impl AsRef<Path>, guest_info: 
     fs::create_dir_all(target_dir).unwrap();
 
     let mut cmd = cargo_command_internal("build", guest_info);
-
-    let features_str = guest_info.options.features.join(",");
-    if !features_str.is_empty() {
-        cmd.args(["--features", &features_str]);
-    }
+    cmd.args(cargo_feature_args(&guest_info.options));
 
     cmd.args([
         "--manifest-path",
@@ -940,5 +956,34 @@ mod tests {
         ]
         .join("\x1f");
         assert!(encoded.contains(&expected));
+    }
+
+    #[test]
+    fn cargo_feature_args_disable_default_features() {
+        let options = GuestOptionsBuilder::default()
+            .default_features(false)
+            .features(vec!["foo".to_string(), "bar".to_string()])
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            cargo_feature_args(&options),
+            vec!["--no-default-features", "--features", "foo,bar"]
+        );
+    }
+
+    #[test]
+    fn guest_options_default_enables_default_features() {
+        assert!(GuestOptions::default().default_features);
+    }
+
+    #[test]
+    fn cargo_feature_args_enable_all_features() {
+        let options = GuestOptionsBuilder::default()
+            .all_features(true)
+            .build()
+            .unwrap();
+
+        assert_eq!(cargo_feature_args(&options), vec!["--all-features"]);
     }
 }

--- a/risc0/cargo-risczero/src/commands/bake.rs
+++ b/risc0/cargo-risczero/src/commands/bake.rs
@@ -60,6 +60,8 @@ impl BakeCommand {
     fn bake_target(&self, pkg: &Package, target_dir: &Path) -> Result<()> {
         let mut guest_opts = GuestOptionsBuilder::default();
         guest_opts.features(self.features.features.clone());
+        guest_opts.all_features(self.features.all_features);
+        guest_opts.default_features(!self.features.no_default_features);
         if self.docker {
             guest_opts.use_docker(
                 DockerOptionsBuilder::default()

--- a/risc0/cargo-risczero/src/commands/build.rs
+++ b/risc0/cargo-risczero/src/commands/build.rs
@@ -42,6 +42,8 @@ impl BuildCommand {
 
         let guest_opts = GuestOptionsBuilder::default()
             .features(self.features.features.clone())
+            .all_features(self.features.all_features)
+            .default_features(!self.features.no_default_features)
             .use_docker(DockerOptionsBuilder::default().build()?)
             .build()?;
 


### PR DESCRIPTION
## Summary

- Add guest options for `--all-features` and `--no-default-features`.
- Forward guest feature flags from `cargo risczero build` and `cargo risczero bake` into the actual guest `cargo build`.
- Reuse the same feature-argument builder for local and Docker guest builds.
- Add unit coverage for feature argument generation and the `GuestOptions` default behavior.

## Motivation

`cargo risczero build --no-default-features` forwarded feature flags to cargo metadata, but the actual guest build only received explicit `--features` values. As a result, default features could remain enabled during guest compilation.

Fixes #3772.

## Testing

- `cargo test -p risc0-build cargo_feature_args`
- `cargo test -p risc0-build guest_options_default_enables_default_features`
- `cargo check -p cargo-risczero --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`