### PR TITLE
fix: replace panics with proper error returns in STARK verify path

### DIFF
--- a/risc0/circuit/rv32im/src/lib.rs
+++ b/risc0/circuit/rv32im/src/lib.rs
@@ -144,7 +144,7 @@ impl<'a> Decoder<'a> {
     fn read_digest_from_words(&mut self) -> Result<Digest> {
         let slice = try_cast_slice(self.read(DIGEST_WORDS)?)?;
         let buf = slice.iter().map(|x| x.as_u32()).collect::<Vec<u32>>();
-        Ok(Digest::try_from(buf).unwrap())
+        Ok(Digest::try_from(buf).map_err(|_| anyhow::anyhow!("invalid digest words"))?)
     }
 
     fn read_digest_from_shorts(&mut self) -> Result<Digest> {

--- a/risc0/zkp/src/verify/mod.rs
+++ b/risc0/zkp/src/verify/mod.rs
@@ -300,10 +300,7 @@ impl<'a, F: Field> Verifier<'a, F> {
         // Ensure that we were given verifiers for all tap groups
         for (reg_group_id, verifier) in self.merkle_verifiers.iter().enumerate() {
             if !verifier.is_some() {
-                panic!(
-                    "Missing merkle verifier for reg group {reg_group_id} ({})",
-                    self.taps.group_name(reg_group_id)
-                );
+                return Err(VerificationError::InvalidProof);
             }
         }
 
@@ -457,7 +454,7 @@ impl<'a, F: Field> Verifier<'a, F> {
                 .iter()
                 .map(|merkle: &Option<MerkleTreeVerifier>| -> Result<&'a [F::Elem], VerificationError> {
                     merkle.as_ref()
-                        .unwrap()
+                        .ok_or(VerificationError::InvalidProof)?
                         .verify(self.iop().deref_mut(), hashfn, idx)
                 })
                 .collect::<Result<Vec<_>,_>>()?;
@@ -482,10 +479,10 @@ impl<'a, F: Field> Verifier<'a, F> {
 
         // Extract the out buffer and po2 from slice while checking sizes.
         let (out, &[po2_elem]) = slice.split_at(size) else {
-            unreachable!("slice returned by read_field_elem_slice is wrong size");
+            return Err(VerificationError::ReceiptFormatError);
         };
         let (&[po2], &[]) = po2_elem.to_u32_words().split_at(1) else {
-            unreachable!("po2 elem is larger than u32");
+            return Err(VerificationError::ReceiptFormatError);
         };
         if po2 as usize > MAX_CYCLES_PO2 {
             tracing::error!("po2 in seal is larger than the max po2: {po2} > {MAX_CYCLES_PO2}");


### PR DESCRIPTION
Four panic sites in the proof verification path that should return Errors instead:

1. `verify_validity` guard (mod.rs:303-307): `panic!()` on missing merkle verifier → `Err(InvalidProof)`
2. FRI verify closure (mod.rs:460): `.unwrap()` on `Option<MerkleTreeVerifier>` → `.ok_or(InvalidProof)?`
3. `read_slice_with_po2` (mod.rs:484-490): two `unreachable!()` macros → `Err(ReceiptFormatError)`
4. `read_digest_from_words` (lib.rs:147): `.unwrap()` on `Digest::try_from` → `map_err` with anyhow error

In all four cases the invariants make the panic unreachable under current logic, but if those invariants ever change during maintenance the code now degrades gracefully instead of crashing the verifier.