### PR TITLE
rzup: Pass codgen-units=16 when building the Rust toolchain

### DIFF
--- a/rzup/src/rust-toolchain-build-config.toml
+++ b/rzup/src/rust-toolchain-build-config.toml
@@ -9,6 +9,9 @@ cargo-native-static = true
 lld = true
 llvm-tools = true
 omit-git-hash = false
+# With a single CGU, std's embedded LTO bitcode (pulled in by our `lto = true` guests)
+# keeps atomics that -C passes=lower-atomic already stripped from its regular object code.
+codegen-units-std = 16
 
 [llvm]
 download-ci-llvm = false


### PR DESCRIPTION
This is important for the atomic lowering pass we do.