### PR TITLE
fix: return error instead of panicking in from_slice on invalid byte slice

### DIFF
--- a/risc0/zkvm/src/serde/deserializer.rs
+++ b/risc0/zkvm/src/serde/deserializer.rs
@@ -85,7 +85,7 @@ pub fn from_slice<T: DeserializeOwned, P: Pod>(slice: &[P]) -> Result<T> {
             let mut deserializer = Deserializer::new(vec.as_slice());
             T::deserialize(&mut deserializer)
         }
-        Err(ref e) => panic!("failed to cast or read slice as [u32]: {e}"),
+        Err(_) => return Err(Error::DeserializeUnexpectedEnd),
     }
 }
 


### PR DESCRIPTION
When `from_slice` receives a byte slice whose length is not a multiple of 4 (the u32 word size), `bytemuck::try_cast_slice` can fail with errors other than alignment mismatch. The catch-all arm was panicking instead of returning an `Err`, violating the function's `Result` contract.

Fixes #3754