### PR TITLE
fix: constrain fast executor JALR match to func3=0

### DIFF
--- a/risc0/circuit/rv32im/src/execute/rv32im.rs
+++ b/risc0/circuit/rv32im/src/execute/rv32im.rs
@@ -285,7 +285,7 @@ impl Emulator {
             // J-format jal
             (0b1101111, _, _) => self.step_compute(ctx, InsnKind::Jal, decoded),
             // I-format jalr
-            (0b1100111, _, _) => self.step_compute(ctx, InsnKind::JalR, decoded),
+            (0b1100111, 0b000, _) => self.step_compute(ctx, InsnKind::JalR, decoded),
             // System instruction
             (0b1110011, 0b000, 0b0011000) => self.step_system(ctx, InsnKind::Mret, decoded),
             (0b1110011, 0b000, 0b0000000) => self.step_system(ctx, InsnKind::Eany, decoded),


### PR DESCRIPTION
The fast executor's JALR decode arm used `(0b1100111, _, _)`, accepting any `func3` value. The RISC-V spec only defines JALR for `func3 = 0b000`. The proof-side preflight decoder correctly enforces this constraint, creating an executor/preflight semantic mismatch: a segment produced by fast execution from a reserved encoding gets rejected by preflight with "Invalid PC or instruction in user mode".

Fixes #3767