### PR TITLE
fix: replace deprecated Command::cargo_bin with cargo_bin! macro

### DIFF
--- a/risc0/r0vm/tests/standard_lib.rs
+++ b/risc0/r0vm/tests/standard_lib.rs
@@ -15,7 +15,7 @@
 
 use std::path::Path;
 
-use assert_cmd::Command;
+use assert_cmd::cargo_bin;
 use assert_fs::{TempDir, fixture::PathChild};
 use risc0_zkvm::Receipt;
 use risc0_zkvm_methods::STANDARD_LIB_ID;
@@ -38,7 +38,7 @@ fn stdio_outputs_in_receipt() {
     let temp = TempDir::new().unwrap();
     let receipt_file = temp.child("receipt.dat");
 
-    let mut cmd = Command::cargo_bin("r0vm").unwrap();
+    let mut cmd = cargo_bin!("r0vm");
 
     cmd.arg("--elf")
         .arg(risc0_zkvm_methods::STANDARD_LIB_PATH)


### PR DESCRIPTION
`Command::cargo_bin` relies on cargo implementation details that will break on future Cargo versions (rust-lang/cargo#16147, rust-lang/cargo#15010). The `cargo_bin!` macro is the recommended replacement.

Fixes #3612