### PR TITLE
fix(rzup): use parse_version helper in uninstall and default commands

### DIFF
--- a/rzup/src/cli/commands.rs
+++ b/rzup/src/cli/commands.rs
@@ -192,8 +192,7 @@ pub(crate) struct DefaultCommand {
 
 impl DefaultCommand {
     pub(crate) fn execute(self, rzup: &mut Rzup) -> Result<()> {
-        let version = Version::parse(&self.version)
-            .map_err(|_| RzupError::InvalidVersion(self.version.clone()))?;
+        let version = parse_version(Some(&self.name), &self.version)?;
         let component = self.name.parse()?;
         if rzup.version_exists(&component, &version)? {
             rzup.set_default_version(&component, version.clone())?;
@@ -276,8 +275,7 @@ pub(crate) struct UninstallCommand {
 
 impl UninstallCommand {
     pub(crate) fn execute(&self, rzup: &mut Rzup) -> Result<()> {
-        let version = Version::parse(&self.version)
-            .map_err(|_| RzupError::InvalidVersion(self.version.clone()))?;
+        let version = parse_version(Some(&self.name), &self.version)?;
         rzup.uninstall_component(&self.name.parse()?, version)
     }
 }


### PR DESCRIPTION
`rzup install cpp 2024.01.05` succeeds but `rzup uninstall cpp 2024.01.05` and `rzup default cpp 2024.01.05` fail with a semver parse error on the same string.

**Root cause:** `install` routes `cpp`/`gdb` version strings through `parse_version`, which normalises leading-zero numeric segments before calling `semver::Version::parse`. `uninstall` and `default` called `Version::parse` directly, so `01` and `05` were rejected as invalid leading-zero identifiers per the semver spec.

**Fix:** Replace the bare `Version::parse` call in `DefaultCommand::execute` and `UninstallCommand::execute` with `parse_version(Some(&self.name), &self.version)?`. This function is already defined in the same file and used by `InstallCommand`  no new code added, just two call-site fixes.

**Testing:**

rzup install cpp 2024.01.05 # succeeds (unchanged)
rzup uninstall cpp 2024.01.05 # succeeds (was: semver error)
rzup default cpp 2024.01.05 # succeeds (was: semver error)


Fixes #3788