### PR TITLE
fix(rzup): preserve all pre-release segments in extract_version

### DIFF
--- a/rzup/src/paths.rs
+++ b/rzup/src/paths.rs
@@ -89,14 +89,16 @@ impl Paths {
 
     pub fn parse_version_from_path(dir_name: &str, component: &Component) -> Option<Version> {
         fn extract_version(version_part: &str) -> Option<Version> {
-            let segments: Vec<&str> = version_part.split('-').collect();
-            match segments.len() {
-                1 => Version::parse(version_part).ok(),
-                2 | 3 => {
-                    let version_with_pre = format!("{}-{}", segments[0], segments[1]);
-                    Version::parse(&version_with_pre).ok()
+            // Split on the first '-' only: everything before is the numeric
+            // version, everything after is the pre-release identifier.
+            // Additional hyphens within the pre-release part are normalised
+            // to dots so semver::Version::parse accepts them.
+            match version_part.split_once('-') {
+                None => Version::parse(version_part).ok(),
+                Some((base, pre)) => {
+                    let pre_normalized = pre.replace('-', ".");
+                    Version::parse(&format!("{base}-{pre_normalized}")).ok()
                 }
-                _ => None,
             }
         }
 


### PR DESCRIPTION
The inner `extract_version` function in `parse_version_from_path` capped at 3 hyphen-separated segments, dropping anything beyond `segments[1]`, and returned `None` for 4+ segments entirely:

```rust
// before
2 | 3 => format!("{}-{}", segments[0], segments[1]),  // drops segments[2]
_ => None,  // 4+ → directory invisible to rzup
```

A toolchain directory whose version part contains more than one hyphen (e.g. `v1.2.1-rc.0-build.1-cargo-risczero-linux-x86_64`) would be parsed as `1.2.1-rc.0` (losing `build.1`), or return `None` entirely for 4+ segments.

**Fix:** Replace the segment-count match with `split_once('-')` — split on the first hyphen only, then normalise any additional hyphens in the pre-release part to dots. This produces a valid semver pre-release string that `semver::Version::parse` accepts.

All 9 existing `paths::tests` pass unchanged.

Fixes #3789